### PR TITLE
feat(jit): add @pl.jit.graph, and cover Graph record-and-replay on device

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1276,6 +1276,12 @@ jobs:
         # per-test and new tests need no edit. swimlane is --ignore'd here — it runs
         # in its own flagged step. (paged_attention has its own step below — passing
         # it as an explicit path here collapses pytest's dir collection.)
+        # test_graph_execution is --ignore'd for a different reason: a ChipWorker
+        # binds one (platform, device_id, runtime), and that file mixes
+        # host_build_graph cases with a default-runtime A/B twin. Two runtimes in
+        # one process poison the shared lane — the first Graph test failed 507018
+        # and took the rest of the step's tests with it — so it runs --forked
+        # below, one process per test.
         run: |
           source activate.sh
           echo "[device] DEVICE_ID=$DEVICE_ID"
@@ -1286,6 +1292,7 @@ jobs:
               --ignore=tests/st/distributed \
               --ignore=tests/st/codegen \
               --ignore=tests/st/runtime/framework_and_models/test_perf_swimlane.py \
+              --ignore=tests/st/runtime/framework_and_models/test_graph_execution.py \
               --device=\$TASK_DEVICE --platform=a2a3"
 
       - name: Test paged-attention codegen (numeric compare, in device env)
@@ -1316,6 +1323,15 @@ jobs:
           source activate.sh
           task-submit --device "$DEVICE_ID" --timeout 3600 --max-time 600 \
             --run "cd $GITHUB_WORKSPACE/st-direct-checkout && source activate.sh && python -m pytest tests/st/runtime/framework_and_models/test_perf_swimlane.py -v --device=\$TASK_DEVICE --platform=a2a3 --enable-chip-swimlane --forked"
+
+      - name: Test Graph record-and-replay (one process per test)
+        # --forked because a ChipWorker binds one (platform, device_id, runtime):
+        # the host_build_graph cases and the default-runtime A/B twin in this file
+        # cannot share a process.
+        run: |
+          source activate.sh
+          task-submit --device "$DEVICE_ID" --timeout 3600 --max-time 600 \
+            --run "cd $GITHUB_WORKSPACE/st-direct-checkout && source activate.sh && python -m pytest tests/st/runtime/framework_and_models/test_graph_execution.py -v --device=\$TASK_DEVICE --platform=a2a3 --forked"
 
       - name: Test dump-args output
         run: |

--- a/docs/en/user/language/01-functions.md
+++ b/docs/en/user/language/01-functions.md
@@ -72,8 +72,9 @@ core levels:
 | `@pl.jit.incore` | `InCore` | A device kernel (accepts `level=` to target a specific hierarchy level) |
 | `@pl.jit.inline` | `Inline` | Helper spliced into every call site by `InlineFunctions` |
 | `@pl.jit.opaque` | `Opaque` | A separate IR function that may hold orchestration loops and `pl.at` scopes |
+| `@pl.jit.graph` | `Graph` | A recordable orchestration fragment — the `host_build_graph` runtime records its task topology on the first call and replays it after, so N calls cost one graph build rather than N. Requires compiling under `RuntimeKind.HOST_BUILD_GRAPH` |
 
-Sub-function dependencies (`.incore` / `.inline` / `.opaque`) are auto-discovered from
+Sub-function dependencies (`.incore` / `.inline` / `.opaque` / `.graph`) are auto-discovered from
 the entry's body — call them by name. A `@pl.jit.host` entry additionally discovers
 `@pl.jit` chip-orchestration dependencies, so a full distributed program needs no
 `@pl.program` class.

