### PR TITLE
fix(distributed): support explicit L3 task dependencies

### DIFF
--- a/docs/en/dev/language/02-manual_dependencies.md
+++ b/docs/en/dev/language/02-manual_dependencies.md
@@ -24,7 +24,8 @@ unit that fits your use case; combine if needed.
 
 ## Mechanism B — declare explicit task→task edges (`deps=`)
 
-These surfaces all produce `set_dependencies` codegen; choose by producer
+In L2 orchestration these surfaces all produce `set_dependencies` codegen
+(the distributed HOST lowering differs — see below); choose by producer
 shape (single kernel call, outlined `pl.at` region, or dependency-only fan-in).
 
 | Surface | Producer shape | Notes |
@@ -40,6 +41,18 @@ shape (single kernel call, outlined `pl.at` region, or dependency-only fan-in).
 plain auto-tracked orchestration, inside `pl.manual_scope()`, or with a
 `manual_dep=True` tensor; explicit edges are added on top of auto-tracking.
 The earlier "`deps=` only inside `pl.manual_scope`" restriction no longer applies.
+
+**Distributed HOST orchestrators lower differently.** A `pl.submit` in a
+HOST-level orchestrator of a distributed program keeps the same surface but
+targets the L3 runtime: the TaskId is backed by the opaque `TaskHandle`
+returned by `submit_next_level`, and each `deps=` entry lowers to
+`TaskArgs.add_dep_wait(...)` (an ordering-only edge — it does not retain
+producer resources) instead of `set_dependencies`. Only `deps=` is supported
+there: `core_num`, `sync_start`, `allow_early_resolve` and `predicate=` are
+rejected, `pl.spmd_submit` is unavailable, and every callee argument
+(including `Out` / `InOut`) must be passed because L3 does not allocate
+output tensors. Explicit edges add to the automatic per-rank comm ordering
+chain the distributed codegen maintains.
 
 Plain `out = self.kernel(...)` is **fire-and-forget**: it returns no task
 id, and `deps=` is rejected on it (the parser raises, hinting "use

--- a/docs/en/user/distributed/04-debugging.md
+++ b/docs/en/user/distributed/04-debugging.md
@@ -7,7 +7,7 @@ one rank while the cause is on another.
 
 | Symptom | Likely Cause | Fix |
 | ------- | ------------ | --- |
-| **All ranks hang** | Notify/wait ordering — a rank is waiting on a peer that hasn't notified yet | Ensure every rank calls `notify` before any rank calls `wait`. The notify loop should precede the wait loop. |
+| **All ranks hang** | Notify/wait ordering — a rank is waiting on a peer that hasn't notified yet | Ensure every rank calls `notify` before any rank calls `wait`. The notify loop should precede the wait loop. When a rank's `wait` lives in a different dispatch from its own send, you can also pin the order explicitly with `pl.submit(..., deps=[send_task])` — see [Declaring an Edge](../tasks/02-submit.md). |
 | **Silent data corruption** | `remote_load` offsets or shape don't match what the peer stored | Verify offsets align with the peer's store offsets. A 1-element shift introduces a full row of garbage. |
 | **Signal cell never reaches expected value** | Wrong `NotifyOp`: used `Set` instead of `AtomicAdd` for a multi-participant barrier | Use `AtomicAdd` when N ranks contribute to the same slot; use `Set` for 1:1 exchanges. |
 | **Shape mismatch at compile time** | `NR` (world size) used in type annotations without `pl.dynamic` | Wrap runtime-resolved dims in `pl.dynamic("NR")`. The compiler needs the name to bind the runtime value. |

--- a/docs/en/user/tasks/02-submit.md
+++ b/docs/en/user/tasks/02-submit.md
@@ -128,6 +128,31 @@ a, tid = pl.spmd_submit(self.k1, x, core_num=8)
 `sync_start` (default `False`) requires all blocks to launch atomically. `deps=`,
 `allow_early_resolve=` and `predicate=` behave exactly as on `pl.submit`.
 
+### `pl.submit` in a distributed HOST orchestrator
+
+Inside a distributed program's HOST-level orchestrator (`@pl.function(level=pl.Level.HOST,
+role=pl.Role.Orchestrator)`), `pl.submit` names a chip dispatch the same way — but the
+TaskId is backed by the L3 runtime's opaque `TaskHandle`, and each `deps=[producer]` entry
+lowers to `TaskArgs.add_dep_wait(producer)`: an ordering-only edge that does not extend the
+producer's resource lifetime. Explicit edges add to the automatically maintained per-rank
+communication ordering; declare one when a rank's dispatches interact through a comm window
+in an order you want pinned explicitly — e.g. a WAIT living in a different dispatch from the
+same rank's SEND:
+
+```python
+_sent, send_task = pl.submit(self.send_orch, x, echo, dst, signal, peer, device=rank)
+_received, _ = pl.submit(self.recv_orch, out, dst, signal, device=rank,
+                         deps=[send_task])
+```
+
+Two differences from the L2 form above:
+
+- **Every callee argument is required, including `Out` / `InOut` tensors** — L3 does not
+  allocate output tensors, so nothing can fill an omitted slot.
+- **Only `deps=` is available.** `core_num`, `sync_start`, `allow_early_resolve` and
+  `predicate=` have no L3 counterpart and are rejected; `pl.spmd_submit` is likewise not
+  available at HOST level.
+
 ### Fan-in through a TaskId array
 
 One TaskId names one task. To wait on a *set* of tasks — a loop's worth of producers —
@@ -160,6 +185,7 @@ like any other. See [Control Flow](../language/02-control-flow.md).
 | **`deps= entries must be a TaskId variable`** | A TaskId reached by indexing a flat submit result | Bind the TaskId to its own name and pass that |
 | **`pl.spmd() does not accept 'deps=' here`** | `deps=` was passed to the bare `with` or the `for` form | Bind the region with `as tid:` — only that form takes `deps=` |
 | **`core_num` missing** | It is a required keyword on `pl.spmd_submit` | Pass `core_num=N`; positional slots are the kernel's arguments |
+| **`requires every callee argument, including Out/InOut tensors`** | A distributed HOST submit omitted an `Out`/`InOut` argument | Pass every callee argument — L3 does not allocate outputs |
 | **A consumer only waits on the last producer of a loop** | One TaskId was reused instead of collected | Collect into a `pl.array` of `pl.TASK_ID` and pass the array |
 | **Explicit edge seems ignored in auto scope** | It is not — the wait set is the union | Look for a *missing* edge elsewhere, not a discarded one |
 

--- a/docs/zh/dev/language/02-manual_dependencies.md
+++ b/docs/zh/dev/language/02-manual_dependencies.md
@@ -21,7 +21,8 @@ DSL 暴露**两套正交的机制**，用户可任意组合：
 
 ## 机制 B——显式声明 task 间的边（`deps=`）
 
-这些表面都会下沉为 `set_dependencies` codegen；按 producer 形态选择：
+在 L2 编排里这些表面都会下沉为 `set_dependencies` codegen（分布式 HOST
+的下译不同——见下文）；按 producer 形态选择：
 单个 kernel 调用、outlined `pl.at` 区域，或 dependency-only fan-in。
 
 | 表层语法 | producer 形态 | 备注 |
@@ -36,6 +37,15 @@ DSL 暴露**两套正交的机制**，用户可任意组合：
 **这些表面都不依赖机制 A 的状态。** 显式 deps 可用于普通自动跟踪、
 `pl.manual_scope()` 内或 `manual_dep=True` tensor 上，并总是在自动跟踪结果
 **之上**追加；早期"`deps=` 只在 `pl.manual_scope` 内有效"的限制已经解除。
+
+**分布式 HOST 编排的下译不同。** 分布式程序 HOST 级编排函数里的 `pl.submit`
+表面写法相同，但目标是 L3 运行时：TaskId 由 `submit_next_level` 返回的不透明
+`TaskHandle` 背书，每个 `deps=` 条目下译为 `TaskArgs.add_dep_wait(...)`
+（只约束顺序的边——不保留 producer 资源），而非 `set_dependencies`。那里只支持
+`deps=`：`core_num`、`sync_start`、`allow_early_resolve` 与 `predicate=`
+会被拒绝，`pl.spmd_submit` 不可用，且被调方每个实参（包括 `Out` / `InOut`）
+都必须传入，因为 L3 不分配输出张量。显式边叠加在分布式 codegen 自动维护的
+per-rank 通信排序链之上。
 
 普通的 `out = self.kernel(...)` 是 **fire-and-forget**：它不返回 task id，
 并且在它上面写 `deps=` 会被拒绝（parser 报错，提示 "use `pl.submit`"）。

--- a/docs/zh/user/distributed/04-debugging.md
+++ b/docs/zh/user/distributed/04-debugging.md
@@ -7,7 +7,7 @@ rank 上。
 
 | 症状 | 可能原因 | 修复 |
 | ---- | -------- | ---- |
-| **所有 rank 挂起** | notify/wait 顺序错误 | 确保 notify 循环在 wait 循环之前。 |
+| **所有 rank 挂起** | notify/wait 顺序错误 | 确保 notify 循环在 wait 循环之前。若某 rank 的 `wait` 与它自己的 send 分属不同派发，也可用 `pl.submit(..., deps=[send_task])` 显式钉住顺序——见[声明一条边](../tasks/02-submit.md)。 |
 | **静默数据损坏** | `remote_load` offsets 或 shape 不匹配 | 验证 offsets 与对端的 store offsets 对齐。 |
 | **Signal cell 永不达到期望值** | 错误 `NotifyOp` | 多参与者屏障用 `AtomicAdd`；1:1 交换用 `Set`。 |
 | **编译时形状不匹配** | `NR` 未使用 `pl.dynamic` | 将运行时维度包裹在 `pl.dynamic("NR")` 中。 |

--- a/docs/zh/user/tasks/02-submit.md
+++ b/docs/zh/user/tasks/02-submit.md
@@ -105,6 +105,25 @@ a, tid = pl.spmd_submit(self.k1, x, core_num=8)
 
 `core_num` 是**必需的关键字** —— 位置槽属于 kernel。`sync_start`（默认 `False`）要求所有 block 原子启动。`deps=`、`allow_early_resolve=` 与 `predicate=` 的行为与 `pl.submit` 完全一致。
 
+### 分布式 HOST 编排里的 `pl.submit`
+
+在分布式程序的 HOST 级编排函数（`@pl.function(level=pl.Level.HOST,
+role=pl.Role.Orchestrator)`）里，`pl.submit` 以同样的方式命名一次 chip 派发 —— 但 TaskId 由
+L3 运行时的不透明任务句柄（`TaskHandle`）背书，每个 `deps=[producer]` 条目下译为
+`TaskArgs.add_dep_wait(producer)`：一条只约束执行顺序、不延长 producer 资源生命期的边。显式边叠加在自动维护的 per-rank 通信排序之上；当同一 rank 的派发通过通信 window 交互、而你想显式钉住顺序时使用它 —— 例如 WAIT 与同 rank 的 SEND 分属不同派发：
+
+```python
+_sent, send_task = pl.submit(self.send_orch, x, echo, dst, signal, peer, device=rank)
+_received, _ = pl.submit(self.recv_orch, out, dst, signal, device=rank,
+                         deps=[send_task])
+```
+
+与上文 L2 形式的两点差异：
+
+- **必须传入被调方的每一个实参，包括 `Out` / `InOut` 张量** —— L3 不分配输出张量，省略的槽位没有任何东西能补上。
+- **只有 `deps=` 可用。** `core_num`、`sync_start`、`allow_early_resolve` 与 `predicate=`
+  在 L3 没有对应物，会被拒绝；`pl.spmd_submit` 同样在 HOST 级不可用。
+
 ### 用 TaskId 数组做扇入
 
 一个 TaskId 只指代一个任务。要等待**一组**任务 —— 比如一个循环产出的全部生产者 —— 把它们收进一个 `pl.TASK_ID` 的 `pl.array`，再把数组本身作为依赖传入：
@@ -131,6 +150,7 @@ out, _ = pl.submit(self.consumer, data, out, deps=[tids])
 | **`deps= entries must be a TaskId variable`** | TaskId 是对扁平 submit 结果做下标得到的 | 把 TaskId 绑定到独立的名字再传 |
 | **`pl.spmd() does not accept 'deps=' here`** | 向裸 `with` 或 `for` 形式传了 `deps=` | 用 `as tid:` 绑定该区域 —— 只有这种形式接受 `deps=` |
 | **`core_num` 缺失** | 它是 `pl.spmd_submit` 的必需关键字 | 传 `core_num=N`；位置槽是 kernel 的实参 |
+| **`requires every callee argument, including Out/InOut tensors`** | 分布式 HOST submit 省略了 `Out`/`InOut` 实参 | 传入被调方的每一个实参 —— L3 不分配输出 |
 | **消费者只等到了循环的最后一个生产者** | 复用了一个 TaskId 而没有收集 | 收进 `pl.TASK_ID` 的 `pl.array` 并把数组传入 |
 | **auto 作用域里显式边似乎被忽略** | 并没有 —— 等待集合是并集 | 去别处找**缺失**的边，而不是被丢弃的边 |
 

--- a/include/pypto/codegen/distributed/distributed_codegen.h
+++ b/include/pypto/codegen/distributed/distributed_codegen.h
@@ -138,6 +138,7 @@ class DistributedCodegen : public CodegenBase {
 
   // Expression visitors
   void VisitExpr_(const ir::CallPtr& op) override;
+  void VisitExpr_(const ir::SubmitPtr& op) override;
   void VisitExpr_(const ir::VarPtr& op) override;
   void VisitExpr_(const ir::ConstIntPtr& op) override;
   void VisitExpr_(const ir::ConstFloatPtr& op) override;
@@ -192,7 +193,8 @@ class DistributedCodegen : public CodegenBase {
   void EmitEntryMarker(const std::string& func_name);
 
   // Call-site lowering
-  void EmitCallToWorker(const ir::CallPtr& call, const ir::FunctionPtr& callee);
+  void EmitCallToWorker(const ir::CallPtr& call, const ir::FunctionPtr& callee,
+                        const ir::SubmitPtr& submit = nullptr);
   /**
    * @brief Emit a same-level worker / next-level orchestrator call if @p expr
    *        is one. Returns true if it emitted; false if @p expr is not a
@@ -312,6 +314,11 @@ class DistributedCodegen : public CodegenBase {
   // EmitCallToWorker when the callee has a TupleType return; consumed by
   // VisitStmt_(AssignStmt) when it encounters TupleGetItemExpr unpacking.
   std::map<std::pair<std::string, int>, std::string> tuple_element_tensors_;
+
+  // A distributed ``pl.submit`` returns the runtime TaskHandle as its final
+  // tuple element. Keep it separate from tensor aliases so a later
+  // ``deps=[tid]`` can lower to ``TaskArgs.add_dep_wait(tid)``.
+  std::map<std::pair<std::string, int>, std::string> tuple_element_task_handles_;
 
   // HOST orchestrator AssignStmt defs, populated before comm-domain emission.
   std::unordered_map<const ir::Var*, ir::ExprPtr> host_orch_var_defs_;

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -6821,6 +6821,68 @@ class ASTParser:
             arg_idx += 1
         return callee_params, paired_args
 
+    def _validate_kernel_call_arity(
+        self,
+        method_name: str,
+        func_obj: Any,
+        n_args: int,
+        span: ir.Span,
+        as_submit: bool,
+    ) -> None:
+        """Check a ``self.<method>(...)`` call site's positional-argument count.
+
+        One place decides the call flavour; the resulting ``(lo, hi)`` window
+        then covers all three checks — an exact-arity check is just ``lo == hi``.
+
+        Args:
+            method_name: Callee name, for the diagnostic.
+            func_obj: The callee ``ir.Function``.
+            n_args: Positional argument count at the call site.
+            span: Source span of the call.
+            as_submit: Whether the site is ``pl.submit`` / ``pl.spmd_submit``.
+
+        Raises:
+            ParserTypeError: The argument count is outside the callee's window.
+        """
+        n_params = len(func_obj.params)
+        if as_submit and self._func_level == ir.Level.HOST:
+            # A distributed HOST submit dispatches to L3, which allocates no
+            # output tensors, so it cannot omit Out/InOut params the way an
+            # Orchestration-level submit can.
+            flavour, lo, hi = "host_submit", n_params, n_params
+        elif as_submit:
+            # For submit (pl.submit / pl.spmd_submit), Out- and InOut-directed
+            # parameters are runtime-allocated outputs that MAY be omitted at
+            # the call site. The lower bound is the count of non-Out/InOut
+            # params; the upper bound is all params (when Out params are passed
+            # explicitly).
+            flavour = "submit"
+            lo = sum(
+                1
+                for d in func_obj.param_directions
+                if d not in (ir.ParamDirection.Out, ir.ParamDirection.InOut)
+            )
+            hi = n_params
+        else:
+            flavour, lo, hi = "call", n_params, n_params
+
+        if lo <= n_args <= hi:
+            return
+
+        param_info = [f"{p.name_hint}: {d.name}" for p, d in zip(func_obj.params, func_obj.param_directions)]
+        hint = f"Parameters: {param_info}"
+        if flavour == "host_submit":
+            message = (
+                "Distributed HOST pl.submit(...) requires every callee argument, including "
+                f"Out/InOut tensors; function '{method_name}' expects {hi} argument(s), got {n_args}"
+            )
+        elif flavour == "submit":
+            message = f"Function '{method_name}' expects {lo}..{hi} argument(s), got {n_args}"
+            hint += ". Out/InOut params may be omitted in submit calls."
+        else:
+            message = f"Function '{method_name}' expects {hi} argument(s), got {n_args}"
+        raise ParserTypeError(message, span=span, hint=hint)
+
     def _parse_kernel_call(
         self,
         method_attr: ast.Attribute,
@@ -6873,47 +6935,7 @@ class ASTParser:
 
         # Validate argument count before parsing args to fail fast.
         if func_obj is not None:
-            host_submit = as_submit and self._func_level == ir.Level.HOST
-            if as_submit and not host_submit:
-                # For submit (pl.submit / pl.spmd_submit), Out- and InOut-
-                # directed parameters are runtime-allocated outputs that
-                # MAY be omitted at the call site. The lower bound is the
-                # count of non-Out/InOut params; the upper bound is all
-                # params (when Out params are passed explicitly).
-                expected_lo = sum(
-                    1
-                    for d in func_obj.param_directions
-                    if d not in (ir.ParamDirection.Out, ir.ParamDirection.InOut)
-                )
-                expected_hi = len(func_obj.params)
-                ok = expected_lo <= len(arg_nodes) <= expected_hi
-            else:
-                expected_hi = len(func_obj.params)
-                expected_lo = expected_hi
-                ok = len(arg_nodes) == expected_hi
-            if not ok:
-                param_info = [
-                    f"{p.name_hint}: {d.name}" for p, d in zip(func_obj.params, func_obj.param_directions)
-                ]
-                hint = (
-                    f"Parameters: {param_info}. Out/InOut params may be omitted in submit calls."
-                    if as_submit and not host_submit
-                    else f"Parameters: {param_info}"
-                )
-                message = (
-                    "Distributed HOST pl.submit(...) requires every callee argument, including "
-                    f"Out/InOut tensors; function '{method_name}' expects {expected_hi} argument(s), "
-                    f"got {len(arg_nodes)}"
-                    if host_submit
-                    else f"Function '{method_name}' expects "
-                    + (f"{expected_lo}..{expected_hi}" if as_submit else f"{expected_hi}")
-                    + f" argument(s), got {len(arg_nodes)}"
-                )
-                raise ParserTypeError(
-                    message,
-                    span=span,
-                    hint=hint,
-                )
+            self._validate_kernel_call_arity(method_name, func_obj, len(arg_nodes), span, as_submit)
 
         arg_directions = self._extract_arg_directions_from_attrs(method_name, keywords, len(arg_nodes), span)
         if arg_directions is None:

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -6873,7 +6873,8 @@ class ASTParser:
 
         # Validate argument count before parsing args to fail fast.
         if func_obj is not None:
-            if as_submit:
+            host_submit = as_submit and self._func_level == ir.Level.HOST
+            if as_submit and not host_submit:
                 # For submit (pl.submit / pl.spmd_submit), Out- and InOut-
                 # directed parameters are runtime-allocated outputs that
                 # MAY be omitted at the call site. The lower bound is the
@@ -6888,20 +6889,28 @@ class ASTParser:
                 ok = expected_lo <= len(arg_nodes) <= expected_hi
             else:
                 expected_hi = len(func_obj.params)
-                ok = len(arg_nodes) == len(func_obj.params)
+                expected_lo = expected_hi
+                ok = len(arg_nodes) == expected_hi
             if not ok:
                 param_info = [
                     f"{p.name_hint}: {d.name}" for p, d in zip(func_obj.params, func_obj.param_directions)
                 ]
                 hint = (
                     f"Parameters: {param_info}. Out/InOut params may be omitted in submit calls."
-                    if as_submit
+                    if as_submit and not host_submit
                     else f"Parameters: {param_info}"
                 )
-                raise ParserTypeError(
-                    f"Function '{method_name}' expects "
+                message = (
+                    "Distributed HOST pl.submit(...) requires every callee argument, including "
+                    f"Out/InOut tensors; function '{method_name}' expects {expected_hi} argument(s), "
+                    f"got {len(arg_nodes)}"
+                    if host_submit
+                    else f"Function '{method_name}' expects "
                     + (f"{expected_lo}..{expected_hi}" if as_submit else f"{expected_hi}")
-                    + f" argument(s), got {len(arg_nodes)}",
+                    + f" argument(s), got {len(arg_nodes)}"
+                )
+                raise ParserTypeError(
+                    message,
                     span=span,
                     hint=hint,
                 )

--- a/python/pypto/language/scope.py
+++ b/python/pypto/language/scope.py
@@ -142,6 +142,14 @@ def submit(*args: Any, **kwargs: Any) -> Any:
     ``deps=[...]`` as a precision tool to patch edges the runtime cannot
     infer; in ``pl.manual_scope()``, use it to declare every edge.
 
+    In a distributed HOST orchestrator, the returned TaskId is backed by the
+    L3 runtime's opaque ``TaskHandle``. Each explicit ``deps=[producer]`` entry
+    lowers to ``TaskArgs.add_dep_wait(producer)`` and therefore adds ordering
+    without extending the producer's resource lifetime, on top of the
+    automatically maintained per-rank communication ordering. This HOST form
+    accepts individual TaskIds and requires every callee argument, including
+    Out/InOut tensors, because L3 does not allocate output tensors.
+
     The optional ``dumps=[...]`` kwarg is the submit-side selective tensor
     dump surface (symmetric with ``deps=``): it lists tensor arguments of
     this submit to mark for dump (simpler#844), so an enabled dump pipeline

--- a/src/codegen/distributed/distributed_codegen.cpp
+++ b/src/codegen/distributed/distributed_codegen.cpp
@@ -89,6 +89,7 @@ std::string DistributedCodegen::Generate(const ir::ProgramPtr& program) {
   host_orch_var_defs_.clear();
   unwrap_hoisted_var_refs_ = false;
   tuple_element_tensors_.clear();
+  tuple_element_task_handles_.clear();
   emitted_builtin_variants_.clear();
   builtin_next_level_specs_.clear();
 
@@ -672,7 +673,8 @@ void DistributedCodegen::RegisterParamsAndEmitScalarBindings(const ir::FunctionP
 // ========================================================================
 
 bool DistributedCodegen::TryEmitHierarchyCall(const ir::ExprPtr& expr) {
-  auto call = std::dynamic_pointer_cast<const ir::Call>(expr);
+  const auto submit = ir::As<ir::Submit>(expr);
+  const auto call = submit ? ir::SubmitToCallView(submit) : ir::As<ir::Call>(expr);
   if (!call) return false;
   auto gv = std::dynamic_pointer_cast<const ir::GlobalVar>(call->op_);
   if (!gv) return false;
@@ -694,7 +696,7 @@ bool DistributedCodegen::TryEmitHierarchyCall(const ir::ExprPtr& expr) {
                                static_cast<int>(callee_level) == static_cast<int>(current_level) - 1;
 
   if (same_level_sub_worker || next_level_orch) {
-    EmitCallToWorker(call, callee);
+    EmitCallToWorker(call, callee, submit);
     return true;
   }
 
@@ -725,14 +727,31 @@ void DistributedCodegen::VisitStmt_(const ir::AssignStmtPtr& op) {
     INTERNAL_CHECK_SPAN(ir::AsVarLike(tge->tuple_) != nullptr, op->span_)
         << "Internal error: TupleGetItemExpr tuple_ must be a Var-like expression "
         << "for distributed codegen tuple-return unpacking";
+    // A DistributedTensor element aliases a comm window, which resolves through
+    // the type's window_buffer_ and never lives in the tensors dict — emitting
+    // a tensors[...] alias here would KeyError at run time.
+    if (ir::As<ir::DistributedTensorType>(op->var_->GetType())) {
+      declared_vars_.insert(var_name);
+      current_target_var_ = "";
+      return;
+    }
     VisitExpr(tge->tuple_);
     std::string tuple_var = current_expr_value_;
     current_expr_value_ = "";
-    auto it = tuple_element_tensors_.find(std::make_pair(tuple_var, tge->index_));
-    INTERNAL_CHECK_SPAN(it != tuple_element_tensors_.end(), op->span_)
-        << "Internal error: TupleGetItemExpr unpacking found no Out parameter "
-        << "for tuple var '" << tuple_var << "' index " << tge->index_;
-    emitter_.EmitLine("tensors[\"" + var_name + "\"] = tensors[\"" + it->second + "\"]");
+    const auto scalar_type = ir::As<ir::ScalarType>(op->var_->GetType());
+    if (scalar_type && scalar_type->dtype_ == DataType::TASK_ID) {
+      auto it = tuple_element_task_handles_.find(std::make_pair(tuple_var, tge->index_));
+      INTERNAL_CHECK_SPAN(it != tuple_element_task_handles_.end(), op->span_)
+          << "Internal error: distributed Submit TaskId unpacking found no TaskHandle "
+          << "for tuple var '" << tuple_var << "' index " << tge->index_;
+      emitter_.EmitLine(var_name + " = " + it->second);
+    } else {
+      auto it = tuple_element_tensors_.find(std::make_pair(tuple_var, tge->index_));
+      INTERNAL_CHECK_SPAN(it != tuple_element_tensors_.end(), op->span_)
+          << "Internal error: TupleGetItemExpr unpacking found no Out parameter "
+          << "for tuple var '" << tuple_var << "' index " << tge->index_;
+      emitter_.EmitLine("tensors[\"" + var_name + "\"] = tensors[\"" + it->second + "\"]");
+    }
     declared_vars_.insert(var_name);
     current_target_var_ = "";
     return;
@@ -990,6 +1009,12 @@ void DistributedCodegen::VisitExpr_(const ir::CallPtr& op) {
   current_expr_value_ = op_name + "(" + FormatArgs(op->args_) + ")";
 }
 
+void DistributedCodegen::VisitExpr_(const ir::SubmitPtr& op) {
+  INTERNAL_CHECK(op != nullptr) << "Internal error: null Submit";
+  INTERNAL_CHECK_SPAN(TryEmitHierarchyCall(op), op->span_)
+      << "Internal error: distributed codegen only supports Submit for hierarchy calls";
+}
+
 void DistributedCodegen::VisitExpr_(const ir::VarPtr& op) {
   INTERNAL_CHECK(op != nullptr) << "Internal error: null Var";
   if (unwrap_hoisted_var_refs_) {
@@ -1033,9 +1058,23 @@ void DistributedCodegen::VisitExpr_(const ir::ConstBoolPtr& op) {
 // Call-site lowering
 // ========================================================================
 
-void DistributedCodegen::EmitCallToWorker(const ir::CallPtr& call, const ir::FunctionPtr& callee) {
+void DistributedCodegen::EmitCallToWorker(const ir::CallPtr& call, const ir::FunctionPtr& callee,
+                                          const ir::SubmitPtr& submit) {
   bool is_sub = IsSubWorker(callee);
   std::string ta_var = "_ta_" + std::to_string(task_args_counter_++);
+
+  CHECK_SPAN(!submit || !is_sub, call->span_)
+      << "pl.submit(...) in distributed HOST orchestration only supports next-level CHIP dispatches; "
+         "submit same-level SubWorker calls directly instead";
+  CHECK_SPAN(!submit || (!submit->core_num_.has_value() && !submit->sync_start_ &&
+                         !submit->allow_early_resolve_ && !submit->predicate_.has_value()),
+             call->span_)
+      << "Distributed HOST pl.submit(...) supports explicit deps only; core_num, sync_start, "
+         "allow_early_resolve, and predicate are not available for L3 TaskHandle submissions";
+  INTERNAL_CHECK_SPAN(!submit || call->args_.size() == callee->params_.size(), call->span_)
+      << "Internal error: distributed HOST Submit must cover every callee parameter; got "
+      << call->args_.size() << " arguments for " << callee->params_.size() << " parameters in '"
+      << callee->name_ << "'";
 
   // ``device=`` attr (set by N3 parser) is the single source of truth for
   // both the per-rank ``__comm_d0[<r>]`` subscript (used by DistributedTensor
@@ -1203,10 +1242,33 @@ void DistributedCodegen::EmitCallToWorker(const ir::CallPtr& call, const ir::Fun
     // chip count is only known at run time, so the choice cannot be baked here.
     // ``_submit_chip`` also owns the per-dispatch DFX ``output_prefix``
     // namespacing — see its docstring.
+    if (submit) {
+      INTERNAL_CHECK_SPAN(!target.empty(), submit->span_)
+          << "Internal error: distributed Submit must have an assignment target";
+      for (size_t i = 0; i < submit->deps_.size(); ++i) {
+        const auto dep_type = ir::As<ir::ScalarType>(submit->deps_[i]->GetType());
+        CHECK_SPAN(dep_type && dep_type->dtype_ == DataType::TASK_ID, submit->span_)
+            << "Distributed HOST pl.submit(..., deps=[...]) accepts individual TaskId handles only; "
+               "dependency "
+            << i << " has type " << submit->deps_[i]->GetType()->TypeName();
+        VisitExpr(submit->deps_[i]);
+        const std::string dep = current_expr_value_;
+        current_expr_value_.clear();
+        emitter_.EmitLine(ta_var + ".add_dep_wait(" + dep + ")");
+      }
+    }
     emitter_.EmitLine("_keep.append(" + ta_var + ")");
     const std::string worker_arg = rank_expr.empty() ? "None" : rank_expr;
-    emitter_.EmitLine("_submit_chip(orch, callables[\"" + callee->name_ + "\"], " + ta_var + ", config, " +
-                      worker_arg + ")");
+    const std::string submit_expr = "_submit_chip(orch, callables[\"" + callee->name_ + "\"], " + ta_var +
+                                    ", config, " + worker_arg + ")";
+    if (submit) {
+      const std::string task_handle = ta_var + "_handle";
+      emitter_.EmitLine(task_handle + " = " + submit_expr);
+      tuple_element_task_handles_[std::make_pair(target, static_cast<int>(callee->return_types_.size()))] =
+          task_handle;
+    } else {
+      emitter_.EmitLine(submit_expr);
+    }
   }
 
   // If this call has an assignment target (return value), alias it to the OUT
@@ -1218,6 +1280,7 @@ void DistributedCodegen::EmitCallToWorker(const ir::CallPtr& call, const ir::Fun
     //   2. tuple[T1, T2]    → return_types_ = [T1, T2]             (flat entries)
     // Both produce TupleGetItemExpr for unpacking, so handle both.
     bool is_tuple_return =
+        submit != nullptr ||
         std::dynamic_pointer_cast<const ir::TupleType>(callee->return_types_.front()) != nullptr ||
         callee->return_types_.size() > 1;
     if (is_tuple_return) {
@@ -1236,11 +1299,18 @@ void DistributedCodegen::EmitCallToWorker(const ir::CallPtr& call, const ir::Fun
           ++out_idx;
         }
       }
-    } else {
+      if (submit && out_idx == 0) {
+        tuple_element_tensors_[std::make_pair(target, 0)] = target;
+      }
+    } else if (!ir::As<ir::DistributedTensorType>(call->GetType())) {
       // Single return: alias target to the first Out/InOut parameter tensor.
+      // Comm windows resolve through window_buffer_, not the tensors dict, so
+      // a DistributedTensor return gets no alias and window-typed params are
+      // skipped when picking the aliased tensor.
       for (size_t i = 0; i < callee->param_directions_.size() && i < call->args_.size(); ++i) {
         if (callee->param_directions_[i] == ir::ParamDirection::Out ||
             callee->param_directions_[i] == ir::ParamDirection::InOut) {
+          if (ir::As<ir::DistributedTensorType>(call->args_[i]->GetType())) continue;
           VisitExpr(call->args_[i]);
           std::string out_arg = current_expr_value_;
           current_expr_value_ = "";

--- a/src/codegen/distributed/distributed_codegen.cpp
+++ b/src/codegen/distributed/distributed_codegen.cpp
@@ -1011,8 +1011,13 @@ void DistributedCodegen::VisitExpr_(const ir::CallPtr& op) {
 
 void DistributedCodegen::VisitExpr_(const ir::SubmitPtr& op) {
   INTERNAL_CHECK(op != nullptr) << "Internal error: null Submit";
-  INTERNAL_CHECK_SPAN(TryEmitHierarchyCall(op), op->span_)
-      << "Internal error: distributed codegen only supports Submit for hierarchy calls";
+  // Evaluated outside the check macro: TryEmitHierarchyCall *emits* the
+  // dispatch, so it must not read as a check condition.
+  const bool emitted = TryEmitHierarchyCall(op);
+  CHECK_SPAN(emitted, op->span_)
+      << "pl.submit(...) in a distributed HOST orchestrator only supports next-level dispatch of "
+         "an Orchestration function; declare the callee with "
+         "@pl.function(type=pl.FunctionType.Orchestration)";
 }
 
 void DistributedCodegen::VisitExpr_(const ir::VarPtr& op) {
@@ -1071,10 +1076,28 @@ void DistributedCodegen::EmitCallToWorker(const ir::CallPtr& call, const ir::Fun
              call->span_)
       << "Distributed HOST pl.submit(...) supports explicit deps only; core_num, sync_start, "
          "allow_early_resolve, and predicate are not available for L3 TaskHandle submissions";
+  // Stays INTERNAL: an argument-count check in an emitter is internal by
+  // convention (`error-checking.md`, enforced by
+  // tests/lint/check_emitter_check_classification.py rule B). The user-facing
+  // form of this rule — "a distributed HOST submit must pass every callee
+  // argument, including Out/InOut tensors" — is reported by the N3 parser at
+  // the call site, so reaching codegen with a gap is a compiler-side failure.
   INTERNAL_CHECK_SPAN(!submit || call->args_.size() == callee->params_.size(), call->span_)
       << "Internal error: distributed HOST Submit must cover every callee parameter; got "
       << call->args_.size() << " arguments for " << callee->params_.size() << " parameters in '"
       << callee->name_ << "'";
+  // A ``-> pl.Tuple[T1, T2]`` callee declares ONE return type (a TupleType), so
+  // the Submit's return tuple is [TupleType(T1, T2), TaskId] — element 0 is the
+  // whole inner tuple, which the Out-param-ordinal aliasing below cannot model
+  // (it would alias element 0 to just the first Out param). Orchestration
+  // codegen does not model this shape either and no pass flattens it, so reject
+  // it here with an actionable message instead of mis-aliasing.
+  CHECK_SPAN(!submit || callee->return_types_.size() != 1 ||
+                 !std::dynamic_pointer_cast<const ir::TupleType>(callee->return_types_.front()),
+             call->span_)
+      << "Distributed HOST pl.submit(...) does not support a callee declaring a nested "
+         "`-> pl.Tuple[...]` return; declare it as `-> tuple[...]` so each result is its own "
+         "return value";
 
   // ``device=`` attr (set by N3 parser) is the single source of truth for
   // both the per-rank ``__comm_d0[<r>]`` subscript (used by DistributedTensor
@@ -1262,10 +1285,21 @@ void DistributedCodegen::EmitCallToWorker(const ir::CallPtr& call, const ir::Fun
     const std::string submit_expr = "_submit_chip(orch, callables[\"" + callee->name_ + "\"], " + ta_var +
                                     ", config, " + worker_arg + ")";
     if (submit) {
+      // The producer TaskId is the LAST element of the Submit's own return
+      // tuple (the parser builds ``TupleType([*callee returns, Scalar[TASK_ID]])``).
+      // Derive the index from that type rather than from
+      // ``callee->return_types_``: the two agree only because each declared
+      // return contributes one entry to both, which is a coincidence of the
+      // shapes accepted here, not a rule. Mirrors ``n_outs`` in orchestration
+      // codegen's ``GenerateSubmitReturnAliases``.
+      const auto submit_ret = ir::As<ir::TupleType>(submit->GetType());
+      INTERNAL_CHECK_SPAN(submit_ret && !submit_ret->types_.empty(), submit->span_)
+          << "Internal error: distributed Submit return type must be a non-empty TupleType, got "
+          << submit->GetType()->TypeName();
+      const int task_id_index = static_cast<int>(submit_ret->types_.size()) - 1;
       const std::string task_handle = ta_var + "_handle";
       emitter_.EmitLine(task_handle + " = " + submit_expr);
-      tuple_element_task_handles_[std::make_pair(target, static_cast<int>(callee->return_types_.size()))] =
-          task_handle;
+      tuple_element_task_handles_[std::make_pair(target, task_id_index)] = task_handle;
     } else {
       emitter_.EmitLine(submit_expr);
     }

--- a/tests/st/distributed/test_l3_comm_dispatch_order.py
+++ b/tests/st/distributed/test_l3_comm_dispatch_order.py
@@ -1,0 +1,225 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""L3 regression for an explicit dependency between communication dispatches.
+
+Issue #2397 exposed a deterministic deadlock when a rank's send and wait lived
+in different L3 dispatches. The wait had no tensor producer, became READY at
+submission, and entered the rank's worker FIFO before the send, which was still
+waiting on an earlier compute result.
+
+This test preserves that exact shape on two ranks:
+
+1. compute;
+2. SEND (``remote_store`` + ``notify``);
+3. compute;
+4. WAIT in a separate dispatch;
+5. compute.
+
+Both ranks explicitly make WAIT depend on their own SEND. The dependency is
+declared with ``pl.submit(..., deps=[send_task])`` and lowers to the L3
+``TaskArgs.add_dep_wait`` interface, on top of the automatic per-rank comm
+ordering token, so the two mechanisms must coexist on one dispatch.
+"""
+
+import sys
+
+import pypto.language as pl
+import pypto.language.distributed as pld
+import pytest
+import torch
+from pypto import ir
+from pypto.ir.distributed_compiled_program import DistributedConfig
+
+D = 16
+P = 2
+SIGNAL_ROWS = 8
+
+
+def _build_split_send_wait_program():
+    """Build the two-rank split SEND/WAIT reproducer from issue #2397."""
+
+    @pl.program
+    class SplitSendWait:
+        @pl.function(type=pl.FunctionType.InCore)
+        def compute(
+            self,
+            inp: pl.Tensor[[D, D], pl.FP32],
+            out: pl.Out[pl.Tensor[[D, D], pl.FP32]],
+        ) -> pl.Tensor[[D, D], pl.FP32]:
+            tile = pl.load(inp, [0, 0], [D, D])
+            return pl.store(pl.add(tile, tile), [0, 0], out)
+
+        @pl.function(type=pl.FunctionType.InCore)
+        def send(
+            self,
+            inp: pl.Tensor[[D, D], pl.FP32],
+            echo: pl.Out[pl.Tensor[[D, D], pl.FP32]],
+            dst: pld.DistributedTensor[[D, D], pl.FP32],
+            signal: pld.DistributedTensor[[SIGNAL_ROWS, 1], pl.INT32],
+            peer: pl.Scalar[pl.INT32],
+        ) -> pl.Tensor[[D, D], pl.FP32]:
+            tile = pl.load(inp, [0, 0], [D, D])
+            echo = pl.store(tile, [0, 0], echo)
+            pld.tile.remote_store(tile, target=dst, peer=peer, offsets=[0, 0])
+            pld.system.notify(
+                target=signal,
+                peer=peer,
+                offsets=[0, 0],
+                value=1,
+                op=pld.NotifyOp.AtomicAdd,
+            )
+            return echo
+
+        @pl.function(type=pl.FunctionType.InCore)
+        def recv(
+            self,
+            out: pl.Out[pl.Tensor[[D, D], pl.FP32]],
+            dst: pld.DistributedTensor[[D, D], pl.FP32],
+            signal: pld.DistributedTensor[[SIGNAL_ROWS, 1], pl.INT32],
+        ) -> pl.Tensor[[D, D], pl.FP32]:
+            pld.system.wait(signal=signal, offsets=[0, 0], expected=1, cmp=pld.WaitCmp.Ge)
+            return pl.store(pl.load(dst, [0, 0], [D, D]), [0, 0], out)
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def compute_orch(
+            self,
+            inp: pl.Tensor[[D, D], pl.FP32],
+            out: pl.Out[pl.Tensor[[D, D], pl.FP32]],
+        ) -> pl.Tensor[[D, D], pl.FP32]:
+            return self.compute(inp, out)
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def send_orch(
+            self,
+            inp: pl.Tensor[[D, D], pl.FP32],
+            echo: pl.Out[pl.Tensor[[D, D], pl.FP32]],
+            dst: pld.DistributedTensor[[D, D], pl.FP32],
+            signal: pld.DistributedTensor[[SIGNAL_ROWS, 1], pl.INT32],
+            peer: pl.Scalar[pl.INT32],
+        ) -> pl.Tensor[[D, D], pl.FP32]:
+            return self.send(inp, echo, dst, signal, peer)
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def recv_orch(
+            self,
+            out: pl.Out[pl.Tensor[[D, D], pl.FP32]],
+            dst: pld.DistributedTensor[[D, D], pl.FP32],
+            signal: pld.DistributedTensor[[SIGNAL_ROWS, 1], pl.INT32],
+        ) -> pl.Tensor[[D, D], pl.FP32]:
+            return self.recv(out, dst, signal)
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(
+            self,
+            inputs: pl.Tensor[[P, D, D], pl.FP32],
+            echoes: pl.Out[pl.Tensor[[P, D, D], pl.FP32]],
+            forward: pl.Out[pl.Tensor[[P, D, D], pl.FP32]],
+            reverse: pl.Out[pl.Tensor[[P, D, D], pl.FP32]],
+        ):
+            forward_dst_buf = pld.alloc_window_buffer(D * D * pl.FP32.get_byte())
+            forward_signal_buf = pld.alloc_window_buffer(SIGNAL_ROWS * pl.INT32.get_byte())
+            reverse_dst_buf = pld.alloc_window_buffer(D * D * pl.FP32.get_byte())
+            reverse_signal_buf = pld.alloc_window_buffer(SIGNAL_ROWS * pl.INT32.get_byte())
+
+            compute_0 = pl.create_tensor([P, D, D], dtype=pl.FP32)
+            compute_1 = pl.create_tensor([P, D, D], dtype=pl.FP32)
+            compute_2 = pl.create_tensor([P, D, D], dtype=pl.FP32)
+
+            for rank in pl.range(P):
+                forward_dst = pld.window(forward_dst_buf, [D, D], dtype=pl.FP32)
+                forward_signal = pld.window(forward_signal_buf, [SIGNAL_ROWS, 1], dtype=pl.INT32)
+                reverse_dst = pld.window(reverse_dst_buf, [D, D], dtype=pl.FP32)
+                reverse_signal = pld.window(reverse_signal_buf, [SIGNAL_ROWS, 1], dtype=pl.INT32)
+
+                if rank == 0:
+                    first = self.compute_orch(inputs[rank], compute_0[rank], device=rank)
+                    _sent, send_task = pl.submit(
+                        self.send_orch,
+                        first,
+                        echoes[rank],
+                        forward_dst,
+                        forward_signal,
+                        rank + 1,
+                        device=rank,
+                    )
+                    second = self.compute_orch(first, compute_1[rank], device=rank)
+                    _received, _recv_task = pl.submit(
+                        self.recv_orch,
+                        reverse[rank],
+                        reverse_dst,
+                        reverse_signal,
+                        device=rank,
+                        deps=[send_task],
+                    )
+                    self.compute_orch(second, compute_2[rank], device=rank)
+                else:
+                    first = self.compute_orch(inputs[rank], compute_0[rank], device=rank)
+                    _sent, send_task = pl.submit(
+                        self.send_orch,
+                        first,
+                        echoes[rank],
+                        reverse_dst,
+                        reverse_signal,
+                        rank - 1,
+                        device=rank,
+                    )
+                    second = self.compute_orch(first, compute_1[rank], device=rank)
+                    _received, _recv_task = pl.submit(
+                        self.recv_orch,
+                        forward[rank],
+                        forward_dst,
+                        forward_signal,
+                        device=rank,
+                        deps=[send_task],
+                    )
+                    self.compute_orch(second, compute_2[rank], device=rank)
+
+            return echoes, forward, reverse
+
+    return SplitSendWait
+
+
+def test_split_send_wait_dispatch_order(test_config, device_ids):
+    """Separate WAIT dispatches must not enter a rank FIFO before its SEND."""
+    if len(device_ids) < P:
+        pytest.skip(f"split SEND/WAIT regression needs {P} devices, got {device_ids}")
+
+    compiled = ir.compile(
+        _build_split_send_wait_program(),
+        platform=test_config.platform,
+        distributed_config=DistributedConfig(
+            device_ids=device_ids[:P],
+            num_sub_workers=0,
+        ),
+    )
+
+    orch_src = (compiled.output_dir / "orchestration" / "host_orch.py").read_text()
+    dep_waits = [line for line in orch_src.splitlines() if ".add_dep_wait(" in line]
+    assert len(dep_waits) == P, orch_src
+    assert all("send_task" in line for line in dep_waits), dep_waits
+    assert "_last_task" not in orch_src
+
+    inputs = torch.arange(P * D * D, dtype=torch.float32).reshape(P, D, D)
+    echoes = torch.zeros_like(inputs)
+    forward = torch.zeros_like(inputs)
+    reverse = torch.zeros_like(inputs)
+
+    compiled(inputs, echoes, forward, reverse)
+
+    doubled = inputs * 2.0
+    assert torch.equal(echoes, doubled)
+    assert torch.equal(forward[1], doubled[0])
+    assert torch.count_nonzero(forward[0]) == 0
+    assert torch.equal(reverse[0], doubled[1])
+    assert torch.count_nonzero(reverse[1]) == 0
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v", "-s"] + sys.argv[1:]))

--- a/tests/ut/codegen/distributed/test_host_orch_distributed.py
+++ b/tests/ut/codegen/distributed/test_host_orch_distributed.py
@@ -754,6 +754,50 @@ def test_host_submit_requires_explicit_output_arguments():
                 return 0
 
 
+def test_host_submit_rejects_nested_tuple_return():
+    """A ``-> pl.Tuple[...]`` callee has no modellable per-element aliasing.
+
+    ``-> pl.Tuple[A, B]`` declares ONE return type, so the Submit's return tuple
+    is ``[TupleType(A, B), TaskId]`` — element 0 is the whole inner tuple, which
+    the Out-param-ordinal aliasing cannot express. Reject it with an actionable
+    message instead of aliasing element 0 to just the first Out param.
+    """
+
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(
+            self,
+            data: pl.Tensor[[SIZE], pl.FP32],
+            out_a: pl.Out[pl.Tensor[[SIZE], pl.FP32]],
+            out_b: pl.Out[pl.Tensor[[SIZE], pl.FP32]],
+        ) -> pl.Tuple[pl.Tensor[[SIZE], pl.FP32], pl.Tensor[[SIZE], pl.FP32]]:
+            return self.chip_worker(data, out_a, out_b)
+
+        @pl.function(type=pl.FunctionType.InCore)
+        def chip_worker(
+            self,
+            data: pl.Tensor[[SIZE], pl.FP32],
+            out_a: pl.Out[pl.Tensor[[SIZE], pl.FP32]],
+            out_b: pl.Out[pl.Tensor[[SIZE], pl.FP32]],
+        ) -> tuple[pl.Tensor[[SIZE], pl.FP32], pl.Tensor[[SIZE], pl.FP32]]:
+            tile = pl.load(data, [0], [SIZE])
+            return pl.store(tile, [0], out_a), pl.store(tile, [0], out_b)
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(
+            self,
+            data: pl.Tensor[[SIZE], pl.FP32],
+            out_a: pl.Out[pl.Tensor[[SIZE], pl.FP32]],
+            out_b: pl.Out[pl.Tensor[[SIZE], pl.FP32]],
+        ):
+            _packed, _task = pl.submit(self.chip_orch, data, out_a, out_b, device=0)
+            return 0
+
+    with pytest.raises(ValueError, match=r"nested\s+`-> pl\.Tuple\[\.\.\.\]` return"):
+        _lower(Prog)
+
+
 def test_host_allreduce_builtin_codegen_uses_next_level_callable_key():
     @pl.program
     class Prog:

--- a/tests/ut/codegen/distributed/test_host_orch_distributed.py
+++ b/tests/ut/codegen/distributed/test_host_orch_distributed.py
@@ -40,6 +40,7 @@ import pypto.language.distributed as pld
 import pytest
 from pypto import codegen
 from pypto.backend import BackendType, pto_backend
+from pypto.language.parser.diagnostics import ParserTypeError
 from pypto.pypto_core import passes  # match the import path used by ut/conftest.py
 
 SIZE = 64
@@ -668,6 +669,91 @@ def test_two_groups_handle_routing_is_per_dispatch_not_state_bleed():
     assert scalars == ["__comm_d0", "__comm_d1"], (scalars, code)
 
 
+def test_host_submit_deps_lower_to_l3_add_dep_wait():
+    """Only a user-declared Submit dependency emits an L3 ordering edge."""
+
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(
+            self, data: pl.InOut[pld.DistributedTensor[[SIZE], pl.FP32]]
+        ) -> pld.DistributedTensor[[SIZE], pl.FP32]:
+            return data
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(self):
+            data_buf = pld.alloc_window_buffer(SIZE * pl.FP32.get_byte())
+            data = pld.window(data_buf, [SIZE], dtype=pl.FP32)
+            _produced, producer_task = pl.submit(self.chip_orch, data, device=0)
+            _consumed, _consumer_task = pl.submit(
+                self.chip_orch,
+                data,
+                device=0,
+                deps=[producer_task],
+            )
+            return 0
+
+    generated = _lower(Prog)
+
+    assert "_ta_0_handle = _submit_chip(" in generated, generated
+    assert "producer_task = _ta_0_handle" in generated, generated
+    assert "_ta_1.add_dep_wait(producer_task)" in generated, generated
+    assert "_ta_1_handle = _submit_chip(" in generated, generated
+    assert "_consumer_task = _ta_1_handle" in generated, generated
+    assert "_last_task" not in generated, generated
+    # The unpacked DistributedTensor results alias comm windows, which resolve
+    # through the window handle and never live in the tensors dict.
+    assert 'tensors["_produced"]' not in generated, generated
+    assert 'tensors["_consumed"]' not in generated, generated
+    compile(generated, "<host_orch>", "exec")
+
+
+def test_dist_tensor_result_never_aliases_through_tensors_dict():
+    """A window-typed dispatch result must not emit a tensors[...] alias."""
+
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(
+            self, data: pl.InOut[pld.DistributedTensor[[SIZE], pl.FP32]]
+        ) -> pld.DistributedTensor[[SIZE], pl.FP32]:
+            return data
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(self):
+            data_buf = pld.alloc_window_buffer(SIZE * pl.FP32.get_byte())
+            data = pld.window(data_buf, [SIZE], dtype=pl.FP32)
+            _result = self.chip_orch(data, device=0)
+            return 0
+
+    generated = _lower(Prog)
+
+    assert "_submit_chip(" in generated, generated
+    assert 'tensors["_result"]' not in generated, generated
+    compile(generated, "<host_orch>", "exec")
+
+
+def test_host_submit_requires_explicit_output_arguments():
+    """L3 TaskHandle submits cannot request lower-level output allocation."""
+
+    with pytest.raises(ParserTypeError, match="requires every callee argument, including Out/InOut tensors"):
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def chip_orch(
+                self,
+                data: pl.Tensor[[SIZE], pl.FP32],
+                out: pl.Out[pl.Tensor[[SIZE], pl.FP32]],
+            ) -> pl.Tensor[[SIZE], pl.FP32]:
+                return out
+
+            @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+            def host_orch(self, data: pl.Tensor[[SIZE], pl.FP32]):
+                _out, _task = pl.submit(self.chip_orch, data, device=0)
+                return 0
+
+
 def test_host_allreduce_builtin_codegen_uses_next_level_callable_key():
     @pl.program
     class Prog:
@@ -702,6 +788,7 @@ def test_host_allreduce_builtin_codegen_uses_next_level_callable_key():
     assert "distributed_collectives" not in generated, generated
     assert "pld_collectives" not in generated, generated
     assert "data = data" not in generated, generated
+    assert "add_dep_wait" not in generated, generated
 
     specs = cg.get_builtin_next_level_specs()
     assert len(specs) == 1


### PR DESCRIPTION
Fixes #2397.

## Problem

PR #2398 preserves the order of a rank's L3 communication dispatches with a synthetic per-rank ordering token threaded through every comm dispatch as `INOUT`. That automatic chain fixes the #2397 deadlock, but the ordering stays invisible to the user and cannot express edges the token does not cover.

The pinned runtime now returns a `TaskHandle` from `submit_next_level` and supports `TaskArgs.add_dep_wait`, so dependencies can also be declared explicitly.

## Summary

This PR is **additive only**: the automatic ordering token from #2398 is kept unchanged, and explicit L3 dependency support is added for distributed HOST `pl.submit`.

Users declare the dependency themselves:

```python
_sent, send_task = pl.submit(self.send_orch, ..., device=rank)
_received, wait_task = pl.submit(
    self.wait_orch,
    ...,
    device=rank,
    deps=[send_task],
)
```

The implementation works as follows:

- `src/codegen/distributed/distributed_codegen.cpp` recognizes first-class `Submit` nodes (routing through `SubmitToCallView` so the existing Call emission is reused), captures the L3 `TaskHandle` returned by `_submit_chip`, and exposes it as the TaskId returned by `pl.submit`.
- When another HOST `pl.submit` contains `deps=[send_task]`, codegen emits `TaskArgs.add_dep_wait(send_task)` before submitting that task. Explicit edges add to the automatic per-rank chain (final fanin = union), so the two mechanisms coexist on one dispatch.
- `python/pypto/language/parser/ast_parser.py` validates that distributed HOST submits pass all callee arguments, including Out/InOut tensors, because L3 does not allocate output tensors.
- Guardrails: `core_num`, `sync_start`, `allow_early_resolve`, `predicate`, and same-level SubWorker submits are rejected with clear errors — they have no L3 counterpart.
- Window-typed dispatch results no longer emit a `tensors[...]` alias (windows resolve through the window handle, never the tensors dict); the same pre-existing defect on the plain-call single-return path is fixed alongside.

`add_dep_wait` is used instead of `add_dep` because this edge only constrains execution order and does not need to retain producer resources.

## Tests

- `tests/ut/codegen/distributed/test_host_orch_distributed.py` verifies that an explicit `deps` entry emits the corresponding `add_dep_wait`, that HOST submits require every callee argument, and that window-typed results never alias through the tensors dict.
- `tests/st/distributed/test_l3_comm_dispatch_order.py` covers the original two-rank `compute -> SEND -> compute -> WAIT -> compute` sequence, with each rank explicitly making WAIT depend on its own SEND, coexisting with the automatic ordering token.
- All #2398 coverage (`test_l3_host_tensor_allgather.py`, worker/codegen UTs) is untouched and still passes.
- Local: `tests/ut/codegen/` + `tests/ut/runtime/test_distributed_worker.py` — 1189 passed, 2 skipped. Pre-commit: all hooks passed.
