### PR TITLE
fix(ir): box a matmul's M axis wherever it lands, and refuse a partial box in PyPTO

### DIFF
--- a/docs/en/dev/codegen/00-pto_codegen.md
+++ b/docs/en/dev/codegen/00-pto_codegen.md
@@ -530,6 +530,54 @@ then byte-identical to the location-free form; this is the escape hatch for a
 ptoas build whose parser rejects a trailing location, since ptoas ships
 independently of PyPTO.
 
+## Boxed Tile Extents
+
+Every `pto.alloc_tile` PyPTO emits is validated against the box grid PTOAS will
+check it against. PTO addresses a boxed tile one box at a time, so a tile whose
+*physical* extent is not a whole number of boxes has no address at all.
+
+The rule mirrors PTOAS' `verifyBoxedTileLayout` exactly:
+
+| Layout | Box (rows x cols) |
+| ------ | ----------------- |
+| fractal 1024 (`Acc`) | 16 x 16 |
+| fractal 512, `slayout = row_major` (`Mat` / `Left`) | 16 x (32 / sizeof(dtype)) |
+| fractal 512, `slayout = col_major` (`Right`, the transposed dual) | (32 / sizeof(dtype)) x 16 |
+| `slayout = none_box` | not boxed — no rule |
+
+with PTOAS' own exemptions kept: the *row* rule is skipped for `Vec` and for a
+single-row tile (the NZ map degenerates there), while the column rule always
+applies. The MX-scale fractal and sub-byte carriers are left to PTOAS, which
+diagnoses them itself.
+
+**Why here rather than in PTOAS.** PTOAS rejects the same shape, but its message
+names its own internals and offers no remedy:
+
+```text
+'pto.alloc_tile' op expects result boxed tile rows to be a multiple of innerRows (16), but got 100
+```
+
+Raising at the emission site instead reports the tile, the axis, the extent to
+reach, and how to reach it:
+
+```text
+a Mat tile of physical shape [100, 128] and dtype fp16 must be a whole number of
+16x16 fractal boxes, but its row extent 100 is not a multiple of 16. PTO addresses
+a boxed tile one box at a time, so a partial box has no address. The *logical*
+extent is free -- allocate 112 on that axis and declare 100 as the tile's
+valid_shape (`valid_shape=` on pl.load / pl.tile.create + pl.set_validshape),
+which moves and computes only the real data. A tensor-level pl.matmul /
+pl.matmul_acc does this for its M axis automatically.
+```
+
+`ComputeAllocTileFields` is the single choke point every allocation passes
+through — the per-variable declaration, the hoisted `extra_alloc_tiles`, and the
+control-flow paths alike — so the check sees exactly what is emitted and cannot
+drift from it. A tensor-level `pl.matmul` / `pl.matmul_acc` never trips it: the
+M axis is boxed for the user in
+[`ConvertTensorToTileOps`](../passes/10-convert_tensor_to_tile_ops.md#cube-operand-m-axis-boxing).
+The axes that remain the user's responsibility are `K` and `N`.
+
 ## Complete Example
 
 ### Input: PyPTO Program

--- a/docs/en/dev/codegen/00-pto_codegen.md
+++ b/docs/en/dev/codegen/00-pto_codegen.md
@@ -573,8 +573,8 @@ pl.matmul_acc does this for its M axis automatically.
 `ComputeAllocTileFields` is the single choke point every allocation passes
 through — the per-variable declaration, the hoisted `extra_alloc_tiles`, and the
 control-flow paths alike — so the check sees exactly what is emitted and cannot
-drift from it. A tensor-level `pl.matmul` / `pl.matmul_acc` never trips it: the
-M axis is boxed for the user in
+drift from it. A tensor-level `pl.matmul` / `pl.matmul_acc` never trips it *on
+its M axis*, which is boxed for the user in
 [`ConvertTensorToTileOps`](../passes/10-convert_tensor_to_tile_ops.md#cube-operand-m-axis-boxing).
 The axes that remain the user's responsibility are `K` and `N`.
 

--- a/docs/en/dev/passes/10-convert_tensor_to_tile_ops.md
+++ b/docs/en/dev/passes/10-convert_tensor_to_tile_ops.md
@@ -253,7 +253,7 @@ acc = pl.create_tensor([100, 64], pl.FP32)
 c = pl.matmul_acc(acc, a, b)
 
 # After
-acc_storage = pl.tile.create([112, 64], dtype=pl.FP32, target_memory=pl.Mem.Acc)
+acc_storage = pl.tile.create([112, 64], dtype=pl.FP32, target_memory=pl.Mem.Acc, compact=True)
 acc_tile = pl.tile.set_validshape(acc_storage, 100, 64)   # Tile[[112, 64]] valid [100, 64]
 a_mat = pl.tile.load(a, [0, 0], [112, 128], [100, 128], target_memory=pl.Mem.Mat)
 c_tile = pl.tile.matmul_acc(acc_tile, a_mat, b_mat)

--- a/docs/en/dev/passes/10-convert_tensor_to_tile_ops.md
+++ b/docs/en/dev/passes/10-convert_tensor_to_tile_ops.md
@@ -160,7 +160,7 @@ When `tensor.slice` feeds into `tensor.matmul` or `tensor.matmul_acc`, the slice
 
 The demand is propagated **through** zero-copy metadata ops that declare `set_output_memory_inherit_input()` — `tensor.slice`, `tensor.view`, `tensor.reshape`, `tensor.reinterpret_view`, `tensor.set_validshape`. So an operand written as `pl.matmul(pl.set_validshape(a[:, :K], rows, K), b)` still loads straight to Mat. An op that aliases its input's storage but omits that declaration breaks the chain: the operand materializes in Vec and needs a `tile.move` to Mat, which is a vector→cube boundary that flips an otherwise pure-CUBE InCore scope to `MIXED` and makes [`ExpandMixedKernel`](22-expand_mixed_kernel.md) split it into an AIC/AIV pair.
 
-## Cube Operand Row Boxing
+## Cube Operand M-Axis Boxing
 
 A cube operand has two independent extents, and only one of them is constrained.
 
@@ -168,13 +168,14 @@ A cube operand has two independent extents, and only one of them is constrained.
   `N` from the operands' *valid* region, bounded at `[1, 4095]` with no
   divisibility rule; `pto.mad` carries a `disable_gemv` clause whose whole
   purpose is selecting the L0A organization at `%m == 1`.
-- The **physical** extent must be a whole number of NZ fractal boxes. The inner
-  box is 16 rows on every generation and dtype (`FRACTAL_NZ_ROW`). ptoas enforces
-  it directly — `'pto.alloc_tile' op expects result boxed tile rows to be a
+- The **physical** extent must be a whole number of NZ fractal boxes. A box is
+  16 rows tall on every generation and dtype; it is
+  `32 bytes / sizeof(dtype)` wide (16 for FP16, 32 for INT8). ptoas enforces it
+  directly — `'pto.alloc_tile' op expects result boxed tile rows to be a
   multiple of innerRows (16)` — and pto-isa's `TExtract` repeats it as a static
   assertion on the Mat source it reads.
 
-So the left operand of a 2-D `tensor.matmul` bridges into Mat with its row extent
+So every cube tile the matmul's M axis runs through is allocated with that extent
 rounded up to the box, and the tensor's true extent declared as `valid_shape`:
 
 ```python
@@ -198,26 +199,103 @@ picks a 16-aligned tile and peels the remainder, and a multiple of 16 can only b
 split into 16-aligned pieces, tail included. It therefore needs no boundary
 special case.
 
-The rule rides on the *demand*, not on one code path. Three sites can answer a
-matmul's Mat requirement, and all three box: `BridgeInputSpaces` for an operand
+### Which axis carries M
+
+M does not always land on the row axis. An `a_trans` operand is loaded
+*naturally* and reinterpreted by a zero-copy `tile.transpose_view`, so its
+loaded tile has `K` on rows and `M` on **columns** — the box rule follows M to
+whichever axis holds it (`InputSpaceReq::cube_m_axis` resolves the axis from the
+operand's own transpose flag):
+
+```python
+# a: Tensor[[128, 100]], a_trans=True — M is the load's column extent
+a_mat = pl.tile.load(a, [0, 0], [128, 112], [128, 100], target_memory=pl.Mem.Mat)
+a_t   = pl.tile.transpose_view(a_mat)   # Tile[[112, 128]] valid [100, 128]
+```
+
+That also means the *granularity* differs per tile even though the padded extent
+must not: an Acc box is 16 rows for every dtype, while a transposed operand's
+column box is `32 / sizeof(dtype)`. A transposed INT8 operand therefore needs 32,
+and the accumulator paired with it has to adopt that same 32 — each taking its
+own would give a 128-row product against a 112-row accumulator, which
+`tile.matmul_acc` rejects. `InputSpaceReq::m_align_from_arg` names the left
+operand as the single decider, and the alignment is the lcm of its box and the
+accumulator's 16 rows (every granularity involved is a power of two, so the lcm
+is the max).
+
+The rule rides on the *demand*, not on one code path. Four sites can answer a
+matmul's operand requirement, and all four box: `BridgeInputSpaces` for an operand
 that is still a tensor at the call; `HandleConsumerDrivenLoad` when a
 `tensor.slice` (or any `set_output_memory_inherit_input()` chain) answers it at
-the producer; and the Phase-1 entry loop when the producer is a parameter, which
-is what a `pl.matmul(pl.set_validshape(a, ...), b)` reaches. `ConsumerSpaceReq`
-therefore carries the box flag alongside the memory space. When several consumers share one
-producer, the rows are boxed only if every one of them asks for it, so a consumer
-that reads the tile at its declared physical shape is never handed a padded one.
+the producer; the Phase-1 entry loop when the producer is a parameter, which
+is what a `pl.matmul(pl.set_validshape(a, ...), b)` reaches; and
+`HandleBoxedAccCreate` for an accumulator, which is allocated rather than loaded.
+`ConsumerSpaceReq` therefore carries the box flag alongside the memory space. When
+several consumers share one producer, the rows are boxed only if every one of them
+asks for it, so a consumer that reads the tile at its declared physical shape is
+never handed a padded one.
+
+### `tensor.matmul_acc` boxes its accumulator with its operand
+
+`tensor.matmul_acc` takes exactly `tensor.matmul`'s M constraint, because the two
+cube tiles the M axis runs through must be boxed *together*: `tile.matmul_acc`
+requires the accumulator and the matrix product to agree on physical M, so boxing
+the left operand alone would trade a ptoas rejection for an operand-mismatch one.
+
+The accumulator is never loaded — nothing but the matrix unit writes L0C — so its
+allocation is the site that answers the demand. `HandleBoxedAccCreate` rewrites
+the `tensor.create` that seeds it, and the narrowing rides on a separate
+`tile.set_validshape` because `tile.create` takes no valid extent:
+
+```python
+# Before  (M = 100)
+acc = pl.create_tensor([100, 64], pl.FP32)
+c = pl.matmul_acc(acc, a, b)
+
+# After
+acc_storage = pl.tile.create([112, 64], dtype=pl.FP32, target_memory=pl.Mem.Acc)
+acc_tile = pl.tile.set_validshape(acc_storage, 100, 64)   # Tile[[112, 64]] valid [100, 64]
+a_mat = pl.tile.load(a, [0, 0], [112, 128], [100, 128], target_memory=pl.Mem.Mat)
+c_tile = pl.tile.matmul_acc(acc_tile, a_mat, b_mat)
+```
+
+Two details this path settles that the operand path does not:
+
+- **The space is stated, not left to [`InferTileMemorySpace`](18-infer_tile_memory_space.md).**
+  The plain `tensor.create` conversion deliberately leaves `target_memory` unset,
+  having no consumer context to derive it from; here there is one, and it is the
+  same demand that asked for the boxing. Stating it also matters for correctness:
+  an Acc tile's implicit view is boxed NZ, so a seed left unresolved would carry
+  the raw row-major view and disagree with the `tile.matmul_acc` result it is
+  carried against across a split-K loop.
+- **The demand crosses the loop carry.** A split-K accumulator is allocated before
+  the loop and reaches its `tile.matmul_acc` as an `IterArg`, so
+  `ConsumerSpaceCollector` matches operands with `AsVarLike` (an `IterArg` carries
+  its own `ObjectKind`) and records a propagation edge from each `IterArg` to the
+  value that seeds it.
+
+The boxed accumulator is declared **compact**. `mad` lays the product out at a
+pitch of `ceil(validRow/16)*16` — 112 for a 100-row product — while a
+non-compact reader derives its stride from the physical row count, which the box
+rounded to 112 or, at a 32-row alignment, to 128. Compact makes every reader
+recompute the pitch `mad` actually used; without it `AccCompactValid` rejects the
+program (issue #2470).
 
 Scope, and what is deliberately left out:
 
 | Case | Boxed? | Why |
 | ---- | ------ | --- |
-| 2-D `tensor.matmul` left operand | Yes | Its row axis is M, whose box height is 16 for every dtype |
-| Right operand | No | Its rows are `K`, whose granularity is `32 bytes / sizeof(dtype)` — dtype-dependent, and not settled here |
-| `a_trans` left operand | No | The natural load's row axis is K; the zero-copy `tile.transpose_view` makes the *column* axis M |
+| 2-D `tensor.matmul` left operand | Yes, on rows | Its row axis is M, whose box height is 16 for every dtype |
+| 2-D `tensor.matmul_acc` left operand and accumulator | Yes, on rows | Same axis, same rule — and the op requires the two to agree on physical M, so they move together |
+| `a_trans` left operand, and the accumulator paired with it | Yes, on columns | The natural load's row axis is K, so M is the column extent; the accumulator adopts that operand's column granularity via `m_align_from_arg` |
+| Right operand | No | Its rows are `K`, the reduction axis — padding it would feed uninitialised L1 into the sum unless the hardware masks by valid col, which is unverified |
+| Output `N` | No | Same open question as `K`; [`AutoTileMatmulL0`](16-auto_tile_matmul_l0.md)'s `PH-AT-007` declines it for the same reason |
 | Rank >= 3 operand | No | It lowers to `tile.batch_matmul`, whose rows [`FlattenTileNdTo2D`](13-flatten_tile_nd_to_2d.md) row-packs into one `[B*M, N]` tile — the box rule binds that packed extent, not this dimension |
-| Dynamic row extent | No | No compile-time box to round to |
-| `tensor.matmul_acc` left operand | No | `tile.matmul_acc` requires the accumulator and the product to agree on *physical* M, and the accumulator arrives from a separate `tile.create` this rule cannot reach |
+| Dynamic M extent | No | No compile-time box to round to |
+
+Every case this pass declines still reaches a PyPTO-level error rather than a
+ptoas one: [PTO codegen](../codegen/00-pto_codegen.md#boxed-tile-extents)
+validates the box grid of every `pto.alloc_tile` it emits.
 
 ## Transpose Lowering
 

--- a/docs/en/dev/passes/16-auto_tile_matmul_l0.md
+++ b/docs/en/dev/passes/16-auto_tile_matmul_l0.md
@@ -297,8 +297,11 @@ innerRows (16)`.
 The invariant that makes the peel legal is established upstream, not here:
 [`ConvertTensorToTileOps`](10-convert_tensor_to_tile_ops.md) allocates every 2-D
 cube tile the M axis runs through — the left operand, and for `tensor.matmul_acc` the
-accumulator with it — with its rows rounded up to the box and the true extent in
-`valid_shape`. The `M` this pass sees is therefore already a multiple of 16, and
+accumulator with it — with *the axis carrying M* rounded up to the box and the
+true extent in `valid_shape`. That axis is the rows for a natural operand, and
+the columns for an `a_trans` one, whose natural load is boxed before
+`tile.transpose_view` swaps M onto the product's row axis; `tensor.matmul_acc`
+gives its accumulator the same M alignment either way. The `M` this pass sees is therefore already a multiple of 16, and
 `M % m` with both `M` and `m` multiples of 16 is a multiple of 16 as well. Every
 emitted tile — interior and tail alike — is a whole number of boxes by
 construction, for the accumulating spelling as much as the plain one.

--- a/docs/en/dev/passes/16-auto_tile_matmul_l0.md
+++ b/docs/en/dev/passes/16-auto_tile_matmul_l0.md
@@ -295,12 +295,13 @@ rows must still form whole NZ fractal boxes — ptoas rejects anything else with
 innerRows (16)`.
 
 The invariant that makes the peel legal is established upstream, not here:
-[`ConvertTensorToTileOps`](10-convert_tensor_to_tile_ops.md) bridges a 2-D
-matmul's left operand into Mat with its rows rounded up to the box and the true
-extent in `valid_shape`. The `M` this pass sees is therefore already a multiple
-of 16, and `M % m` with both `M` and `m` multiples of 16 is a multiple of 16 as
-well. Every emitted tile — interior and tail alike — is a whole number
-of boxes by construction.
+[`ConvertTensorToTileOps`](10-convert_tensor_to_tile_ops.md) allocates every 2-D
+cube tile the M axis runs through — the left operand, and for `tensor.matmul_acc` the
+accumulator with it — with its rows rounded up to the box and the true extent in
+`valid_shape`. The `M` this pass sees is therefore already a multiple of 16, and
+`M % m` with both `M` and `m` multiples of 16 is a multiple of 16 as well. Every
+emitted tile — interior and tail alike — is a whole number of boxes by
+construction, for the accumulating spelling as much as the plain one.
 
 Padding the tensor at conversion is what makes this work; padding it *only* at
 the operand would not be enough on its own, because this pass would still

--- a/docs/zh/dev/codegen/00-pto_codegen.md
+++ b/docs/zh/dev/codegen/00-pto_codegen.md
@@ -533,7 +533,7 @@ allocate 112 on that axis and declare 100 as the tile's valid_shape ...
 
 `ComputeAllocTileFields` 是所有分配的唯一收口——逐变量声明、被提升出来的
 `extra_alloc_tiles`、以及控制流路径都经过它——因此校验看到的正是最终发射的内容，不会与之
-漂移。张量层的 `pl.matmul` / `pl.matmul_acc` 永远不会触发它：M 轴已由
+漂移。张量层的 `pl.matmul` / `pl.matmul_acc` 不会因 *M 轴*触发它：M 轴已由
 [`ConvertTensorToTileOps`](../passes/10-convert_tensor_to_tile_ops.md#cube-operand-m-axis-boxing)
 自动对齐；仍需用户自行保证的是 `K` 与 `N`。
 

--- a/docs/zh/dev/codegen/00-pto_codegen.md
+++ b/docs/zh/dev/codegen/00-pto_codegen.md
@@ -499,6 +499,44 @@ pto.tmul ins(%tile_a_buf : !pto.tile_buf<...>,
 输出与不带位置的形式逐字节一致; 由于 ptoas 独立于 PyPTO 发布, 这是应对某个
 ptoas 版本解析器拒绝尾随位置时的应急开关。
 
+## 分块 Tile 尺寸校验
+
+PyPTO 发射的每一条 `pto.alloc_tile` 都会按 PTOAS 将要检查的分块网格先行校验。
+PTO 以「块」为单位寻址分块 tile，因此*物理*尺寸不是整数个块的 tile 根本没有地址。
+
+该规则与 PTOAS 的 `verifyBoxedTileLayout` 完全一致：
+
+| 布局 | 块尺寸（行 x 列） |
+| ---- | ----------------- |
+| fractal 1024（`Acc`） | 16 x 16 |
+| fractal 512，`slayout = row_major`（`Mat` / `Left`） | 16 x (32 / sizeof(dtype)) |
+| fractal 512，`slayout = col_major`（`Right`，转置对偶） | (32 / sizeof(dtype)) x 16 |
+| `slayout = none_box` | 非分块，无此约束 |
+
+并保留 PTOAS 自身的豁免：*行*方向的规则对 `Vec` 以及单行 tile（此时 NZ 映射退化）
+跳过，而列方向的规则始终生效。MX scale fractal 与亚字节载体交由 PTOAS 自行诊断。
+
+**为什么放在这里而不是交给 PTOAS。** PTOAS 会拒绝同样的形状，但它的报错只提及自身内部
+概念，也不给出修复方式：
+
+```text
+'pto.alloc_tile' op expects result boxed tile rows to be a multiple of innerRows (16), but got 100
+```
+
+在发射点报错则能同时给出 tile、出问题的轴、需要达到的尺寸，以及达到它的方式：
+
+```text
+a Mat tile of physical shape [100, 128] and dtype fp16 must be a whole number of
+16x16 fractal boxes, but its row extent 100 is not a multiple of 16. ...
+allocate 112 on that axis and declare 100 as the tile's valid_shape ...
+```
+
+`ComputeAllocTileFields` 是所有分配的唯一收口——逐变量声明、被提升出来的
+`extra_alloc_tiles`、以及控制流路径都经过它——因此校验看到的正是最终发射的内容，不会与之
+漂移。张量层的 `pl.matmul` / `pl.matmul_acc` 永远不会触发它：M 轴已由
+[`ConvertTensorToTileOps`](../passes/10-convert_tensor_to_tile_ops.md#cube-operand-m-axis-boxing)
+自动对齐；仍需用户自行保证的是 `K` 与 `N`。
+
 ## 完整示例
 
 ### 输入: PyPTO 程序

--- a/docs/zh/dev/passes/10-convert_tensor_to_tile_ops.md
+++ b/docs/zh/dev/passes/10-convert_tensor_to_tile_ops.md
@@ -201,7 +201,7 @@ dtype 下都是 16 行，而转置操作数的列块是 `32 / sizeof(dtype)`。�
 累加器 16 行的最小公倍数（所涉粒度均为 2 的幂，故最小公倍数即最大值）。
 
 这条规则挂在「需求」上，而不是挂在某一条代码路径上。有四处可以满足 matmul 操作数的需求，
-四处都会做行对齐：操作数在调用点仍是张量时由 `BridgeInputSpaces` 处理；`tensor.slice`
+四处都会按 M 所在的轴对齐：操作数在调用点仍是张量时由 `BridgeInputSpaces` 处理；`tensor.slice`
 （以及任何 `set_output_memory_inherit_input()` 传播链）在生产者处满足需求时由
 `HandleConsumerDrivenLoad` 处理；生产者是函数参数时由 Phase-1 入口循环处理 ——
 `pl.matmul(pl.set_validshape(a, ...), b)` 走的正是这一条；累加器不是被加载而是被分配的，
@@ -225,7 +225,7 @@ acc = pl.create_tensor([100, 64], pl.FP32)
 c = pl.matmul_acc(acc, a, b)
 
 # 转换后
-acc_storage = pl.tile.create([112, 64], dtype=pl.FP32, target_memory=pl.Mem.Acc)
+acc_storage = pl.tile.create([112, 64], dtype=pl.FP32, target_memory=pl.Mem.Acc, compact=True)
 acc_tile = pl.tile.set_validshape(acc_storage, 100, 64)   # Tile[[112, 64]]，valid [100, 64]
 a_mat = pl.tile.load(a, [0, 0], [112, 128], [100, 128], target_memory=pl.Mem.Mat)
 c_tile = pl.tile.matmul_acc(acc_tile, a_mat, b_mat)

--- a/docs/zh/dev/passes/10-convert_tensor_to_tile_ops.md
+++ b/docs/zh/dev/passes/10-convert_tensor_to_tile_ops.md
@@ -145,20 +145,20 @@ InCore、Spmd、Group 函数在本阶段被跳过 —— 它们已在阶段一 /
 
 该需求会**穿过**声明了 `set_output_memory_inherit_input()` 的零拷贝元数据 op 继续向上传播 —— `tensor.slice`、`tensor.view`、`tensor.reshape`、`tensor.reinterpret_view`、`tensor.set_validshape`。因此 `pl.matmul(pl.set_validshape(a[:, :K], rows, K), b)` 这样的操作数仍然直接加载到 Mat。若某个别名输入存储的 op 漏掉该声明，传播链就会断开：操作数被物化到 Vec，再通过 `tile.move` 桥接到 Mat，而这是一个 vector→cube 边界，会把本应是纯 CUBE 的 InCore scope 判定为 `MIXED`，导致 [`ExpandMixedKernel`](22-expand_mixed_kernel.md) 将其拆分为 AIC/AIV 两个函数。
 
-## Cube 操作数的行分形对齐（Row Boxing）
+## Cube 操作数的 M 轴分形对齐（M-Axis Boxing）
 
 一个 cube 操作数有两个彼此独立的尺寸概念，而只有其中一个受到约束。
 
 - **逻辑（logical）尺寸**基本不受限。`pto.tmatmul` 从操作数的 *valid* 区域推导
   `M`、`K`、`N`，取值范围 `[1, 4095]`，没有整除要求；`pto.mad` 的 `disable_gemv`
   子句存在的唯一目的，就是在 `%m == 1` 时选择 L0A 的组织方式。
-- **物理（physical）尺寸**必须是整数个 NZ 分形块。内层块在所有代次和所有 dtype 下
-  都是 16 行（`FRACTAL_NZ_ROW`）。ptoas 直接强制这一点 ——
-  `'pto.alloc_tile' op expects result boxed tile rows to be a multiple of
+- **物理（physical）尺寸**必须是整数个 NZ 分形块。块高在所有代次和所有 dtype 下都是
+  16 行；块宽是 `32 字节 / sizeof(dtype)`（FP16 为 16，INT8 为 32）。ptoas 直接强制
+  这一点 —— `'pto.alloc_tile' op expects result boxed tile rows to be a multiple of
   innerRows (16)` —— pto-isa 的 `TExtract` 也对其读取的 Mat 源 tile 用静态断言
   重复了同一条约束。
 
-因此 2-D `tensor.matmul` 的左操作数在桥接到 Mat 时，行方向的物理尺寸向上对齐到分形块，
+因此凡是 matmul M 轴穿过的 cube tile，该轴的物理尺寸都向上对齐到分形块，
 并把张量的真实尺寸声明为 `valid_shape`：
 
 ```python
@@ -180,24 +180,88 @@ compact 模式寻址整块内部更窄的 valid 区域，`tile.store` 也只写�
 16 对齐的 tile 并剥离余数，而 16 的倍数只能被切分成同样 16 对齐的块（尾块也不例外），
 所以它不需要任何边界特判。
 
-这条规则挂在「需求」上，而不是挂在某一条代码路径上。有三处可以满足 matmul 的 Mat 需求，
-三处都会做行对齐：操作数在调用点仍是张量时由 `BridgeInputSpaces` 处理；`tensor.slice`
+### M 落在哪条轴上
+
+M 并不总是落在行轴。`a_trans` 操作数按*自然*方式加载、再由零拷贝的
+`tile.transpose_view` 重解释，因此其加载 tile 的行轴是 `K`、**列**轴才是 `M` ——
+分形规则会跟随 M 到它实际所在的那条轴（`InputSpaceReq::cube_m_axis` 由该操作数自身的
+转置标志解析出轴号）：
+
+```python
+# a: Tensor[[128, 100]]，a_trans=True —— M 是本次加载的列尺寸
+a_mat = pl.tile.load(a, [0, 0], [128, 112], [128, 100], target_memory=pl.Mem.Mat)
+a_t   = pl.tile.transpose_view(a_mat)   # Tile[[112, 128]]，valid [100, 128]
+```
+
+这也意味着：虽然对齐后的尺寸必须一致，各 tile 自身的*粒度*却不同 —— Acc 块在所有
+dtype 下都是 16 行，而转置操作数的列块是 `32 / sizeof(dtype)`。因此转置的 INT8
+操作数需要 32，与之配对的累加器也必须采用同一个 32；各取各的粒度会得到 128 行的乘积
+与 112 行的累加器，而 `tile.matmul_acc` 会拒绝这一组合。
+`InputSpaceReq::m_align_from_arg` 指定左操作数为唯一决定者，最终对齐值取它的块尺寸与
+累加器 16 行的最小公倍数（所涉粒度均为 2 的幂，故最小公倍数即最大值）。
+
+这条规则挂在「需求」上，而不是挂在某一条代码路径上。有四处可以满足 matmul 操作数的需求，
+四处都会做行对齐：操作数在调用点仍是张量时由 `BridgeInputSpaces` 处理；`tensor.slice`
 （以及任何 `set_output_memory_inherit_input()` 传播链）在生产者处满足需求时由
 `HandleConsumerDrivenLoad` 处理；生产者是函数参数时由 Phase-1 入口循环处理 ——
-`pl.matmul(pl.set_validshape(a, ...), b)` 走的正是这一条。因此 `ConsumerSpaceReq`
+`pl.matmul(pl.set_validshape(a, ...), b)` 走的正是这一条；累加器不是被加载而是被分配的，
+由 `HandleBoxedAccCreate` 处理。因此 `ConsumerSpaceReq`
 在携带内存空间的同时也携带对齐标记。当多个消费者共享同一个生产者时，只有它们全部提出
 该需求时才会对齐，从而保证按声明物理尺寸读取该 tile 的消费者不会拿到被 padding 过的 tile。
+
+### `tensor.matmul_acc` 的累加器与其操作数一同对齐
+
+`tensor.matmul_acc` 与 `tensor.matmul` 的 M 约束完全相同，因为 M 轴穿过的两个 cube tile
+必须**同时**对齐：`tile.matmul_acc` 要求累加器与乘积的物理 M 一致，只对左操作数做对齐
+只会把 ptoas 的拒绝换成一个操作数不匹配的报错。
+
+累加器从不被加载 —— 除矩阵单元外没有任何部件写 L0C —— 因此满足该需求的位置是它的分配点。
+`HandleBoxedAccCreate` 改写为它做种子的 `tensor.create`；由于 `tile.create` 不接受 valid
+尺寸，收窄由一条独立的 `tile.set_validshape` 承担：
+
+```python
+# 转换前（M = 100）
+acc = pl.create_tensor([100, 64], pl.FP32)
+c = pl.matmul_acc(acc, a, b)
+
+# 转换后
+acc_storage = pl.tile.create([112, 64], dtype=pl.FP32, target_memory=pl.Mem.Acc)
+acc_tile = pl.tile.set_validshape(acc_storage, 100, 64)   # Tile[[112, 64]]，valid [100, 64]
+a_mat = pl.tile.load(a, [0, 0], [112, 128], [100, 128], target_memory=pl.Mem.Mat)
+c_tile = pl.tile.matmul_acc(acc_tile, a_mat, b_mat)
+```
+
+这条路径需要额外确定两件操作数路径上没有的事：
+
+- **内存空间在此显式声明，而不是留给 [`InferTileMemorySpace`](18-infer_tile_memory_space.md)。**
+  普通的 `tensor.create` 转换刻意不写 `target_memory`，因为它没有消费者上下文可供推导；
+  而这里有，且正是提出对齐需求的那一个。显式声明还关乎正确性：Acc tile 的隐式 view 是
+  分块 NZ，若种子的空间未定，它会带着原始 row-major view，与跨 split-K 循环与之做循环
+  携带的 `tile.matmul_acc` 结果不一致。
+- **需求需要跨越循环携带。** split-K 累加器在循环外分配，以 `IterArg` 的身份到达
+  `tile.matmul_acc`，因此 `ConsumerSpaceCollector` 用 `AsVarLike` 匹配操作数
+  （`IterArg` 有自己的 `ObjectKind`），并为每个 `IterArg` 记录一条指向其种子值的传播边。
+
+对齐后的累加器会声明为 **compact**。`mad` 以 `ceil(validRow/16)*16` 的 pitch 写出乘积
+（100 行的乘积即 112），而非 compact 的读取方是按物理行数推导 stride 的 —— 而分形对齐
+已把它取整为 112，或在 32 行对齐时取整为 128。compact 让所有读取方重新计算 `mad` 实际
+使用的 pitch；不声明它则会被 `AccCompactValid` 直接拒绝（issue #2470）。
 
 作用范围，以及刻意排除的情况：
 
 | 情况 | 是否对齐 | 原因 |
 | ---- | -------- | ---- |
-| 2-D `tensor.matmul` 左操作数 | 是 | 其行轴即 M，块高在所有 dtype 下都是 16 |
-| 右操作数 | 否 | 其行是 `K`，粒度为 `32 字节 / sizeof(dtype)`，与 dtype 相关，此处不做结论 |
-| `a_trans` 左操作数 | 否 | 自然加载的行轴是 K，零拷贝 `tile.transpose_view` 使 *列*轴才是 M |
+| 2-D `tensor.matmul` 左操作数 | 是，按行 | 其行轴即 M，块高在所有 dtype 下都是 16 |
+| 2-D `tensor.matmul_acc` 的左操作数与累加器 | 是，按行 | 同一条轴、同一条规则 —— 且该 op 要求二者物理 M 一致，因此必须一同对齐 |
+| `a_trans` 左操作数，以及与之配对的累加器 | 是，按列 | 自然加载的行轴是 K，M 是列尺寸；累加器经 `m_align_from_arg` 采用该操作数的列粒度 |
+| 右操作数 | 否 | 其行是 `K`，即归约轴 —— 除非硬件按 valid col 做掩码（尚未验证），补齐会把未初始化的 L1 数据带入求和 |
+| 输出的 `N` | 否 | 与 `K` 同属尚未解决的问题；[`AutoTileMatmulL0`](16-auto_tile_matmul_l0.md) 的 `PH-AT-007` 出于同样原因不予处理 |
 | rank >= 3 的操作数 | 否 | 它下沉为 `tile.batch_matmul`，其行被 [`FlattenTileNdTo2D`](13-flatten_tile_nd_to_2d.md) 打包成单个 `[B*M, N]` tile —— 分形规则约束的是打包后的尺寸，而非该维度 |
-| 行尺寸为动态值 | 否 | 没有编译期常量可供对齐 |
-| `tensor.matmul_acc` 左操作数 | 否 | `tile.matmul_acc` 要求累加器与乘积的*物理* M 一致，而累加器来自本规则无法触及的另一处 `tile.create` |
+| M 尺寸为动态值 | 否 | 没有编译期常量可供对齐 |
+
+本 pass 不处理的每一种情况，最终仍由 PyPTO 而非 ptoas 报错：
+[PTO codegen](../codegen/00-pto_codegen.md) 会校验它发射的每一条 `pto.alloc_tile`
+的分块网格。
 
 ## Transpose 下沉
 

--- a/docs/zh/dev/passes/16-auto_tile_matmul_l0.md
+++ b/docs/zh/dev/passes/16-auto_tile_matmul_l0.md
@@ -277,10 +277,12 @@ chooser 返回 16 对齐的 `(m, n, k)`，本 pass 剥离网格未覆盖的部�
 innerRows (16)`。
 
 使这次剥离保持合法的不变式由上游建立，而不在本 pass：
-[`ConvertTensorToTileOps`](10-convert_tensor_to_tile_ops.md) 在把 2-D matmul 的左
-操作数桥接到 Mat 时，已把行数向上对齐到分形块，并把真实尺寸放入 `valid_shape`。因此本
+[`ConvertTensorToTileOps`](10-convert_tensor_to_tile_ops.md) 会把所有行轴即 M 的 2-D
+cube tile —— 左操作数，以及 `tensor.matmul_acc` 场景下与之配对的累加器 —— 的行数向上
+对齐到分形块，并把真实尺寸放入 `valid_shape`。因此本
 pass 看到的 `M` 已经是 16 的倍数；而当 `M` 与 `m` 均为 16 的倍数时，
-`M % m` 同样是 16 的倍数。于是内部块与尾块都天然是整数个分形块。
+`M % m` 同样是 16 的倍数。于是内部块与尾块都天然是整数个分形块 —— 累加写法与普通写法
+一视同仁。
 
 关键在于「在转换阶段给张量加 padding」：如果只在操作数处补齐，本 pass 仍会用未补齐的
 逻辑 `M` 计算尾块尺寸，问题依旧存在。

--- a/docs/zh/dev/passes/16-auto_tile_matmul_l0.md
+++ b/docs/zh/dev/passes/16-auto_tile_matmul_l0.md
@@ -277,9 +277,11 @@ chooser 返回 16 对齐的 `(m, n, k)`，本 pass 剥离网格未覆盖的部�
 innerRows (16)`。
 
 使这次剥离保持合法的不变式由上游建立，而不在本 pass：
-[`ConvertTensorToTileOps`](10-convert_tensor_to_tile_ops.md) 会把所有行轴即 M 的 2-D
-cube tile —— 左操作数，以及 `tensor.matmul_acc` 场景下与之配对的累加器 —— 的行数向上
-对齐到分形块，并把真实尺寸放入 `valid_shape`。因此本
+[`ConvertTensorToTileOps`](10-convert_tensor_to_tile_ops.md) 会把所有 M 轴穿过的 2-D
+cube tile —— 左操作数，以及 `tensor.matmul_acc` 场景下与之配对的累加器 —— *承载 M 的
+那条轴*向上对齐到分形块，并把真实尺寸放入 `valid_shape`。对自然操作数而言该轴是行，对
+`a_trans` 操作数而言是列（其自然加载在 `tile.transpose_view` 把 M 换到乘积行轴之前就已
+对齐）；两种情形下 `tensor.matmul_acc` 都让累加器采用同一个 M 对齐值。因此本
 pass 看到的 `M` 已经是 16 的倍数；而当 `M` 与 `m` 均为 16 的倍数时，
 `M % m` 同样是 16 的倍数。于是内部块与尾块都天然是整数个分形块 —— 累加写法与普通写法
 一视同仁。

--- a/include/pypto/codegen/pto/pto_type_utils.h
+++ b/include/pypto/codegen/pto/pto_type_utils.h
@@ -13,7 +13,6 @@
 #define PYPTO_CODEGEN_PTO_PTO_TYPE_UTILS_H_
 
 #include <cstdint>
-#include <optional>
 #include <string>
 
 #include "pypto/core/dtype.h"
@@ -107,14 +106,22 @@ struct TileTypeComponents {
 /// sub-byte carrier, a single-row tile, and Vec's row axis are all exempt —
 /// the same exemptions PTOAS applies.
 ///
+/// A boxed tile's physical extents must be static by the time it is emitted —
+/// ``InitMemRef`` refuses a dynamic ``TileType::shape_`` outright, telling the
+/// author to put the runtime extent in ``TileView`` instead. That matters here
+/// because ``ExtractTileTypeInfo`` substitutes its struct default for a
+/// non-``ConstInt`` dimension, so a dynamic extent would be checked (and
+/// rendered) as a placeholder rather than as itself. The assumption is asserted
+/// rather than assumed silently.
+///
+/// @param tile_type  Tile being allocated; supplies the dtype, the memory space
+///                   (Vec relaxes the row rule) and the physical shape.
 /// @param components Rendered tile geometry, as it will appear in the emitted
 ///                   ``!pto.tile_buf<...>`` type string.
-/// @param dtype      Element type the box granularity is derived from.
-/// @param space      Resolved memory space (Vec relaxes the row rule).
 /// @param span       IR location reported on failure; may be null when the
 ///                   emitter has no statement in scope.
-void CheckBoxedTileExtents(const TileTypeComponents& components, const DataType& dtype,
-                           const std::optional<ir::MemorySpace>& space, const ir::Span* span);
+void CheckBoxedTileExtents(const ir::TileType& tile_type, const TileTypeComponents& components,
+                           const ir::Span* span);
 
 TileTypeComponents ExtractTileTypeInfo(const ir::TileType& tile_type,
                                        const std::string& dtype_str_override = "");

--- a/include/pypto/codegen/pto/pto_type_utils.h
+++ b/include/pypto/codegen/pto/pto_type_utils.h
@@ -13,10 +13,12 @@
 #define PYPTO_CODEGEN_PTO_PTO_TYPE_UTILS_H_
 
 #include <cstdint>
+#include <optional>
 #include <string>
 
 #include "pypto/core/dtype.h"
 #include "pypto/ir/memory_space.h"
+#include "pypto/ir/span.h"
 #include "pypto/ir/type.h"
 
 namespace pypto {
@@ -87,6 +89,33 @@ struct TileTypeComponents {
 /// @param dtype_str_override Optional override for the dtype string (e.g.,
 ///                           PTOCodegen::GetTypeString); empty falls back to
 ///                           DataTypeToMLIR(tile_type.dtype_).
+/// Reject a boxed tile whose physical extent is not a whole number of fractal
+/// boxes, before the `pto.alloc_tile` that declares it reaches PTOAS.
+///
+/// PTO addresses a boxed tile one box at a time, so a partial box has no
+/// address at all. PTOAS enforces that on the op it receives, but its message
+/// (``'pto.alloc_tile' op expects result boxed tile rows to be a multiple of
+/// innerRows (16)``) names PTOAS internals, points at whichever line the
+/// location happened to carry, and offers no remedy. Checking the same rule
+/// where PyPTO emits the allocation reports the tile, the axis, the extent to
+/// reach, and how to reach it.
+///
+/// The rule mirrors PTOAS' ``verifyBoxedTileLayout`` exactly: the box is 16x16
+/// for the fractal-1024 accumulator, and ``16 x (32 / sizeof(dtype))`` for a
+/// fractal-512 Mat/Left/Right tile (transposed on a ``col_major`` scatter
+/// layout). A non-boxed (``none_box``) layout, the MX-scale fractal, a
+/// sub-byte carrier, a single-row tile, and Vec's row axis are all exempt —
+/// the same exemptions PTOAS applies.
+///
+/// @param components Rendered tile geometry, as it will appear in the emitted
+///                   ``!pto.tile_buf<...>`` type string.
+/// @param dtype      Element type the box granularity is derived from.
+/// @param space      Resolved memory space (Vec relaxes the row rule).
+/// @param span       IR location reported on failure; may be null when the
+///                   emitter has no statement in scope.
+void CheckBoxedTileExtents(const TileTypeComponents& components, const DataType& dtype,
+                           const std::optional<ir::MemorySpace>& space, const ir::Span* span);
+
 TileTypeComponents ExtractTileTypeInfo(const ir::TileType& tile_type,
                                        const std::string& dtype_str_override = "");
 

--- a/include/pypto/ir/transforms/op_conversion_registry.h
+++ b/include/pypto/ir/transforms/op_conversion_registry.h
@@ -71,14 +71,27 @@ using ConversionFunc = std::function<ConversionResult(
 struct InputSpaceReq {
   MemorySpace space;                       ///< Required memory space
   std::optional<std::string> trans_kwarg;  ///< Read transpose flag from this kwarg (if any)
-  /// Whether the bridged tile is a *cube* operand, i.e. one the MAD reads out
-  /// of a whole number of NZ fractal boxes.  The logical extent of such an
-  /// operand is essentially free (``pto.mad`` derives ``%m`` from the operand's
-  /// valid rows), but its physical row count must be a multiple of the box
-  /// height, so the bridge load allocates the boxed row count and carries the
-  /// tensor's true extent in ``valid_shape``.  Only the row axis is boxed —
-  /// the column granularity is dtype-dependent and is not settled here.
-  bool cube_row_boxed = false;
+  /// Whether this operand carries the matmul's **M** axis, i.e. an axis the MAD
+  /// reads out of a whole number of NZ fractal boxes.  The logical extent of a
+  /// cube operand is essentially free (``pto.mad`` derives ``%m`` from the
+  /// operand's valid extent), but its *physical* extent on that axis must be a
+  /// multiple of the box, so the bridged tile allocates the boxed extent and
+  /// carries the tensor's true extent in ``valid_shape``.
+  ///
+  /// Which axis M lands on depends on this operand's own ``trans_kwarg``: an
+  /// untransposed operand has M on rows, while a transposed one is loaded
+  /// naturally with K on rows, so its M is the *column* axis.  The reduction
+  /// axis (K) and the output axis (N) are never boxed here — padding K would
+  /// feed uninitialised L1 into the sum.
+  bool cube_m_axis = false;
+  /// Index of the operand whose layout fixes the M alignment for the *whole*
+  /// call, when that is not this operand itself.  Every cube tile M runs
+  /// through has to agree on one padded extent — ``tile.matmul_acc`` requires
+  /// the accumulator and the product to have the same physical M — but the
+  /// granularity differs per tile: an Acc box is 16 rows for every dtype, while
+  /// a transposed left operand's column box is ``32 / sizeof(dtype)`` (32 for
+  /// INT8).  Naming one decider makes them share a single alignment.
+  std::optional<size_t> m_align_from_arg;
 };
 
 /**

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -1489,8 +1489,8 @@ PTOCodegen::AllocTileFields PTOCodegen::ComputeAllocTileFields(
   // place a physically illegal box grid can be caught with the IR location and
   // an actionable remedy -- rather than by PTOAS, whose message names its own
   // internals and points at whichever line the location happened to carry.
-  CheckBoxedTileExtents(ExtractTileTypeInfo(*tile_type, GetTypeString(tile_type->dtype_)), tile_type->dtype_,
-                        tile_type->GetMemorySpace(), current_span_);
+  CheckBoxedTileExtents(*tile_type, ExtractTileTypeInfo(*tile_type, GetTypeString(tile_type->dtype_)),
+                        current_span_);
 
   // Cast a non-index integer SSA to `index` (PTOAS expects index typed
   // valid_row / valid_col operands). Floating-point operands are rejected.

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -1485,6 +1485,13 @@ PTOCodegen::AllocTileFields PTOCodegen::ComputeAllocTileFields(
   // extent is conveyed via valid_row / valid_col operands below.
   fields.type_str = GetTileBufTypeStringFromTileType(tile_type);
 
+  // Every `pto.alloc_tile` PyPTO emits passes through here, so this is the one
+  // place a physically illegal box grid can be caught with the IR location and
+  // an actionable remedy -- rather than by PTOAS, whose message names its own
+  // internals and points at whichever line the location happened to carry.
+  CheckBoxedTileExtents(ExtractTileTypeInfo(*tile_type, GetTypeString(tile_type->dtype_)), tile_type->dtype_,
+                        tile_type->GetMemorySpace(), current_span_);
+
   // Cast a non-index integer SSA to `index` (PTOAS expects index typed
   // valid_row / valid_col operands). Floating-point operands are rejected.
   auto cast_to_index = [&](const std::string& ssa, const ir::ExprPtr& expr) -> std::string {

--- a/src/codegen/pto/pto_type_utils.cpp
+++ b/src/codegen/pto/pto_type_utils.cpp
@@ -12,8 +12,10 @@
 #include "pypto/codegen/pto/pto_type_utils.h"
 
 #include <cstdint>
+#include <optional>
 #include <sstream>
 #include <string>
+#include <utility>
 
 #include "pypto/core/dtype.h"
 #include "pypto/core/error.h"
@@ -21,6 +23,7 @@
 #include "pypto/ir/expr.h"
 #include "pypto/ir/kind_traits.h"
 #include "pypto/ir/scalar_expr.h"
+#include "pypto/ir/storage_size.h"
 #include "pypto/ir/tile_view_semantics.h"
 #include "pypto/ir/type.h"
 
@@ -155,6 +158,72 @@ std::string FormatMultiTileBufTypeString(const std::string& slot_type_str, uint6
   std::ostringstream oss;
   oss << "!pto.multi_tile_buf<" << slot_type_str << ", count=" << count << ">";
   return oss.str();
+}
+
+namespace {
+
+/// Bytes a boxed fractal row is aligned to, mirroring PTOAS' `kAlignedBytes`.
+constexpr int64_t kBoxAlignedBytes = 32;
+
+/// Box granularity PTOAS derives for @p fractal / @p slayout, or nullopt when
+/// the layout is one this rule does not cover (see `CheckBoxedTileExtents`).
+std::optional<std::pair<int64_t, int64_t>> BoxGranularity(uint64_t fractal, ir::TileLayout slayout,
+                                                          int64_t elem_bytes) {
+  if (fractal == ir::tile_view_semantics::kAccFractal) {
+    return std::pair<int64_t, int64_t>{16, 16};
+  }
+  if (fractal != 512 || elem_bytes <= 0 || kBoxAlignedBytes % elem_bytes != 0) {
+    // The MX-scale fractal carries its own contract, and a carrier wider than
+    // the alignment has no whole-box grid; PTOAS diagnoses both itself.
+    return std::nullopt;
+  }
+  const int64_t packed = kBoxAlignedBytes / elem_bytes;
+  if (slayout == ir::TileLayout::row_major) return std::pair<int64_t, int64_t>{16, packed};
+  if (slayout == ir::TileLayout::col_major) return std::pair<int64_t, int64_t>{packed, 16};
+  return std::nullopt;
+}
+
+}  // namespace
+
+void CheckBoxedTileExtents(const TileTypeComponents& components, const DataType& dtype,
+                           const std::optional<ir::MemorySpace>& space, const ir::Span* span) {
+  // A non-boxed tile is addressed as a flat run of bytes; the box rule is not
+  // about it. (PTOAS checks a byte-size alignment there instead.)
+  if (components.slayout == ir::TileLayout::none_box) return;
+
+  const int64_t bits = static_cast<int64_t>(ir::storage_size::GetStorageBitWidth(dtype));
+  if (bits <= 0 || bits % 8 != 0) return;  // sub-byte carrier: not this rule
+  auto box = BoxGranularity(components.fractal, components.slayout, bits / 8);
+  if (!box) return;
+  const auto [inner_rows, inner_cols] = *box;
+
+  const std::string where = space.has_value() ? ir::MemorySpaceToString(*space) : std::string("unresolved");
+  auto report = [&](const char* axis, int64_t extent, int64_t inner) {
+    const int64_t padded = (extent + inner - 1) / inner * inner;
+    // The span is optional: some allocations are hoisted out of any single
+    // statement, and a location-less message still names the tile.
+    CHECK_SPAN(false, span != nullptr ? *span : ir::Span("", 0, 0))
+        << "a " << where << " tile of physical shape [" << components.rows << ", " << components.cols
+        << "] and dtype " << dtype.ToString() << " must be a whole number of " << inner_rows << "x"
+        << inner_cols << " fractal boxes, but its " << axis << " extent " << extent
+        << " is not a multiple of " << inner
+        << ". PTO addresses a boxed tile one box at a time, so a partial box has no address. The "
+           "*logical* extent is free -- allocate "
+        << padded << " on that axis and declare " << extent
+        << " as the tile's valid_shape (`valid_shape=` on pl.load / pl.tile.create + "
+           "pl.set_validshape), which moves and computes only the real data. A tensor-level "
+           "pl.matmul / pl.matmul_acc does this for its M axis automatically.";
+  };
+
+  // PTOAS exempts the row axis for Vec (unboxed rows) and for a single-row tile
+  // (the NZ map degenerates); the column rule always applies.
+  const bool row_exempt = (space.has_value() && *space == ir::MemorySpace::Vec) || components.rows == 1;
+  if (!row_exempt && inner_rows > 0 && components.rows % inner_rows != 0) {
+    report("row", components.rows, inner_rows);
+  }
+  if (inner_cols > 0 && components.cols % inner_cols != 0) {
+    report("column", components.cols, inner_cols);
+  }
 }
 
 TileTypeComponents ExtractTileTypeInfo(const ir::TileType& tile_type, const std::string& dtype_str_override) {

--- a/src/codegen/pto/pto_type_utils.cpp
+++ b/src/codegen/pto/pto_type_utils.cpp
@@ -22,9 +22,12 @@
 #include "pypto/core/logging.h"
 #include "pypto/ir/expr.h"
 #include "pypto/ir/kind_traits.h"
+#include "pypto/ir/memory_space.h"
 #include "pypto/ir/scalar_expr.h"
+#include "pypto/ir/span.h"
 #include "pypto/ir/storage_size.h"
 #include "pypto/ir/tile_view_semantics.h"
+#include "pypto/ir/transforms/printer.h"
 #include "pypto/ir/type.h"
 
 namespace pypto {
@@ -185,17 +188,35 @@ std::optional<std::pair<int64_t, int64_t>> BoxGranularity(uint64_t fractal, ir::
 
 }  // namespace
 
-void CheckBoxedTileExtents(const TileTypeComponents& components, const DataType& dtype,
-                           const std::optional<ir::MemorySpace>& space, const ir::Span* span) {
+void CheckBoxedTileExtents(const ir::TileType& tile_type, const TileTypeComponents& components,
+                           const ir::Span* span) {
   // A non-boxed tile is addressed as a flat run of bytes; the box rule is not
   // about it. (PTOAS checks a byte-size alignment there instead.)
   if (components.slayout == ir::TileLayout::none_box) return;
+
+  const DataType& dtype = tile_type.dtype_;
+  const auto space = tile_type.GetMemorySpace();
+
+  // `ExtractTileTypeInfo` falls back to its struct default for a dimension that
+  // is not a `ConstInt`, so a dynamic physical extent would be checked -- and
+  // emitted -- as that placeholder instead of as itself. `InitMemRef` (pass 32)
+  // already refuses a dynamic `TileType::shape_`, so reaching codegen with one
+  // is a pass bug, not user input.
+  for (const auto& dim : tile_type.shape_) {
+    INTERNAL_CHECK(As<ir::ConstInt>(dim))
+        << "Internal error: a boxed tile reached codegen with a dynamic physical extent ("
+        << ir::PythonPrint(dim)
+        << "); InitMemRef requires a static TileType::shape_, with any runtime extent in TileView";
+  }
 
   const int64_t bits = static_cast<int64_t>(ir::storage_size::GetStorageBitWidth(dtype));
   if (bits <= 0 || bits % 8 != 0) return;  // sub-byte carrier: not this rule
   auto box = BoxGranularity(components.fractal, components.slayout, bits / 8);
   if (!box) return;
-  const auto [inner_rows, inner_cols] = *box;
+  // Plain locals rather than a structured binding: the lambda below captures
+  // them, which C++17 does not allow for binding names.
+  const int64_t inner_rows = box->first;
+  const int64_t inner_cols = box->second;
 
   const std::string where = space.has_value() ? ir::MemorySpaceToString(*space) : std::string("unresolved");
   auto report = [&](const char* axis, int64_t extent, int64_t inner) {

--- a/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
+++ b/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
@@ -462,6 +462,32 @@ struct ConsumerSpaceReq {
   size_t cube_m_axis = 0;
 };
 
+/// Fold @p incoming into @p existing, the requirement already recorded for a
+/// shared producer.
+///
+/// Two rules, and both paths that record a demand -- a direct operand use and
+/// the backward sweep over inherit-input / alias / loop-carry edges -- have to
+/// apply them identically, or which demand a producer sees depends on the order
+/// its consumers happen to be visited in.
+///
+///   * A specialized space (Mat/Left/Right/Acc/Bias) beats the default Vec, so
+///     a load-like producer can emit that space directly.
+///   * The M boxing survives only where every consumer agrees on it. A differing
+///     axis or alignment means one of them reads the tile at its declared
+///     physical shape, and one buffer cannot carry two physical extents; the
+///     padding is dropped so the mismatch is reported against the shape the
+///     author actually wrote, the same way whichever consumer is visited first.
+void MergeConsumerReq(ConsumerSpaceReq* existing, const ConsumerSpaceReq& incoming) {
+  if (existing->space == MemorySpace::Vec && incoming.space != MemorySpace::Vec) {
+    *existing = incoming;
+    return;
+  }
+  if (existing->space != incoming.space) return;
+  if (existing->cube_m_axis != incoming.cube_m_axis || existing->cube_m_align != incoming.cube_m_align) {
+    existing->cube_m_align = 0;
+  }
+}
+
 /**
  * @brief Visitor that collects consumer memory space requirements for variables.
  *
@@ -497,9 +523,10 @@ class ConsumerSpaceCollector : public IRVisitor {
       if (out_it == consumer_reqs_.end()) continue;
       const auto& req = out_it->second;
       auto [ins_it, inserted] = consumer_reqs_.try_emplace(src, req);
-      if (!inserted && ins_it->second.space == MemorySpace::Vec && req.space != MemorySpace::Vec) {
-        ins_it->second = req;
-      }
+      // Same reconciliation as a direct use: a source reached both directly and
+      // through an alias must not keep whichever demand this sweep happened to
+      // reach first (see MergeConsumerReq).
+      if (!inserted) MergeConsumerReq(&ins_it->second, req);
     }
   }
 
@@ -574,26 +601,11 @@ class ConsumerSpaceCollector : public IRVisitor {
                                                                       req.m_align_from_arg.value_or(idx))
                                               : 0;
         const ConsumerSpaceReq resolved{req.space, align, CubeMAxis(call, req)};
-        // Prioritize non-Vec spaces: if an existing requirement is the default Vec but this
-        // consumer needs a specialized space (Mat/Left/Right/Acc/Bias), override it so the
-        // load-like producer can emit the specialized space directly.
+        // Several consumers can share one producer (a sliced KV feeding two
+        // matmuls, an accumulator seed read by two accumulations); MergeConsumerReq
+        // is the single rule for reconciling them.
         auto [it, inserted] = consumer_reqs_.try_emplace(var.get(), resolved);
-        if (inserted) continue;
-        if (it->second.space == MemorySpace::Vec && req.space != MemorySpace::Vec) {
-          it->second = resolved;
-        } else if (it->second.space == resolved.space) {
-          // Several consumers share one producer (e.g. a sliced KV feeding two
-          // matmuls). Box only when every one of them wants it, so a consumer
-          // that reads the tile at its declared physical shape is never handed a
-          // padded one.
-          // Box only to an extent every consumer agrees on: a differing axis
-          // or alignment means one of them reads the tile at its declared
-          // physical shape, which must never be handed a padded one.
-          if (it->second.cube_m_axis != resolved.cube_m_axis ||
-              it->second.cube_m_align != resolved.cube_m_align) {
-            it->second.cube_m_align = 0;
-          }
-        }
+        if (!inserted) MergeConsumerReq(&it->second, resolved);
       }
     }
     IRVisitor::VisitStmt_(op);

--- a/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
+++ b/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
@@ -81,11 +81,11 @@ CallPtr MarkCompilerMatBridge(const CallPtr& call, MemorySpace space) {
   return marked;
 }
 
-/// Physical shape a cube load must allocate for the window @p shape.
+/// Physical extent a cube tile must allocate on the matmul's M axis.
 ///
 /// PTO-ISA keeps two independent notions of size for a cube operand, and only
 /// one of them is constrained.  The *logical* extent is essentially free:
-/// ``pto.mad`` derives ``%m`` from the operand's valid rows, bounds it at
+/// ``pto.mad`` derives ``%m`` from the operand's valid extent, bounds it at
 /// ``[1, 4095]``, and documents ``%m == 1`` as a first-class case.  The
 /// *physical* extent must be a whole number of NZ fractal boxes — ptoas
 /// enforces exactly that (``'pto.alloc_tile' op expects result boxed tile rows
@@ -98,33 +98,79 @@ CallPtr MarkCompilerMatBridge(const CallPtr& call, MemorySpace space) {
 /// valid extent, so no extra DMA; and the MAD cost is ``ceil(M/16)`` passes,
 /// which rounding M up to a multiple of 16 leaves unchanged.
 ///
-/// Returns @p shape unchanged — leaving the emitted load byte-identical to its
-/// historical form — unless every precondition holds:
-///
-///   * rank 2.  A rank >= 3 operand lowers to ``tile.batch_matmul``, whose rows
-///     ``FlattenTileNdTo2D`` row-packs into one ``[B*M, N]`` tile; the box rule
-///     binds that packed extent, not this dimension.
-///   * a static row extent.  A dynamic one has no compile-time box to round to.
-///   * a Mat view whose ``slayout`` is row-major, the orientation whose row axis
-///     really is the matmul's M axis.  The transposed dual boxes 16 on the
-///     *column* axis instead and its row granularity is dtype-dependent; that
-///     rule is deliberately not settled here.
-std::vector<ExprPtr> BoxLoadRows(const std::vector<ExprPtr>& shape, const DataType& dtype, MemorySpace space,
-                                 const Span& span) {
-  if (shape.size() != 2) return shape;
-  auto rows = As<ConstInt>(shape[0]);
-  if (!rows || rows->value_ <= 0) return shape;
+/// @p axis is the axis of @p shape that carries M (1 for a transposed operand,
+/// whose natural load puts K on rows), and @p align the extent every cube tile
+/// of the call shares (see ``ResolveCubeMAlignment``).  Returns @p shape
+/// unchanged — leaving the emitted tile byte-identical to its historical form —
+/// when no padding applies, when the extent is dynamic (nothing to round at
+/// compile time), or when the tile is not rank 2 (a rank >= 3 operand lowers to
+/// ``tile.batch_matmul``, whose rows ``FlattenTileNdTo2D`` row-packs into one
+/// ``[B*M, N]`` tile; the box rule binds that packed extent, not this one).
+std::vector<ExprPtr> BoxCubeMAxis(const std::vector<ExprPtr>& shape, int64_t align, size_t axis,
+                                  const Span& span) {
+  if (align <= 1 || shape.size() != 2 || axis >= shape.size()) return shape;
+  auto extent = As<ConstInt>(shape[axis]);
+  if (!extent || extent->value_ <= 0) return shape;
 
-  const auto view = tile_view_semantics::GetImplicitTileView(shape, space);
-  if (view.slayout != TileLayout::row_major) return shape;
-  const auto box = tile_view_semantics::GetBoxedTileAlignment(view, dtype);
-  if (!box || box->rows <= 1) return shape;
-
-  const int64_t remainder = rows->value_ % box->rows;
+  const int64_t remainder = extent->value_ % align;
   if (remainder == 0) return shape;
   auto boxed = shape;
-  boxed[0] = std::make_shared<ConstInt>(rows->value_ + box->rows - remainder, DataType::INDEX, span);
+  boxed[axis] = std::make_shared<ConstInt>(extent->value_ + align - remainder, DataType::INDEX, span);
   return boxed;
+}
+
+/// Whether @p call reads the operand @p req describes transposed, which moves
+/// that operand's M from its row axis to its column axis.
+bool ReadsOperandTransposed(const CallPtr& call, const InputSpaceReq& req) {
+  return req.trans_kwarg && call->GetKwarg<bool>(*req.trans_kwarg, false);
+}
+
+/// Axis of the operand @p req describes that carries the matmul's M.
+size_t CubeMAxis(const CallPtr& call, const InputSpaceReq& req) {
+  return ReadsOperandTransposed(call, req) ? 1 : 0;
+}
+
+/// The physical M alignment every cube tile of @p call must share, or 0 when M
+/// cannot be boxed at compile time.
+///
+/// The granularity differs per tile even though the extent must not.  An Acc
+/// box is 16 rows for every dtype; a Mat operand's row box is also 16, but its
+/// *column* box is ``32 / sizeof(dtype)`` — 8 for FP32, 32 for INT8 — and a
+/// transposed left operand has its M on exactly that column axis.  So the
+/// alignment is the lcm of the deciding operand's own box and the accumulator's
+/// 16 rows; every granularity involved is a power of two, so the lcm is the max.
+///
+/// @p decider_idx names the operand whose layout decides (the left operand, see
+/// ``InputSpaceReq::m_align_from_arg``).  Returns 0 when that operand is not a
+/// statically boxed rank-2 tile, which is what keeps rank >= 3 and unresolved
+/// layouts on their historical unboxed path.
+int64_t ResolveCubeMAlignment(const CallPtr& call,
+                              const std::unordered_map<size_t, InputSpaceReq>& input_reqs,
+                              size_t decider_idx) {
+  auto req_it = input_reqs.find(decider_idx);
+  if (req_it == input_reqs.end() || decider_idx >= call->args_.size()) return 0;
+  const auto& decider = req_it->second;
+
+  const auto& arg_type = call->args_[decider_idx]->GetType();
+  std::vector<ExprPtr> shape;
+  DataType dtype = DataType::FP32;
+  if (auto tensor_type = As<TensorType>(arg_type)) {
+    shape = tensor_type->shape_;
+    dtype = tensor_type->dtype_;
+  } else if (auto tile_type = As<TileType>(arg_type)) {
+    shape = tile_type->shape_;
+    dtype = tile_type->dtype_;
+  } else {
+    return 0;
+  }
+  if (shape.size() != 2) return 0;
+
+  const auto view = tile_view_semantics::GetImplicitTileView(shape, decider.space);
+  const auto box = tile_view_semantics::GetBoxedTileAlignment(view, dtype);
+  if (!box) return 0;
+  const int64_t own = ReadsOperandTransposed(call, decider) ? box->cols : box->rows;
+  if (own <= 1) return 0;
+  return std::max<int64_t>(own, kAccFractalRows);
 }
 
 bool IsPassthroughTensorOp(const CallPtr& call) {
@@ -406,11 +452,14 @@ struct ConsumerSpaceReq {
   MemorySpace space;  ///< Required memory space. The consumer-driven load is always
                       ///< natural; a transposed (b_trans/a_trans) operand is realised
                       ///< by a zero-copy tile.transpose_view in BridgeInputSpaces.
-  /// Mirror of ``InputSpaceReq::cube_row_boxed``, so a load-like producer that
-  /// answers the demand directly boxes the same rows ``BridgeInputSpaces``
-  /// would have. Set only when the consumer reads the operand *untransposed*:
-  /// a transposed use makes the loaded tile's row axis K, not M.
-  bool cube_row_boxed = false;
+  /// Resolved form of ``InputSpaceReq::cube_m_axis``, so a load-like producer
+  /// that answers the demand directly boxes exactly what ``BridgeInputSpaces``
+  /// would have: ``cube_m_align`` is the extent every cube tile of the consuming
+  /// call shares (0 when M cannot be boxed), and ``cube_m_axis`` names the axis
+  /// of *this* operand that carries M — 1 when the consumer reads it
+  /// transposed, whose natural load puts K on rows.
+  int64_t cube_m_align = 0;
+  size_t cube_m_axis = 0;
 };
 
 /**
@@ -455,6 +504,21 @@ class ConsumerSpaceCollector : public IRVisitor {
   }
 
  protected:
+  /// A loop carry's demand is equally a demand on the value that seeds it: the
+  /// two share one buffer for the whole loop, so an accumulator allocated
+  /// before the loop must be built the way the body's `tile.matmul_acc` reads
+  /// it. The edge flows strictly backward (the seed is defined before the
+  /// loop), so the reverse sweep in PropagateThroughInheritInputOps resolves it
+  /// in the same single pass as the others.
+  void VisitExpr_(const IterArgPtr& op) override {
+    if (op && op->initValue_) {
+      if (auto seed = AsVarLike(op->initValue_)) {
+        propagation_edges_.emplace_back(op.get(), seed.get());
+      }
+    }
+    IRVisitor::VisitExpr_(op);
+  }
+
   void VisitStmt_(const AssignStmtPtr& op) override {
     if (!op) return;
     auto is_shaped = [](const TypePtr& t) { return As<TensorType>(t) || As<TileType>(t); };
@@ -499,11 +563,17 @@ class ConsumerSpaceCollector : public IRVisitor {
     // supplies the transpose. (No more transpose-at-load baking.)
     for (const auto& [idx, req] : entry->input_reqs) {
       if (idx >= call->args_.size()) continue;
-      if (auto var = As<Var>(call->args_[idx])) {
-        // A transposed use reinterprets the loaded tile's row axis as K, so the
-        // M-axis box rule does not apply to it (see ConsumerSpaceReq).
-        const bool transposed = req.trans_kwarg && call->GetKwarg<bool>(*req.trans_kwarg, false);
-        const ConsumerSpaceReq resolved{req.space, req.cube_row_boxed && !transposed};
+      // `AsVarLike`, not `As<Var>`: a loop-carried operand is an `IterArg`,
+      // which carries its own ObjectKind and would otherwise record no demand
+      // at all (see `ir-kind-traits.md`). A split-K accumulator reaches its
+      // `tile.matmul_acc` exactly that way.
+      if (auto var = AsVarLike(call->args_[idx])) {
+        // A transposed use moves this operand's M to its column axis, and the
+        // alignment is the one the whole call shares (see ConsumerSpaceReq).
+        const int64_t align = req.cube_m_axis ? ResolveCubeMAlignment(call, entry->input_reqs,
+                                                                      req.m_align_from_arg.value_or(idx))
+                                              : 0;
+        const ConsumerSpaceReq resolved{req.space, align, CubeMAxis(call, req)};
         // Prioritize non-Vec spaces: if an existing requirement is the default Vec but this
         // consumer needs a specialized space (Mat/Left/Right/Acc/Bias), override it so the
         // load-like producer can emit the specialized space directly.
@@ -516,7 +586,13 @@ class ConsumerSpaceCollector : public IRVisitor {
           // matmuls). Box only when every one of them wants it, so a consumer
           // that reads the tile at its declared physical shape is never handed a
           // padded one.
-          it->second.cube_row_boxed = it->second.cube_row_boxed && resolved.cube_row_boxed;
+          // Box only to an extent every consumer agrees on: a differing axis
+          // or alignment means one of them reads the tile at its declared
+          // physical shape, which must never be handed a padded one.
+          if (it->second.cube_m_axis != resolved.cube_m_axis ||
+              it->second.cube_m_align != resolved.cube_m_align) {
+            it->second.cube_m_align = 0;
+          }
         }
       }
     }
@@ -786,6 +862,18 @@ class TensorToTileMutator : public TypePropagatingMutator {
       }
     }
 
+    // Consumer-driven row boxing for an allocation that feeds a cube
+    // accumulator. Unlike an operand, an accumulator is never loaded from GM, so
+    // its create site is the only place its physical row count can still be
+    // rounded up to the box.
+    if (IsOp(call, "tensor.create")) {
+      auto consumer_req = consumer_collector_.GetConsumerReq(op->var_.get());
+      if (consumer_req && consumer_req->cube_m_align > 0) {
+        auto boxed_create = HandleBoxedAccCreate(op, call, *consumer_req);
+        if (boxed_create) return boxed_create;
+      }
+    }
+
     // Auto-bridge: load TensorType args to the memory space required by input_reqs
     auto [bridged_args, bridge_stmts] = BridgeInputSpaces(call, entry->input_reqs);
 
@@ -848,9 +936,81 @@ class TensorToTileMutator : public TypePropagatingMutator {
   }
 
  private:
+  /// Handle a `tensor.create` that seeds a cube accumulator: allocate whole NZ
+  /// fractal boxes on the row axis and declare the requested rectangle as
+  /// `valid_shape`.
+  ///
+  /// `tile.matmul_acc` requires the accumulator and the matrix product to agree
+  /// on *physical* M, so the accumulator has to be boxed by exactly the rule
+  /// `BoxCubeMAxis` applies to the left operand (see its comment for why the box
+  /// binds the physical extent and not the logical one). The operand reaches
+  /// that rule through its bridge load; an accumulator is never loaded — there
+  /// is no data path into Acc — so its allocation is the only site left.
+  ///
+  /// The narrowing rides on a separate `tile.set_validshape` because
+  /// `tile.create` takes no valid extent. It is metadata-only, so the pair costs
+  /// nothing. Returns nullptr when no padding applies, leaving the historical
+  /// single-`tile.create` lowering byte-identical.
+  StmtPtr HandleBoxedAccCreate(const AssignStmtPtr& op, const CallPtr& call, const ConsumerSpaceReq& req) {
+    if (call->args_.size() != 1) return nullptr;
+    auto shape_tuple = As<MakeTuple>(call->args_[0]);
+    if (!shape_tuple || shape_tuple->elements_.size() != 2) return nullptr;
+    const auto& shape = shape_tuple->elements_;
+
+    auto boxed = BoxCubeMAxis(shape, req.cube_m_align, req.cube_m_axis, call->span_);
+    if (AreExprVectorsEqual(boxed, shape)) return nullptr;
+
+    // Route the boxed allocation through the registered converter so it keeps
+    // the capacity check and the kwarg filtering `tensor.create` performs.
+    const auto* entry = conv_registry_.Lookup("tensor.create");
+    INTERNAL_CHECK_SPAN(entry, call->span_)
+        << "Internal error: tensor.create has no registered tile conversion";
+    auto converted =
+        As<Call>(entry->func({MakeShapeTuple(boxed, call->span_)}, call->kwargs_, call->span_).result);
+    INTERNAL_CHECK_SPAN(converted, call->span_)
+        << "Internal error: the tensor.create conversion must produce a Call";
+
+    // ... then stamp the space. The converter deliberately leaves `tensor.create`
+    // unresolved because it has no consumer context to derive a space from; here
+    // there is one, and it is the same demand that asked for the boxing. Stating
+    // it matters beyond saving InferTileMemorySpace the work: an Acc tile's
+    // implicit view is boxed NZ, so a seed left unresolved would carry the raw
+    // row-major view and disagree with the `tile.matmul_acc` result it is
+    // carried against across a loop.
+    auto create_kwargs = converted->kwargs_;
+    create_kwargs.emplace_back("target_memory", req.space);
+    // Compact, because the padding is what makes the two readings of an L0C
+    // stride disagree. `mad` lays the product out at a pitch of
+    // ceil(validRow/16)*16 -- 112 for a 100-row product -- while a non-compact
+    // reader derives its stride from the physical row count, which the box
+    // rounded to 112 or, at a 32-row alignment (a transposed INT8 operand), to
+    // 128. Compact makes every reader recompute the pitch `mad` actually used.
+    // Reaching here means padding applies, so the two never coincide by
+    // accident; `AccCompactValid` rejects the unstamped form outright.
+    if (req.space == MemorySpace::Acc) create_kwargs.emplace_back("compact", true);
+    auto storage = op_registry_.Create("tile.create", converted->args_, create_kwargs, call->span_);
+
+    auto storage_var = std::make_shared<Var>(MakeTileValueName(op->var_->name_hint_) + "_storage",
+                                             storage->GetType(), op->var_->span_);
+    auto narrowed =
+        op_registry_.Create("tile.set_validshape", {storage_var, shape[0], shape[1]}, call->span_);
+    auto tile_var =
+        std::make_shared<Var>(MakeTileValueName(op->var_->name_hint_), narrowed->GetType(), op->var_->span_);
+    var_remap_[op->var_.get()] = tile_var;
+
+    std::vector<StmtPtr> stmts = {
+        std::make_shared<AssignStmt>(storage_var, storage, op->span_),
+        std::make_shared<AssignStmt>(tile_var, narrowed, op->span_),
+    };
+    return SeqStmts::Flatten(std::move(stmts), op->span_);
+  }
+
   /// Handle tensor.slice whose consumer needs a specific memory space — produce tile.load with that space.
   StmtPtr HandleConsumerDrivenLoad(const AssignStmtPtr& op, const CallPtr& call,
                                    const ConsumerSpaceReq& req) {
+    // Acc is not a load target (see BridgeInputSpaces): nothing but the matrix
+    // unit writes L0C.
+    if (req.space == MemorySpace::Acc) return nullptr;
     const auto& input = call->args_[0];
     auto tensor_type = AsTensorTypeLike(input->GetType());
     if (!tensor_type) return nullptr;
@@ -886,8 +1046,8 @@ class TensorToTileMutator : public TypePropagatingMutator {
     // so only the allocation grows. Skipped when the slice drops a dimension:
     // the result is then not the rank-2 tile the M-axis rule is about.
     ExprPtr physical_shape_arg = shape_arg;
-    if (req.cube_row_boxed && drop_dims.empty()) {
-      auto boxed = BoxLoadRows(full_shape, tensor_type->dtype_, req.space, call->span_);
+    if (req.cube_m_align > 0 && drop_dims.empty()) {
+      auto boxed = BoxCubeMAxis(full_shape, req.cube_m_align, req.cube_m_axis, call->span_);
       if (!AreExprVectorsEqual(boxed, full_shape)) {
         physical_shape_arg = MakeShapeTuple(boxed, call->span_);
       }
@@ -945,19 +1105,19 @@ class TensorToTileMutator : public TypePropagatingMutator {
     // and return the bound load Var. The load is always natural; a transposed
     // operand is realised by a zero-copy tile.transpose_view on the result.
     //
-    // `row_boxed` marks a cube operand (see InputSpaceReq::cube_row_boxed): the
-    // load then allocates a whole number of NZ fractal boxes on the row axis and
-    // declares the tensor's true extent as valid_shape. `BoxLoadRows` returns the
-    // physical shape; it equals `tensor_type->shape_` whenever no padding applies,
-    // so a fractal-sized operand keeps its historical byte-identical load.
+    // `m_align` / `m_axis` mark a cube operand (see InputSpaceReq::cube_m_axis):
+    // the load then allocates a whole number of NZ fractal boxes on the axis that
+    // carries M and declares the tensor's true extent as valid_shape.
+    // `BoxCubeMAxis` returns the physical shape; it equals `tensor_type->shape_`
+    // whenever no padding applies, so a fractal-sized operand keeps its
+    // historical byte-identical load.
     auto emit_load = [&](const ExprPtr& arg, const TensorTypePtr& tensor_type, MemorySpace space, size_t idx,
-                         bool row_boxed) -> VarPtr {
+                         int64_t m_align, size_t m_axis) -> VarPtr {
       auto offsets = MakeZeroOffsets(tensor_type->shape_.size(), call->span_);
       auto valid = MakeShapeTuple(tensor_type->shape_, call->span_);
-      auto shapes = row_boxed ? MakeShapeTuple(
-                                    BoxLoadRows(tensor_type->shape_, tensor_type->dtype_, space, call->span_),
-                                    call->span_)
-                              : valid;
+      auto boxed = BoxCubeMAxis(tensor_type->shape_, m_align, m_axis, call->span_);
+      auto shapes =
+          AreExprVectorsEqual(boxed, tensor_type->shape_) ? valid : MakeShapeTuple(boxed, call->span_);
       std::vector<std::pair<std::string, std::any>> load_kw = {{"target_memory", space}};
       AppendCachePolicyKwarg(arg, cache_policies_, &load_kw);
       auto load = MarkCompilerMatBridge(
@@ -1007,17 +1167,24 @@ class TensorToTileMutator : public TypePropagatingMutator {
     for (size_t idx : sorted_indices) {
       const auto& req = input_reqs.at(idx);
       if (idx >= args.size()) continue;
+      // Acc is never a bridge target: only the matrix unit writes L0C, so no
+      // load can put a GM tensor there. An Acc req exists to carry the cube
+      // row-box demand back to the operand's producer (HandleBoxedAccCreate);
+      // leaving the operand alone here keeps InferTileMemorySpace's "no data
+      // path into Acc memory" diagnostic, which names the real limitation.
+      if (req.space == MemorySpace::Acc) continue;
       const bool use_view = req.trans_kwarg ? call->GetKwarg<bool>(*req.trans_kwarg, false) : false;
       auto tensor_type = As<TensorType>(args[idx]->GetType());
 
       if (tensor_type) {
         // GM operand: load NATURAL (2D and ND alike), then reinterpret as its
         // transpose with a zero-copy view when b_trans/a_trans.
-        // A transposed operand keeps its natural (unboxed) load: the
+        // A transposed operand is boxed on its *column* axis: the
         // tile.transpose_view below reinterprets the row axis as the matmul's K,
-        // so boxing rows here would pad the wrong axis.
-        const bool row_boxed = req.cube_row_boxed && !use_view;
-        auto loaded = emit_load(args[idx], tensor_type, req.space, idx, row_boxed);
+        // so M is the column extent the natural load allocates.
+        const int64_t m_align =
+            req.cube_m_axis ? ResolveCubeMAlignment(call, input_reqs, req.m_align_from_arg.value_or(idx)) : 0;
+        auto loaded = emit_load(args[idx], tensor_type, req.space, idx, m_align, CubeMAxis(call, req));
         args[idx] = use_view ? emit_view(loaded) : loaded;
         continue;
       }
@@ -2059,6 +2226,10 @@ IncoreTransformResult TransformIncoreFunction(const FunctionPtr& func) {
     // overwrite a real answer with a default and make pass 17 honour it (it
     // never overrides a present kwarg).
     auto entry_req = consumer_collector.GetConsumerReq(var.get());
+    // An Acc demand is not a load target either (see BridgeInputSpaces): a
+    // parameter cannot be loaded into L0C, so the entry load stays natural and
+    // the accumulator constraint is reported where it actually holds.
+    if (entry_req.has_value() && entry_req->space == MemorySpace::Acc) entry_req.reset();
     std::vector<std::pair<std::string, std::any>> load_kwargs;
     if (entry_req.has_value()) {
       load_kwargs.emplace_back("target_memory", entry_req->space);
@@ -2069,8 +2240,9 @@ IncoreTransformResult TransformIncoreFunction(const FunctionPtr& func) {
     // BridgeInputSpaces / HandleConsumerDrivenLoad -- so the same row boxing has
     // to apply, or the cube operand keeps its unaligned physical row count.
     ExprPtr shapes = valid;
-    if (entry_req.has_value() && entry_req->cube_row_boxed) {
-      auto boxed = BoxLoadRows(tensor_type->shape_, tensor_type->dtype_, entry_req->space, load_span);
+    if (entry_req.has_value() && entry_req->cube_m_align > 0) {
+      auto boxed =
+          BoxCubeMAxis(tensor_type->shape_, entry_req->cube_m_align, entry_req->cube_m_axis, load_span);
       if (!AreExprVectorsEqual(boxed, tensor_type->shape_)) {
         shapes = MakeShapeTuple(boxed, load_span);
       }

--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -1152,7 +1152,7 @@ void OpConversionRegistry::RegisterMatmulOps() {
         const std::string out_op = nd ? "tile.batch_matmul" : "tile.matmul";
         return ConversionResult{OpRegistry::GetInstance().Create(out_op, {args[0], args[1]}, span)};
       },
-      {{0, {MemorySpace::Mat, "a_trans", /*cube_row_boxed=*/true}}, {1, {MemorySpace::Mat, "b_trans"}}});
+      {{0, {MemorySpace::Mat, "a_trans", /*cube_m_axis=*/true}}, {1, {MemorySpace::Mat, "b_trans"}}});
 
   // tensor.matmul_acc: 2D × 2D × 2D → tile.matmul_acc; any operand ≥3D →
   // tile.batch_matmul_acc. Same a_trans/b_trans handling as tensor.matmul.
@@ -1175,14 +1175,18 @@ void OpConversionRegistry::RegisterMatmulOps() {
         if (args.size() == 4) out_args.push_back(args[3]);
         return ConversionResult{OpRegistry::GetInstance().Create(out_op, out_args, span)};
       },
-      // The left operand is deliberately NOT row-boxed here, unlike
-      // tensor.matmul's. tile.matmul_acc requires the accumulator and the
-      // product to agree on *physical* M, and the accumulator arrives from a
-      // separate tile.create whose allocation this rule cannot reach — boxing
-      // only the operand would turn an unaligned M from a ptoas rejection into
-      // an operand-mismatch one. Boxing an accumulator needs consumer-driven
-      // information about the create site and is left as follow-up work.
-      {{1, {MemorySpace::Mat, "a_trans"}}, {2, {MemorySpace::Mat, "b_trans"}}});
+      // Same M boxing as tensor.matmul, on *both* cube tiles the M axis runs
+      // through. tile.matmul_acc requires the accumulator and the product to
+      // agree on physical M, so boxing the left operand alone would trade a
+      // ptoas rejection for an operand-mismatch one — the two have to move
+      // together, which is what `m_align_from_arg` states: the accumulator's own
+      // Acc box is 16 rows, but it adopts whatever extent the left operand's
+      // layout requires. The accumulator's req carries no bridge load (there is
+      // no data path into Acc); it exists so ConsumerSpaceCollector can hand the
+      // demand back to the allocation site, where HandleBoxedAccCreate answers it.
+      {{0, {MemorySpace::Acc, std::nullopt, /*cube_m_axis=*/true, /*m_align_from_arg=*/1}},
+       {1, {MemorySpace::Mat, "a_trans", /*cube_m_axis=*/true}},
+       {2, {MemorySpace::Mat, "b_trans"}}});
 }
 
 // ============================================================================

--- a/tests/ut/codegen/test_codegen_preconditions.py
+++ b/tests/ut/codegen/test_codegen_preconditions.py
@@ -89,6 +89,111 @@ def test_device_kernel_rejects_descending_loop():
         codegen.PTOCodegen().generate(optimized)
 
 
+@pytest.mark.parametrize(
+    ("name", "rows", "cols", "dtype", "axis", "inner", "padded"),
+    [
+        # M on the row axis: the box is 16 rows for every dtype.
+        ("row_axis", 100, 128, pl.FP16, "row", 16, 112),
+        # K on the column axis: the box holds 32 bytes' worth of elements, so
+        # 16 for FP16 -- the axis this compiler does not pad for the user.
+        ("col_axis", 128, 24, pl.FP16, "column", 16, 32),
+        # An 8-bit column box is 32 elements wide, not 16.
+        ("col_axis_int8", 128, 24, pl.INT8, "column", 32, 32),
+    ],
+)
+def test_sub_fractal_cube_tile_is_rejected_by_pypto(name, rows, cols, dtype, axis, inner, padded):
+    """A partial fractal box is refused here, not left for PTOAS to refuse.
+
+    PTO addresses a boxed tile one box at a time, so a tile whose physical
+    extent is not a whole number of boxes has no address. PTOAS enforces that on
+    the ``pto.alloc_tile`` it receives, but its message names PTOAS internals
+    (``expects result boxed tile rows to be a multiple of innerRows (16)``) and
+    offers no remedy. Checking it where PyPTO emits the allocation reports the
+    tile, the axis, the extent to reach, and how to reach it.
+
+    Both axes and both granularities are covered: the row box is 16 for every
+    dtype, while the column box holds 32 bytes' worth of elements.
+    """
+
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kern(
+            self,
+            a: pl.Tensor[[rows, cols], dtype],
+            b: pl.Tensor[[cols, 64], dtype],
+            out: pl.Out[pl.Tensor[[rows, 64], pl.FP32]],
+        ) -> pl.Tensor[[rows, 64], pl.FP32]:
+            # Written at the tile level so the shape reaches codegen verbatim:
+            # a tensor-level pl.matmul would box its M axis automatically.
+            am = pl.tile.load(a, [0, 0], [rows, cols], target_memory=pl.MemorySpace.Mat)
+            bm = pl.tile.load(b, [0, 0], [cols, 64], target_memory=pl.MemorySpace.Mat)
+            acc = pl.tile.matmul(am, bm)
+            return pl.tile.store(acc, [0, 0], out)
+
+    backend.reset_for_testing()
+    backend.set_backend_type(BackendType.Ascend910B)
+    optimized = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(Prog)
+
+    with pytest.raises(ValueError) as excinfo:
+        codegen.PTOCodegen().generate(optimized)
+    message = str(excinfo.value)
+    assert f"its {axis} extent" in message, message
+    assert f"not a multiple of {inner}" in message, message
+    # The remedy has to name the extent to reach and where to declare the real one.
+    assert f"allocate {padded} on that axis" in message, message
+    assert "valid_shape" in message, message
+
+
+def test_fractal_sized_cube_tile_still_lowers():
+    """The guard above does not over-reach: a whole-box tile is untouched."""
+
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kern(
+            self,
+            a: pl.Tensor[[112, 128], pl.FP16],
+            b: pl.Tensor[[128, 64], pl.FP16],
+            out: pl.Out[pl.Tensor[[112, 64], pl.FP32]],
+        ) -> pl.Tensor[[112, 64], pl.FP32]:
+            am = pl.tile.load(a, [0, 0], [112, 128], target_memory=pl.MemorySpace.Mat)
+            bm = pl.tile.load(b, [0, 0], [128, 64], target_memory=pl.MemorySpace.Mat)
+            acc = pl.tile.matmul(am, bm)
+            return pl.tile.store(acc, [0, 0], out)
+
+    backend.reset_for_testing()
+    backend.set_backend_type(BackendType.Ascend910B)
+    optimized = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(Prog)
+    assert codegen.PTOCodegen().generate(optimized)
+
+
+def test_sub_fractal_rows_are_accepted_where_pto_exempts_them():
+    """Vec is exempt from the row rule, so an unaligned Vec tile still lowers.
+
+    PTO only boxes the matrix spaces; a Vec tile's rows are unconstrained. The
+    guard mirrors that exemption rather than imposing a stricter rule than the
+    hardware's.
+    """
+
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.AIV)
+        def kern(
+            self,
+            x: pl.Tensor[[100, 64], pl.FP32],
+            out: pl.Out[pl.Tensor[[100, 64], pl.FP32]],
+        ) -> pl.Tensor[[100, 64], pl.FP32]:
+            t: pl.Tile[[100, 64], pl.FP32] = pl.load(x, [0, 0], [100, 64])
+            t = pl.add(t, t)
+            return pl.store(t, [0, 0], out)
+
+    backend.reset_for_testing()
+    backend.set_backend_type(BackendType.Ascend910B)
+    optimized = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(Prog)
+    assert codegen.PTOCodegen().generate(optimized)
+
+
 def test_device_kernel_accepts_ascending_loop():
     """The ascending counterpart of the descending-loop rejection still lowers.
 

--- a/tests/ut/codegen/test_pto_codegen_ops.py
+++ b/tests/ut/codegen/test_pto_codegen_ops.py
@@ -4854,24 +4854,28 @@ class TestB03TriAndGatherCodegen:
             def kernel(
                 self,
                 mem: pl.Tensor[[64, 32], dtype],
-                idx: pl.Tensor[[1, 16], pl.INT32],
-                eye: pl.Tensor[[16, 16], dtype],
-                out: pl.Tensor[[16, 32], pl.FP32],
-            ) -> pl.Tensor[[16, 32], pl.FP32]:
-                gathered: pl.Tile[[16, 32], dtype] = pl.tile.mgather(
+                idx: pl.Tensor[[1, 32], pl.INT32],
+                # K = 32, not 16: an 8-bit Mat tile's column box holds
+                # 32 bytes / 1 byte = 32 elements, so a 16-column operand is a
+                # partial box with no address. This operand is scaffolding for
+                # the mgather under test, so it takes the legal K.
+                eye: pl.Tensor[[32, 32], dtype],
+                out: pl.Tensor[[32, 32], pl.FP32],
+            ) -> pl.Tensor[[32, 32], pl.FP32]:
+                gathered: pl.Tile[[32, 32], dtype] = pl.tile.mgather(
                     mem,
                     idx,
                     target_memory=pl.MemorySpace.Mat,
                 )
-                eye_tile: pl.Tile[[16, 16], dtype] = pl.load(
-                    eye, [0, 0], [16, 16], target_memory=pl.MemorySpace.Mat
+                eye_tile: pl.Tile[[32, 32], dtype] = pl.load(
+                    eye, [0, 0], [32, 32], target_memory=pl.MemorySpace.Mat
                 )
-                product: pl.Tile[[16, 32], pl.FP32] = pl.matmul(eye_tile, gathered)
+                product: pl.Tile[[32, 32], pl.FP32] = pl.matmul(eye_tile, gathered)
                 return pl.store(product, [0, 0], out)
 
         mlir = self._generate_mlir(Prog, BackendType.Ascend950)
         mem_type = f"!pto.partition_tensor_view<64x32x{dtype_text}>"
-        idx_type = "!pto.partition_tensor_view<1x16xi32>"
+        idx_type = "!pto.partition_tensor_view<1x32xi32>"
         self._assert_partition_view(mlir, result="%mem_pview", source="%mem_view", result_type=mem_type)
         self._assert_partition_view(mlir, result="%idx_pview", source="%idx_view", result_type=idx_type)
         gathered_type = self._alloc_tile_type(mlir, "%gathered")

--- a/tests/ut/ir/transforms/test_auto_tile_matmul_l0.py
+++ b/tests/ut/ir/transforms/test_auto_tile_matmul_l0.py
@@ -1029,6 +1029,42 @@ class TestAutoTileMatmulL0FractalBoundary:
         printed = ir.python_print(After)
         assert f"valid_shape=[{m_dim}, " in printed, f"the accumulator must carry the true M={m_dim} extent"
 
+    @pytest.mark.parametrize("m_dim", [1, 17, 40, 100, 250])
+    def test_no_sub_fractal_cube_rows_for_the_accumulating_spelling(self, m_dim):
+        """``pl.matmul_acc`` holds the same invariant at the same set of M.
+
+        The accumulating spelling has a second cube tile the rule has to reach:
+        the accumulator, which is allocated rather than loaded. Since
+        ``tile.matmul_acc`` requires it and the product to agree on physical M,
+        an accumulator left at the declared extent would either reach ptoas
+        sub-fractal or be rejected outright against a boxed operand -- so the
+        two are boxed together, and this pass sees a 16-aligned M either way.
+        """
+        k_dim, n_dim = 256, 512
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                a: pl.Tensor[[m_dim, k_dim], pl.FP16],
+                b: pl.Tensor[[k_dim, n_dim], pl.FP16],
+                out: pl.Out[pl.Tensor[[m_dim, n_dim], pl.FP32]],
+            ) -> pl.Tensor[[m_dim, n_dim], pl.FP32]:
+                acc = pl.create_tensor([m_dim, n_dim], pl.FP32)
+                c = pl.matmul_acc(acc, a, b)
+                out = pl.assemble(out, c, [0, 0])
+                return out
+
+        After = passes.auto_tile_matmul_l0()(_lower_to_tile_ops(Before))
+        rows = _cube_m_axis_rows(After)
+        assert rows, "expected at least one Left/Acc tile in the lowered program"
+        sub_fractal = sorted({r for r in rows if r % 16})
+        assert not sub_fractal, f"sub-fractal cube rows for M={m_dim}: {sub_fractal}"
+
+        printed = ir.python_print(After)
+        assert f"valid_shape=[{m_dim}, " in printed, f"the accumulator must carry the true M={m_dim} extent"
+
 
 class TestAutoTileMatmulL0PredicatedAcc:
     """A caller-written ``init_cond`` is threaded through the K-only emitter.

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -2003,6 +2003,66 @@ class TestConvertTensorToTileOps:
         # agreement holds -- which is what the pass would otherwise break.
         assert "[32, 128], [17, 128]" in printed, printed
 
+    @pytest.mark.parametrize("acc_trans_first", [False, True])
+    def test_conflicting_cube_m_demands_leave_the_seed_unboxed(self, acc_trans_first):
+        """Two consumers wanting different M alignments must not race.
+
+        One buffer cannot carry two physical M extents, so this program cannot
+        compile either way -- the point is *which* extent it is reported against.
+        INT8 is the only dtype where the two demands differ (a plain operand's M
+        box is 16, an ``a_trans`` operand's column box is 32) while both share the
+        INT32 accumulator dtype, and routing one use through
+        ``tensor.set_validshape`` makes that demand arrive on the seed through the
+        backward propagation sweep rather than as a direct use.
+
+        The sweep used to keep whichever demand it reached first, so the seed was
+        boxed to 112 or 128 depending on statement order and the mismatch was
+        reported against a shape the author never wrote. ``MergeConsumerReq`` now
+        applies the same reconciliation on both paths: the disputed padding is
+        dropped, and the accumulator is reported at its declared extent either way.
+        """
+        rows, k_dim, n_dim = 100, 128, 64
+
+        if acc_trans_first:
+
+            @pl.program
+            class Before:
+                @pl.function(type=pl.FunctionType.InCore)
+                def main_incore_0(
+                    self,
+                    a: pl.Tensor[[rows, k_dim], pl.INT8],
+                    at: pl.Tensor[[k_dim, rows], pl.INT8],
+                    b: pl.Tensor[[k_dim, n_dim], pl.INT8],
+                ) -> pl.Tensor[[rows, n_dim], pl.INT32]:
+                    acc: pl.Tensor[[rows, n_dim], pl.INT32] = pl.create_tensor([rows, n_dim], dtype=pl.INT32)
+                    accv: pl.Tensor[[rows, n_dim], pl.INT32] = pl.tensor.set_validshape(acc, rows, n_dim)
+                    y: pl.Tensor[[rows, n_dim], pl.INT32] = pl.matmul_acc(acc, at, b, a_trans=True)
+                    x: pl.Tensor[[rows, n_dim], pl.INT32] = pl.matmul_acc(accv, a, b)
+                    return pl.tensor.add(x, y)
+        else:
+
+            @pl.program
+            class Before:
+                @pl.function(type=pl.FunctionType.InCore)
+                def main_incore_0(
+                    self,
+                    a: pl.Tensor[[rows, k_dim], pl.INT8],
+                    at: pl.Tensor[[k_dim, rows], pl.INT8],
+                    b: pl.Tensor[[k_dim, n_dim], pl.INT8],
+                ) -> pl.Tensor[[rows, n_dim], pl.INT32]:
+                    acc: pl.Tensor[[rows, n_dim], pl.INT32] = pl.create_tensor([rows, n_dim], dtype=pl.INT32)
+                    accv: pl.Tensor[[rows, n_dim], pl.INT32] = pl.tensor.set_validshape(acc, rows, n_dim)
+                    x: pl.Tensor[[rows, n_dim], pl.INT32] = pl.matmul_acc(accv, a, b)
+                    y: pl.Tensor[[rows, n_dim], pl.INT32] = pl.matmul_acc(acc, at, b, a_trans=True)
+                    return pl.tensor.add(x, y)
+
+        with pytest.raises(ValueError) as excinfo:
+            passes.convert_tensor_to_tile_ops()(Before)
+        message = str(excinfo.value)
+        # The seed keeps its declared extent in both orders; only the operand it
+        # is measured against differs, and each call names its own.
+        assert f"acc M={rows}" in message, message
+
     def test_mixed_kernel_vec_btrans_moves_to_mat_then_views(self):
         """A Vec compute result (add) feeding a b_trans=True 2D matmul is bridged to Mat
         via a NATURAL tile.move, then transposed by a zero-copy tile.transpose_view — NOT

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -1771,19 +1771,27 @@ class TestConvertTensorToTileOps:
 
         _assert_convert_equal(Before, Expected)
 
-    def test_matmul_a_trans_lhs_keeps_its_natural_load(self):
-        """A transposed left operand is NOT row-boxed.
+    @pytest.mark.parametrize(
+        ("name", "dtype", "acc_dtype", "cols", "boxed_cols"),
+        [
+            # The column box holds 32 bytes' worth of elements: 16 for FP16, 32 for INT8.
+            ("fp16", DataType.FP16, DataType.FP32, 17, 32),
+            ("int8", DataType.INT8, DataType.INT32, 100, 128),
+        ],
+    )
+    def test_matmul_a_trans_lhs_is_boxed_on_its_column_axis(self, name, dtype, acc_dtype, cols, boxed_cols):
+        """A transposed left operand is boxed on its COLUMN axis, not its rows.
 
         ``a_trans`` loads the operand naturally and reinterprets it with a
         zero-copy ``tile.transpose_view``, so the loaded tile's row axis is the
-        matmul's ``K``, not its ``M``. Boxing rows there would pad the wrong axis;
-        the transposed dual's own granularity is dtype-dependent and is not
-        settled by this rule.
+        matmul's ``K`` and its *column* axis is ``M``. The box rule follows M to
+        whichever axis carries it. The granularity there is the fractal-512
+        column box, ``32 / sizeof(dtype)`` -- which is why the INT8 case pads to
+        128 rather than to the 112 a row-axis box would give.
         """
-        lhs_shape = [128, 17]
+        lhs_shape = [128, cols]
         rhs_shape = [128, 64]
-        out_shape = [17, 64]
-        dtype = DataType.FP16
+        out_shape = [cols, 64]
         in_specs: list[InSpec] = [("lhs", lhs_shape, dtype), ("rhs", rhs_shape, dtype)]
 
         def before_body(ib, ins):
@@ -1793,7 +1801,7 @@ class TestConvertTensorToTileOps:
             lhs_p, rhs_p = params
             lhs_mat = ib.let(
                 "lhs_mat",
-                tile_ops.load(lhs_p, [0, 0], lhs_shape, lhs_shape, target_memory=MemorySpace.Mat),
+                tile_ops.load(lhs_p, [0, 0], [128, boxed_cols], lhs_shape, target_memory=MemorySpace.Mat),
             )
             lhs_operand = ib.let("lhs_mat_t", tile_ops.transpose_view(lhs_mat))
             rhs_mat = ib.let(
@@ -1802,11 +1810,198 @@ class TestConvertTensorToTileOps:
             )
             return ib.let("y_tile", tile_ops.matmul(lhs_operand, rhs_mat))
 
-        before = _make_before(in_specs=in_specs, out_shape=out_shape, out_dtype=dtype, body=before_body)
+        before = _make_before(in_specs=in_specs, out_shape=out_shape, out_dtype=acc_dtype, body=before_body)
         expected = _make_expected(
-            in_specs=in_specs, out_shape=out_shape, out_dtype=dtype, body=expected_body, preload=False
+            in_specs=in_specs, out_shape=out_shape, out_dtype=acc_dtype, body=expected_body, preload=False
         )
         _assert_convert_equal(before, expected)
+
+    @pytest.mark.parametrize(
+        ("name", "rows", "boxed_rows"),
+        [
+            ("single_row", 1, 16),
+            ("just_over_one_box", 17, 32),
+            ("mid_box", 100, 112),
+        ],
+    )
+    def test_matmul_acc_boxes_its_accumulator_with_its_lhs(self, name, rows, boxed_rows):
+        """``tensor.matmul_acc`` takes exactly ``tensor.matmul``'s M constraint.
+
+        The same box rule binds both cube operands the M axis runs through, and
+        it has to bind them *together*: ``tile.matmul_acc`` requires the
+        accumulator and the product to agree on physical M, so boxing the left
+        operand alone would trade one hard error for another. The accumulator is
+        never loaded -- nothing but the matrix unit writes L0C -- so its
+        allocation is where the demand is answered, and the narrowing rides on a
+        ``tile.set_validshape`` because ``tile.create`` takes no valid extent.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self, a: pl.Tensor[[rows, 128], pl.FP16], b: pl.Tensor[[128, 64], pl.FP16]
+            ) -> pl.Tensor[[rows, 64], pl.FP32]:
+                acc: pl.Tensor[[rows, 64], pl.FP32] = pl.create_tensor([rows, 64], dtype=pl.FP32)
+                y: pl.Tensor[[rows, 64], pl.FP32] = pl.matmul_acc(acc, a, b)
+                return y
+
+            @pl.function
+            def main(
+                self, a: pl.Tensor[[rows, 128], pl.FP16], b: pl.Tensor[[128, 64], pl.FP16]
+            ) -> pl.Tensor[[rows, 64], pl.FP32]:
+                y: pl.Tensor[[rows, 64], pl.FP32] = self.main_incore_0(a, b)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                a: pl.Tensor[[rows, 128], pl.FP16],
+                b: pl.Tensor[[128, 64], pl.FP16],
+                ret0_out: pl.Out[pl.Tensor[[rows, 64], pl.FP32]],
+            ) -> pl.Tensor[[rows, 64], pl.FP32]:
+                # compact: the box rounds the allocation past the pitch `mad`
+                # writes at (ceil(valid/16)*16), so every reader has to recompute
+                # that pitch rather than derive it from the physical rows.
+                acc_storage = pl.tile.create(
+                    [boxed_rows, 64], dtype=pl.FP32, target_memory=pl.MemorySpace.Acc, compact=True
+                )
+                acc_tile = pl.tile.set_validshape(acc_storage, rows, 64)
+                a_mat: pl.Tile[[boxed_rows, 128], pl.FP16, pl.MemorySpace.Mat] = pl.load(
+                    a, [0, 0], [boxed_rows, 128], [rows, 128], target_memory=pl.MemorySpace.Mat
+                )
+                b_mat: pl.Tile[[128, 64], pl.FP16, pl.MemorySpace.Mat] = pl.load(
+                    b, [0, 0], [128, 64], [128, 64], target_memory=pl.MemorySpace.Mat
+                )
+                y_tile = pl.tile.matmul_acc(acc_tile, a_mat, b_mat)
+                out_store: pl.Tensor[[rows, 64], pl.FP32] = pl.store(y_tile, [0, 0], ret0_out)
+                return out_store
+
+            @pl.function
+            def main(
+                self, a: pl.Tensor[[rows, 128], pl.FP16], b: pl.Tensor[[128, 64], pl.FP16]
+            ) -> pl.Tensor[[rows, 64], pl.FP32]:
+                ret0_out: pl.Tensor[[rows, 64], pl.FP32] = pl.create_tensor([rows, 64], dtype=pl.FP32)
+                y: pl.Tensor[[rows, 64], pl.FP32] = self.main_incore_0(a, b, ret0_out)
+                return y
+
+        _assert_convert_equal(Before, Expected)
+
+    @pytest.mark.parametrize(
+        ("name", "dtype", "acc_dtype", "cols", "boxed"),
+        [
+            # FP16's column box is 16, so M lands on the same 16 the accumulator
+            # wants. INT8's is 32, which is the case that proves the two share
+            # one alignment rather than each taking its own.
+            ("fp16", DataType.FP16, DataType.FP32, 17, 32),
+            ("int8", DataType.INT8, DataType.INT32, 100, 128),
+        ],
+    )
+    def test_matmul_acc_a_trans_shares_the_operand_column_alignment(
+        self, name, dtype, acc_dtype, cols, boxed
+    ):
+        """An ``a_trans`` accumulator adopts the operand's column granularity.
+
+        The op requires the accumulator and the product to agree on physical M,
+        but the two tiles' own box granularities differ: an Acc box is 16 rows
+        for every dtype, while a transposed operand's column box is
+        ``32 / sizeof(dtype)`` -- 32 for INT8. Each taking its own would give a
+        128-row product and a 112-row accumulator. ``m_align_from_arg`` makes the
+        accumulator adopt the left operand's, so both land on 128.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self, a: pl.Tensor[[128, cols], dtype], b: pl.Tensor[[128, 64], dtype]
+            ) -> pl.Tensor[[cols, 64], acc_dtype]:
+                acc: pl.Tensor[[cols, 64], acc_dtype] = pl.create_tensor([cols, 64], dtype=acc_dtype)
+                y: pl.Tensor[[cols, 64], acc_dtype] = pl.matmul_acc(acc, a, b, a_trans=True)
+                return y
+
+            @pl.function
+            def main(
+                self, a: pl.Tensor[[128, cols], dtype], b: pl.Tensor[[128, 64], dtype]
+            ) -> pl.Tensor[[cols, 64], acc_dtype]:
+                y: pl.Tensor[[cols, 64], acc_dtype] = self.main_incore_0(a, b)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                a: pl.Tensor[[128, cols], dtype],
+                b: pl.Tensor[[128, 64], dtype],
+                ret0_out: pl.Out[pl.Tensor[[cols, 64], acc_dtype]],
+            ) -> pl.Tensor[[cols, 64], acc_dtype]:
+                acc_storage = pl.tile.create(
+                    [boxed, 64], dtype=acc_dtype, target_memory=pl.MemorySpace.Acc, compact=True
+                )
+                acc_tile = pl.tile.set_validshape(acc_storage, cols, 64)
+                # M is the operand's column axis: the natural load pads there and
+                # transpose_view swaps it onto the product's row axis.
+                a_mat: pl.Tile[[128, boxed], dtype, pl.MemorySpace.Mat] = pl.load(
+                    a, [0, 0], [128, boxed], [128, cols], target_memory=pl.MemorySpace.Mat
+                )
+                a_mat_t = pl.tile.transpose_view(a_mat)
+                b_mat: pl.Tile[[128, 64], dtype, pl.MemorySpace.Mat] = pl.load(
+                    b, [0, 0], [128, 64], [128, 64], target_memory=pl.MemorySpace.Mat
+                )
+                y_tile = pl.tile.matmul_acc(acc_tile, a_mat_t, b_mat)
+                out_store: pl.Tensor[[cols, 64], acc_dtype] = pl.store(y_tile, [0, 0], ret0_out)
+                return out_store
+
+            @pl.function
+            def main(
+                self, a: pl.Tensor[[128, cols], dtype], b: pl.Tensor[[128, 64], dtype]
+            ) -> pl.Tensor[[cols, 64], acc_dtype]:
+                ret0_out: pl.Tensor[[cols, 64], acc_dtype] = pl.create_tensor([cols, 64], dtype=acc_dtype)
+                y: pl.Tensor[[cols, 64], acc_dtype] = self.main_incore_0(a, b, ret0_out)
+                return y
+
+        _assert_convert_equal(Before, Expected)
+
+    def test_loop_carried_accumulator_seed_is_row_boxed(self):
+        """A split-K accumulator reaches its matmul_acc as an ``IterArg``.
+
+        The seed is allocated before the loop and the body accumulates into the
+        carry, so the demand has to cross two hops the collector used to drop:
+        an ``IterArg`` is not matched by ``As<Var>`` at the use site, and its
+        link back to the seed is not an inherit-input edge. Without both, the
+        seed keeps its unaligned physical rows while the boxed operand gives a
+        wider product, and the op rejects the pair on physical M.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self, a: pl.Tensor[[17, 128], pl.FP16], b: pl.Tensor[[128, 64], pl.FP16]
+            ) -> pl.Tensor[[17, 64], pl.FP32]:
+                seed: pl.Tensor[[17, 64], pl.FP32] = pl.create_tensor([17, 64], dtype=pl.FP32)
+                for _k, (carry,) in pl.range(2, init_values=(seed,)):
+                    step: pl.Tensor[[17, 64], pl.FP32] = pl.matmul_acc(carry, a, b)
+                    acc: pl.Tensor[[17, 64], pl.FP32] = pl.yield_(step)
+                return acc
+
+            @pl.function
+            def main(
+                self, a: pl.Tensor[[17, 128], pl.FP16], b: pl.Tensor[[128, 64], pl.FP16]
+            ) -> pl.Tensor[[17, 64], pl.FP32]:
+                y: pl.Tensor[[17, 64], pl.FP32] = self.main_incore_0(a, b)
+                return y
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        printed = ir.python_print(After)
+        assert "pl.tile.create([32, 64]" in printed, printed
+        assert "pl.tile.set_validshape(" in printed, printed
+        # The operand is boxed to the same physical M, so the op's physical-M
+        # agreement holds -- which is what the pass would otherwise break.
+        assert "[32, 128], [17, 128]" in printed, printed
 
     def test_mixed_kernel_vec_btrans_moves_to_mat_then_views(self):
         """A Vec compute result (add) feeding a b_trans=True 2D matmul is bridged to Mat


