### PR TITLE
fix(ir): load a cube matmul's right operand into whole NZ fractal boxes

### DIFF
--- a/docs/en/dev/passes/10-convert_tensor_to_tile_ops.md
+++ b/docs/en/dev/passes/10-convert_tensor_to_tile_ops.md
@@ -281,6 +281,29 @@ rounded to 112 or, at a 32-row alignment, to 128. Compact makes every reader
 recompute the pitch `mad` actually used; without it `AccCompactValid` rejects the
 program (issue #2470).
 
+### The `N` granularity
+
+`M`'s alignment reconciles the tiles it runs through — a `Mat` operand and its
+accumulator (see `ResolveCubeMAlignment`). `N`'s has to reconcile *memory
+spaces* instead, which `M`'s does not:
+
+- the right operand is loaded into `Mat` and then promoted on to `Right` by
+  [`InferTileMemorySpace`](18-infer_tile_memory_space.md), and `Right` boxes the
+  same 512-byte fractal under the opposite `slayout`, which swaps the row and
+  column granularities:
+
+    | Space | `slayout` | fp32 box | fp16 box |
+    | ----- | --------- | -------- | -------- |
+    | `Mat` | `row_major` | 16 x 8 | 16 x 16 |
+    | `Right` | `col_major` | 8 x 16 | 16 x 16 |
+
+- the product lands in an `Acc`, whose `N` box is 16 for every dtype.
+
+Both numbers are real, and ptoas asks for each against the tile that carries it,
+so rounding to `Mat`'s 8 alone yields a box that clears the load and is rejected
+one op later at `Right`. `ResolveCubeNAlignment` therefore takes the lcm of all
+three; every granularity is a power of two, so the lcm is the maximum.
+
 Scope, and what is deliberately left out:
 
 | Case | Boxed? | Why |
@@ -288,10 +311,11 @@ Scope, and what is deliberately left out:
 | 2-D `tensor.matmul` left operand | Yes, on rows | Its row axis is M, whose box height is 16 for every dtype |
 | 2-D `tensor.matmul_acc` left operand and accumulator | Yes, on rows | Same axis, same rule — and the op requires the two to agree on physical M, so they move together |
 | `a_trans` left operand, and the accumulator paired with it | Yes, on columns | The natural load's row axis is K, so M is the column extent; the accumulator adopts that operand's column granularity via `m_align_from_arg` |
-| Right operand | No | Its rows are `K`, the reduction axis — padding it would feed uninitialised L1 into the sum unless the hardware masks by valid col, which is unverified |
-| Output `N` | No | Same open question as `K`; [`AutoTileMatmulL0`](16-auto_tile_matmul_l0.md)'s `PH-AT-007` declines it for the same reason |
+| 2-D `tensor.matmul` right operand | Yes, on the axis carrying `N` | Columns normally; rows under `b_trans`, whose natural load puts `K` on the columns. `N`'s padded cells land outside the result's valid region, so nothing reads them |
+| `tensor.matmul_acc` right operand | No | Its accumulator has to agree with the product on physical `N` just as it does on `M`, which needs the same cross-tile decider reaching the `tile.create` that allocates it |
+| Either operand's `K` axis | No | Padding the reduction axis would feed uninitialised L1 into the sum unless the hardware masks by valid col, which is unverified; [`AutoTileMatmulL0`](16-auto_tile_matmul_l0.md)'s `PH-AT-007` declines it for the same reason |
 | Rank >= 3 operand | No | It lowers to `tile.batch_matmul`, whose rows [`FlattenTileNdTo2D`](13-flatten_tile_nd_to_2d.md) row-packs into one `[B*M, N]` tile — the box rule binds that packed extent, not this dimension |
-| Dynamic M extent | No | No compile-time box to round to |
+| Dynamic extent | No | No compile-time box to round to |
 
 Every case this pass declines still reaches a PyPTO-level error rather than a
 ptoas one: [PTO codegen](../codegen/00-pto_codegen.md#boxed-tile-extents)

--- a/docs/zh/dev/passes/10-convert_tensor_to_tile_ops.md
+++ b/docs/zh/dev/passes/10-convert_tensor_to_tile_ops.md
@@ -247,6 +247,26 @@ c_tile = pl.tile.matmul_acc(acc_tile, a_mat, b_mat)
 已把它取整为 112，或在 32 行对齐时取整为 128。compact 让所有读取方重新计算 `mad` 实际
 使用的 pitch；不声明它则会被 `AccCompactValid` 直接拒绝（issue #2470）。
 
+### `N` 的粒度
+
+`M` 的对齐调和的是它流经的各个 tile（`Mat` 操作数与其累加器，见
+`ResolveCubeMAlignment`）。`N` 要调和的则是**内存空间**，这是 `M` 不需要的：
+
+- 右操作数被加载进 `Mat`，随后由
+  [`InferTileMemorySpace`](18-infer_tile_memory_space.md) 提升到 `Right`，而
+  `Right` 用相反的 `slayout` 装载同一个 512 字节分形，于是行列粒度对调：
+
+    | 空间 | `slayout` | fp32 块 | fp16 块 |
+    | ---- | --------- | ------- | ------- |
+    | `Mat` | `row_major` | 16 x 8 | 16 x 16 |
+    | `Right` | `col_major` | 8 x 16 | 16 x 16 |
+
+- 乘积落在 `Acc` 中，其 `N` 方向的块在所有 dtype 下都是 16。
+
+两个数字都是真实的，ptoas 针对各自承载它的 tile 分别提出要求。因此只按 `Mat` 的 8
+对齐，会得到一个「加载处合法、下一个 op 就被拒」的物理尺寸。`ResolveCubeNAlignment`
+因而取三者的最小公倍数；所有粒度都是 2 的幂，故最小公倍数即最大值。
+
 作用范围，以及刻意排除的情况：
 
 | 情况 | 是否对齐 | 原因 |
@@ -254,10 +274,11 @@ c_tile = pl.tile.matmul_acc(acc_tile, a_mat, b_mat)
 | 2-D `tensor.matmul` 左操作数 | 是，按行 | 其行轴即 M，块高在所有 dtype 下都是 16 |
 | 2-D `tensor.matmul_acc` 的左操作数与累加器 | 是，按行 | 同一条轴、同一条规则 —— 且该 op 要求二者物理 M 一致，因此必须一同对齐 |
 | `a_trans` 左操作数，以及与之配对的累加器 | 是，按列 | 自然加载的行轴是 K，M 是列尺寸；累加器经 `m_align_from_arg` 采用该操作数的列粒度 |
-| 右操作数 | 否 | 其行是 `K`，即归约轴 —— 除非硬件按 valid col 做掩码（尚未验证），补齐会把未初始化的 L1 数据带入求和 |
-| 输出的 `N` | 否 | 与 `K` 同属尚未解决的问题；[`AutoTileMatmulL0`](16-auto_tile_matmul_l0.md) 的 `PH-AT-007` 出于同样原因不予处理 |
+| 2-D `tensor.matmul` 右操作数 | 是，在承载 `N` 的那根轴上 | 通常是列；`b_trans` 时是行，因为其自然加载把 `K` 放在列上。`N` 的 padding 落在结果无效区之外，不会被任何人读取 |
+| `tensor.matmul_acc` 右操作数 | 否 | 其累加器必须像在 `M` 上那样与乘积的物理 `N` 一致，这需要同样的跨 tile 决定者传播到分配它的 `tile.create` |
+| 任一操作数的 `K` 轴 | 否 | 除非硬件按 valid col 做掩码（尚未验证），补齐归约轴会把未初始化的 L1 数据带入求和 |
 | rank >= 3 的操作数 | 否 | 它下沉为 `tile.batch_matmul`，其行被 [`FlattenTileNdTo2D`](13-flatten_tile_nd_to_2d.md) 打包成单个 `[B*M, N]` tile —— 分形规则约束的是打包后的尺寸，而非该维度 |
-| M 尺寸为动态值 | 否 | 没有编译期常量可供对齐 |
+| 尺寸为动态值 | 否 | 没有编译期常量可供对齐 |
 
 本 pass 不处理的每一种情况，最终仍由 PyPTO 而非 ptoas 报错：
 [PTO codegen](../codegen/00-pto_codegen.md) 会校验它发射的每一条 `pto.alloc_tile`

--- a/include/pypto/ir/transforms/op_conversion_registry.h
+++ b/include/pypto/ir/transforms/op_conversion_registry.h
@@ -92,6 +92,17 @@ struct InputSpaceReq {
   /// a transposed left operand's column box is ``32 / sizeof(dtype)`` (32 for
   /// INT8).  Naming one decider makes them share a single alignment.
   std::optional<size_t> m_align_from_arg;
+  /// Whether this operand carries the matmul's **N** axis. The output axis is
+  /// boxed on exactly the same grounds as M: only the *physical* extent is
+  /// constrained, and N's padded cells land outside the result's valid region,
+  /// so nothing reads them. K remains unboxable -- padding it would feed
+  /// uninitialised L1 into the sum -- which is why an operand declares at most
+  /// one of ``cube_m_axis`` / ``cube_n_axis``: its remaining axis is K.
+  ///
+  /// Which axis N lands on mirrors M: an untransposed right operand has N on
+  /// its columns, while a transposed one is loaded naturally with K on columns,
+  /// so its N is the *row* axis.
+  bool cube_n_axis = false;
 };
 
 /**

--- a/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
+++ b/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
@@ -173,6 +173,72 @@ int64_t ResolveCubeMAlignment(const CallPtr& call,
   return std::max<int64_t>(own, kAccFractalRows);
 }
 
+/// Axis of the operand @p req describes that carries the matmul's N.
+///
+/// The mirror of ``CubeMAxis``: an untransposed right operand has N on its
+/// columns, and a transposed one is loaded naturally with K on its columns, so
+/// its N is the row axis.
+size_t CubeNAxis(const CallPtr& call, const InputSpaceReq& req) {
+  return ReadsOperandTransposed(call, req) ? 0 : 1;
+}
+
+/// The physical N alignment the right operand must be allocated to, or 0 when N
+/// cannot be boxed at compile time.
+///
+/// Unlike M, N needs no cross-operand decider: it is carried by the right
+/// operand and the accumulator alone, and both are reached from this one shape.
+/// It does need reconciling across *memory spaces*, which M does not:
+///
+///   * the operand is loaded into ``Mat`` and then promoted on to ``Right`` by
+///     InferTileMemorySpace, and ``Right`` boxes the same fractal under the
+///     opposite ``slayout`` -- which swaps the row and column granularities
+///     (fp32: ``Mat`` is 16x8, ``Right`` is 8x16). A column count legal only
+///     where it was loaded is rejected at the very next op, so the two have to
+///     be reconciled, and the lcm of the box's own two extents is a multiple of
+///     either by construction.
+///   * the product lands in an ``Acc`` whose N box is 16 for every dtype.
+///
+/// Every granularity involved is a power of two, so both lcms are maxima.
+int64_t ResolveCubeNAlignment(const CallPtr& call, const InputSpaceReq& req, size_t idx) {
+  if (idx >= call->args_.size()) return 0;
+  const auto& arg_type = call->args_[idx]->GetType();
+  std::vector<ExprPtr> shape;
+  DataType dtype = DataType::FP32;
+  if (auto tensor_type = As<TensorType>(arg_type)) {
+    shape = tensor_type->shape_;
+    dtype = tensor_type->dtype_;
+  } else if (auto tile_type = As<TileType>(arg_type)) {
+    shape = tile_type->shape_;
+    dtype = tile_type->dtype_;
+  } else {
+    return 0;
+  }
+  if (shape.size() != 2) return 0;
+
+  const auto view = tile_view_semantics::GetImplicitTileView(shape, req.space);
+  const auto box = tile_view_semantics::GetBoxedTileAlignment(view, dtype);
+  if (!box || box->rows <= 0 || box->cols <= 0) return 0;
+  return std::max<int64_t>({box->rows, box->cols, kAccFractalRows});
+}
+
+/// The boxed axis of operand @p idx and the extent it must be allocated to.
+///
+/// One resolver for both load-emitting sites, so a bridged operand and a
+/// consumer-driven one cannot disagree. An operand declares at most one boxed
+/// axis, since the axis it does not carry is the contraction axis.
+std::pair<int64_t, size_t> ResolveBoxedAxis(const CallPtr& call,
+                                            const std::unordered_map<size_t, InputSpaceReq>& input_reqs,
+                                            size_t idx, const InputSpaceReq& req) {
+  if (req.cube_m_axis) {
+    return {ResolveCubeMAlignment(call, input_reqs, req.m_align_from_arg.value_or(idx)),
+            CubeMAxis(call, req)};
+  }
+  if (req.cube_n_axis) {
+    return {ResolveCubeNAlignment(call, req, idx), CubeNAxis(call, req)};
+  }
+  return {0, 0};
+}
+
 bool IsPassthroughTensorOp(const CallPtr& call) {
   return IsOp(call, "tensor.dim") || IsOp(call, "tensor.view");
 }
@@ -597,10 +663,8 @@ class ConsumerSpaceCollector : public IRVisitor {
       if (auto var = AsVarLike(call->args_[idx])) {
         // A transposed use moves this operand's M to its column axis, and the
         // alignment is the one the whole call shares (see ConsumerSpaceReq).
-        const int64_t align = req.cube_m_axis ? ResolveCubeMAlignment(call, entry->input_reqs,
-                                                                      req.m_align_from_arg.value_or(idx))
-                                              : 0;
-        const ConsumerSpaceReq resolved{req.space, align, CubeMAxis(call, req)};
+        const auto [align, boxed_axis] = ResolveBoxedAxis(call, entry->input_reqs, idx, req);
+        const ConsumerSpaceReq resolved{req.space, align, boxed_axis};
         // Several consumers can share one producer (a sliced KV feeding two
         // matmuls, an accumulator seed read by two accumulations); MergeConsumerReq
         // is the single rule for reconciling them.
@@ -1194,9 +1258,8 @@ class TensorToTileMutator : public TypePropagatingMutator {
         // A transposed operand is boxed on its *column* axis: the
         // tile.transpose_view below reinterprets the row axis as the matmul's K,
         // so M is the column extent the natural load allocates.
-        const int64_t m_align =
-            req.cube_m_axis ? ResolveCubeMAlignment(call, input_reqs, req.m_align_from_arg.value_or(idx)) : 0;
-        auto loaded = emit_load(args[idx], tensor_type, req.space, idx, m_align, CubeMAxis(call, req));
+        const auto [box_align, boxed_axis] = ResolveBoxedAxis(call, input_reqs, idx, req);
+        auto loaded = emit_load(args[idx], tensor_type, req.space, idx, box_align, boxed_axis);
         args[idx] = use_view ? emit_view(loaded) : loaded;
         continue;
       }

--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -1152,7 +1152,14 @@ void OpConversionRegistry::RegisterMatmulOps() {
         const std::string out_op = nd ? "tile.batch_matmul" : "tile.matmul";
         return ConversionResult{OpRegistry::GetInstance().Create(out_op, {args[0], args[1]}, span)};
       },
-      {{0, {MemorySpace::Mat, "a_trans", /*cube_m_axis=*/true}}, {1, {MemorySpace::Mat, "b_trans"}}});
+      // The right operand carries N. tensor.matmul_acc deliberately does not
+      // declare it: its accumulator must agree with the product on physical N
+      // just as it must on M, which needs the same cross-tile decider M has
+      // (see m_align_from_arg) reaching the tile.create that allocates it.
+      {{0, {MemorySpace::Mat, "a_trans", /*cube_m_axis=*/true}},
+       {1,
+        {MemorySpace::Mat, "b_trans", /*cube_m_axis=*/false, /*m_align_from_arg=*/std::nullopt,
+         /*cube_n_axis=*/true}}});
 
   // tensor.matmul_acc: 2D × 2D × 2D → tile.matmul_acc; any operand ≥3D →
   // tile.batch_matmul_acc. Same a_trans/b_trans handling as tensor.matmul.