--- a/docs/zh/user/language/01-functions.md
+++ b/docs/zh/user/language/01-functions.md
@@ -58,8 +58,9 @@ def entry(
 | `@pl.jit.incore` | `InCore` | 设备 kernel（可接受 `level=` 指定层级） |
 | `@pl.jit.inline` | `Inline` | 由 `InlineFunctions` 在每个调用点展开的辅助函数 |
 | `@pl.jit.opaque` | `Opaque` | 独立 IR 函数，可包含编排循环与 `pl.at` 作用域 |
+| `@pl.jit.graph` | `Graph` | 可录制的编排片段 —— `host_build_graph` runtime 在首次调用时录制其 task 拓扑、之后回放，因此 N 次调用只付一次建图代价。需要在 `RuntimeKind.HOST_BUILD_GRAPH` 下编译 |
 
-子函数依赖（`.incore` / `.inline` / `.opaque`）从入口函数体自动发现 —— 按名字调用即可。`@pl.jit.host` 入口还会额外发现 `@pl.jit`（chip 编排）依赖，因此一个完整的分布式程序无需任何 `@pl.program` 类。
+子函数依赖（`.incore` / `.inline` / `.opaque` / `.graph`）从入口函数体自动发现 —— 按名字调用即可。`@pl.jit.host` 入口还会额外发现 `@pl.jit`（chip 编排）依赖，因此一个完整的分布式程序无需任何 `@pl.program` 类。
 
 下面这段只展示发现结构 —— kernel 体已省略，它用到的分布式类型见[分布式](../distributed/index.md)：
 

--- a/python/pypto/jit/decorator.py
+++ b/python/pypto/jit/decorator.py
@@ -33,6 +33,11 @@ Public API
             with pl.at(level=pl.Level.CORE_GROUP):          # loops + pl.at scopes
                 ...
 
+    @pl.jit.graph
+    def layer(a: pl.Tensor, c: pl.InOut[pl.Tensor]):        # FunctionType.Graph
+        with pl.at(level=pl.Level.CORE_GROUP):              # recorded once,
+            ...                                             # replayed after
+
     @pl.jit
     def entry(a: pl.Tensor, c: pl.Out[pl.Tensor]):
         c = sub_kernel(a, c)   # dep discovered automatically (any of incore/inline/opaque)
@@ -2656,7 +2661,7 @@ def _discover_deps(func: Any, caller_func_type: str = "orchestration") -> list[J
 
     all_vars = {**func_globals, **closure_vars}
 
-    allowed_dep_types: set[str] = {"incore", "inline", "opaque", "extern"}
+    allowed_dep_types: set[str] = {"incore", "inline", "opaque", "extern", "graph"}
     if caller_func_type == "host":
         allowed_dep_types.add("orchestration")
 
@@ -2697,6 +2702,11 @@ class _SubFunctionDecorator:
         ``InlineFunctions`` IR pass).
       - ``opaque``  → ``FunctionType.Opaque`` (separate IR function; may wrap
         orchestration loops and ``pl.at`` scopes).
+      - ``graph``   → ``FunctionType.Graph`` (a recordable orchestration
+        fragment; the host_build_graph runtime records its task topology on the
+        first call and replays it after, so N calls cost one graph build rather
+        than N). Requires ``RuntimeKind.HOST_BUILD_GRAPH`` — compile under a
+        ``PassContext(runtime=...)``, or ``LegalizeGraphBoundary`` rejects it.
     """
 
     def __init__(self, func_type: str, *, allow_level: bool, allow_auto_scope: bool = False) -> None:
@@ -2870,6 +2880,7 @@ class _JITDecorator:
         self.incore = _SubFunctionDecorator("incore", allow_level=True)
         self.inline = _SubFunctionDecorator("inline", allow_level=False, allow_auto_scope=True)
         self.opaque = _SubFunctionDecorator("opaque", allow_level=False)
+        self.graph = _SubFunctionDecorator("graph", allow_level=False)
         self.extern = _ExternKernelDecorator()
 
     def __call__(self, func: Any = None, *, auto_scope: bool = True) -> Any:

--- a/python/pypto/jit/specializer.py
+++ b/python/pypto/jit/specializer.py
@@ -124,7 +124,7 @@ class SpecializeContext:
     Attributes:
         func_name: Python function name.
         source: Dedented source code of the function.
-        func_type: 'orchestration' | 'incore' | 'inline' | 'opaque' | None (auto).
+        func_type: 'orchestration' | 'incore' | 'inline' | 'opaque' | 'graph' | None (auto).
         level: pl.Level value or None.
         param_names: Ordered parameter names (excluding 'self').
         tensor_meta: TensorMeta per tensor param name.
@@ -1984,6 +1984,8 @@ class Specializer:
             return f"@pl.function(type=pl.FunctionType.Inline{auto_scope_suffix})"
         if ctx.func_type == "opaque":
             return "@pl.function(type=pl.FunctionType.Opaque)"
+        if ctx.func_type == "graph":
+            return "@pl.function(type=pl.FunctionType.Graph)"
         # InCore
         if ctx.level is None:
             return "@pl.function(type=pl.FunctionType.InCore)"

--- a/tests/st/runtime/framework_and_models/test_graph_execution.py
+++ b/tests/st/runtime/framework_and_models/test_graph_execution.py
@@ -1,0 +1,390 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""End-to-end coverage for ``@pl.jit.graph`` under the host_build_graph runtime.
+
+The unit tests around ``LegalizeGraphBoundary`` and orchestration codegen cover
+the compile side, including one that compiles the emitted
+``orchestration/main.cpp`` against the pinned runtime headers. None of them can
+show that a *recorded* graph replays correctly, which is the half where this
+feature fails quietly:
+
+* **A frozen boundary scalar is a wrong answer.** The runtime tracks a boundary
+  scalar by the address of its argument slot. A value the region derives has no
+  slot, so it is classified as static data and every replay reuses the first
+  call's number, with no diagnostic. ``test_per_layer_accumulate`` is shaped to
+  catch it — each call reads its own band of a weight tensor whose bands hold
+  distinct values, so a frozen offset re-adds band 0 and misses by a wide margin.
+* **A declined recording is silent too.** ``rt_submit_graph`` falls back to
+  running the body as ordinary tasks when ``rt_graph_args_cacheable`` refuses the
+  boundary — correct numbers, no speedup, no log line. The runtime exposes no
+  Python-visible counter for that, so the guard is on the compile side:
+  ``TestGraphIsNotSilentlyDroppedAtCompile`` asserts the lowered IR really
+  carries a ``FunctionType.Graph`` function.
+
+The runtime ABI comes from the enclosing ``PassContext``, which is what
+``@pl.jit`` reads when it lowers; ``graph_runtime`` supplies one.
+
+**Run this file with ``--forked``.** A ``ChipWorker`` binds one
+``(platform, device_id, runtime)``, and this file deliberately mixes the two: the
+Graph cases need ``host_build_graph`` while the A/B twin runs on the default
+runtime. Sharing one process poisons the lane — the first Graph test fails 507018
+and every later test in that process goes with it, including unrelated ones. CI
+gives the file its own ``--forked`` step for that reason.
+"""
+
+import pypto.language as pl
+import pytest
+import torch
+from pypto.ir.printer import python_print
+from pypto.pypto_core import passes
+
+ROWS = 128
+COLS = 128
+LAYERS = 4
+
+
+@pytest.fixture
+def graph_runtime():
+    """Compile under host_build_graph — a Graph is rejected under any other."""
+    with passes.PassContext([], runtime=passes.RuntimeKind.HOST_BUILD_GRAPH):
+        yield
+
+
+def _banded_weights() -> torch.Tensor:
+    """Weights whose layer *i* band holds ``i + 1``.
+
+    Distinct per band on purpose: a frozen offset re-reads one band, so the sum
+    lands far outside tolerance instead of coincidentally matching.
+    """
+    w = torch.empty(LAYERS * ROWS, COLS, dtype=torch.float32)
+    for i in range(LAYERS):
+        w[i * ROWS : (i + 1) * ROWS, :] = float(i + 1)
+    return w
+
+
+def _band_total() -> float:
+    return float(sum(i + 1 for i in range(LAYERS)))
+
+
+# --- Kernels ---
+
+
+@pl.jit.graph
+def accumulate_band(w: pl.Tensor, acc: pl.InOut[pl.Tensor], layer_idx: pl.Scalar[pl.INDEX]):
+    """``base`` is derived from the boundary scalar, so Step A hoists it out.
+
+    Left in the region it would have no argument slot and every replay would
+    re-add layer 0's band.
+    """
+    base = layer_idx * ROWS
+    with pl.at(level=pl.Level.CORE_GROUP):
+        band = pl.load(w, [base, 0], [ROWS, COLS])
+        cur = pl.load(acc, [0, 0], [ROWS, COLS])
+        pl.store(pl.add(cur, band), [0, 0], acc)
+    return acc
+
+
+@pl.jit
+def per_layer_accumulate(w: pl.Tensor, acc: pl.InOut[pl.Tensor]):
+    for i in pl.range(LAYERS):
+        acc = accumulate_band(w, acc, i)
+    return acc
+
+
+@pl.jit
+def no_graph_per_layer_accumulate(w: pl.Tensor, acc: pl.InOut[pl.Tensor]):
+    """Same arithmetic, no Graph — the body is inlined rather than called.
+
+    An Orchestration entry launches tasks; it does not call another
+    Orchestration. Being *callable* is what ``Graph`` adds, so the twin can only
+    mirror the maths, not the structure.
+    """
+    for i in pl.range(LAYERS):
+        base = i * ROWS
+        with pl.at(level=pl.Level.CORE_GROUP):
+            band = pl.load(w, [base, 0], [ROWS, COLS])
+            cur = pl.load(acc, [0, 0], [ROWS, COLS])
+            pl.store(pl.add(cur, band), [0, 0], acc)
+    return acc
+
+
+@pl.jit.graph
+def accumulate_view(w: pl.Tensor, acc: pl.InOut[pl.Tensor], layer_idx: pl.Scalar[pl.INDEX]):
+    """Step B: a boundary tensor sliced by a per-layer offset.
+
+    The slice is hoisted to the call site and arrives as its own boundary
+    tensor, so each replay addresses its own window.
+    """
+    wl = pl.tensor.slice(w, [ROWS, COLS], [layer_idx * ROWS, 0])
+    with pl.at(level=pl.Level.CORE_GROUP):
+        band = pl.load(wl, [0, 0], [ROWS, COLS])
+        cur = pl.load(acc, [0, 0], [ROWS, COLS])
+        pl.store(pl.add(cur, band), [0, 0], acc)
+    return acc
+
+
+@pl.jit
+def boundary_view_accumulate(w: pl.Tensor, acc: pl.InOut[pl.Tensor]):
+    for i in pl.range(LAYERS):
+        acc = accumulate_view(w, acc, i)
+    return acc
+
+
+@pl.jit.graph
+def double_via_scratch(a: pl.Tensor, acc: pl.InOut[pl.Tensor]):
+    """Step C: a constant-shaped allocation inside the region.
+
+    Recorded as a kernel-less node, so the region's topology is more than one
+    task per call.
+    """
+    tmp = pl.create_tensor([ROWS, COLS], pl.FP32)
+    with pl.at(level=pl.Level.CORE_GROUP):
+        t = pl.load(a, [0, 0], [ROWS, COLS])
+        pl.store(pl.add(t, t), [0, 0], tmp)
+    with pl.at(level=pl.Level.CORE_GROUP):
+        u = pl.load(tmp, [0, 0], [ROWS, COLS])
+        v = pl.load(acc, [0, 0], [ROWS, COLS])
+        pl.store(pl.add(u, v), [0, 0], acc)
+    return acc
+
+
+@pl.jit
+def region_alloc_accumulate(a: pl.Tensor, acc: pl.InOut[pl.Tensor]):
+    for _ in pl.range(LAYERS):
+        acc = double_via_scratch(a, acc)
+    return acc
+
+
+@pl.jit.graph
+def add_layer(a: pl.Tensor, acc: pl.InOut[pl.Tensor]):
+    with pl.at(level=pl.Level.CORE_GROUP):
+        t = pl.load(a, [0, 0], [ROWS, COLS])
+        c = pl.load(acc, [0, 0], [ROWS, COLS])
+        pl.store(pl.add(c, t), [0, 0], acc)
+    return acc
+
+
+@pl.jit.graph
+def double_layer(acc: pl.InOut[pl.Tensor]):
+    with pl.at(level=pl.Level.CORE_GROUP):
+        c = pl.load(acc, [0, 0], [ROWS, COLS])
+        pl.store(pl.add(c, c), [0, 0], acc)
+    return acc
+
+
+@pl.jit
+def two_distinct_graphs(a: pl.Tensor, acc: pl.InOut[pl.Tensor]):
+    """Two Graph functions interleaved.
+
+    The runtime keys a recording on the emitted function's address, so these
+    must stay two recordings — sharing one would apply ``add_layer``'s topology
+    to ``double_layer`` and change the result.
+    """
+    for _ in pl.range(LAYERS):
+        acc = add_layer(a, acc)
+        acc = double_layer(acc)
+    return acc
+
+
+@pl.jit.graph
+def scale_once(a: pl.Tensor, out: pl.InOut[pl.Tensor]):
+    with pl.at(level=pl.Level.CORE_GROUP):
+        t = pl.load(a, [0, 0], [ROWS, COLS])
+        pl.store(pl.add(t, t), [0, 0], out)
+    return out
+
+
+@pl.jit
+def single_launch(a: pl.Tensor, out: pl.InOut[pl.Tensor]):
+    out = scale_once(a, out)
+    return out
+
+
+# --- Device execution ---
+
+
+class TestGraphExecution:
+    """Numerical results after record-and-replay."""
+
+    def test_single_launch(self, test_config, graph_runtime):
+        single_launch._cache.clear()
+        a = torch.full((ROWS, COLS), 3.0, dtype=torch.float32)
+        out = torch.zeros((ROWS, COLS), dtype=torch.float32)
+
+        single_launch(a, out, config=test_config)
+
+        expected = a * 2
+        assert torch.allclose(out, expected, rtol=1e-5, atol=1e-5), (
+            f"max diff = {(out - expected).abs().max().item()}"
+        )
+
+    def test_per_layer_accumulate(self, test_config, graph_runtime):
+        """The one that catches a frozen boundary scalar.
+
+        Every band must be added exactly once. A frozen offset adds band 0 four
+        times — 4.0 instead of 10.0 — nowhere near tolerance.
+        """
+        per_layer_accumulate._cache.clear()
+        w = _banded_weights()
+        acc = torch.zeros((ROWS, COLS), dtype=torch.float32)
+
+        per_layer_accumulate(w, acc, config=test_config)
+
+        expected = torch.full((ROWS, COLS), _band_total())
+        assert torch.allclose(acc, expected, rtol=1e-5, atol=1e-5), (
+            f"max diff = {(acc - expected).abs().max().item()}; a frozen per-layer "
+            f"offset would give {float(LAYERS)} everywhere"
+        )
+
+    def test_no_graph_per_layer_accumulate(self, test_config):
+        """Same golden without a Graph, so a failure here is arithmetic.
+
+        Deliberately outside ``graph_runtime``: this one runs on the default
+        runtime, which is what makes the pair an A/B on the feature.
+        """
+        no_graph_per_layer_accumulate._cache.clear()
+        w = _banded_weights()
+        acc = torch.zeros((ROWS, COLS), dtype=torch.float32)
+
+        no_graph_per_layer_accumulate(w, acc, config=test_config)
+
+        expected = torch.full((ROWS, COLS), _band_total())
+        assert torch.allclose(acc, expected, rtol=1e-5, atol=1e-5), (
+            f"max diff = {(acc - expected).abs().max().item()}"
+        )
+
+    def test_boundary_view(self, test_config, graph_runtime):
+        boundary_view_accumulate._cache.clear()
+        w = _banded_weights()
+        acc = torch.zeros((ROWS, COLS), dtype=torch.float32)
+
+        boundary_view_accumulate(w, acc, config=test_config)
+
+        expected = torch.full((ROWS, COLS), _band_total())
+        assert torch.allclose(acc, expected, rtol=1e-5, atol=1e-5), (
+            f"max diff = {(acc - expected).abs().max().item()}"
+        )
+
+    def test_region_alloc(self, test_config, graph_runtime):
+        region_alloc_accumulate._cache.clear()
+        a = torch.full((ROWS, COLS), 1.5, dtype=torch.float32)
+        acc = torch.zeros((ROWS, COLS), dtype=torch.float32)
+
+        region_alloc_accumulate(a, acc, config=test_config)
+
+        expected = a * 2 * LAYERS
+        assert torch.allclose(acc, expected, rtol=1e-5, atol=1e-5), (
+            f"max diff = {(acc - expected).abs().max().item()}"
+        )
+
+    def test_two_distinct_graphs(self, test_config, graph_runtime):
+        two_distinct_graphs._cache.clear()
+        a = torch.full((ROWS, COLS), 1.0, dtype=torch.float32)
+        acc = torch.zeros((ROWS, COLS), dtype=torch.float32)
+
+        two_distinct_graphs(a, acc, config=test_config)
+
+        expected = torch.zeros((ROWS, COLS), dtype=torch.float32)
+        for _ in range(LAYERS):
+            expected = (expected + a) * 2
+        assert torch.allclose(acc, expected, rtol=1e-5, atol=1e-5), (
+            f"max diff = {(acc - expected).abs().max().item()}"
+        )
+
+    def test_replay_serves_a_second_call(self, test_config, graph_runtime):
+        """The second invocation replays rather than rebuilds.
+
+        Its *correctness* is the point: replay patches boundary addresses and
+        scalars, so fresh inputs must give a fresh answer rather than the
+        recorded one.
+        """
+        per_layer_accumulate._cache.clear()
+        w = _banded_weights()
+
+        first = torch.zeros((ROWS, COLS), dtype=torch.float32)
+        per_layer_accumulate(w, first, config=test_config)
+
+        second = torch.full((ROWS, COLS), 100.0, dtype=torch.float32)
+        per_layer_accumulate(w, second, config=test_config)
+
+        assert torch.allclose(first, torch.full((ROWS, COLS), _band_total()), rtol=1e-5, atol=1e-5)
+        assert torch.allclose(
+            second, torch.full((ROWS, COLS), 100.0 + _band_total()), rtol=1e-5, atol=1e-5
+        ), "the second call reused the first call's result instead of replaying against its own boundary"
+
+
+# --- Compile side ---
+
+
+class TestGraphIsNotSilentlyDroppedAtCompile:
+    """A declined recording is numerically correct, so goldens cannot see it.
+
+    ``rt_submit_graph`` runs the body as ordinary tasks when the boundary is not
+    cacheable, and the runtime exposes no Python-visible counter for it. What is
+    checkable is that the compiler produced a Graph at all: a region that
+    silently lowered to ordinary tasks carries no ``FunctionType.Graph``.
+    """
+
+    @staticmethod
+    def _lower(fn, *args, config):
+        with passes.PassContext([], runtime=passes.RuntimeKind.HOST_BUILD_GRAPH):
+            return python_print(fn.lower(*args, config=config))
+
+    def test_graph_survives_lowering(self, test_config):
+        src = self._lower(
+            per_layer_accumulate,
+            torch.zeros(LAYERS * ROWS, COLS),
+            torch.zeros(ROWS, COLS),
+            config=test_config,
+        )
+        assert "type=pl.FunctionType.Graph" in src, src
+        assert "def accumulate_band" in src, src
+
+    def test_the_derived_offset_moves_to_the_caller(self, test_config):
+        """Step A hoisted ``base``, so the entry scales it, not the region.
+
+        Inside the region it would have no argument slot and replay would reuse
+        the first call's value — which is what ``test_per_layer_accumulate``
+        would then fail on.
+        """
+        src = self._lower(
+            per_layer_accumulate,
+            torch.zeros(LAYERS * ROWS, COLS),
+            torch.zeros(ROWS, COLS),
+            config=test_config,
+        )
+        entry = src[src.index("def per_layer_accumulate") :]
+        assert f"* {ROWS}" in entry, entry
+
+    def test_two_graphs_stay_two_functions(self, test_config):
+        src = self._lower(
+            two_distinct_graphs,
+            torch.zeros(ROWS, COLS),
+            torch.zeros(ROWS, COLS),
+            config=test_config,
+        )
+        assert src.count("type=pl.FunctionType.Graph") == 2, src
+
+    def test_a_graph_under_the_default_runtime_is_rejected(self, test_config):
+        """The default runtime has neither `rt_submit_graph` nor `GraphTaskArgs`.
+
+        Compiling a Graph against it used to emit orchestration C++ naming
+        undeclared symbols; it is a compile-time error now.
+        """
+        with pytest.raises(ValueError, match="requires the host_build_graph runtime"):
+            per_layer_accumulate.lower(
+                torch.zeros(LAYERS * ROWS, COLS),
+                torch.zeros(ROWS, COLS),
+                config=test_config,
+            )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Why

Two gaps, and the second one only surfaced while closing the first.

**No ST coverage.** `FunctionType.Graph` landed across #2416 / #2421 / #2423 with
unit coverage of the compile side — including a test that compiles the emitted
`orchestration/main.cpp` against the pinned runtime headers. A `grep` for
`FunctionType.Graph` / `host_build_graph` / `rt_submit_graph` across `tests/st/`
returned nothing, so nothing showed that a *recorded* graph replays correctly.

**No JIT frontend.** Writing those tests in `@pl.jit` form turned out to be
impossible: `pl.jit` exposed `extern`, `host`, `incore`, `inline`, `opaque` — no
`graph`. The feature shipped reachable only from `@pl.program`.

## `@pl.jit.graph`

The decorator machinery was already factored for this, so it is three small
pieces: a `_SubFunctionDecorator("graph", allow_level=False)`, `"graph"` added to
the admissible dep types, and one branch in the specializer emitting
`@pl.function(type=pl.FunctionType.Graph)`. The runtime ABI comes from the
enclosing `PassContext`, which `@pl.jit` already reads when it lowers, so nothing
else needed plumbing.

Confirmed on the lowered IR — the marker survives outlining:

```
@pl.function(type=pl.FunctionType.Graph, level=CHIP, role=Orchestrator)  def accumulate_band(
@pl.function(type=pl.FunctionType.Orchestration, ...)                    def per_layer_accumulate(
@pl.function(type=pl.FunctionType.AIV, ...)                              def accumulate_band_incore_0(
```

## Coverage

Both of this feature's failure modes are quiet, which is what the cases are
shaped around.

| Test | Covers |
| ---- | ------ |
| `test_single_launch` | the minimal shape |
| `test_per_layer_accumulate` | **the frozen-scalar catcher** — bands hold distinct values, so a frozen offset gives 4.0 where 10.0 is expected |
| `test_no_graph_per_layer_accumulate` | same maths, no Graph, default runtime — an A/B on the feature |
| `test_boundary_view` | Step B: a boundary tensor sliced by a per-layer offset |
| `test_region_alloc` | Step C: a constant-shaped allocation in the region |
| `test_two_distinct_graphs` | two Graphs must stay two recordings — the runtime keys one on the emitted function's address |
| `test_replay_serves_a_second_call` | replay must patch boundary addresses and scalars, so fresh inputs give a fresh answer |

For the silent-fallback half there is no Python-visible runtime counter, so the
guard is on the compile side: `TestGraphIsNotSilentlyDroppedAtCompile` asserts the
lowered IR carries a `FunctionType.Graph`, which a region lowered to ordinary
tasks would not.

## Verification

Compile-side tests: 4 passed. Full `tests/ut`: 10895 passed. preflight clean.

**The seven device tests have not run locally.** This environment's installed
`_task_interface` is ABI-incompatible with the `runtime/` submodule, and an
unrelated existing case (`test_ci.py::TestCi::test_ci_ascend_start0`) fails
identically at the same import — so device validation happens first in CI.

## Not covered

"Compiled a graph, but the runtime declined to cache it" stays untested. It needs
a runtime-side counter for graph cache admission, which is a simpler-side change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
