### PR TITLE
test(codegen): pin Graph allocation node counting to what codegen emits

### DIFF
--- a/src/ir/transforms/legalize_graph_boundary_pass.cpp
+++ b/src/ir/transforms/legalize_graph_boundary_pass.cpp
@@ -756,7 +756,15 @@ class RegionAllocationChecker : public IRVisitor {
     // Checked on the *result* type rather than the call arguments: the shape
     // arrives as one list-shaped operand, and the extents are what end up in the
     // TensorCreateInfo the recording copies.
-    auto tensor = As<TensorType>(op->GetType());
+    //
+    // `AsTensorTypeLike`, not `As<TensorType>`, to match the test codegen applies
+    // to the same create (`ShapeDependsOnLocalVars`). `GraphNodeCounter` charges
+    // every create to the shared batch on the strength of this rejection; one
+    // that slipped past here but read as shape-dependent to codegen would take
+    // its own node, and the region would be under-counted. `tensor.create` only
+    // deduces a plain TensorType today, so the two spellings select the same
+    // creates — they are kept identical so that stays true.
+    auto tensor = AsTensorTypeLike(op->GetType());
     if (!tensor) return;
     for (const auto& extent : tensor->shape_) {
       CHECK_SPAN(IsLiteralScalarExpr(extent), op->span_)

--- a/src/ir/verifier/verify_graph_functions.cpp
+++ b/src/ir/verifier/verify_graph_functions.cpp
@@ -431,7 +431,10 @@ class GraphBodyChecker : public IRVisitor {
       return;
     }
     if (!IsOp(op, "tensor.create")) return;
-    auto tensor = As<TensorType>(op->GetType());
+    // `AsTensorTypeLike` for the same reason the pass uses it, and for the same
+    // reason the boundary-parameter check above does: it is the test codegen
+    // applies when deciding what a tensor is.
+    auto tensor = AsTensorTypeLike(op->GetType());
     if (!tensor) return;
     for (const auto& extent : tensor->shape_) {
       if (IsLiteralScalarExpr(extent)) continue;

--- a/tests/ut/codegen/test_orchestration_codegen_graph.py
+++ b/tests/ut/codegen/test_orchestration_codegen_graph.py
@@ -365,6 +365,84 @@ class _SubmitDeps:
         return c, d
 
 
+@pl.program
+class _BatchedAllocs:
+    """A Graph whose body allocates 20 tensors, each consumed by a launch.
+
+    The interleaving is the point: a launch between two creates does not close
+    the batch, so codegen packs all 20 into ``ceil(20 / 16) = 2``
+    ``alloc_tensors`` calls -- two recorded nodes, not twenty.
+    """
+
+    @pl.function(type=pl.FunctionType.AIV)
+    def kernel(
+        self, x: pl.Tensor[[128, 128], pl.FP32], o: pl.InOut[pl.Tensor[[128, 128], pl.FP32]]
+    ) -> pl.Tensor[[128, 128], pl.FP32]:
+        t: pl.Tile[[128, 128], pl.FP32] = pl.load(x, [0, 0], [128, 128])
+        o = pl.store(t, [0, 0], o)
+        return o
+
+    @pl.function(type=pl.FunctionType.Graph)
+    def layer(
+        self,
+        a: pl.Tensor[[128, 128], pl.FP32],
+        c: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+    ) -> pl.Tensor[[128, 128], pl.FP32]:
+        # Chained so every buffer stays live: an unused create would be folded
+        # away and the batch would never reach the packing boundary.
+        s0: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], pl.FP32)
+        s0 = self.kernel(a, s0)
+        s1: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], pl.FP32)
+        s1 = self.kernel(s0, s1)
+        s2: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], pl.FP32)
+        s2 = self.kernel(s1, s2)
+        s3: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], pl.FP32)
+        s3 = self.kernel(s2, s3)
+        s4: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], pl.FP32)
+        s4 = self.kernel(s3, s4)
+        s5: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], pl.FP32)
+        s5 = self.kernel(s4, s5)
+        s6: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], pl.FP32)
+        s6 = self.kernel(s5, s6)
+        s7: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], pl.FP32)
+        s7 = self.kernel(s6, s7)
+        s8: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], pl.FP32)
+        s8 = self.kernel(s7, s8)
+        s9: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], pl.FP32)
+        s9 = self.kernel(s8, s9)
+        s10: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], pl.FP32)
+        s10 = self.kernel(s9, s10)
+        s11: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], pl.FP32)
+        s11 = self.kernel(s10, s11)
+        s12: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], pl.FP32)
+        s12 = self.kernel(s11, s12)
+        s13: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], pl.FP32)
+        s13 = self.kernel(s12, s13)
+        s14: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], pl.FP32)
+        s14 = self.kernel(s13, s14)
+        s15: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], pl.FP32)
+        s15 = self.kernel(s14, s15)
+        s16: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], pl.FP32)
+        s16 = self.kernel(s15, s16)
+        s17: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], pl.FP32)
+        s17 = self.kernel(s16, s17)
+        s18: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], pl.FP32)
+        s18 = self.kernel(s17, s18)
+        s19: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], pl.FP32)
+        s19 = self.kernel(s18, s19)
+        c = self.kernel(s19, c)
+        return c
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def main(
+        self,
+        a: pl.Tensor[[128, 128], pl.FP32],
+        c: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+    ) -> pl.Tensor[[128, 128], pl.FP32]:
+        c = self.layer(a, c)
+        return c
+
+
 def _compile_orch(program) -> str:
     """Compile one program for host_build_graph and return orchestration/main.cpp."""
     out_dir = tempfile.mkdtemp()