### PR DESCRIPTION
## The bug

`pl.matmul` boxes its left operand's M to a whole NZ fractal (#2572), so any M
compiles. Two spellings of the same computation did not:

| form | M = 100 before |
| ---- | -------------- |
| `pl.matmul(a, b)` | fine |
| `pl.matmul_acc(acc, a, b)` | `'pto.alloc_tile' op expects result boxed tile rows to be a multiple of innerRows (16), but got 100` |
| `pl.matmul(a, b, a_trans=True)` | `... boxed tile cols to be a multiple of innerCols (16), but got 100` |

Both messages come from ptoas, name ptoas internals, and offer no remedy.

## The M axis, on every cube tile it runs through

`tile.matmul_acc` requires the accumulator and the product to agree on *physical*
M, so boxing the left operand alone trades one hard error for another — the two
have to move together. An accumulator is never loaded (nothing but the matrix
unit writes L0C), so its `tensor.create` is the site that answers the demand:
`HandleBoxedAccCreate` rewrites it into a boxed `tile.create` plus a
`tile.set_validshape` restoring the declared rectangle.

M also does not always land on rows. An `a_trans` operand is loaded naturally and
reinterpreted by a zero-copy `tile.transpose_view`, so its M is the **column**
extent. The box rule now follows M to whichever axis carries it:

