### PR TITLE
feat(ir): map a symbolic slice offset into blocked NZ coordinates

### DIFF
--- a/docs/en/dev/passes/14-block_nz_tensor_views.md
+++ b/docs/en/dev/passes/14-block_nz_tensor_views.md
@@ -101,37 +101,55 @@ wt: pl.Tile[[256, 512], pl.INT8, pl.Mem.Mat] =
 
 A trailing offset does not have to be a constant, but its alignment must be
 **proven** — never assumed. An offset arrives here as the SSA name it was bound
-to, not as the arithmetic that produced it, so `DivideIndexExactly`
+to, not as the arithmetic that produced it, so `IsProvableMultipleOf`
 (`tensor_view_semantics.h`) walks two kinds of binding the pass collects from
 the enclosing function in one read-only sweep:
 
-| Binding | Proof | Quotient built |
-| ------- | ----- | -------------- |
-| `AssignStmt` (`n0 = nb * 256`) | one factor of the product is a multiple | folded: `nb * 16` |
-| `ForStmt` (`for k0 in pl.pipeline(512, 4096, 512)`) | `start` and `step` are both multiples | `k0 // 32` |
-| `ConstInt` | the value is a multiple | folded: `256 -> 16` |
+| Binding | Proof |
+| ------- | ----- |
+| `AssignStmt` (`n0 = nb * 256`) | one factor of the product is a multiple |
+| `ForStmt` (`for k0 in pl.pipeline(512, 4096, 512)`) | `start` and `step` are both multiples |
+| `ConstInt` | the value is a multiple |
 
-Sums, differences and constant multiples compose from those, since
-`(a±b)/d = a/d ± b/d` when `d` divides both and `(a*b)/d = (a/d)*b` when `d`
-divides `a`. The grouped-matmul weight path that motivated the feature therefore
-compiles:
+Sums, differences and products compose from those. The grouped-matmul weight
+path that motivated the feature therefore compiles:
 
 ```python
 for nb in pl.spmd(N // N_TILE):
-    n0 = nb * N_TILE                     # -> row fractal offset  nb * (N_TILE/16)
+    n0 = nb * N_TILE                     # -> row fractal offset  n0 // 16
     for k0 in pl.pipeline(K_TILE, K, K_TILE, stage=2):
         wt = w[n0 : n0 + N_TILE, k0 : k0 + K_TILE]   # -> c0 block offset  k0 // c0
 ```
 
-Two limits are deliberate. A loop variable divides to a `FloorDiv` rather than a
-folded product because nothing in the IR names its trip count — the division is
-exact only *because* divisibility was proven first. And an `IterArg` is never
-resolved: its value changes every iteration, so neither its initial value nor any
-binding recorded for it describes the value a given use sees.
-
 Anything the walk cannot prove is rejected with a diagnostic naming the provable
 forms. That refusal is the design: an NZ tensor addressed from a guessed
 coordinate reads the wrong fractal, and nothing downstream would notice.
+
+#### Why the offset is divided, not re-associated
+
+Only the *result* of the offset is divided (`FloorDiv(offset, divisor)`). The
+tempting rewrite — turning `n0 = nb * 256` into `nb * 16` and saving the runtime
+division — is unsound, because IR arithmetic wraps at its declared width while
+the rewritten form does not:
+
+```text
+x : INT32 = 1 << 24
+(x * 256) / 16   ==  0            # x * 256 wraps to 0 in i32
+x * (256 / 16)   ==  268435456    # re-associated: no wrap, wrong fractal
+```
+
+Widening is not the culprit, and rebuilding at the original width does not help:
+for `a * b = q * 2^W + r`, the original yields `r / d` while any re-association
+yields `r / d + q * 2^(W - log2 d)`. Dividing the offset as a whole keeps its
+own dtype and overflow behaviour intact.
+
+The proof itself survives wraparound because every divisor here is a power of
+two and so divides `2^W`: reducing a multiple of `d` modulo `2^W` leaves a
+multiple of `d`. An `INTERNAL_CHECK` pins that precondition.
+
+One further limit is deliberate: an `IterArg` is never resolved, because its
+value changes every iteration, so neither its initial value nor any binding
+recorded for it describes the value a given use sees.
 
 The destination `TileType` is **preserved verbatim**: the GM partition becomes
 rank-(r+2), the tile stays the logical 2-D operand. The load is therefore rebuilt

--- a/docs/en/dev/passes/14-block_nz_tensor_views.md
+++ b/docs/en/dev/passes/14-block_nz_tensor_views.md
@@ -97,21 +97,41 @@ wt: pl.Tile[[256, 512], pl.INT8, pl.Mem.Mat] =
     pl.tile.load(w, [1, 16, 16, 0, 0], [1, 16, 16, 16, 32], target_memory=pl.Mem.Mat)
 ```
 
-The two trailing offsets must be **constants**. Milestone 1 performs the
-`k0/c0` / `n0/16` mapping only on `ConstInt`, so a symbolic offset is rejected
-even when it is provably aligned — mapping one would need a divisibility proof
-plus an algebraic rewrite (`nb*256` -> `nb*16`), which is not implemented.
+### Symbolic trailing offsets
 
-A loop-derived slice is therefore **not supported yet**:
+A trailing offset does not have to be a constant, but its alignment must be
+**proven** — never assumed. An offset arrives here as the SSA name it was bound
+to, not as the arithmetic that produced it, so `DivideIndexExactly`
+(`tensor_view_semantics.h`) walks two kinds of binding the pass collects from
+the enclosing function in one read-only sweep:
+
+| Binding | Proof | Quotient built |
+| ------- | ----- | -------------- |
+| `AssignStmt` (`n0 = nb * 256`) | one factor of the product is a multiple | folded: `nb * 16` |
+| `ForStmt` (`for k0 in pl.pipeline(512, 4096, 512)`) | `start` and `step` are both multiples | `k0 // 32` |
+| `ConstInt` | the value is a multiple | folded: `256 -> 16` |
+
+Sums, differences and constant multiples compose from those, since
+`(a±b)/d = a/d ± b/d` when `d` divides both and `(a*b)/d = (a/d)*b` when `d`
+divides `a`. The grouped-matmul weight path that motivated the feature therefore
+compiles:
 
 ```python
 for nb in pl.spmd(N // N_TILE):
-    n0 = nb * N_TILE
-    wt = w[n0 : n0 + N_TILE, 0:K_TILE]   # rejected: dynamic offset on shape[-2]
+    n0 = nb * N_TILE                     # -> row fractal offset  nb * (N_TILE/16)
+    for k0 in pl.pipeline(K_TILE, K, K_TILE, stage=2):
+        wt = w[n0 : n0 + N_TILE, k0 : k0 + K_TILE]   # -> c0 block offset  k0 // c0
 ```
 
-This is the main gap between this milestone and the grouped-matmul weight path
-that motivated it. Tracked as issue #2548.
+Two limits are deliberate. A loop variable divides to a `FloorDiv` rather than a
+folded product because nothing in the IR names its trip count — the division is
+exact only *because* divisibility was proven first. And an `IterArg` is never
+resolved: its value changes every iteration, so neither its initial value nor any
+binding recorded for it describes the value a given use sees.
+
+Anything the walk cannot prove is rejected with a diagnostic naming the provable
+forms. That refusal is the design: an NZ tensor addressed from a guessed
+coordinate reads the wrong fractal, and nothing downstream would notice.
 
 The destination `TileType` is **preserved verbatim**: the GM partition becomes
 rank-(r+2), the tile stays the logical 2-D operand. The load is therefore rebuilt
@@ -149,7 +169,8 @@ diagnostic naming the fix — an NZ tensor must never be silently mis-addressed.
 | `shape[-1] % c0 != 0` | rejected — a partial C0 line has no representation |
 | dynamic `shape[-2]` / `shape[-1]` | rejected — divisibility cannot be proven |
 | slice offset not fractal-aligned | rejected — no blocked representation |