@@ -399,6 +477,36 @@ def test_graph_helper_binds_submit_task_ids():
     body = _graph_body(_compile_orch(_SubmitDeps))
     assert "TaskId t1 = task_0_outs.task_id();" in body, body
     assert "] = t1;" in body, body
+
+
+def _alloc_batch_sizes(body: str) -> list[int]:
+    """Operand count of each ``alloc_tensors`` call in @p body, in order."""
+    return [len(args.split(",")) for args in re.findall(r"alloc_tensors\(([^)]*)\)", body)]
+
+
+def test_graph_allocations_are_packed_sixteen_to_a_node():
+    """Pins codegen to the node count `LegalizeGraphBoundary` charges it.
+
+    The pass and the verifier both estimate a Graph's recorded node count from
+    `alloc_batching::BatchedAllocationNodes`, and reject the region when the
+    total leaves `1..GRAPH_MAX_NODES`. That estimate is only correct because
+    codegen packs `kAllocTensorsArgs` creates per `alloc_tensors` and lets a
+    launch sit between two creates without closing the batch -- which nothing
+    on the codegen side asserted, so a change here would desynchronise the two
+    silently: an over-count rejects a legal Graph, an under-count admits one the
+    runtime then declines to cache and replays as ordinary tasks.
+
+    The counterpart is
+    `test_legalize_graph_boundary.py::test_interleaved_allocations_batch_across_the_statement_list`,
+    which pins the same 20 creates to 2 nodes on the pass side.
+    """
+    body = _graph_body(_compile_orch(_BatchedAllocs))
+    # 16 + 4, not 20 single-create calls and not a batch closed by each launch.
+    assert _alloc_batch_sizes(body) == [16, 4], body
+    # The other half of the node total the pass computes: 21 launches + 2
+    # allocation nodes. A launch that stopped being emitted would make the
+    # batching assertion above pass while the totals still diverged.
+    assert body.count("rt_submit_") == 21, body
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

A Graph region's recorded node count is decided in one place and re-derived in
two. Orchestration codegen packs eligible `tensor.create`s into `alloc_tensors`
calls and therefore *decides* how many nodes a statement list becomes;
`LegalizeGraphBoundary` rejects a Graph whose total leaves `1..GRAPH_MAX_NODES`,
and `VerifyGraphFunctions` re-derives the same total. A drift between them is
silent in both directions: an over-count rejects a legal Graph with a misleading
"launches N tasks" message, an under-count admits a Graph the `host_build_graph`
runtime then declines to cache, so the region runs as ordinary tasks with
correct results and none of the intended speedup. Neither shows up in a
numerical test.

This does not extract the shared decision (#2538 covers that, and it is worth
designing rather than doing mechanically). It closes the two places where the
counters' correctness rests on an unchecked premise. No behavior changes.

## Changes

- `tests/ut/codegen/test_orchestration_codegen_graph.py`: compile a Graph body
  with 20 creates interleaved with launches and assert codegen emits `[16, 4]`
  operands across two `alloc_tensors` calls, plus the 21 launches making up the
  rest of the node total. The pass test
  `test_interleaved_allocations_batch_across_the_statement_list` already pins
  the same 20 creates to 2 nodes on the counter side and states this codegen
  behavior in its docstring — nothing asserted it.
- `src/ir/transforms/legalize_graph_boundary_pass.cpp`,
  `src/ir/verifier/verify_graph_functions.cpp`: select a `tensor.create` with
  `AsTensorTypeLike` rather than `As<TensorType>`, matching the test codegen
  applies to the same create in `ShapeDependsOnLocalVars`. `GraphNodeCounter`
  charges every create to the shared batch on the strength of this rejection;
  a create that slipped past here but read as shape-dependent to codegen would
  take its own node and under-count the region. Unreachable today —
  `DeduceTensorCreateType` always builds a plain `TensorType` and no pass
  retypes a create's result — so the two spellings select exactly the same
  creates. The boundary-parameter check in the same verifier already uses
  `AsTensorTypeLike` for this reason.

## Verification

- `cmake --build build --parallel 32`: exit 0.
- `pytest tests/ut/codegen/ tests/ut/ir/ tests/lint/ -q -n 16`: 7964 passed,
  5 skipped, 1 xfailed. Run by the push transaction at the rebased head.
- Mutation check on the new test: setting `alloc_batching::kAllocTensorsArgs`
  to 8 and rebuilding fails it with `assert [8, 8, 4] == [16, 4]`; restoring 16
  passes. The assertion binds to codegen's actual output, not to a tautology.
- `clang-format --dry-run --Werror` on both C++ files: exit 0. `ruff
  format --diff` / `ruff check` on the test file: clean, but run with ruff
  0.16.0 against the repository's pinned 0.14.8 (that version is not installable
  here), so treat the Python formatting check as partial.

No behavior change, no interface change, no migration step.

Refs #2538