```python
# a: Tensor[[128, 100]], a_trans=True
a_mat = pl.tile.load(a, [0, 0], [128, 112], [128, 100], target_memory=pl.Mem.Mat)
a_t   = pl.tile.transpose_view(a_mat)   # Tile[[112, 128]] valid [100, 128]
```

That axis' granularity is `32 / sizeof(dtype)` — **32 for INT8**, against the
accumulator's 16 rows. Each tile taking its own would give a 128-row product
against a 112-row accumulator, so `InputSpaceReq::m_align_from_arg` names the
left operand as the single decider and every cube tile of the call adopts
`lcm(its box, 16)`.

`cube_row_boxed` accordingly became `cube_m_axis`, and `BoxLoadRows` became
`BoxCubeMAxis(shape, align, axis)`.

Two consequences worth a reviewer's attention:

- **The boxed accumulator is declared `compact`.** `mad` writes at a pitch of
  `ceil(validRow/16)*16` while a non-compact reader derives its stride from the
  physical rows, which the box rounded past (112, or 128 at a 32-row alignment).
  `AccCompactValid` (#2470) rejects the unstamped form — it fired on the INT8
  `a_trans` case during development, which is how the omission was caught.
- **`ConsumerSpaceCollector` matched operands with `As<Var>`,** which does not
  match `IterArg`. A split-K accumulator reaches its `tile.matmul_acc` as a loop
  carry, so it recorded no demand at all. Now `AsVarLike`, plus a propagation
  edge from each `IterArg` to the value that seeds it.

## Refusing a partial box in PyPTO, not in ptoas

Where PyPTO does not pad — `K`, `N`, rank >= 3, dynamic extents, hand-written
tile programs — the shape used to reach ptoas and come back with the message
above. `CheckBoxedTileExtents` mirrors ptoas' `verifyBoxedTileLayout`
(`lib/PTO/IR/PTO.cpp:1818`), exemptions included: the row rule is skipped for Vec
and single-row tiles, the column rule always applies, and the MX fractal and
sub-byte carriers are left to ptoas.

It runs in `ComputeAllocTileFields` — the one choke point every `pto.alloc_tile`
passes through, per-variable declarations and hoisted `extra_alloc_tiles` alike —
so it sees exactly what is emitted and cannot drift from it:

```text
a Mat tile of physical shape [100, 128] and dtype fp16 must be a whole number of
16x16 fractal boxes, but its row extent 100 is not a multiple of 16. PTO addresses
a boxed tile one box at a time, so a partial box has no address. The *logical*
extent is free -- allocate 112 on that axis and declare 100 as the tile's
valid_shape (`valid_shape=` on pl.load / pl.tile.create + pl.set_validshape),
which moves and computes only the real data. A tensor-level pl.matmul /
pl.matmul_acc does this for its M axis automatically. [kernel.py:11:9]
```

**It immediately found a latent defect.**
`test_mgather_a5_low_precision_reaches_mat_codegen` built an FP8 `[16, 16]` Mat
tile, whose 8-bit column box is 32. The test only rendered MLIR, so that shape
had never met ptoas. Its scaffolding `eye` operand now takes the legal `K = 32`.

## Test plan

- **On device** (910B, `platform="a2a3"`) against `torch.matmul`: plain
  M ∈ {1, 17, 40, 100, 128, 250}, and `a_trans` M ∈ {17, 100, 128} × {FP16, INT8},
  for both spellings — exact, **zero mismatched elements** in every case.
- **End to end through ptoas**: 29 forms (plain / split-K / `a_trans` / `b_trans` /
  rank-3) × M. `matmul` and `matmul_acc` now succeed and fail identically at every
  point; nothing in the matrix fails any more.
- `pytest tests/ut` — 10847 passed, 3 skipped, 1 xfailed.
- `pytest tests/st/codegen` — 60 passed.
- `pre-commit run --all-files` — all hooks pass.
- New: boxing cases for the accumulator (rows) and the `a_trans` operand
  (columns, FP16 and INT8), the split-K `IterArg` seed, an `AutoTileMatmulL0`
  fractal-boundary sweep for the accumulating spelling, and five codegen cases
  pinning the new refusal and its non-over-reach (whole-box tiles and Vec's row
  exemption still lower).

## Expectations that moved with the behaviour

- `test_matmul_a_trans_lhs_keeps_its_natural_load` pinned the limitation this
  removes. Rewritten as `test_matmul_a_trans_lhs_is_boxed_on_its_column_axis`,
  parametrized over FP16 (box 16) and INT8 (box 32).
- The boxed-accumulator cases now expect `compact=True` on the `tile.create`.

## Scope

`K` and `N` are still not padded, and now fail with the PyPTO message rather than
the ptoas one. That is a separate question — the MAD reduces over `ceil(K/16)`
fractals, so padded K columns hold uninitialised L1 unless the hardware masks by
valid col, which is unverified. `AutoTileMatmulL0`'s `PH-AT-007` declines it for
the same reason.