-| **dynamic (non-constant) trailing slice offset** | **rejected — only `ConstInt` offsets are mapped; a provably aligned symbolic offset is refused too (#2548)** |
+| symbolic trailing slice offset, alignment provable | mapped — see [Symbolic trailing offsets](#symbolic-trailing-offsets) |
+| symbolic trailing slice offset, alignment not provable | rejected — never divided on the assumption that it is aligned |
 | rank < 2 | rejected |
 | `target_memory != Mat` (or absent) | rejected — NZ→NZ is the cube operand path |
 | consumer other than `tile.load` | rejected — NZ is read-only here |

--- a/docs/en/dev/passes/14-block_nz_tensor_views.md
+++ b/docs/en/dev/passes/14-block_nz_tensor_views.md
@@ -105,14 +105,17 @@ to, not as the arithmetic that produced it, so `IsProvableMultipleOf`
 (`tensor_view_semantics.h`) walks two kinds of binding the pass collects from
 the enclosing function in one read-only sweep:
 
-| Binding | Proof |
-| ------- | ----- |
-| `AssignStmt` (`n0 = nb * 256`) | one factor of the product is a multiple |
-| `ForStmt` (`for k0 in pl.pipeline(512, 4096, 512)`) | `start` and `step` are both multiples |
-| `ConstInt` | the value is a multiple |
+| Binding | Multiple of the axis factor | Non-negative |
+| ------- | --------------------------- | ------------ |
+| `AssignStmt` (`n0 = nb * 256`) | one factor of the product is a multiple | both factors are non-negative |
+| `ForStmt` (`for k0 in pl.pipeline(512, 4096, 512)`) | `start` and `step` are both multiples | `start` and `step` are both non-negative |
+| `tile.get_block_idx` / `tile.get_block_num` | — | a lane number is never negative |
+| `ConstInt` | the value is a multiple | the value is `>= 0` |
 
-Sums, differences and products compose from those. The grouped-matmul weight
-path that motivated the feature therefore compiles:
+Sums and products compose from those; a difference proves divisibility but never
+its sign, so it is refused. **Both** columns must hold — see [Why the sign is
+proven too](#why-the-sign-is-proven-too). The grouped-matmul weight path that
+motivated the feature therefore compiles:
 
 ```python
 for nb in pl.spmd(N // N_TILE):
@@ -151,6 +154,20 @@ One further limit is deliberate: an `IterArg` is never resolved, because its
 value changes every iteration, so neither its initial value nor any binding
 recorded for it describes the value a given use sees.
 
+#### Why the sign is proven too
+
+Divisibility alone does not make a coordinate safe. `n0 = -16` is a clean
+multiple of 16, and `FloorDiv(n0, 16)` is `-1`; codegen then *clamps* a negative
+`pto.partition_view` offset to 0 instead of failing, so the load reads fractal 0
+and returns silently wrong data — the same shape [#2543] fixed for row indices.
+
+The constant path already refuses a negative literal, so proving only
+divisibility for a symbolic offset would mean the identical value is caught
+written inline and waved through once bound to a name.
+`IsProvableNonNegative` closes that gap.
+
+[#2543]: https://github.com/hw-native-sys/pypto/pull/2543
+
 The destination `TileType` is **preserved verbatim**: the GM partition becomes
 rank-(r+2), the tile stays the logical 2-D operand. The load is therefore rebuilt
 with the explicit-type `Call` constructor rather than `OpRegistry::Create`, which
@@ -187,8 +204,9 @@ diagnostic naming the fix — an NZ tensor must never be silently mis-addressed.
 | `shape[-1] % c0 != 0` | rejected — a partial C0 line has no representation |
 | dynamic `shape[-2]` / `shape[-1]` | rejected — divisibility cannot be proven |
 | slice offset not fractal-aligned | rejected — no blocked representation |
-| symbolic trailing slice offset, alignment provable | mapped — see [Symbolic trailing offsets](#symbolic-trailing-offsets) |
+| symbolic trailing slice offset, alignment and sign both provable | mapped — see [Symbolic trailing offsets](#symbolic-trailing-offsets) |
 | symbolic trailing slice offset, alignment not provable | rejected — never divided on the assumption that it is aligned |
+| symbolic trailing slice offset, sign not provable | rejected — a negative offset is clamped, not caught, at the partition view |
 | rank < 2 | rejected |
 | `target_memory != Mat` (or absent) | rejected — NZ→NZ is the cube operand path |
 | consumer other than `tile.load` | rejected — NZ is read-only here |

--- a/docs/zh/dev/passes/14-block_nz_tensor_views.md
+++ b/docs/zh/dev/passes/14-block_nz_tensor_views.md
@@ -97,14 +97,16 @@ wt: pl.Tile[[256, 512], pl.INT8, pl.Mem.Mat] =
 `IsProvableMultipleOf`（`tensor_view_semantics.h`）会沿着本 pass 一次只读扫描收集到的
 两类绑定往回走：
 
-| 绑定形式 | 证明依据 |
-| -------- | -------- |
-| `AssignStmt`（`n0 = nb * 256`） | 乘积中的某个因子是倍数 |
-| `ForStmt`（`for k0 in pl.pipeline(512, 4096, 512)`） | `start` 与 `step` 同时是倍数 |
-| `ConstInt` | 该值本身是倍数 |
+| 绑定形式 | 是轴因子的倍数 | 非负 |
+| -------- | -------------- | ---- |
+| `AssignStmt`（`n0 = nb * 256`） | 乘积中的某个因子是倍数 | 两个因子都非负 |
+| `ForStmt`（`for k0 in pl.pipeline(512, 4096, 512)`） | `start` 与 `step` 同时是倍数 | `start` 与 `step` 同时非负 |
+| `tile.get_block_idx` / `tile.get_block_num` | —— | lane 编号不可能为负 |
+| `ConstInt` | 该值本身是倍数 | 该值 `>= 0` |
 
-在此基础上，和、差与乘积可以组合。因此催生该特性的 grouped-matmul 权重路径现在可以
-编译：
+在此基础上，和与乘积可以组合；差能证明整除性但无法证明符号，因此被拒绝。**两列必须
+同时成立**——见[为什么符号也要证明](#为什么符号也要证明)。因此催生该特性的
+grouped-matmul 权重路径现在可以编译：
 
 ```python
 for nb in pl.spmd(N // N_TILE):
@@ -137,6 +139,18 @@ x * (256 / 16)   ==  268435456    # 重组后：不回绕，读到错误的 frac
 
 另有一处限制是刻意保留的：`IterArg` 永远不会被解析——它的值每次迭代都在变，无论是初值
 还是为它记录的任何绑定，都无法描述某一次使用真正看到的值。
+
+#### 为什么符号也要证明
+
+只证明整除性并不足以保证坐标安全。`n0 = -16` 是 16 的整数倍，而 `FloorDiv(n0, 16)`
+等于 `-1`；codegen 随后会把 `pto.partition_view` 上的负 offset **钳位**到 0 而不是报错，
+于是这次 load 会读到 fractal 0 并返回静默错误的数据——正是 [#2543] 为行索引修掉的那种
+形态。
+
+常量路径本来就会拒绝负的字面量，所以如果符号形式只证明整除性，就会出现同一个值写成
+字面量被拦下、绑定成名字后却被放行的矛盾。`IsProvableNonNegative` 补上了这个缺口。
+
+[#2543]: https://github.com/hw-native-sys/pypto/pull/2543
 
 目标 `TileType` **原样保留**：GM 分区变成 rank-(r+2)，而 tile 保持逻辑 2-D 操作数。
 因此该 load 使用显式类型的 `Call` 构造函数重建，而不是 `OpRegistry::Create`——后者
@@ -172,8 +186,9 @@ pto.tload ins(%w_pview : !pto.partition_tensor_view<16x16x16x32xi8>)
 | `shape[-1] % c0 != 0` | 拒绝——不完整的 C0 线没有表示 |
 | `shape[-2]` / `shape[-1]` 为动态维 | 拒绝——无法静态证明整除 |
 | 切片偏移未对齐到分形边界 | 拒绝——没有分块表示 |
-| 末尾切片偏移为符号形式且对齐可证明 | 映射——见[符号形式的末尾 offset](#符号形式的末尾-offset) |
+| 末尾切片偏移为符号形式且对齐与符号均可证明 | 映射——见[符号形式的末尾 offset](#符号形式的末尾-offset) |
 | 末尾切片偏移为符号形式但对齐无法证明 | 拒绝——绝不基于「大概是对齐的」去做除法 |
+| 末尾切片偏移为符号形式但符号无法证明 | 拒绝——负 offset 在 partition view 上会被钳位而不是报错 |
 | rank < 2 | 拒绝 |
 | `target_memory != Mat`（或缺省） | 拒绝——NZ→NZ 是 cube 操作数路径 |
 | `tile.load` 之外的消费者 | 拒绝——此处 NZ 是只读的 |

--- a/docs/zh/dev/passes/14-block_nz_tensor_views.md
+++ b/docs/zh/dev/passes/14-block_nz_tensor_views.md
@@ -90,19 +90,37 @@ wt: pl.Tile[[256, 512], pl.INT8, pl.Mem.Mat] =
     pl.tile.load(w, [1, 16, 16, 0, 0], [1, 16, 16, 16, 32], target_memory=pl.Mem.Mat)
 ```
 
-末尾两个 offset 必须是**常量**。里程碑 1 只对 `ConstInt` 做 `k0/c0` / `n0/16` 映射，
-因此即使符号表达式可证明对齐也会被拒绝——要映射它需要整除性证明加代数改写
-（`nb*256` -> `nb*16`），目前没有实现。
+### 符号形式的末尾 offset
 
-所以**尚不支持循环推导出的切片**：
+末尾 offset 不必是常量，但它的对齐必须被**证明**，绝不允许假设。offset 到达本 pass
+时只是它被绑定到的那个 SSA 名字，产生它的算术在别处，因此
+`DivideIndexExactly`（`tensor_view_semantics.h`）会沿着本 pass 一次只读扫描收集到的
+两类绑定往回走：
+
+| 绑定形式 | 证明依据 | 构造出的商 |
+| -------- | -------- | ---------- |
+| `AssignStmt`（`n0 = nb * 256`） | 乘积中的某个因子是倍数 | 折叠形式：`nb * 16` |
+| `ForStmt`（`for k0 in pl.pipeline(512, 4096, 512)`） | `start` 与 `step` 同时是倍数 | `k0 // 32` |
+| `ConstInt` | 该值本身是倍数 | 折叠形式：`256 -> 16` |
+
+在此基础上，和、差以及常数倍可以组合：当 `d` 同时整除两边时
+`(a±b)/d = a/d ± b/d`，当 `d` 整除 `a` 时 `(a*b)/d = (a/d)*b`。因此催生该特性的
+grouped-matmul 权重路径现在可以编译：
 
 ```python
 for nb in pl.spmd(N // N_TILE):
-    n0 = nb * N_TILE
-    wt = w[n0 : n0 + N_TILE, 0:K_TILE]   # 被拒绝：shape[-2] 上是动态 offset
+    n0 = nb * N_TILE                     # -> 行 fractal offset  nb * (N_TILE/16)
+    for k0 in pl.pipeline(K_TILE, K, K_TILE, stage=2):
+        wt = w[n0 : n0 + N_TILE, k0 : k0 + K_TILE]   # -> c0 block offset  k0 // c0
 ```
 
-这是本里程碑与催生它的 grouped-matmul 权重路径之间最主要的差距，已记录为 issue #2548。
+有两处限制是刻意保留的。循环变量得到的是 `FloorDiv` 而不是折叠后的乘积，因为 IR 里
+没有任何节点表示它的迭代次数——这个除法之所以精确，正是因为先证明了整除性。另外
+`IterArg` 永远不会被解析：它的值每次迭代都在变，无论是初值还是为它记录的任何绑定，
+都无法描述某一次使用真正看到的值。
+
+凡是走不通证明的表达式一律拒绝，并在诊断中列出可证明的形式。这种拒绝正是设计本身：
+NZ 张量一旦按猜出来的坐标寻址，就会读到错误的 fractal，而下游不会有任何地方发现。
 
 目标 `TileType` **原样保留**：GM 分区变成 rank-(r+2)，而 tile 保持逻辑 2-D 操作数。
 因此该 load 使用显式类型的 `Call` 构造函数重建，而不是 `OpRegistry::Create`——后者
@@ -138,7 +156,8 @@ pto.tload ins(%w_pview : !pto.partition_tensor_view<16x16x16x32xi8>)
 | `shape[-1] % c0 != 0` | 拒绝——不完整的 C0 线没有表示 |
 | `shape[-2]` / `shape[-1]` 为动态维 | 拒绝——无法静态证明整除 |
 | 切片偏移未对齐到分形边界 | 拒绝——没有分块表示 |
-| **末尾切片偏移为动态（非常量）** | **拒绝——只映射 `ConstInt` 偏移；即使符号表达式可证明对齐也一并拒绝（#2548）** |
+| 末尾切片偏移为符号形式且对齐可证明 | 映射——见[符号形式的末尾 offset](#符号形式的末尾-offset) |
+| 末尾切片偏移为符号形式但对齐无法证明 | 拒绝——绝不基于「大概是对齐的」去做除法 |
 | rank < 2 | 拒绝 |
 | `target_memory != Mat`（或缺省） | 拒绝——NZ→NZ 是 cube 操作数路径 |
 | `tile.load` 之外的消费者 | 拒绝——此处 NZ 是只读的 |

--- a/docs/zh/dev/passes/14-block_nz_tensor_views.md
+++ b/docs/zh/dev/passes/14-block_nz_tensor_views.md
@@ -94,33 +94,49 @@ wt: pl.Tile[[256, 512], pl.INT8, pl.Mem.Mat] =
 
 末尾 offset 不必是常量，但它的对齐必须被**证明**，绝不允许假设。offset 到达本 pass
 时只是它被绑定到的那个 SSA 名字，产生它的算术在别处，因此
-`DivideIndexExactly`（`tensor_view_semantics.h`）会沿着本 pass 一次只读扫描收集到的
+`IsProvableMultipleOf`（`tensor_view_semantics.h`）会沿着本 pass 一次只读扫描收集到的
 两类绑定往回走：
 
-| 绑定形式 | 证明依据 | 构造出的商 |
-| -------- | -------- | ---------- |
-| `AssignStmt`（`n0 = nb * 256`） | 乘积中的某个因子是倍数 | 折叠形式：`nb * 16` |
-| `ForStmt`（`for k0 in pl.pipeline(512, 4096, 512)`） | `start` 与 `step` 同时是倍数 | `k0 // 32` |
-| `ConstInt` | 该值本身是倍数 | 折叠形式：`256 -> 16` |
+| 绑定形式 | 证明依据 |
+| -------- | -------- |
+| `AssignStmt`（`n0 = nb * 256`） | 乘积中的某个因子是倍数 |
+| `ForStmt`（`for k0 in pl.pipeline(512, 4096, 512)`） | `start` 与 `step` 同时是倍数 |
+| `ConstInt` | 该值本身是倍数 |
 
-在此基础上，和、差以及常数倍可以组合：当 `d` 同时整除两边时
-`(a±b)/d = a/d ± b/d`，当 `d` 整除 `a` 时 `(a*b)/d = (a/d)*b`。因此催生该特性的
-grouped-matmul 权重路径现在可以编译：
+在此基础上，和、差与乘积可以组合。因此催生该特性的 grouped-matmul 权重路径现在可以
+编译：
 
 ```python
 for nb in pl.spmd(N // N_TILE):
-    n0 = nb * N_TILE                     # -> 行 fractal offset  nb * (N_TILE/16)
+    n0 = nb * N_TILE                     # -> 行 fractal offset  n0 // 16
     for k0 in pl.pipeline(K_TILE, K, K_TILE, stage=2):
         wt = w[n0 : n0 + N_TILE, k0 : k0 + K_TILE]   # -> c0 block offset  k0 // c0
 ```
 
-有两处限制是刻意保留的。循环变量得到的是 `FloorDiv` 而不是折叠后的乘积，因为 IR 里
-没有任何节点表示它的迭代次数——这个除法之所以精确，正是因为先证明了整除性。另外
-`IterArg` 永远不会被解析：它的值每次迭代都在变，无论是初值还是为它记录的任何绑定，
-都无法描述某一次使用真正看到的值。
-
 凡是走不通证明的表达式一律拒绝，并在诊断中列出可证明的形式。这种拒绝正是设计本身：
 NZ 张量一旦按猜出来的坐标寻址，就会读到错误的 fractal，而下游不会有任何地方发现。
+
+#### 为什么是整体相除，而不是代数重组
+
+被除的只是 offset 的**求值结果**（`FloorDiv(offset, divisor)`）。那个看起来很诱人的
+改写——把 `n0 = nb * 256` 变成 `nb * 16`，从而省掉运行期的除法——是不成立的：IR 的
+算术在其声明位宽上回绕，而重组后的形式不会在同一处回绕：
+
+```text
+x : INT32 = 1 << 24
+(x * 256) / 16   ==  0            # x * 256 在 i32 中回绕为 0
+x * (256 / 16)   ==  268435456    # 重组后：不回绕，读到错误的 fractal
+```
+
+位宽提升并不是元凶，按原位宽重建同样救不回来：对 `a * b = q * 2^W + r`，原表达式得到
+`r / d`，而任何重组都得到 `r / d + q * 2^(W - log2 d)`。把 offset 整体相除，才能完整
+保留它自己的 dtype 与溢出行为。
+
+证明本身能够在回绕下继续成立，是因为这里的除数一定是 2 的幂、因而整除 `2^W`：一个
+`d` 的倍数对 `2^W` 取模之后仍然是 `d` 的倍数。这一前提由 `INTERNAL_CHECK` 固定下来。
+
+另有一处限制是刻意保留的：`IterArg` 永远不会被解析——它的值每次迭代都在变，无论是初值
+还是为它记录的任何绑定，都无法描述某一次使用真正看到的值。
 
 目标 `TileType` **原样保留**：GM 分区变成 rank-(r+2)，而 tile 保持逻辑 2-D 操作数。
 因此该 load 使用显式类型的 `Call` 构造函数重建，而不是 `OpRegistry::Create`——后者

--- a/include/pypto/ir/transforms/utils/tensor_view_semantics.h
+++ b/include/pypto/ir/transforms/utils/tensor_view_semantics.h
@@ -210,6 +210,12 @@ struct NzOffsetFacts {
   /// exact structural quotient (nothing in the IR names its trip count), so the
   /// property is the only thing that licenses dividing it.
   std::function<bool(const VarPtr&, int64_t)> is_multiple_of;
+  /// Whether a ``Var`` is non-negative by construction. Two sources qualify: a
+  /// loop variable whose start and step are both non-negative, and a variable
+  /// bound to an operator whose result cannot be negative (the SPMD block
+  /// index). The second is an *operator* fact, which is why the owning pass
+  /// supplies it rather than this header deciding it structurally.
+  std::function<bool(const VarPtr&)> is_non_negative;
 };
 
 /// Node-visit allowance for one ``IsProvableMultipleOf`` walk.
@@ -282,6 +288,50 @@ inline bool IsProvableMultipleOf(const ExprPtr& expr, int64_t divisor, const NzO
   return false;
 }
 
+/// Whether every runtime value of ``expr`` is non-negative.
+///
+/// Divisibility alone does not make a blocked coordinate safe. ``n0 = -16`` is
+/// a perfectly good multiple of 16, and ``FloorDiv(n0, 16)`` is ``-1``; codegen
+/// then clamps a negative ``pto.partition_view`` offset to 0 rather than
+/// failing, so the load silently reads fractal 0 instead of reporting anything.
+/// That is the same silent-wrong-data shape #2543 fixed for row indices. A
+/// literal ``-16`` is already rejected by the constant path, so without this a
+/// negative offset would be caught inline and waved through once bound to a
+/// name.
+///
+/// ``Sub`` is deliberately absent: ``a - b`` is negative whenever ``b > a``,
+/// and nothing here bounds either side. A difference is therefore refused, even
+/// though its divisibility is provable.
+inline bool IsProvableNonNegative(const ExprPtr& expr, const NzOffsetFacts& facts, int* budget) {
+  if (!expr || --*budget < 0) return false;
+
+  if (auto const_expr = As<ConstInt>(expr)) return const_expr->value_ >= 0;
+
+  // Both operands non-negative implies the product and the sum are too. The
+  // converse cases (two negatives multiplying to a positive) are not worth
+  // proving: refusing them costs nothing real.
+  if (auto mul = As<Mul>(expr)) {
+    return IsProvableNonNegative(mul->left_, facts, budget) &&
+           IsProvableNonNegative(mul->right_, facts, budget);
+  }
+
+  if (auto add = As<Add>(expr)) {
+    return IsProvableNonNegative(add->left_, facts, budget) &&
+           IsProvableNonNegative(add->right_, facts, budget);
+  }
+
+  if (auto var = As<Var>(expr)) {
+    if (facts.is_non_negative && facts.is_non_negative(var)) return true;
+    if (facts.definition) {
+      if (auto def = facts.definition(var)) {
+        return IsProvableNonNegative(def, facts, budget);
+      }
+    }
+  }
+
+  return false;
+}
+
 /// Map logical offsets ``[..., r0, c0off]`` into the blocked NZ coordinate
 /// system ``[..., c0off/c0, r0/16, 0, 0]`` produced by ``BlockNzShape``.
 ///
@@ -307,6 +357,9 @@ inline std::vector<ExprPtr> BlockNzOffsets(const std::vector<ExprPtr>& offsets, 
           << ", got " << const_offset->value_ << ".";
       return std::make_shared<ConstInt>(const_offset->value_ / divisor, DataType::INDEX, span);
     }
+    // Both halves of the constant path's "non-negative multiple" contract have
+    // to be re-proven for a symbolic offset, or the same value would be
+    // rejected written inline and accepted once bound to a name.
     int budget = kNzDivideStepBudget;
     CHECK_SPAN(IsProvableMultipleOf(offset, divisor, facts, &budget), span)
         << "NZ layout requires the slice offset on shape[" << axis << "] to be a multiple of " << unit
@@ -314,6 +367,15 @@ inline std::vector<ExprPtr> BlockNzOffsets(const std::vector<ExprPtr>& offsets, 
         << "start and step are both multiples of " << unit
         << ", and any sum, difference or constant multiple built from those. Slice on a " << unit
         << "-aligned boundary, or annotate the tensor as pl.ND.";
+    int sign_budget = kNzDivideStepBudget;
+    CHECK_SPAN(IsProvableNonNegative(offset, facts, &sign_budget), span)
+        << "NZ layout requires the slice offset on shape[" << axis
+        << "] to be non-negative, and this one cannot be proven to be. A negative offset is clamped to 0 "
+        << "at the partition view rather than rejected, so it would read the wrong fractal silently. "
+        << "Provable forms are a non-negative constant, the SPMD block index, a loop variable whose "
+        << "start and step are both non-negative, and any sum or product built from those — note that a "
+        << "difference never qualifies. Slice from a non-negative offset, or annotate the tensor as "
+        << "pl.ND.";
     // Divide the offset's *result*, never its arithmetic: the expression keeps
     // its own dtype and wraparound behaviour, and only the value it produces is
     // divided. See ``IsProvableMultipleOf`` for why re-association is unsound.

--- a/include/pypto/ir/transforms/utils/tensor_view_semantics.h
+++ b/include/pypto/ir/transforms/utils/tensor_view_semantics.h
@@ -212,92 +212,84 @@ struct NzOffsetFacts {
   std::function<bool(const VarPtr&, int64_t)> is_multiple_of;
 };
 
-/// Node-visit allowance for one ``DivideIndexExactly`` walk.
+/// Node-visit allowance for one ``IsProvableMultipleOf`` walk.
 ///
 /// The walk follows SSA definitions, so a diamond-shaped def chain
 /// (``x = y + y``) can be re-entered exponentially. Bounding the visits keeps
-/// the rewrite O(1) per offset — and the pass O(N) — and exhausting the budget
+/// the proof O(1) per offset — and the pass O(N) — and exhausting the budget
 /// degrades to a refusal, never to a wrong answer.
 constexpr int kNzDivideStepBudget = 256;
 
-/// The exact quotient ``expr / divisor``, or nullptr when exactness cannot be
-/// proven.
+/// Whether every runtime value of ``expr`` is a multiple of ``divisor``.
 ///
-/// "Exact" is the whole contract: the result must equal ``expr / divisor`` for
-/// *every* runtime value ``expr`` can take, so a caller may substitute it for a
-/// blocked coordinate with no range check. Each arm preserves that —
-/// ``(a*b)/d = (a/d)*b`` when ``d | a``, ``(a±b)/d = a/d ± b/d`` when ``d``
-/// divides both — and anything unrecognised refuses. Refusing is the point: an
-/// NZ tensor addressed from a guessed coordinate reads the wrong fractal with
-/// no diagnostic anywhere.
-inline ExprPtr DivideIndexExactly(const ExprPtr& expr, int64_t divisor, const NzOffsetFacts& facts,
-                                  int* budget, const Span& span) {
-  INTERNAL_CHECK(divisor > 0) << "Internal error: DivideIndexExactly needs a positive divisor, got "
-                              << divisor;
-  if (!expr || --*budget < 0) return nullptr;
+/// This only *proves* the property; it deliberately does not build the
+/// quotient. Re-associating the offset arithmetic to divide it symbolically —
+/// rewriting ``nb * 256`` into ``nb * 16`` — is unsound, because IR arithmetic
+/// wraps at its declared width while the rewritten form does not:
+///
+///     x : INT32 = 1 << 24
+///     (x * 256) / 16   ==  0            // x * 256 wraps to 0 in i32
+///     x * (256 / 16)   ==  268435456    // re-associated: no wrap, wrong answer
+///
+/// Widening is not the culprit and matching the original width does not help:
+/// with ``a * b = q * 2^W + r``, the original yields ``r / d`` while any
+/// re-association yields ``r / d + q * 2^(W - log2 d)``. Callers therefore
+/// divide the *result* of the original expression (``FloorDiv(expr, divisor)``),
+/// which evaluates the offset exactly as written and only then divides.
+///
+/// The proof itself survives wraparound because every divisor here is a power
+/// of two and therefore divides ``2^W``: reducing a multiple of ``d`` modulo
+/// ``2^W`` leaves a multiple of ``d``. ``INTERNAL_CHECK`` pins that precondition
+/// rather than leaving it implicit.
+inline bool IsProvableMultipleOf(const ExprPtr& expr, int64_t divisor, const NzOffsetFacts& facts,
+                                 int* budget) {
+  INTERNAL_CHECK(divisor > 0 && (divisor & (divisor - 1)) == 0)
+      << "Internal error: NZ divisibility proofs require a power-of-two divisor (it must divide the "
+         "wraparound modulus to survive fixed-width overflow), got "
+      << divisor;
+  if (!expr || --*budget < 0) return false;
 
-  if (auto const_expr = As<ConstInt>(expr)) {
-    if (const_expr->value_ % divisor != 0) return nullptr;
-    return std::make_shared<ConstInt>(const_expr->value_ / divisor, DataType::INDEX, span);
-  }
+  if (auto const_expr = As<ConstInt>(expr)) return const_expr->value_ % divisor == 0;
 
-  // Rebuilt through the promoting ``Make*`` helpers rather than ``MakeIndexMul``:
-  // a ``tile.load`` offset only has to be an *integer* scalar, so forcing INDEX
-  // on a node whose operands are INT32 would leave the declared dtype
-  // disagreeing with them and emit ill-typed arithmetic.
+  // One divisible factor makes the whole product divisible.
   if (auto mul = As<Mul>(expr)) {
-    // One divisible factor is enough, and dividing it leaves the other alone.
-    if (auto left = DivideIndexExactly(mul->left_, divisor, facts, budget, span)) {
-      return MakeMul(left, mul->right_, span);
-    }
-    if (auto right = DivideIndexExactly(mul->right_, divisor, facts, budget, span)) {
-      return MakeMul(mul->left_, right, span);
-    }
-    return nullptr;
+    return IsProvableMultipleOf(mul->left_, divisor, facts, budget) ||
+           IsProvableMultipleOf(mul->right_, divisor, facts, budget);
   }
 
   if (auto add = As<Add>(expr)) {
-    auto left = DivideIndexExactly(add->left_, divisor, facts, budget, span);
-    if (!left) return nullptr;
-    auto right = DivideIndexExactly(add->right_, divisor, facts, budget, span);
-    if (!right) return nullptr;
-    return MakeAdd(left, right, span);
+    return IsProvableMultipleOf(add->left_, divisor, facts, budget) &&
+           IsProvableMultipleOf(add->right_, divisor, facts, budget);
   }
 
   if (auto sub = As<Sub>(expr)) {
-    auto left = DivideIndexExactly(sub->left_, divisor, facts, budget, span);
-    if (!left) return nullptr;
-    auto right = DivideIndexExactly(sub->right_, divisor, facts, budget, span);
-    if (!right) return nullptr;
-    return MakeSub(left, right, span);
+    return IsProvableMultipleOf(sub->left_, divisor, facts, budget) &&
+           IsProvableMultipleOf(sub->right_, divisor, facts, budget);
   }
 
   // ``As<Var>`` deliberately excludes ``IterArg`` (see ir-kind-traits): an
   // IterArg's value changes every iteration, so neither its initial value nor
   // any binding recorded for it proves anything about the value this use sees.
   if (auto var = As<Var>(expr)) {
-    if (facts.is_multiple_of && facts.is_multiple_of(var, divisor)) {
-      // Proven a multiple, so the floor division is the exact quotient. There is
-      // no cheaper spelling: the loop's trip count is implicit in the ForStmt.
-      return MakeFloorDiv(var, std::make_shared<ConstInt>(divisor, DataType::INDEX, span), span);
-    }
+    if (facts.is_multiple_of && facts.is_multiple_of(var, divisor)) return true;
     if (facts.definition) {
       if (auto def = facts.definition(var)) {
-        return DivideIndexExactly(def, divisor, facts, budget, span);
+        return IsProvableMultipleOf(def, divisor, facts, budget);
       }
     }
   }
 
-  return nullptr;
+  return false;
 }
 
 /// Map logical offsets ``[..., r0, c0off]`` into the blocked NZ coordinate
 /// system ``[..., c0off/c0, r0/16, 0, 0]`` produced by ``BlockNzShape``.
 ///
-/// A slice must start on a fractal boundary. A constant offset is checked
-/// directly; a symbolic one is accepted only when ``DivideIndexExactly`` can
-/// *prove* it a multiple of the axis factor and build the quotient. Anything
-/// else is rejected rather than silently truncated.
+/// A slice must start on a fractal boundary. A constant offset is folded
+/// directly; a symbolic one is accepted only when ``IsProvableMultipleOf``
+/// proves it a multiple of the axis factor, and is then divided as a whole
+/// rather than re-associated. Anything else is rejected rather than silently
+/// truncated.
 inline std::vector<ExprPtr> BlockNzOffsets(const std::vector<ExprPtr>& offsets, DataType dtype,
                                            const Span& span = Span::unknown(),
                                            const NzOffsetFacts& facts = {}) {
@@ -316,14 +308,16 @@ inline std::vector<ExprPtr> BlockNzOffsets(const std::vector<ExprPtr>& offsets, 
       return std::make_shared<ConstInt>(const_offset->value_ / divisor, DataType::INDEX, span);
     }
     int budget = kNzDivideStepBudget;
-    auto quotient = DivideIndexExactly(offset, divisor, facts, &budget, span);
-    CHECK_SPAN(quotient, span)
+    CHECK_SPAN(IsProvableMultipleOf(offset, divisor, facts, &budget), span)
         << "NZ layout requires the slice offset on shape[" << axis << "] to be a multiple of " << unit
         << ", and this one cannot be proven to be. Provable forms are a constant, a loop variable whose "
         << "start and step are both multiples of " << unit
         << ", and any sum, difference or constant multiple built from those. Slice on a " << unit
         << "-aligned boundary, or annotate the tensor as pl.ND.";
-    return quotient;
+    // Divide the offset's *result*, never its arithmetic: the expression keeps
+    // its own dtype and wraparound behaviour, and only the value it produces is
+    // divided. See ``IsProvableMultipleOf`` for why re-association is unsound.
+    return MakeFloorDiv(offset, std::make_shared<ConstInt>(divisor, DataType::INDEX, span), span);
   };
 
   // Evaluate the row axis first so its diagnostic wins when both are malformed.

--- a/include/pypto/ir/transforms/utils/tensor_view_semantics.h
+++ b/include/pypto/ir/transforms/utils/tensor_view_semantics.h
@@ -14,10 +14,12 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <sstream>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "pypto/core/dtype.h"
@@ -192,42 +194,149 @@ inline std::vector<ExprPtr> BlockNzShape(const std::vector<ExprPtr>& shape, Data
   return blocked;
 }
 
+/// How an index expression is bound, supplied by the pass that owns the
+/// enclosing function.
+///
+/// A slice offset reaches ``BlockNzOffsets`` as the SSA name it was bound to
+/// (``n0__ssa_v0``), never as the arithmetic that produced it, so without these
+/// facts the only provable offset is a literal constant. Both callbacks are
+/// optional: a default-constructed ``NzOffsetFacts`` proves nothing beyond
+/// constant folding.
+struct NzOffsetFacts {
+  /// The expression an SSA ``Var`` was assigned, or nullptr when unknown.
+  std::function<ExprPtr(const VarPtr&)> definition;
+  /// Whether a ``Var`` holds a multiple of ``divisor`` by construction — a loop
+  /// variable whose start and step are both multiples. Such a variable has no
+  /// exact structural quotient (nothing in the IR names its trip count), so the
+  /// property is the only thing that licenses dividing it.
+  std::function<bool(const VarPtr&, int64_t)> is_multiple_of;
+};
+
+/// Node-visit allowance for one ``DivideIndexExactly`` walk.
+///
+/// The walk follows SSA definitions, so a diamond-shaped def chain
+/// (``x = y + y``) can be re-entered exponentially. Bounding the visits keeps
+/// the rewrite O(1) per offset — and the pass O(N) — and exhausting the budget
+/// degrades to a refusal, never to a wrong answer.
+constexpr int kNzDivideStepBudget = 256;
+
+/// The exact quotient ``expr / divisor``, or nullptr when exactness cannot be
+/// proven.
+///
+/// "Exact" is the whole contract: the result must equal ``expr / divisor`` for
+/// *every* runtime value ``expr`` can take, so a caller may substitute it for a
+/// blocked coordinate with no range check. Each arm preserves that —
+/// ``(a*b)/d = (a/d)*b`` when ``d | a``, ``(a±b)/d = a/d ± b/d`` when ``d``
+/// divides both — and anything unrecognised refuses. Refusing is the point: an
+/// NZ tensor addressed from a guessed coordinate reads the wrong fractal with
+/// no diagnostic anywhere.
+inline ExprPtr DivideIndexExactly(const ExprPtr& expr, int64_t divisor, const NzOffsetFacts& facts,
+                                  int* budget, const Span& span) {
+  INTERNAL_CHECK(divisor > 0) << "Internal error: DivideIndexExactly needs a positive divisor, got "
+                              << divisor;
+  if (!expr || --*budget < 0) return nullptr;
+
+  if (auto const_expr = As<ConstInt>(expr)) {
+    if (const_expr->value_ % divisor != 0) return nullptr;
+    return std::make_shared<ConstInt>(const_expr->value_ / divisor, DataType::INDEX, span);
+  }
+
+  // Rebuilt through the promoting ``Make*`` helpers rather than ``MakeIndexMul``:
+  // a ``tile.load`` offset only has to be an *integer* scalar, so forcing INDEX
+  // on a node whose operands are INT32 would leave the declared dtype
+  // disagreeing with them and emit ill-typed arithmetic.
+  if (auto mul = As<Mul>(expr)) {
+    // One divisible factor is enough, and dividing it leaves the other alone.
+    if (auto left = DivideIndexExactly(mul->left_, divisor, facts, budget, span)) {
+      return MakeMul(left, mul->right_, span);
+    }
+    if (auto right = DivideIndexExactly(mul->right_, divisor, facts, budget, span)) {
+      return MakeMul(mul->left_, right, span);
+    }
+    return nullptr;
+  }
+
+  if (auto add = As<Add>(expr)) {
+    auto left = DivideIndexExactly(add->left_, divisor, facts, budget, span);
+    if (!left) return nullptr;
+    auto right = DivideIndexExactly(add->right_, divisor, facts, budget, span);
+    if (!right) return nullptr;
+    return MakeAdd(left, right, span);
+  }
+
+  if (auto sub = As<Sub>(expr)) {
+    auto left = DivideIndexExactly(sub->left_, divisor, facts, budget, span);
+    if (!left) return nullptr;
+    auto right = DivideIndexExactly(sub->right_, divisor, facts, budget, span);
+    if (!right) return nullptr;
+    return MakeSub(left, right, span);
+  }
+
+  // ``As<Var>`` deliberately excludes ``IterArg`` (see ir-kind-traits): an
+  // IterArg's value changes every iteration, so neither its initial value nor
+  // any binding recorded for it proves anything about the value this use sees.
+  if (auto var = As<Var>(expr)) {
+    if (facts.is_multiple_of && facts.is_multiple_of(var, divisor)) {
+      // Proven a multiple, so the floor division is the exact quotient. There is
+      // no cheaper spelling: the loop's trip count is implicit in the ForStmt.
+      return MakeFloorDiv(var, std::make_shared<ConstInt>(divisor, DataType::INDEX, span), span);
+    }
+    if (facts.definition) {
+      if (auto def = facts.definition(var)) {
+        return DivideIndexExactly(def, divisor, facts, budget, span);
+      }
+    }
+  }
+
+  return nullptr;
+}
+
 /// Map logical offsets ``[..., r0, c0off]`` into the blocked NZ coordinate
 /// system ``[..., c0off/c0, r0/16, 0, 0]`` produced by ``BlockNzShape``.
 ///
-/// A slice must start on a fractal boundary; an unaligned offset has no blocked
-/// representation and is rejected rather than silently truncated.
+/// A slice must start on a fractal boundary. A constant offset is checked
+/// directly; a symbolic one is accepted only when ``DivideIndexExactly`` can
+/// *prove* it a multiple of the axis factor and build the quotient. Anything
+/// else is rejected rather than silently truncated.
 inline std::vector<ExprPtr> BlockNzOffsets(const std::vector<ExprPtr>& offsets, DataType dtype,
-                                           const Span& span = Span::unknown()) {
+                                           const Span& span = Span::unknown(),
+                                           const NzOffsetFacts& facts = {}) {
   CHECK_SPAN(offsets.size() >= 2, span) << "NZ layout requires rank >= 2 offsets, got " << offsets.size();
   const int64_t c0 = NzC0Elems(dtype);
 
-  // Milestone 1 maps only *constant* trailing offsets. A symbolic offset would
-  // need a divisibility proof plus an algebraic rewrite (``nb*256`` -> ``nb*16``
-  // for the 16-row axis); that is not implemented, so even a provably aligned
-  // expression is refused rather than guessed at. This is the limit that keeps
-  // a loop-derived slice (``n0 = nb * N_TILE``) out of NZ for now.
-  auto row_off = As<ConstInt>(offsets[offsets.size() - 2]);
-  auto col_off = As<ConstInt>(offsets.back());
-  CHECK_SPAN(row_off, span) << "NZ layout does not support a dynamic offset on shape[-2] yet: only a "
-                            << "constant offset (a multiple of " << kNzFractalRow << ") can be mapped to "
-                            << "blocked coordinates. A loop-derived slice offset is not supported yet.";
-  CHECK_SPAN(col_off, span) << "NZ layout does not support a dynamic offset on shape[-1] yet: only a "
-                            << "constant offset (a multiple of c0 = " << c0 << ") can be mapped to "
-                            << "blocked coordinates. A loop-derived slice offset is not supported yet.";
-  CHECK_SPAN(row_off->value_ >= 0 && row_off->value_ % kNzFractalRow == 0, span)
-      << "NZ slice offset on shape[-2] must be a non-negative multiple of " << kNzFractalRow << ", got "
-      << row_off->value_ << ".";
-  CHECK_SPAN(col_off->value_ >= 0 && col_off->value_ % c0 == 0, span)
-      << "NZ slice offset on shape[-1] must be a non-negative multiple of c0 = " << c0 << ", got "
-      << col_off->value_ << ".";
+  // A constant keeps its own diagnostic: the offending value is in hand, so the
+  // message can name it. Only a symbolic offset needs the proof machinery, and
+  // its message has to describe the shapes that *are* provable instead.
+  auto block_axis = [&](const ExprPtr& offset, int64_t divisor, const char* axis,
+                        const std::string& unit) -> ExprPtr {
+    if (auto const_offset = As<ConstInt>(offset)) {
+      CHECK_SPAN(const_offset->value_ >= 0 && const_offset->value_ % divisor == 0, span)
+          << "NZ slice offset on shape[" << axis << "] must be a non-negative multiple of " << unit
+          << ", got " << const_offset->value_ << ".";
+      return std::make_shared<ConstInt>(const_offset->value_ / divisor, DataType::INDEX, span);
+    }
+    int budget = kNzDivideStepBudget;
+    auto quotient = DivideIndexExactly(offset, divisor, facts, &budget, span);
+    CHECK_SPAN(quotient, span)
+        << "NZ layout requires the slice offset on shape[" << axis << "] to be a multiple of " << unit
+        << ", and this one cannot be proven to be. Provable forms are a constant, a loop variable whose "
+        << "start and step are both multiples of " << unit
+        << ", and any sum, difference or constant multiple built from those. Slice on a " << unit
+        << "-aligned boundary, or annotate the tensor as pl.ND.";
+    return quotient;
+  };
+
+  // Evaluate the row axis first so its diagnostic wins when both are malformed.
+  auto row_blocked =
+      block_axis(offsets[offsets.size() - 2], kNzFractalRow, "-2", std::to_string(kNzFractalRow));
+  auto col_blocked = block_axis(offsets.back(), c0, "-1", "c0 = " + std::to_string(c0));
 
   std::vector<ExprPtr> blocked;
   blocked.reserve(offsets.size() + 2);
   for (size_t i = 0; i + 2 < offsets.size(); ++i) blocked.push_back(offsets[i]);
   auto make_index = [&span](int64_t v) { return std::make_shared<ConstInt>(v, DataType::INDEX, span); };
-  blocked.push_back(make_index(col_off->value_ / c0));
-  blocked.push_back(make_index(row_off->value_ / kNzFractalRow));
+  blocked.push_back(std::move(col_blocked));
+  blocked.push_back(std::move(row_blocked));
   blocked.push_back(make_index(0));  // start of the fractal's rows
   blocked.push_back(make_index(0));  // start of the C0 line
   return blocked;

--- a/src/ir/transforms/block_nz_tensor_views_pass.cpp
+++ b/src/ir/transforms/block_nz_tensor_views_pass.cpp
@@ -53,13 +53,17 @@
  *     NZ source, so the logical window is still intact when this pass runs.
  *
  * Milestone 1 scope: read-only, matmul operands only (``target_memory=Mat``),
- * whole-byte dtypes, static shapes, fractal-aligned shapes and slice offsets.
- * Everything outside that is rejected with a diagnostic naming the authoring
- * fix — an NZ tensor must never be silently mis-addressed.
+ * whole-byte dtypes, static shapes, fractal-aligned shapes and slice offsets. A
+ * slice offset may be symbolic when its alignment is *provable* — see
+ * ``NzOffsetFactStore`` below and ``DivideIndexExactly`` in
+ * ``tensor_view_semantics.h``. Everything outside that is rejected with a
+ * diagnostic naming the authoring fix — an NZ tensor must never be silently
+ * mis-addressed.
  */
 
 #include <any>
 #include <cstddef>
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <optional>
@@ -77,9 +81,11 @@
 #include "pypto/ir/memory_space.h"
 #include "pypto/ir/op_registry.h"
 #include "pypto/ir/program.h"
+#include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/span.h"
 #include "pypto/ir/stmt.h"
 #include "pypto/ir/transforms/base/mutator.h"
+#include "pypto/ir/transforms/base/visitor.h"
 #include "pypto/ir/transforms/pass_properties.h"
 #include "pypto/ir/transforms/passes.h"
 #include "pypto/ir/transforms/utils/mutable_copy.h"
@@ -160,17 +166,92 @@ TypePtr BlockNzType(const TypePtr& type, const Span& span) {
   return type;
 }
 
-/// Rewrite the elements of a ``MakeTuple`` argument through ``fn``.
-ExprPtr BlockTupleArg(const ExprPtr& arg, DataType dtype, const Span& span, bool is_offsets) {
+/// Index bindings a symbolic slice offset has to be proven against.
+///
+/// A slice offset arrives at the ``tile.load`` as the SSA name it was bound to,
+/// so the arithmetic that makes it fractal-aligned lives elsewhere in the
+/// function — in the ``AssignStmt`` that defined it (``n0 = nb * 256``) or in
+/// the ``ForStmt`` that bounds it (``for k0 in pl.pipeline(512, 4096, 512)``).
+/// This collects both in one read-only walk, so the rewrite itself stays a
+/// constant-time lookup and the pass stays O(N).
+///
+/// Collected from the *pre-mutation* body: the mutator only substitutes NZ
+/// tensor Vars, so an index Var is the same node before and after.
+class NzOffsetFactStore {
+ public:
+  explicit NzOffsetFactStore(const StmtPtr& body) {
+    if (!body) return;
+    Collector collector(this);
+    collector.VisitStmt(body);
+  }
+
+  /// A view of this store. The callbacks capture ``this``, so the store must
+  /// outlive every use of the returned facts.
+  [[nodiscard]] tensor_view_semantics::NzOffsetFacts Facts() const {
+    tensor_view_semantics::NzOffsetFacts facts;
+    facts.definition = [this](const VarPtr& var) -> ExprPtr {
+      auto it = definitions_.find(var);
+      return it == definitions_.end() ? nullptr : it->second;
+    };
+    facts.is_multiple_of = [this](const VarPtr& var, int64_t divisor) {
+      auto it = loop_bindings_.find(var);
+      if (it == loop_bindings_.end()) return false;
+      // Every value the loop variable takes is ``start + i * step``, so it is a
+      // multiple of ``divisor`` exactly when both endpoints of that form are.
+      const auto& [start, step] = it->second;
+      return start % divisor == 0 && step % divisor == 0;
+    };
+    return facts;
+  }
+
+ private:
+  class Collector : public IRVisitor {
+   public:
+    explicit Collector(NzOffsetFactStore* store) : store_(store) {}
+
+   protected:
+    void VisitStmt_(const AssignStmtPtr& op) override {
+      // Scalars only: a tensor / tile definition can never be part of an index
+      // expression, and keeping them out bounds the map to the index IR.
+      if (op->var_ && As<ScalarType>(op->var_->GetType())) {
+        store_->definitions_.emplace(op->var_, op->value_);
+      }
+      IRVisitor::VisitStmt_(op);
+    }
+
+    void VisitStmt_(const ForStmtPtr& op) override {
+      auto start = As<ConstInt>(op->start_);
+      auto step = As<ConstInt>(op->step_);
+      if (op->loop_var_ && start && step) {
+        store_->loop_bindings_.emplace(op->loop_var_, std::make_pair(start->value_, step->value_));
+      }
+      IRVisitor::VisitStmt_(op);
+    }
+
+   private:
+    NzOffsetFactStore* store_;
+  };
+
+  std::unordered_map<VarPtr, ExprPtr> definitions_;
+  std::unordered_map<VarPtr, std::pair<int64_t, int64_t>> loop_bindings_;
+};
+
+/// Rewrite the elements of a ``MakeTuple`` coordinate argument into blocked NZ
+/// form. ``facts`` is read only on the offsets path — a shape is a static
+/// extent, never a symbolic expression.
+ExprPtr BlockTupleArg(const ExprPtr& arg, DataType dtype, const Span& span, bool is_offsets,
+                      const tensor_view_semantics::NzOffsetFacts& facts) {
   auto tuple = As<MakeTuple>(arg);
   INTERNAL_CHECK_SPAN(tuple, span) << "Internal error: tile.load coordinate argument must be a MakeTuple";
-  auto blocked = is_offsets ? tensor_view_semantics::BlockNzOffsets(tuple->elements_, dtype, span)
+  auto blocked = is_offsets ? tensor_view_semantics::BlockNzOffsets(tuple->elements_, dtype, span, facts)
                             : tensor_view_semantics::BlockNzShape(tuple->elements_, dtype, span);
   return std::make_shared<MakeTuple>(std::move(blocked), tuple->span_);
 }
 
 class BlockNzMutator : public IRMutator {
  public:
+  explicit BlockNzMutator(tensor_view_semantics::NzOffsetFacts facts) : facts_(std::move(facts)) {}
+
   void AddSubstitution(const VarPtr& old_var, const VarPtr& new_var) { var_cache_[old_var] = new_var; }
 
  protected:
@@ -285,14 +366,15 @@ class BlockNzMutator : public IRMutator {
         << (target.has_value() ? MemorySpaceToString(*target) : std::string("no target_memory"))
         << ". An NZ tensor is a cube weight: load it into Mat, or annotate the tensor as pl.ND.";
 
-    args[1] = BlockTupleArg(args[1], dtype, op->span_, /*is_offsets=*/true);
-    args[2] = BlockTupleArg(args[2], dtype, op->span_, /*is_offsets=*/false);
+    args[1] = BlockTupleArg(args[1], dtype, op->span_, /*is_offsets=*/true, facts_);
+    args[2] = BlockTupleArg(args[2], dtype, op->span_, /*is_offsets=*/false, facts_);
     if (args.size() >= 4) {
-      args[3] = BlockTupleArg(args[3], dtype, op->span_, /*is_offsets=*/false);
+      args[3] = BlockTupleArg(args[3], dtype, op->span_, /*is_offsets=*/false, facts_);
     }
     return args;
   }
 
+  tensor_view_semantics::NzOffsetFacts facts_;
   std::unordered_map<VarPtr, VarPtr> var_cache_;
 };
 
@@ -326,7 +408,9 @@ FunctionPtr TransformFunction(const FunctionPtr& func) {
     new_return_types.push_back(std::move(new_rt));
   }
 
-  BlockNzMutator mutator;
+  // The store owns the maps the facts read, so it must outlive the mutator.
+  NzOffsetFactStore fact_store(func->body_);
+  BlockNzMutator mutator(fact_store.Facts());
   for (const auto& [old_var, new_var] : param_substitutions) {
     mutator.AddSubstitution(old_var, new_var);
   }

--- a/src/ir/transforms/block_nz_tensor_views_pass.cpp
+++ b/src/ir/transforms/block_nz_tensor_views_pass.cpp
@@ -69,6 +69,7 @@
 #include <optional>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -201,6 +202,16 @@ class NzOffsetFactStore {
       const auto& [start, step] = it->second;
       return start % divisor == 0 && step % divisor == 0;
     };
+    facts.is_non_negative = [this](const VarPtr& var) {
+      // The SPMD block index is a lane number, so it is never negative.
+      if (non_negative_vars_.count(var) != 0) return true;
+      auto it = loop_bindings_.find(var);
+      if (it == loop_bindings_.end()) return false;
+      // ``start + i * step`` only stays at or above ``start`` while the step
+      // does not walk downwards, so both have to be non-negative.
+      const auto& [start, step] = it->second;
+      return start >= 0 && step >= 0;
+    };
     return facts;
   }
 
@@ -215,6 +226,14 @@ class NzOffsetFactStore {
       // expression, and keeping them out bounds the map to the index IR.
       if (op->var_ && As<ScalarType>(op->var_->GetType())) {
         store_->definitions_.emplace(op->var_, op->value_);
+        // A block index or block count is a lane number, so it is non-negative
+        // by construction. That is an operator fact rather than a structural
+        // one, which is why it is recorded here rather than derived by the
+        // geometry helpers.
+        auto call = As<Call>(op->value_);
+        if (call && (IsOp(call, "tile.get_block_idx") || IsOp(call, "tile.get_block_num"))) {
+          store_->non_negative_vars_.insert(op->var_);
+        }
       }
       IRVisitor::VisitStmt_(op);
     }
@@ -234,6 +253,7 @@ class NzOffsetFactStore {
 
   std::unordered_map<VarPtr, ExprPtr> definitions_;
   std::unordered_map<VarPtr, std::pair<int64_t, int64_t>> loop_bindings_;
+  std::unordered_set<VarPtr> non_negative_vars_;
 };
 
 /// Rewrite the elements of a ``MakeTuple`` coordinate argument into blocked NZ

--- a/tests/ut/ir/transforms/test_block_nz_tensor_views.py
+++ b/tests/ut/ir/transforms/test_block_nz_tensor_views.py
@@ -24,6 +24,8 @@ Every shape below is written as a literal: a closure variable indexed inside a
 a constant, which breaks the printer round-trip check.
 """
 
+from collections.abc import Sequence
+
 import pypto.language as pl
 import pytest
 from pypto import ir
@@ -71,7 +73,10 @@ def _emit_pto(program: ir.Program, backend_type=BackendType.Ascend910B) -> str:
         optimized = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(program)
     parts: list[str] = []
     for func in optimized.functions.values():
-        if func.func_type in (pl.FunctionType.Orchestration, pl.FunctionType.Group):
+        # The PTO backend only accepts InCore-variant functions; name them
+        # positively so an SPMD wrapper is skipped as readily as an
+        # Orchestration or Group one.
+        if func.func_type not in (pl.FunctionType.InCore, pl.FunctionType.AIC, pl.FunctionType.AIV):
             continue
         single = ir.Program([func], func.name, optimized.span)
         result = codegen.PTOCodegen().generate(single, emit_tile_addr=True)
@@ -79,8 +84,20 @@ def _emit_pto(program: ir.Program, backend_type=BackendType.Ascend910B) -> str:
     return "\n".join(parts)
 
 
-def _values(exprs) -> list[int]:
-    return [e.value for e in exprs]
+def _const(expr: ir.Expr) -> int:
+    """The value of a `ConstInt`, asserting the expression is one."""
+    assert isinstance(expr, ir.ConstInt), f"expected a ConstInt, got {type(expr).__name__}"
+    return expr.value
+
+
+def _values(exprs: Sequence[ir.Expr]) -> list[int]:
+    return [_const(e) for e in exprs]
+
+
+def _elements(expr: ir.Expr) -> Sequence[ir.Expr]:
+    """The elements of a `MakeTuple` coordinate argument."""
+    assert isinstance(expr, ir.MakeTuple), f"expected a MakeTuple, got {type(expr).__name__}"
+    return expr.elements
 
 
 def _nz_param(program: ir.Program) -> ir.TensorType:
@@ -97,18 +114,22 @@ def _nz_param(program: ir.Program) -> ir.TensorType:
 
 
 def _walk(stmt):
-    """Yield every statement in a body, descending into SeqStmts."""
+    """Yield every statement in a body, descending into SeqStmts and loop bodies."""
     if stmt is None:
         return
     if isinstance(stmt, ir.SeqStmts):
         for inner in stmt.stmts:
             yield from _walk(inner)
         return
+    if isinstance(stmt, ir.ForStmt):
+        yield stmt
+        yield from _walk(stmt.body)
+        return
     yield stmt
 
 
-def _nz_load(program: ir.Program):
-    """The single tile.load whose source tensor carries the NZ layout."""
+def _nz_loads(program: ir.Program) -> list[ir.Call]:
+    """Every tile.load whose source tensor carries the NZ layout, in body order."""
     load_name = ir.get_op("tile.load").name
     found = []
     for func in program.functions.values():
@@ -121,6 +142,12 @@ def _nz_load(program: ir.Program):
             view = getattr(call.args[0].type, "tensor_view", None)
             if view is not None and view.layout == ir.TensorLayout.NZ:
                 found.append(call)
+    return found
+
+
+def _nz_load(program: ir.Program) -> ir.Call:
+    """The single tile.load whose source tensor carries the NZ layout."""
+    found = _nz_loads(program)
     assert len(found) == 1, f"expected exactly one NZ tile.load, got {len(found)}"
     return found[0]
 
@@ -225,10 +252,12 @@ def test_nd_tensor_is_untouched():
 def test_tile_load_coordinates_are_blocked_and_tile_stays_2d():
     """The GM window becomes rank-4; the destination tile stays [256, 512]."""
     call = _nz_load(_run(NzMatmul))
-    assert _values(call.args[1].elements) == [0, 0, 0, 0]  # offsets
-    assert _values(call.args[2].elements) == [16, 16, 16, 32]  # shapes
+    assert _values(_elements(call.args[1])) == [0, 0, 0, 0]  # offsets
+    assert _values(_elements(call.args[2])) == [16, 16, 16, 32]  # shapes
     # The tile the load produces is the logical 2-D operand, not the GM window.
-    assert _values(call.type.shape) == [256, 512]
+    tile_type = call.type
+    assert isinstance(tile_type, ir.TileType)
+    assert _values(tile_type.shape) == [256, 512]
 
 
 def test_slice_offsets_are_mapped_to_fractal_coordinates():
@@ -251,8 +280,80 @@ def test_slice_offsets_are_mapped_to_fractal_coordinates():
 
     call = _nz_load(_run(Sliced))
     # n0 = 256 -> 256/16 = 16 ; k0 = 512 -> 512/32 = 16
-    assert _values(call.args[1].elements) == [16, 16, 0, 0]
-    assert _values(call.args[2].elements) == [16, 16, 16, 32]
+    assert _values(_elements(call.args[1])) == [16, 16, 0, 0]
+    assert _values(_elements(call.args[2])) == [16, 16, 16, 32]
+
+
+def test_maps_an_spmd_derived_slice_offset():
+    """`n0 = nb * 256` becomes `nb * 16` on the 16-row axis.
+
+    The offset reaches the pass as the SSA name `n0`, not as the `Mul`, so this
+    also pins that the rewrite follows the definition chain. The quotient is a
+    folded multiply, not a division: `(nb * 256) / 16` is exactly `nb * 16`.
+    """
+
+    @pl.jit
+    def _spmd_offset(
+        x: pl.Tensor[[64, 512], pl.INT8],
+        w: pl.Tensor[[512, 512], pl.INT8, pl.NZ],
+        out: pl.Out[pl.Tensor[[64, 512], pl.INT32]],
+    ):
+        for nb in pl.spmd(2, name_hint="nz_spmd"):
+            n0 = nb * 256
+            xt = pl.slice(x, [64, 512], [0, 0])
+            wt = w[n0 : n0 + 256, 0:512]
+            acc = pl.matmul(xt, wt, b_trans=True, out_dtype=pl.INT32)
+            out[0:64, n0 : n0 + 256] = pl.reshape(acc, [64, 256])
+        return out
+
+    _, _, tm, sv, sd, dyn = _spmd_offset._bind_args_from_signature({})
+    call = _nz_load(_run(_spmd_offset._compile_to_program(tm, sv, sd, dyn, pl)))
+    col_off, row_off, in_fractal_row, in_c0_line = _elements(call.args[1])
+    assert _const(col_off) == 0
+    assert isinstance(row_off, ir.Mul)
+    assert isinstance(row_off.left, ir.Var) and row_off.left.name_hint.startswith("nb")
+    assert _const(row_off.right) == 256 // 16
+    assert (_const(in_fractal_row), _const(in_c0_line)) == (0, 0)
+
+
+def test_maps_a_loop_variable_slice_offset():
+    """A `pl.pipeline` index divides by c0 once start and step are both multiples.
+
+    `k0` steps 512 from 512, and both are multiples of c0 = 32, so every value it
+    takes is one. Nothing in the IR names the trip count, so unlike the `nb * 256`
+    case there is no folded quotient to build — the exact `k0 // 32` is the
+    answer, and it is exact precisely because the divisibility was proven first.
+    """
+
+    @pl.jit
+    def _loop_offset(
+        x: pl.Tensor[[64, 1024], pl.INT8],
+        w: pl.Tensor[[256, 1024], pl.INT8, pl.NZ],
+        out: pl.Out[pl.Tensor[[64, 256], pl.INT32]],
+    ):
+        for _ in pl.spmd(1, name_hint="nz_loop"):
+            xt = pl.slice(x, [64, 512], [0, 0])
+            acc = pl.matmul(xt, w[0:256, 0:512], b_trans=True, out_dtype=pl.INT32)
+            for k0 in pl.pipeline(512, 1024, 512, stage=2):
+                x_k = pl.slice(x, [64, 512], [0, k0])
+                acc = pl.matmul_acc(acc, x_k, w[0:256, k0 : k0 + 512], b_trans=True)
+            out[0:64, 0:256] = pl.reshape(acc, [64, 256])
+        return out
+
+    _, _, tm, sv, sd, dyn = _loop_offset._bind_args_from_signature({})
+    after = _run(_loop_offset._compile_to_program(tm, sv, sd, dyn, pl))
+
+    # Two NZ loads share the weight: the k0 = 0 prologue and the loop body.
+    offsets = [_elements(call.args[1]) for call in _nz_loads(after)]
+    assert len(offsets) == 2, f"expected two NZ loads, got {len(offsets)}"
+
+    prologue, in_loop = offsets
+    assert _values(prologue) == [0, 0, 0, 0]
+    col_off = in_loop[0]
+    assert isinstance(col_off, ir.FloorDiv)
+    assert isinstance(col_off.left, ir.Var) and col_off.left.name_hint.startswith("k0")
+    assert _const(col_off.right) == 32  # c0 for INT8
+    assert _values(in_loop[1:]) == [0, 0, 0]
 
 
 # ============================================================================
@@ -312,6 +413,55 @@ def test_codegen_rank_is_consistent_across_all_three_sites():
     assert "offsets = [%c0_index, %c0_index, %c0_index, %c0_index]" in pview_line
     assert "sizes = [%c16_index, %c16_index, %c16_index, %c32_index]" in pview_line
     assert "!pto.partition_tensor_view<16x16x16x32xi8>" in pview_line
+
+
+def test_codegen_emits_the_divided_offset_as_one_multiply():
+    """The blocked coordinate reaches `partition_view` as `nb * 16`, not `nb * 256`.
+
+    This is the end-to-end statement of the rewrite: the descriptor is the
+    blocked rank-4 NZ one, and the row-fractal offset is the *divided* index —
+    a single `arith.muli`, with no division left to undo it at runtime.
+    """
+
+    @pl.jit
+    def _spmd_offset(
+        x: pl.Tensor[[64, 512], pl.INT8],
+        w: pl.Tensor[[512, 512], pl.INT8, pl.NZ],
+        out: pl.Out[pl.Tensor[[64, 512], pl.INT32]],
+    ):
+        for nb in pl.spmd(2, name_hint="nz_spmd_cg"):
+            n0 = nb * 256
+            xt = pl.slice(x, [64, 512], [0, 0])
+            wt = w[n0 : n0 + 256, 0:512]
+            acc = pl.matmul(xt, wt, b_trans=True, out_dtype=pl.INT32)
+            out[0:64, n0 : n0 + 256] = pl.reshape(acc, [64, 256])
+        return out
+
+    _, _, tm, sv, sd, dyn = _spmd_offset._bind_args_from_signature({})
+    text = _emit_pto(_spmd_offset._compile_to_program(tm, sv, sd, dyn, pl))
+    lines = text.splitlines()
+
+    nz_view_line = next(line for line in lines if "make_tensor_view" in line and "layout<nz>" in line)
+    assert "%c16_index, %c32_index, %c16_index, %c32_index" in nz_view_line  # [C/c0, R/16, 16, c0]
+
+    ssa = nz_view_line.strip().split(" ")[0]
+    pview_line = next(line for line in lines if "partition_view" in line and f"{ssa}," in line)
+    assert "sizes = [%c16_index, %c16_index, %c16_index, %c32_index]" in pview_line
+    # offsets = [c0-block, row-fractal, 0, 0] — only the row fractal is symbolic.
+    offsets = pview_line.split("offsets = [", 1)[1].split("]", 1)[0].split(", ")
+    assert [offsets[0], offsets[2], offsets[3]] == ["%c0_index"] * 3, pview_line
+
+    # `n0 = nb * 256` still exists — the ND store on `out` uses it — so the claim
+    # is not that it vanished, but that the NZ coordinate is a *different*,
+    # divided value: offsets[1] traces back through the negative clamp to `* 16`.
+    def defining_line(operand: str) -> str:
+        return next(line for line in lines if line.strip().startswith(f"{operand} = "))
+
+    clamp = defining_line(offsets[1])
+    assert "arith.maxsi" in clamp, clamp
+    multiply = defining_line(clamp.split("arith.maxsi ", 1)[1].split(",", 1)[0])
+    assert "arith.muli" in multiply and "%c16_index" in multiply, multiply
+    assert "%nb" in multiply, multiply
 
 
 def test_codegen_tile_keeps_logical_2d_nz_layout():
@@ -396,33 +546,60 @@ def test_rejects_unaligned_slice_offset():
         _run(BadOffset)
 
 
-def test_rejects_dynamic_slice_offset():
-    """A loop-derived slice offset is not mapped, even when provably aligned.
+def test_rejects_a_slice_offset_whose_alignment_cannot_be_proven():
+    """A symbolic offset that is not a provable multiple is refused, not guessed.
 
-    Milestone 1 maps only `ConstInt` trailing offsets: turning `nb * 256` into
-    `nb * 16` for the 16-row axis needs a divisibility proof plus an algebraic
-    rewrite, which is not implemented. This pins the refusal, and with it the
-    gap between this milestone and the grouped-matmul weight path that motivated
-    it — `n0 = nb * N_TILE` is exactly the shape that does not compile yet.
+    `nb * 8` is a multiple of 8, never of the 16-row fractal, so no exact
+    quotient exists. The pass must say so rather than divide anyway — an NZ
+    tensor addressed from a guessed coordinate reads the wrong fractal with no
+    diagnostic anywhere downstream.
     """
 
     @pl.jit
-    def _sym(
+    def _unprovable(
         x: pl.Tensor[[64, 512], pl.INT8],
         w: pl.Tensor[[512, 512], pl.INT8, pl.NZ],
         out: pl.Out[pl.Tensor[[64, 512], pl.INT32]],
     ):
-        for nb in pl.spmd(2, name_hint="nz_sym"):
-            n0 = nb * 256  # a multiple of 16, but not a constant
+        for nb in pl.spmd(2, name_hint="nz_unprovable"):
+            n0 = nb * 8  # not a multiple of the 16-row fractal
             xt = pl.slice(x, [64, 512], [0, 0])
             wt = w[n0 : n0 + 256, 0:512]
             acc = pl.matmul(xt, wt, b_trans=True, out_dtype=pl.INT32)
-            out[0:64, n0 : n0 + 256] = pl.reshape(acc, [64, 256])
+            out[0:64, 0:256] = pl.reshape(acc, [64, 256])
         return out
 
-    _, _, tm, sv, sd, dyn = _sym._bind_args_from_signature({})
-    program = _sym._compile_to_program(tm, sv, sd, dyn, pl)
-    with pytest.raises(ValueError, match="does not support a dynamic offset on shape.-2."):
+    _, _, tm, sv, sd, dyn = _unprovable._bind_args_from_signature({})
+    program = _unprovable._compile_to_program(tm, sv, sd, dyn, pl)
+    with pytest.raises(ValueError, match=r"offset on shape\[-2\] to be a multiple of 16"):
+        _run(program)
+
+
+def test_rejects_a_loop_variable_whose_step_breaks_alignment():
+    """A loop variable is only divisible when *both* its start and step are.
+
+    Start 0 is a multiple of c0 = 32 while step 16 is not, so the offset is
+    aligned on the first iteration and misaligned on the second. Proving from
+    the start alone would silently mis-address every later iteration.
+    """
+
+    @pl.jit
+    def _bad_step(
+        x: pl.Tensor[[64, 512], pl.INT8],
+        w: pl.Tensor[[256, 512], pl.INT8, pl.NZ],
+        out: pl.Out[pl.Tensor[[64, 256], pl.INT32]],
+    ):
+        for _ in pl.spmd(1, name_hint="nz_bad_step"):
+            for k0 in pl.pipeline(0, 32, 16, stage=2):
+                xt = pl.slice(x, [64, 16], [0, k0])
+                wt = w[0:256, k0 : k0 + 16]
+                acc = pl.matmul(xt, wt, b_trans=True, out_dtype=pl.INT32)
+                out[0:64, 0:256] = pl.reshape(acc, [64, 256])
+        return out
+
+    _, _, tm, sv, sd, dyn = _bad_step._bind_args_from_signature({})
+    program = _bad_step._compile_to_program(tm, sv, sd, dyn, pl)
+    with pytest.raises(ValueError, match=r"offset on shape\[-1\] to be a multiple of c0 = 32"):
         _run(program)
 
 

--- a/tests/ut/ir/transforms/test_block_nz_tensor_views.py
+++ b/tests/ut/ir/transforms/test_block_nz_tensor_views.py
@@ -634,6 +634,37 @@ def test_rejects_a_slice_offset_whose_alignment_cannot_be_proven():
         _run(program)
 
 
+def test_rejects_a_slice_offset_whose_sign_cannot_be_proven():
+    """Divisibility is not enough — the offset must also be provably non-negative.
+
+    `nb * 256 - 256` is a clean multiple of 16 and is negative on the first
+    block. A negative offset is *clamped* to 0 at `pto.partition_view` rather
+    than rejected, so it would read fractal 0 and return silently wrong data —
+    the shape #2543 fixed for row indices. A literal `-16` is already refused by
+    the constant path, so accepting this one would mean the same value is caught
+    written inline and waved through once bound to a name.
+    """
+
+    @pl.jit
+    def _maybe_negative(
+        x: pl.Tensor[[64, 512], pl.INT8],
+        w: pl.Tensor[[512, 512], pl.INT8, pl.NZ],
+        out: pl.Out[pl.Tensor[[64, 256], pl.INT32]],
+    ):
+        for nb in pl.spmd(2, name_hint="nz_maybe_neg"):
+            n0 = nb * 256 - 256  # a multiple of 16, but negative when nb == 0
+            xt = pl.slice(x, [64, 512], [0, 0])
+            wt = w[n0 : n0 + 256, 0:512]
+            acc = pl.matmul(xt, wt, b_trans=True, out_dtype=pl.INT32)
+            out[0:64, 0:256] = pl.reshape(acc, [64, 256])
+        return out
+
+    _, _, tm, sv, sd, dyn = _maybe_negative._bind_args_from_signature({})
+    program = _maybe_negative._compile_to_program(tm, sv, sd, dyn, pl)
+    with pytest.raises(ValueError, match=r"offset on shape\[-2\] to be non-negative"):
+        _run(program)
+
+
 def test_rejects_a_loop_variable_whose_step_breaks_alignment():
     """A loop variable is only divisible when *both* its start and step are.
 

--- a/tests/ut/ir/transforms/test_block_nz_tensor_views.py
+++ b/tests/ut/ir/transforms/test_block_nz_tensor_views.py
@@ -285,11 +285,12 @@ def test_slice_offsets_are_mapped_to_fractal_coordinates():
 
 
 def test_maps_an_spmd_derived_slice_offset():
-    """`n0 = nb * 256` becomes `nb * 16` on the 16-row axis.
+    """`n0 = nb * 256` becomes `n0 // 16` on the 16-row axis.
 
-    The offset reaches the pass as the SSA name `n0`, not as the `Mul`, so this
-    also pins that the rewrite follows the definition chain. The quotient is a
-    folded multiply, not a division: `(nb * 256) / 16` is exactly `nb * 16`.
+    The offset reaches the pass as the SSA name `n0`, not as the `Mul`, so the
+    divisibility proof has to follow the definition chain to see the `* 256`.
+    What it emits is the whole offset divided, never the re-associated
+    `nb * 16` — see `test_does_not_reassociate_the_offset_arithmetic`.
     """
 
     @pl.jit
@@ -310,10 +311,65 @@ def test_maps_an_spmd_derived_slice_offset():
     call = _nz_load(_run(_spmd_offset._compile_to_program(tm, sv, sd, dyn, pl)))
     col_off, row_off, in_fractal_row, in_c0_line = _elements(call.args[1])
     assert _const(col_off) == 0
-    assert isinstance(row_off, ir.Mul)
-    assert isinstance(row_off.left, ir.Var) and row_off.left.name_hint.startswith("nb")
-    assert _const(row_off.right) == 256 // 16
+    assert isinstance(row_off, ir.FloorDiv)
+    assert isinstance(row_off.left, ir.Var) and row_off.left.name_hint.startswith("n0")
+    assert _const(row_off.right) == 16
     assert (_const(in_fractal_row), _const(in_c0_line)) == (0, 0)
+
+
+def test_does_not_reassociate_the_offset_arithmetic():
+    """The blocked coordinate divides the offset's *result*, never its arithmetic.
+
+    Rewriting `n0 = nb * 256` into `nb * 16` looks equivalent and is not: IR
+    arithmetic wraps at its declared width, and the re-associated form does not
+    wrap at the same point. With `nb: INT32 = 1 << 24`, `nb * 256` wraps to 0 in
+    i32, so the true coordinate is 0 while `nb * 16` is 268435456 — a read from
+    the wrong fractal with no diagnostic anywhere downstream. Matching the
+    original width does not rescue it either: for `a * b = q * 2^W + r` the
+    original yields `r / d` and any re-association yields
+    `r / d + q * 2^(W - log2 d)`.
+
+    So the emitted expression must still *contain* the original offset. This
+    pins that: the quotient's operand is the offset `Var` itself, and no
+    multiply by the reduced factor 256/16 was synthesized.
+    """
+
+    @pl.jit
+    def _no_reassoc(
+        x: pl.Tensor[[64, 512], pl.INT8],
+        w: pl.Tensor[[512, 512], pl.INT8, pl.NZ],
+        out: pl.Out[pl.Tensor[[64, 512], pl.INT32]],
+    ):
+        for nb in pl.spmd(2, name_hint="nz_no_reassoc"):
+            n0 = nb * 256
+            xt = pl.slice(x, [64, 512], [0, 0])
+            wt = w[n0 : n0 + 256, 0:512]
+            acc = pl.matmul(xt, wt, b_trans=True, out_dtype=pl.INT32)
+            out[0:64, n0 : n0 + 256] = pl.reshape(acc, [64, 256])
+        return out
+
+    _, _, tm, sv, sd, dyn = _no_reassoc._bind_args_from_signature({})
+    after = _run(_no_reassoc._compile_to_program(tm, sv, sd, dyn, pl))
+    row_off = _elements(_nz_load(after).args[1])[1]
+
+    # A division of the offset itself, not a product of the block index.
+    assert isinstance(row_off, ir.FloorDiv), f"offset was re-associated into {type(row_off).__name__}"
+    assert isinstance(row_off.left, ir.Var)
+
+    # `n0` keeps its own definition; nothing multiplied the block index by 16.
+    definitions = {
+        stmt.var.name_hint: stmt.value
+        for func in after.functions.values()
+        for stmt in _walk(func.body)
+        if isinstance(stmt, ir.AssignStmt)
+    }
+    n0_def = definitions[row_off.left.name_hint]
+    assert isinstance(n0_def, ir.Mul) and _const(n0_def.right) == 256
+    assert not [
+        value
+        for value in definitions.values()
+        if isinstance(value, ir.Mul) and isinstance(value.right, ir.ConstInt) and value.right.value == 16
+    ], "a reduced-factor multiply was synthesized"
 
 
 def test_maps_a_loop_variable_slice_offset():
@@ -415,12 +471,12 @@ def test_codegen_rank_is_consistent_across_all_three_sites():
     assert "!pto.partition_tensor_view<16x16x16x32xi8>" in pview_line
 
 
-def test_codegen_emits_the_divided_offset_as_one_multiply():
-    """The blocked coordinate reaches `partition_view` as `nb * 16`, not `nb * 256`.
+def test_codegen_emits_the_divided_offset():
+    """The blocked coordinate reaches `partition_view` as the divided offset.
 
     This is the end-to-end statement of the rewrite: the descriptor is the
-    blocked rank-4 NZ one, and the row-fractal offset is the *divided* index —
-    a single `arith.muli`, with no division left to undo it at runtime.
+    blocked rank-4 NZ one, and the row-fractal coordinate is `n0 / 16` — the
+    offset the kernel computed, divided, rather than a re-derived index.
     """
 
     @pl.jit
@@ -451,17 +507,20 @@ def test_codegen_emits_the_divided_offset_as_one_multiply():
     offsets = pview_line.split("offsets = [", 1)[1].split("]", 1)[0].split(", ")
     assert [offsets[0], offsets[2], offsets[3]] == ["%c0_index"] * 3, pview_line
 
-    # `n0 = nb * 256` still exists — the ND store on `out` uses it — so the claim
-    # is not that it vanished, but that the NZ coordinate is a *different*,
-    # divided value: offsets[1] traces back through the negative clamp to `* 16`.
+    # The NZ coordinate is the kernel's own offset divided: offsets[1] traces
+    # back through the negative clamp to a division by 16, whose dividend is the
+    # `n0 = nb * 256` the ND store on `out` also uses.
     def defining_line(operand: str) -> str:
         return next(line for line in lines if line.strip().startswith(f"{operand} = "))
 
     clamp = defining_line(offsets[1])
     assert "arith.maxsi" in clamp, clamp
-    multiply = defining_line(clamp.split("arith.maxsi ", 1)[1].split(",", 1)[0])
-    assert "arith.muli" in multiply and "%c16_index" in multiply, multiply
-    assert "%nb" in multiply, multiply
+    divide = defining_line(clamp.split("arith.maxsi ", 1)[1].split(",", 1)[0])
+    assert "arith.divsi" in divide and "%c16_index" in divide, divide
+
+    dividend = divide.split("arith.divsi ", 1)[1].split(",", 1)[0]
+    offset_def = defining_line(dividend)
+    assert "arith.muli" in offset_def and "%c256_index" in offset_def, offset_def
 
 
 def test_codegen_tile_keeps_logical_2d_nz_layout():


### PR DESCRIPTION
## Summary

`BlockNzTensorViews` now maps a **symbolic** trailing slice offset into blocked NZ
coordinates, so an NZ weight can be sliced by a loop-derived index. It previously
required `ConstInt` on both trailing offsets, which meant the grouped-matmul weight
path that motivated GM-side NZ (#2533) could not compile at all — the feature could
not express the kernel it was built for. A user writing the slice below now gets a
compiling kernel instead of a diagnostic; a slice whose alignment cannot be proven
is still refused, with a message naming the forms that are provable.

Closes #2548.

## What a symbolic offset actually looks like

#2548 describes the offset as `Mul(nb, 256)`. It never arrives that way: a slice
offset reaches the pass as the SSA name it was bound to, and the motivating kernel
carries two *different* symbolic shapes, one per axis:

```text
nb__ssa_v0: pl.Scalar[pl.INDEX] = pl.tile.get_block_idx()
n0__ssa_v0: pl.Scalar[pl.INDEX] = nb__ssa_v0 * 256
for k0__idx_v0, (...) in pl.pipeline(512, 4096, 512, stage=2):
    w1_k__tile = pl.tile.load(w1__ssa_v0, [0, n0__ssa_v0, k0__idx_v0], ...)
                                             ^^^^^^^^^^  ^^^^^^^^^^
```

| Offset | Form | Aligned because | Non-negative because |
| --- | --- | --- | --- |
| `n0__ssa_v0` (row axis, `/16`) | `Var` defined by `AssignStmt: nb * 256` | the SSA definition chain reaches the `* 256` | `nb` is bound to `tile.get_block_idx` |
| `k0__idx_v0` (C0 axis, `/c0`) | `ForStmt` loop variable | `start` and `step` are both multiples | `start` and `step` are both non-negative |

Handling only the first — what the issue describes — leaves the kernel rejected on
the other axis, so both are implemented.

## Changes

- `include/pypto/ir/transforms/utils/tensor_view_semantics.h`: two proofs, both
  required before an offset is divided, and neither of which constructs a
  quotient.
  - `IsProvableMultipleOf` — `ConstInt`; `Mul` (one factor divides); `Add` /
    `Sub` (both sides divide); `Var` (a known multiple, otherwise recurse into
    its SSA definition).
  - `IsProvableNonNegative` — `ConstInt` `>= 0`; `Mul` / `Add` (both operands);
    `Var` (non-negative by binding, otherwise recurse). `Sub` is deliberately
    absent: `a - b` proves its divisibility and never its sign.

  `BlockNzOffsets` then emits `FloorDiv(offset, divisor)` — see "Why the offset
  is divided, not re-associated". `NzOffsetFacts` carries the bindings the walks
  need, and a default-constructed one reproduces the previous constant-only
  behaviour, so no other caller changes.
- `src/ir/transforms/block_nz_tensor_views_pass.cpp`: new `NzOffsetFactStore`
  collects a function's `AssignStmt` definitions and constant-bounded loop
  variables in one read-only walk, so the rewrite stays a constant-time lookup and
  the pass stays O(N). The walk carries a fixed node-visit budget: following SSA
  definitions through a diamond (`x = y + y`) could otherwise re-enter
  exponentially.
- `docs/{en,zh}/dev/passes/14-block_nz_tensor_views.md`: the scope table's
  blanket "dynamic trailing offset -> rejected" row is replaced by the provable /
  not-provable split, plus a section stating the two limits below.
- `tests/ut/ir/transforms/test_block_nz_tensor_views.py`: see Tests.

Exactness is the contract: the quotient must equal `expr / divisor` for *every*
runtime value the offset can take, so it can stand in for a blocked coordinate with
no range check. Anything unproven is rejected — a guessed coordinate reads the wrong
fractal, and nothing downstream would notice.

## Why the offset is divided, not re-associated

Only the *result* of the offset is divided. The tempting rewrite — turning
`n0 = nb * 256` into `nb * 16` and saving the runtime division — is unsound,
because IR arithmetic wraps at its declared width while the rewritten form does
not:

```text
x : INT32 = 1 << 24
(x * 256) / 16   ==  0            # x * 256 wraps to 0 in i32
x * (256 / 16)   ==  268435456    # re-associated: no wrap, wrong fractal
```

Widening is not the culprit and rebuilding at the original width does not help:
for `a * b = q * 2^W + r`, the original yields `r / d` while any re-association
yields `r / d + q * 2^(W - log2 d)`. Dividing the offset as a whole keeps its own
dtype and overflow behaviour intact. The cost is one `arith.divsi` per symbolic
NZ `tile.load`, against a weight-tile DMA; the constant path still folds to a
literal.

The proof itself survives wraparound because every divisor here is a power of two
and so divides `2^W`. An `INTERNAL_CHECK` pins that precondition.

One further limit is deliberate: `As<Var>` excludes `IterArg` (per
`ir-kind-traits`), because its value changes every iteration, so neither its
initial value nor any binding recorded for it describes the value a given use
sees.

## Why the sign is proven too

Divisibility alone does not make a coordinate safe. `n0 = -16` is a clean
multiple of 16, and `FloorDiv(n0, 16)` is `-1`; `GetIndexOffsetCodes` emits
`arith.maxsi(offset, 0)`, so a negative `pto.partition_view` offset is *clamped*
rather than rejected and the load quietly reads fractal 0 — the same
silently-wrong-data shape #2543 fixed for row indices. The constant path already
refuses a negative literal, so proving only divisibility for a symbolic offset
would mean the identical value is caught written inline and waved through once
bound to a name.

A purely structural sign proof would reject the motivating kernel, because
`n0 = nb * 256` bottoms out at a `Call`. So the pass supplies two binding-level
facts: a loop variable whose `start` and `step` are both non-negative, and a
variable bound to `tile.get_block_idx` / `tile.get_block_num`. The second is an
*operator* fact, which is why the pass records it rather than the geometry header
deciding it.

## Behavior change

`pl.NZ` slices that previously raised now compile when their alignment is provable.
Nothing that compiled before changes: a constant offset takes the same path and
keeps its own diagnostic, which names the offending value. No API, no migration.

## Tests

`test_rejects_dynamic_slice_offset` pinned the limitation this change removes and is
replaced by:

- `test_maps_an_spmd_derived_slice_offset` — `n0 = nb * 256` becomes `n0 // 16`,
  which also pins that the proof follows the definition chain
- `test_maps_a_loop_variable_slice_offset` — a `pl.pipeline` index becomes `k0 // 32`
- `test_does_not_reassociate_the_offset_arithmetic` — the emitted coordinate still
  contains the original offset `Var`, and no reduced-factor multiply was synthesized
- `test_codegen_emits_the_divided_offset` — the coordinate reaches
  `pto.partition_view` as `arith.divsi`, whose dividend walks back to the kernel's
  own `nb * 256`
- `test_rejects_a_slice_offset_whose_alignment_cannot_be_proven` — `nb * 8` on the
  16-row axis is not provably a multiple of 16
- `test_rejects_a_slice_offset_whose_sign_cannot_be_proven` — `nb * 256 - 256` is a
  clean multiple of 16 and negative on the first block
- `test_rejects_a_loop_variable_whose_step_breaks_alignment` — start aligned, step
  not; proving from the start alone would silently mis-address every later iteration

Annotating the file's helpers made previously unchecked attribute access checkable,
so `_const` / `_elements` narrow it rather than dropping the annotations.

## Verification

Run at the pushed commit, after the rebase onto the current base:

- `cmake --build build --parallel 32`: exit 0
- `pytest tests/ut/ir/transforms/test_block_nz_tensor_views.py -q`: 24 passed
- `pytest tests/ut/ir tests/ut/codegen tests/ut/jit -n 16 -q`: 8368 passed,
  7 skipped, 1 xfailed
- `tests/lint/` gates (12 scripts): all exit 0
- `clang-format`, `clang-tidy`, `ruff check`, `ruff format --check`, `pyright`:
  all clean

Run earlier, on the first commit of the range:

- `pytest tests/ut --ignore=tests/ut/runtime -n 16 -q`: 10092 passed. The single
  failure, `test_symlinked_import_path_still_names_the_caller`, is an artefact of
  this checkout's editable install — a re-exec'd subprocess is still served by the
  meta-path finder — and reproduces without this change.

Not run: `pre-commit` is not installed in this environment, so `cpplint` and
`markdownlint-cli2` were not exercised locally; CI owns them. `tests/st` was not
run either — this change is frontend-only and, per the note below, the NZ path is
not yet executable on device.

The #2533 grouped-matmul kernel now compiles through the full Default pipeline and
codegen, emitting the blocked descriptor plus both divided coordinates:

```mlir
%w1_view = pto.make_tensor_view %arg1,
    shape = [%c2, %c128, %c32, %c16, %c32],
    strides = [%c2097152, %c16384, %c512, %c32, %c1]
    {layout = #pto.layout<nz>} : !pto.tensor_view<?x?x?x?x?xi8>
%24 = arith.muli %nb__ssa_v0, %c256_index : index     // the kernel's own n0
%25 = arith.divsi %24, %c16_index : index             // row fractal
%33 = arith.divsi %k0__idx_v0, %c32_index : index     // C0 block
```

## Review feedback addressed

**P1 (Codex) — overflow semantics.** Building the blocked coordinate by
re-associating `nb * 256` into `nb * 16` breaks fixed-width overflow semantics.
Confirmed and fixed in the second commit — see "Why the offset is divided, not
re-associated", pinned by `test_does_not_reassociate_the_offset_arithmetic`.

One correction to that report: it attributed the defect to `MakeMul` promoting an
INT32 operand to INDEX. That promotion is real, but rebuilding at the original
width fails identically (`reassoc@i32` and `reassoc@i64` both give `268435456`
where the original gives `0`), so the fix had to remove the re-association rather
than preserve the width.

**Major (CodeRabbit) — sign.** The symbolic path proved divisibility only, so a
divisible-but-negative offset was accepted and then clamped at the partition
view. Confirmed and fixed in the third commit — see "Why the sign is proven too",
pinned by `test_rejects_a_slice_offset_whose_sign_cannot_be_proven`.

Both inline threads are answered and resolved.

## Still not reachable on device

PTOAS infers a `make_tensor_view`'s layout structurally and overrides the explicit
`nz` annotation (hw-native-sys/PTOAS#527). This PR closes the frontend gap #2548
describes; end-to-end NZ still waits on that issue.