--- a/tests/st/runtime/test_odd_extent_matmul.py
+++ b/tests/st/runtime/test_odd_extent_matmul.py
@@ -1,0 +1,109 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""End-to-end test for issue #1447: a matmul whose N is not a whole number of boxes.
+
+``b`` is ``[K, 17]``. A boxed Mat/Right tile allocates whole inner boxes only, so
+17 columns has no legal allocation and the assembler used to reject the
+``pto.alloc_tile`` the *compiler itself* synthesized, naming a source line that
+holds no tile::
+
+    'pto.alloc_tile' op expects result boxed tile cols to be a multiple of
+    innerCols (8), but got 17
+
+``ConvertTensorToTileOps`` now allocates the next whole box on the operand's
+declared paddable axis and marks only the natural extent valid, so the bridged
+load reads 17 columns into a 32-column box. N is the output width, so the padded
+cells land outside the result's valid region and never reach GM.
+
+**Why this input is discriminating.** The padded columns 17..31 are never
+written, so they hold whatever the previous kernel left. Every value here is a
+small integer exactly representable in FP32 and the reduction is over K=32, so
+the golden is exact: any padded lane that leaked into the stored region — or any
+misplaced column stride from the wider box — mismatches immediately rather than
+hiding under a tolerance.
+"""
+
+from typing import Any
+
+import pypto.language as pl
+import pytest
+import torch
+from harness.core.harness import PLATFORMS, DataType, PTOTestCase, TensorSpec
+from pypto.ir.pass_manager import OptimizationStrategy
+
+M = 32
+K = 32
+N = 17  # deliberately not a multiple of the FP32 Mat/Right box granularity (16)
+
+
+def _make_a() -> torch.Tensor:
+    i = torch.arange(M, dtype=torch.float32).reshape(M, 1)
+    k = torch.arange(K, dtype=torch.float32).reshape(1, K)
+    return ((i + k) % 4.0 - 1.0).contiguous()
+
+
+def _make_b() -> torch.Tensor:
+    k = torch.arange(K, dtype=torch.float32).reshape(K, 1)
+    j = torch.arange(N, dtype=torch.float32).reshape(1, N)
+    return ((k * j) % 3.0 - 1.0).contiguous()
+
+
+@pl.program
+class OddNMatmulProgram:
+    """Plain CORE_GROUP matmul with an odd N. No split: the defect was never
+    split-specific, though issue #1447 first surfaced it under LEFT_RIGHT."""
+
+    @pl.function(type=pl.FunctionType.Opaque)
+    def main(
+        self,
+        a: pl.Tensor[[M, K], pl.FP32],
+        b: pl.Tensor[[K, N], pl.FP32],
+        output: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+    ) -> pl.Tensor[[M, N], pl.FP32]:
+        with pl.at(level=pl.Level.CORE_GROUP):
+            out = pl.matmul(pl.add(a, 0.0), b)
+            output = pl.assemble(output, out, [0, 0])
+        return output
+
+
+class OddNMatmulTestCase(PTOTestCase):
+    """Issue #1447: N=17 matmul must compile and produce the exact product."""
+
+    def get_name(self) -> str:
+        return "odd_extent_matmul_1447"
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("a", [M, K], DataType.FP32, init_value=_make_a),
+            TensorSpec("b", [K, N], DataType.FP32, init_value=_make_b),
+            TensorSpec("output", [M, N], DataType.FP32, init_value=torch.zeros, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return OddNMatmulProgram
+
+    def compute_expected(self, tensors, params=None):
+        tensors["output"][:, :] = tensors["a"] @ tensors["b"]
+
+
+class TestOddExtentMatmul:
+    """A matmul operand whose N is not a whole number of boxes (issue #1447)."""
+
+    @pytest.mark.parametrize("platform", PLATFORMS)
+    def test_odd_n_matmul(self, test_runner, platform):
+        result = test_runner.run(OddNMatmulTestCase(platform=platform))
+        assert result.passed, f"Test failed: {result.error}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -1772,6 +1772,118 @@ class TestConvertTensorToTileOps:
         _assert_convert_equal(Before, Expected)
 
     @pytest.mark.parametrize(
+        ("name", "dtype", "cols", "boxed_cols"),
+        [
+            # FP32 `Mat` boxes 8 columns, so 17 clears Mat's own rule at 24 -- and is
+            # then rejected again at `Right`, which boxes 16. 24 is the case that
+            # separates the two: legal where it is loaded, illegal one op later.
+            ("fp32_odd", DataType.FP32, 17, 32),
+            ("fp32_mat_aligned_only", DataType.FP32, 24, 32),
+            ("fp16_odd", DataType.FP16, 17, 32),
+            ("already_boxed", DataType.FP32, 64, 64),
+        ],
+    )
+    def test_matmul_rhs_n_axis_is_boxed(self, name, dtype, cols, boxed_cols):
+        """An unaligned matmul N loads a whole number of NZ fractal boxes.
+
+        The mirror of the M rule: only the *physical* extent is constrained, and
+        N's padded cells land outside the result's valid region, so nothing reads
+        them. The granularity is not the loaded space's column box alone --
+        ``InferTileMemorySpace`` promotes the right operand from ``Mat`` on to
+        ``Right``, which boxes the same fractal under the opposite ``slayout``
+        and so swaps the row and column granularities (fp32: ``Mat`` is 16x8,
+        ``Right`` is 8x16). ``fp32_mat_aligned_only`` pins exactly that: 24
+        satisfies ``Mat`` and is still rejected at ``Right``.
+
+        The left operand's rows are already whole boxes here, so the M rule
+        leaves it alone and the two axes stay independently observable.
+        """
+        lhs_shape = [32, 128]
+        rhs_shape = [128, cols]
+        out_shape = [32, cols]
+        in_specs: list[InSpec] = [("lhs", lhs_shape, dtype), ("rhs", rhs_shape, dtype)]
+
+        def before_body(ib, ins):
+            return ib.let("y", tensor_ops.matmul(ins[0], ins[1]))
+
+        def expected_body(ib, params):
+            lhs_p, rhs_p = params
+            lhs_mat = ib.let(
+                "lhs_mat",
+                tile_ops.load(lhs_p, [0, 0], lhs_shape, lhs_shape, target_memory=MemorySpace.Mat),
+            )
+            rhs_mat = ib.let(
+                "rhs_mat",
+                tile_ops.load(rhs_p, [0, 0], [128, boxed_cols], rhs_shape, target_memory=MemorySpace.Mat),
+            )
+            return ib.let("y_tile", tile_ops.matmul(lhs_mat, rhs_mat))
+
+        before = _make_before(in_specs=in_specs, out_shape=out_shape, out_dtype=dtype, body=before_body)
+        expected = _make_expected(
+            in_specs=in_specs, out_shape=out_shape, out_dtype=dtype, body=expected_body, preload=False
+        )
+        _assert_convert_equal(before, expected)
+
+    def test_matmul_rhs_reached_through_set_validshape_is_n_boxed(self):
+        """The N rule reaches the Phase-1 entry load too, like the M rule.
+
+        ``tensor.set_validshape`` propagates the Mat demand back to the parameter,
+        whose load the entry loop emits rather than ``BridgeInputSpaces`` or
+        ``HandleConsumerDrivenLoad``. All three sites read the same resolved
+        (alignment, axis) pair, so a right operand reaching the matmul this way
+        is boxed exactly as a bare one is.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self, a: pl.Tensor[[32, 128], pl.FP16], b: pl.Tensor[[128, 17], pl.FP16]
+            ) -> pl.Tensor[[32, 17], pl.FP32]:
+                bv: pl.Tensor[[128, 17], pl.FP16] = pl.tensor.set_validshape(b, 128, 17)
+                y: pl.Tensor[[32, 17], pl.FP32] = pl.matmul(a, bv, out_dtype=pl.FP32)
+                return y
+
+            @pl.function
+            def main(
+                self, a: pl.Tensor[[32, 128], pl.FP16], b: pl.Tensor[[128, 17], pl.FP16]
+            ) -> pl.Tensor[[32, 17], pl.FP32]:
+                y: pl.Tensor[[32, 17], pl.FP32] = self.main_incore_0(a, b)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                a: pl.Tensor[[32, 128], pl.FP16],
+                b: pl.Tensor[[128, 17], pl.FP16],
+                ret0_out: pl.Out[pl.Tensor[[32, 17], pl.FP32]],
+            ) -> pl.Tensor[[32, 17], pl.FP32]:
+                # 17 columns allocated as two whole boxes; valid_shape keeps the
+                # true extent, so the store still writes exactly 17 columns.
+                b_mat: pl.Tile[[128, 32], pl.FP16, pl.MemorySpace.Mat] = pl.load(
+                    b, [0, 0], [128, 32], [128, 17], target_memory=pl.MemorySpace.Mat
+                )
+                bv_tile = pl.tile.set_validshape(b_mat, 128, 17)
+                a_mat: pl.Tile[[32, 128], pl.FP16, pl.MemorySpace.Mat] = pl.load(
+                    a, [0, 0], [32, 128], [32, 128], target_memory=pl.MemorySpace.Mat
+                )
+                y_tile = pl.tile.matmul(a_mat, bv_tile)
+                out_store: pl.Tensor[[32, 17], pl.FP32] = pl.store(y_tile, [0, 0], ret0_out)
+                return out_store
+
+            @pl.function
+            def main(
+                self, a: pl.Tensor[[32, 128], pl.FP16], b: pl.Tensor[[128, 17], pl.FP16]
+            ) -> pl.Tensor[[32, 17], pl.FP32]:
+                ret0_out: pl.Tensor[[32, 17], pl.FP32] = pl.create_tensor([32, 17], dtype=pl.FP32)
+                y: pl.Tensor[[32, 17], pl.FP32] = self.main_incore_0(a, b, ret0_out)
+                return y
+
+        _assert_convert_equal(Before, Expected)
+
+    @pytest.mark.parametrize(
         ("name", "dtype", "acc_dtype", "cols", "boxed_cols"),
         [
             # The column box holds 32 bytes' worth of elements: 16 for FP16, 32 for INT8.
@@ -3829,6 +3941,15 @@ class TestSliceMatmulConversion:
         # Row-boxed physical shape of the left operand's load. `a_trans` keeps its
         # natural (unboxed) load: the transpose_view makes its COLUMN axis the M axis.
         lhs_load_shape = lhs_shape if trans_kw == "a_trans" else [-(-lhs_shape[0] // 16) * 16, lhs_shape[1]]
+        # N-boxed physical shape of the right operand's load -- the mirror of the M
+        # boxing above, on whichever axis N lands on: columns normally, and rows
+        # under `b_trans`, whose natural load puts K on the columns. 16 for both
+        # dtypes here, as for M (ResolveCubeNAlignment has the general rule).
+        rhs_load_shape = (
+            [-(-rhs_shape[0] // 16) * 16, rhs_shape[1]]
+            if trans_kw == "b_trans"
+            else [rhs_shape[0], -(-rhs_shape[1] // 16) * 16]
+        )
 
         def before_body(ib, ins):
             a_in, b_in = ins
@@ -3862,12 +3983,12 @@ class TestSliceMatmulConversion:
                 )
                 other_tile = ib.let(
                     "rhs_mat",
-                    tile_ops.load(b_p, [0, 0], rhs_shape, rhs_shape, target_memory=MemorySpace.Mat),
+                    tile_ops.load(b_p, [0, 0], rhs_load_shape, rhs_shape, target_memory=MemorySpace.Mat),
                 )
                 return ib.let("result_tile", tile_ops.matmul(lhs_operand, other_tile))
             sliced_tile = ib.let(
                 "b_slice_tile",
-                tile_ops.load(b_p, [0, 0], rhs_shape, rhs_shape, target_memory=MemorySpace.Mat),
+                tile_ops.load(b_p, [0, 0], rhs_load_shape, rhs_shape, target_memory=MemorySpace.Mat),
             )
             other_tile = ib.let(
                 "lhs_mat",


### PR DESCRIPTION
## Summary

- add `InputSpaceReq::cube_col_boxed`, the column dual of the row rule #2572
landed, and `BoxLoadCols` to compute the granularity that rule's contract
deliberately left open
- declare it on 2-D `tensor.matmul`'s right operand, whose column axis is N
- cover the new axis with four `ConvertTensorToTileOps` cases plus one pinning
that a `b_trans` operand keeps its natural load, and add an end-to-end
numerical case for an odd N

## Why

#2572 fixed M and named K and N as the same class of hole. N is the half that
needs no new hardware knowledge, and it is what issue #1447 has been open on:

```python
b: pl.Tensor[[32, 17], pl.FP32]
out = pl.matmul(pl.add(a, 0.0), b)
```

```
'pto.alloc_tile' op expects result boxed tile cols to be a multiple of
innerCols (8), but got 17
```

Nothing in that program can be changed to satisfy it short of changing the
tensor's own shape, because `cols` is a field of a tile `ConvertTensorToTileOps`
emits, not one the author wrote. N is the output width, so its padded cells land
outside the result's valid region: `tile.matmul` deduces its result's valid shape
from its operands', so the accumulator arrives 32 columns wide with 17 valid and
`tile.store` writes 17.

## The granularity, and why it is not `box->cols`

#2572 records the column axis as blocked partly because "ptoas and
`tile_view_semantics::GetBoxedTileAlignment` currently disagree on the FP32
column granularity (ptoas demands 16, our model says 8)". They do not disagree.
The two numbers belong to two different tiles, and both are right:

```
%b_mat   : tile_buf<loc=mat,   ..., slayout=row_major>   ptoas: innerCols 8
%b_Right : tile_buf<loc=right, ..., slayout=col_major>   ptoas: innerCols 16
```

`InferTileMemorySpace` promotes the right operand from `Mat` on to `Right`, and
`Right` boxes the same 512-byte fractal under the opposite `slayout`, which swaps
the row and column granularities -- fp32 `Mat` is 16x8 where `Right` is 8x16.
`GetBoxedTileAlignment` reports each correctly; rounding to the loaded space's 8
alone produces a box that clears `Mat` and is rejected one op later at `Right`.
Observed directly: padding 17 to 24 turns the `innerCols (8)` rejection into an
`innerCols (16)` one against `loc=right`.

So the target is the least common multiple of the two granularities, a multiple
of either by construction. `N = 24` is the case that separates the rules and is
pinned as its own test.

## Scope

Deliberately unchanged, on the same grounds #2572 gives for its own axis: a
`b_trans` right operand (its natural column axis is K once `tile.transpose_view`
reinterprets it), `tensor.matmul_acc` (the accumulator arrives from a separate
`tile.create` this rule cannot reach, so boxing only the operand would trade a
ptoas rejection for an operand-mismatch one), rank >= 3, and a dynamic extent.

K remains untouched, and for the reason #2572 states: its padded cells would be
consumed by the reduction rather than dropped with the invalid region.

## Test plan

- `pytest tests/ut/` -- 10830 passed, 1 pre-existing local-environment failure
(`test_symlinked_import_path_still_names_the_caller`, which fails on `main` in
this checkout too)
- end to end through ptoas, N in {17, 24, 40, 64, 100, 128, 250}: all compile.
On `main` the same sweep fails at 17, 24, 40, 100 and 250, and N = 64 / 128
emit byte-identical kernels before and after
- `tests/st/runtime/test_odd_extent_matmul.py` checks the product itself against
a torch golden at N = 17. It was not run on device here: this checkout's
`_task_interface` predates its runtime pin, and a pre-existing ST test fails
identically in the same environment, so the numerical check is left to CI


---

Addresses the case reported in #1447; follows #2572 on the other axis.