### PR TITLE
ci: pin the two unpinned npu jobs to the x86_64 half of the pool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1083,9 +1083,24 @@ jobs:
     # TEST MODE: keep the device runner so DEVICE_ID/DEVICE_ID exist and pin
     # task-submit to that card (validates the new compile-card-free + task-submit
     # execute flow deterministically). FLIP TO PROD: change this to
-    # `[self-hosted, linux, cpu]` and drop --task-submit-device below so
+    # `[self-hosted, linux, x64, cpu]` and drop --task-submit-device below so
     # cases borrow any free card via `--device auto`.
-    runs-on: [self-hosted, linux, npu]
+    #
+    # Pinned to x86_64 to free the aarch64 npu box for the jobs that can only
+    # run there. Since #2525 the `npu` label spans an aarch64 box (runners
+    # `npu-N`) and an x86_64 one (the `*-npu-a2a3-N` instances), and both
+    # `dist-system-tests` and `pypto-lib-model` are pinned to `arm64, npu` (see
+    # their own comments) — so every run of this job that lands on aarch64 takes
+    # that box away from them. `x64` is the label the runner application applies
+    # on its own (`X64`; label matching is case-insensitive) — the same pair
+    # `prebuild-wheels` matrixes over.
+    #
+    # This is a scheduling pin, not a health one, and unlike `dist-system-tests`
+    # it is not working around anything: over the 120 most recent ci.yml runs
+    # both jobs go red on BOTH halves at indistinguishable rates (aarch64 4 red
+    # / 55, x86_64 9 red / 87), failing the same batched step. Lift it if the
+    # arm64 pins it makes room for are lifted.
+    runs-on: [self-hosted, linux, x64, npu]
     defaults:
       run:
         working-directory: st-checkout
@@ -1202,9 +1217,24 @@ jobs:
       contents: read
     # TEST MODE: keep the device runner so DEVICE_ID exists and pin task-submit
     # to that card. FLIP TO PROD: change this to
-    # `[self-hosted, linux, cpu]` and drop --task-submit-device / the
+    # `[self-hosted, linux, x64, cpu]` and drop --task-submit-device / the
     # explicit --device below so cases borrow any free card via `--device auto`.
-    runs-on: [self-hosted, linux, npu]
+    #
+    # Pinned to x86_64 to free the aarch64 npu box for the jobs that can only
+    # run there. Since #2525 the `npu` label spans an aarch64 box (runners
+    # `npu-N`) and an x86_64 one (the `*-npu-a2a3-N` instances), and both
+    # `dist-system-tests` and `pypto-lib-model` are pinned to `arm64, npu` (see
+    # their own comments) — so every run of this job that lands on aarch64 takes
+    # that box away from them. `x64` is the label the runner application applies
+    # on its own (`X64`; label matching is case-insensitive) — the same pair
+    # `prebuild-wheels` matrixes over.
+    #
+    # This is a scheduling pin, not a health one, and unlike `dist-system-tests`
+    # it is not working around anything: over the 120 most recent ci.yml runs
+    # both jobs go red on BOTH halves at indistinguishable rates (aarch64 4 red
+    # / 55, x86_64 9 red / 87), failing the same batched step. Lift it if the
+    # arm64 pins it makes room for are lifted.
+    runs-on: [self-hosted, linux, x64, npu]
     defaults:
       run:
         working-directory: st-direct-checkout


### PR DESCRIPTION
## What

Pin `system-tests` and `system-tests-direct` from `runs-on: [self-hosted, linux, npu]` to `[self-hosted, linux, x64, npu]`.

## Why

`dist-system-tests` and `pypto-lib-model` are both pinned to `arm64, npu`, so the aarch64 npu box is the only place they can run. These two were the last npu jobs in `ci.yml` still matching the bare `npu` label, which spans that box and the x86_64 one — so every time one of them landed on aarch64 it took the box away from a job that had nowhere else to go. Pinning them to the x86_64 half gives the arm64-only jobs an uncontended box.

## This is scheduling, not health

Failure rates for these two jobs over the 120 most recent `ci.yml` runs (`npu-N` = aarch64, `*-npu-a2a3-N` = x86_64; cancelled/skipped excluded):

| Job | aarch64 | x86_64 | Fisher exact |
| --- | ------- | ------ | ------------ |
| `system-tests` | 3 red / 29 (10.3%) | 4 red / 42 (9.5%) | p = 1.00 |
| `system-tests-direct` | 1 red / 26 (3.8%) | 5 red / 45 (11.1%) | p = 0.40 |

Both jobs go red on **both** halves, failing the same batched step — e.g. `system-tests` red on `npu-8` at 812b9dd3 and on `npu-9` at 9b1af492, both aarch64. Spot-checking the reds, most look like the PR under test being broken (same branch red at one commit, green at the next) rather than the host.

So unlike the `arm64` pins this makes room for — `dist-system-tests`' pin rests on a real 11/11 vs 3/5 split — this pin is not working around anything, and is not claimed to improve or worsen pass rates.

Caveat on the evidence: job log bodies are served from `productionresultssa*.blob.core.windows.net`, which is not reachable from where I ran this, so the classification above is from job/step metadata (failing step name, duration, per-branch history), not from reading the failure text.

## Left alone

- `npu-a5` (`ci.yml`) — a separate pool, not the arm64/x86_64-spanning `npu` one.
- `qwen3-perf` (`daily_ci.yml`) — compares against a committed perf baseline; changing which host it samples on is a baseline question, not a scheduling one.

## Note

The existing comments in `ci.yml` name the x86_64 runners `infra024-npu-a2a3-N`; every instance observed in the runs above is `infra028-npu-a2a3-N`. I could not read the runner list (`/actions/runners` returns 403 for me) to tell whether the box was renamed/replaced or the older comments have a typo, so the new comments say `*-npu-a2a3-N` and the existing text is untouched.
