### PR TITLE
perf(runtime): stop revalidating L3 device args in make_tensor_arg

### DIFF
--- a/python/pypto/runtime/runtime_base.py
+++ b/python/pypto/runtime/runtime_base.py
@@ -194,6 +194,20 @@ class Worker(ABC):
         check is object identity in ``_device_buffers``: this rejects foreign
         Workers, freed handles, and pointer-reuse (ABA) cases before a stale
         wire descriptor can enter simpler ``Worker.run``.
+
+        When the caller does not name the placement, the retained Buffer
+        usually does: simpler stamps ``owner_worker_id`` on every allocation it
+        hands out, making the owning key derivable rather than searched.  That
+        matters because scanning ``_device_buffers`` costs a walk of every live
+        allocation per validated argument, which on a distributed dispatch (one
+        call per tensor per rank, against a table holding every rank's shards)
+        is quadratic in the allocation count.
+
+        The scan remains as a fallback rather than a hard requirement: a
+        ``DeviceTensor``'s Buffer is only contracted to expose ``base`` and
+        ``tensor(...)``, so a custom Worker's ``_buffer_for_ptr`` may return a
+        handle that names no placement.  Every simpler-allocated Buffer takes
+        the exact-key path.
         """
         self._require_ready("dispatch DeviceTensor")
         worker_name = type(self).__name__
@@ -208,6 +222,11 @@ class Worker(ABC):
             raise TypeError(
                 f"{label}: {worker_name} does not retain owner Buffers required for DeviceTensor dispatch."
             )
+        if worker_id is None:
+            try:
+                worker_id = int(tensor.buffer.owner_worker_id)
+            except (AttributeError, TypeError, ValueError):
+                worker_id = None  # Placeless handle — fall back to the scan.
         if worker_id is None:
             owned = any(
                 ptr == tensor.data_ptr and buffer is tensor.buffer for (_wid, ptr), buffer in buffers.items()

--- a/python/pypto/runtime/tensor_arg.py
+++ b/python/pypto/runtime/tensor_arg.py
@@ -23,6 +23,29 @@ Host ``torch.Tensor`` arguments are delegated to
 ``simpler_setup.torch_interop.make_tensor_arg(worker, tensor)``. Never route
 this path through :mod:`pypto.runtime.task_interface`: its compatibility
 ``make_tensor_arg`` alias is chip-only and produces a ``ChipTensor``.
+
+Who validates DeviceTensor liveness
+-----------------------------------
+
+**L3 (distributed): the runtime does, and this module must not.** Every
+``orch.submit_next_level`` runs simpler's ``_child_prov_check_dispatch_locked``,
+which looks each device argument's ``CanonicalIdentity`` up in the owner's
+allocation table, requires ``owner_worker_id`` to equal the dispatch target,
+requires the wire descriptor to equal the registered one field-for-field, and
+holds ``_child_prov_lock`` across the native submit. That check is strictly
+stronger than anything reachable from here: identity keying rejects the
+pointer-reuse (ABA) case that an address-keyed check cannot see, and holding the
+lock through the submit makes authorization and dispatch one transaction. A
+check *here* would re-derive a weaker answer and then release its evidence
+before the submit it was meant to protect.
+
+**L2 (direct chip): nothing else does, so this module still checks.** simpler's
+``_submit_l2_locked`` only records touched identities (which serves
+``release_buffer``, not argument liveness) and materializes the args through
+``ImportRegistry``, whose map-once cache is not invalidated by ``Worker.free``.
+Until the runtime grows an L2 equivalent of the L3 guard, this wrapper is the
+only thing standing between a freed ``DeviceTensor`` and a use-after-free, so
+the owner check below runs on every L2 conversion.
 """
 
 import weakref
@@ -31,17 +54,49 @@ from typing import Any
 
 _PYPTO_OWNER_REF_ATTR = "_pypto_tensor_owner_ref"
 
+# The address-free wire ``Tensor`` a DeviceTensor maps to is a pure function of
+# its (retained Buffer, shape, dtype) — all immutable on the frozen handle — so
+# it is memoized on the handle itself and dies with it: no table to grow, no
+# eviction policy, and no key. Keying a dict on the DeviceTensor would be wrong:
+# ``buffer`` is declared ``compare=False, hash=False``, so a handle freed at some
+# address and a fresh one that reuses that address hash and compare equal (the
+# ABA case) and would share one cache entry.
+#
+# Generated ``host_orch`` converts every tensor parameter once per rank per
+# dispatch (DP8 decode: ~142 tensors x 8 ranks), so rebuilding an identical
+# descriptor each time was pure host-side dispatch latency.
+_WIRE_TENSOR_ATTR = "_pypto_wire_tensor"
+
 
 def bind_tensor_arg_owner(worker: Any, owner: Any) -> None:
     """Bind a raw simpler Worker to its weak PyPTO owner.
 
-    Generated orchestration receives the raw simpler Worker (``orch._worker``),
-    while DeviceTensor liveness is tracked by the public PyPTO Worker.  This
-    weak backlink lets wire conversion consult the authoritative PyPTO Buffer
-    registry without introducing a reference cycle or changing generated code.
+    L2 dispatch reaches this module with the raw simpler Worker, while
+    DeviceTensor liveness is tracked by the public PyPTO Worker. This weak
+    backlink lets the L2 conversion consult the authoritative PyPTO Buffer
+    registry without introducing a reference cycle.
+
+    An L3 Worker's own dispatch path validates device arguments, so the binding
+    is not consulted there. The distributed runner installs it regardless
+    because :func:`_validates_liveness_at_submit` fails closed: a Worker whose
+    level cannot be read falls back to checking, and the check must then find a
+    binding rather than reject a legitimate dispatch.
     """
     setattr(worker, _PYPTO_OWNER_REF_ATTR, weakref.ref(owner))
     owner._tensor_arg_worker = worker
+
+
+def _validates_liveness_at_submit(worker: Any) -> bool:
+    """Whether *worker*'s own dispatch path re-checks device-argument liveness.
+
+    True for every hierarchical (L3+) Worker: its ``submit_next_level`` runs the
+    runtime's identity-keyed provenance guard. False for a direct-chip L2 Worker,
+    whose ``_submit_l2_locked`` has no equivalent — see the module docstring.
+    An unrecognizable worker is treated as unguarded, so a missing or surprising
+    ``level`` fails closed into checking rather than silently skipping.
+    """
+    level = getattr(worker, "level", None)
+    return isinstance(level, int) and level > 2
 
 
 def _require_device_tensor_owner(worker: Any, arg: Any) -> None:
@@ -94,17 +149,17 @@ def make_tensor_arg(worker: Any, arg: Any) -> Any:
     """Convert an orchestration tensor argument into a simpler ``Tensor``.
 
     Args:
-        worker: The raw simpler Worker performing dispatch. DeviceTensor
-            conversion requires it to be bound to the same live PyPTO Worker
-            that allocated the Buffer; host tensors use it directly for
-            simpler's worker-aware conversion.
+        worker: The raw simpler Worker performing dispatch. Host tensors use it
+            directly for simpler's worker-aware conversion; a DeviceTensor
+            dispatched by an L2 Worker additionally requires it to be bound to
+            the live PyPTO Worker that allocated the Buffer.
         arg: One of:
             - ``torch.Tensor``: a CPU-contiguous host tensor (delegated to
               simpler's worker-aware wire helper).
-            - :class:`~pypto.runtime.DeviceTensor`: a worker-resident buffer;
-              after owner/liveness validation, its retained ``Buffer``
-              constructs an address-free wire ``Tensor`` (memory is
-              caller-managed).
+            - :class:`~pypto.runtime.DeviceTensor`: a worker-resident buffer
+              whose retained ``Buffer`` yields an address-free wire ``Tensor``
+              (memory is caller-managed). The descriptor is built once per
+              handle and reused.
             - simpler ``Tensor``: returned as-is (already device-side).
 
     Returns:
@@ -120,10 +175,19 @@ def make_tensor_arg(worker: Any, arg: Any) -> Any:
                 "A raw-pointer DeviceTensor cannot cross the public Worker.run wire ABI; "
                 "allocate it with Worker.alloc_tensor() so it retains its simpler Buffer."
             )
-        _require_device_tensor_owner(worker, arg)
+        # Ahead of the memo, not inside it: an L2 caller must be re-checked on
+        # every dispatch, and a cached descriptor is exactly as stale as the
+        # handle it was built from.
+        if not _validates_liveness_at_submit(worker):
+            _require_device_tensor_owner(worker, arg)
+        cached = arg.__dict__.get(_WIRE_TENSOR_ATTR)
+        if cached is not None:
+            return cached
         try:
             dtype = task_interface.torch_dtype_to_datatype(arg.dtype)
         except KeyError as e:
             raise ValueError(f"Unsupported DeviceTensor dtype: {arg.dtype}") from e
-        return arg.buffer.tensor(shapes=arg.shape, dtype=dtype)
+        wire = arg.buffer.tensor(shapes=arg.shape, dtype=dtype)
+        object.__setattr__(arg, _WIRE_TENSOR_ATTR, wire)
+        return wire
     return torch_interop.make_tensor_arg(worker, arg)

--- a/tests/ut/runtime/test_runtime_base.py
+++ b/tests/ut/runtime/test_runtime_base.py
@@ -273,6 +273,134 @@ def test_require_ready_consulted_by_alloc_tensor():
         h.alloc_tensor((4,), torch.float32)
 
 
+class _ScanCountingBuffers(dict):
+    """``_device_buffers`` that records every whole-table traversal."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        self.scans = 0
+        super().__init__(*args, **kwargs)
+
+    def items(self):
+        self.scans += 1
+        return super().items()
+
+    def values(self):
+        self.scans += 1
+        return super().values()
+
+    def keys(self):
+        self.scans += 1
+        return super().keys()
+
+    def __iter__(self):
+        self.scans += 1
+        return super().__iter__()
+
+
+class _OwnedBuffer:
+    """Retained owner Buffer carrying the placement simpler stamps on it."""
+
+    def __init__(self, base: int, owner_worker_id: int = 0) -> None:
+        self.base = base
+        self.owner_worker_id = owner_worker_id
+
+    def tensor(self, shapes, dtype):
+        return shapes, dtype
+
+
+class _OwnershipProbe:
+    """Minimal stand-in exposing only what the ownership check consults."""
+
+    def __init__(self, buffers) -> None:
+        self._device_buffers = buffers
+
+    def _require_ready(self, op: str) -> None:
+        pass
+
+    _require_owned_resident_tensor = Worker._require_owned_resident_tensor
+
+
+def test_ownership_check_never_scans_the_buffer_table():
+    """Regression guard for the DP8 O(N^2) host-dispatch staircase.
+
+    A distributed dispatch validates one argument per tensor per rank against a
+    table holding every rank's shards, so a whole-table walk per validation is
+    quadratic in the allocation count. The retained Buffer names its own
+    placement, making the lookup an exact key.
+    """
+    buffers = _ScanCountingBuffers()
+    for worker_id in range(8):
+        for slot in range(16):
+            ptr = 0x1000 + worker_id * 0x10000 + slot * 0x100
+            buffers[(worker_id, ptr)] = _OwnedBuffer(ptr, worker_id)
+
+    probe = _OwnershipProbe(buffers)
+    for (worker_id, ptr), buffer in list(buffers.items()):
+        tensor = DeviceTensor(ptr, (4,), torch.float32, buffer=buffer)
+        probe._require_owned_resident_tensor(tensor, f"Argument on worker {worker_id}")
+
+    # list(buffers.items()) above is the loop's own traversal, not the check's.
+    assert buffers.scans == 1
+
+
+def test_ownership_check_derives_placement_from_the_retained_buffer():
+    """A non-zero worker_id is resolved without the caller naming it."""
+    buffer = _OwnedBuffer(0x2000, owner_worker_id=5)
+    buffers = _ScanCountingBuffers({(5, 0x2000): buffer})
+    probe = _OwnershipProbe(buffers)
+    tensor = DeviceTensor(0x2000, (4,), torch.float32, buffer=buffer)
+
+    probe._require_owned_resident_tensor(tensor, "Argument")
+    assert buffers.scans == 0
+
+
+def test_ownership_check_rejects_a_freed_handle():
+    buffer = _OwnedBuffer(0x2000, owner_worker_id=5)
+    probe = _OwnershipProbe(_ScanCountingBuffers())  # nothing live
+    tensor = DeviceTensor(0x2000, (4,), torch.float32, buffer=buffer)
+
+    with pytest.raises(ValueError, match="not a live allocation.*on worker_id=5"):
+        probe._require_owned_resident_tensor(tensor, "Argument")
+
+
+def test_ownership_check_rejects_pointer_reuse_by_a_stale_handle():
+    """The address is live again, but under a different allocation."""
+    stale_buffer = _OwnedBuffer(0x2000, owner_worker_id=5)
+    fresh_buffer = _OwnedBuffer(0x2000, owner_worker_id=5)
+    probe = _OwnershipProbe(_ScanCountingBuffers({(5, 0x2000): fresh_buffer}))
+    stale = DeviceTensor(0x2000, (4,), torch.float32, buffer=stale_buffer)
+
+    with pytest.raises(ValueError, match="not a live allocation"):
+        probe._require_owned_resident_tensor(stale, "Argument")
+
+
+def test_ownership_check_falls_back_to_a_scan_for_a_placeless_buffer():
+    """A Buffer only has to expose ``base`` and ``tensor(...)``.
+
+    A custom Worker's ``_buffer_for_ptr`` may return a handle that names no
+    worker, so the exact-key path is an optimization for simpler-allocated
+    Buffers, not a new requirement on the DeviceTensor contract.
+    """
+
+    class _PlacelessBuffer:
+        base = 0x2000
+
+        def tensor(self, shapes, dtype):
+            return shapes, dtype
+
+    buffer = _PlacelessBuffer()
+    buffers = _ScanCountingBuffers({(0, 0x2000): buffer})
+    probe = _OwnershipProbe(buffers)
+    tensor = DeviceTensor(0x2000, (4,), torch.float32, buffer=buffer)
+
+    probe._require_owned_resident_tensor(tensor, "Argument")
+    assert buffers.scans == 1
+
+    stale = DeviceTensor(0x2000, (4,), torch.float32, buffer=_PlacelessBuffer())
+    with pytest.raises(ValueError, match="not a live allocation"):
+        probe._require_owned_resident_tensor(stale, "Argument")
+
+
 def test_chip_worker_subclasses_worker_abc():
     assert issubclass(ChipWorker, Worker)
 

--- a/tests/ut/runtime/test_tensor_arg.py
+++ b/tests/ut/runtime/test_tensor_arg.py
@@ -12,7 +12,10 @@ orchestration code.
 
 It must:
 - derive an address-free wire ``Tensor`` from a worker-resident
-  :class:`DeviceTensor`'s retained ``Buffer``;
+  :class:`DeviceTensor`'s retained ``Buffer``, and build it only once per handle;
+- leave liveness validation to the runtime on an L3 dispatch, whose
+  ``submit_next_level`` runs an identity-keyed provenance guard, while still
+  validating on an L2 dispatch, whose submit path has no equivalent;
 - pass an already-built ``Tensor`` through unchanged;
 - delegate a host ``torch.Tensor`` to simpler's worker-aware wire helper.
 """
@@ -36,19 +39,143 @@ else:
 pytestmark = pytest.mark.skipif(not _has_simpler, reason="make_tensor_arg requires the simpler package")
 
 
+def _worker(level: int, name: str = "worker") -> MagicMock:
+    """A stand-in simpler Worker at *level*.
+
+    ``level`` is what decides whether this module validates DeviceTensor
+    liveness itself (L2) or defers to the runtime's submit-time guard (L3+).
+    """
+    worker = MagicMock(name=name)
+    worker.level = level
+    return worker
+
+
+class _RecordingBuffer:
+    """Retained owner Buffer that records every wire-descriptor build."""
+
+    def __init__(self, base: int = 0xABCD) -> None:
+        self.base = base
+        self.owner_worker_id = 0
+        self.tensor_calls: list[tuple[tuple[int, ...], object]] = []
+
+    def tensor(self, *, shapes, dtype):
+        self.tensor_calls.append((tuple(shapes), dtype))
+        return MagicMock(name=f"wire_tensor_{len(self.tensor_calls)}")
+
+
+class _RejectingBuffer:
+    """Retained owner Buffer whose descriptor build must never be reached."""
+
+    def __init__(self, base: int = 0xABCD) -> None:
+        self.base = base
+        self.owner_worker_id = 0
+
+    def tensor(self, *, shapes, dtype):
+        raise AssertionError("a rejected DeviceTensor must not reach buffer.tensor()")
+
+
 def test_device_tensor_derives_wire_tensor_from_retained_buffer():
-    captured: dict = {"tensor_calls": []}
-
-    class FakeBuffer:
-        base = 0xABCD
-
-        def tensor(self, *, shapes, dtype):
-            captured["tensor_calls"].append({"shapes": tuple(shapes), "dtype": dtype})
-            return MagicMock(name="wire_tensor")
-
-    buffer = FakeBuffer()
+    buffer = _RecordingBuffer()
     dt = DeviceTensor(buffer.base, (8, 16), torch.float16, buffer=buffer)
-    worker = MagicMock(name="worker")
+    worker = _worker(3)
+
+    from pypto.runtime.tensor_arg import make_tensor_arg  # noqa: PLC0415
+
+    with patch(
+        "pypto.runtime.task_interface.torch_dtype_to_datatype",
+        side_effect=lambda d: f"<dtype:{d}>",
+    ):
+        make_tensor_arg(worker, dt)
+
+    assert len(buffer.tensor_calls) == 1
+    shapes, dtype = buffer.tensor_calls[0]
+    assert shapes == (8, 16)
+    assert dtype == "<dtype:torch.float16>"
+
+
+def test_wire_tensor_is_built_once_per_device_tensor():
+    """A stable handle re-dispatched every step must not rebuild its descriptor.
+
+    The wire ``Tensor`` is address-free and a pure function of the handle's
+    (Buffer, shape, dtype), all immutable — so rebuilding it per rank per
+    dispatch was pure host-side latency.
+    """
+    buffer = _RecordingBuffer()
+    dt = DeviceTensor(buffer.base, (8, 16), torch.float16, buffer=buffer)
+    worker = _worker(3)
+
+    from pypto.runtime.tensor_arg import make_tensor_arg  # noqa: PLC0415
+
+    with patch(
+        "pypto.runtime.task_interface.torch_dtype_to_datatype",
+        side_effect=lambda d: f"<dtype:{d}>",
+    ):
+        first = make_tensor_arg(worker, dt)
+        second = make_tensor_arg(worker, dt)
+        third = make_tensor_arg(_worker(3, "another_rank"), dt)
+
+    assert first is second is third
+    assert len(buffer.tensor_calls) == 1
+
+
+def test_memo_is_per_handle_so_pointer_reuse_cannot_share_a_descriptor():
+    """Two handles at one address must not share a cached descriptor.
+
+    ``DeviceTensor`` excludes ``buffer`` from ``__eq__`` / ``__hash__``, so a
+    freed handle and the fresh allocation that reuses its address compare equal.
+    Memoizing per handle keeps them apart; a dict keyed on the handle would not.
+    """
+    freed_buffer = _RecordingBuffer(0x1000)
+    fresh_buffer = _RecordingBuffer(0x1000)
+    freed = DeviceTensor(0x1000, (8, 16), torch.float16, buffer=freed_buffer)
+    fresh = DeviceTensor(0x1000, (8, 16), torch.float16, buffer=fresh_buffer)
+    assert freed == fresh and hash(freed) == hash(fresh)
+
+    from pypto.runtime.tensor_arg import make_tensor_arg  # noqa: PLC0415
+
+    with patch(
+        "pypto.runtime.task_interface.torch_dtype_to_datatype",
+        side_effect=lambda d: f"<dtype:{d}>",
+    ):
+        freed_wire = make_tensor_arg(_worker(3), freed)
+        fresh_wire = make_tensor_arg(_worker(3), fresh)
+
+    assert freed_wire is not fresh_wire
+    assert len(freed_buffer.tensor_calls) == 1
+    assert len(fresh_buffer.tensor_calls) == 1
+
+
+def test_l3_dispatch_defers_liveness_validation_to_the_runtime():
+    """Regression guard for the DP8 host-dispatch staircase (O(N^2) packing).
+
+    ``orch.submit_next_level`` validates every device argument against the
+    owner's identity-keyed allocation table, under a lock held through the
+    native submit. Re-deriving a weaker answer here cost a walk of the whole
+    buffer table per argument per rank.
+    """
+    buffer = _RecordingBuffer()
+    dt = DeviceTensor(buffer.base, (4,), torch.float32, buffer=buffer)
+    worker = _worker(3)
+    owner = MagicMock(name="pypto_owner")
+
+    from pypto.runtime.tensor_arg import bind_tensor_arg_owner, make_tensor_arg  # noqa: PLC0415
+
+    bind_tensor_arg_owner(worker, owner)
+
+    with patch(
+        "pypto.runtime.task_interface.torch_dtype_to_datatype",
+        side_effect=lambda d: f"<dtype:{d}>",
+    ):
+        make_tensor_arg(worker, dt)
+
+    owner._require_owned_resident_tensor.assert_not_called()
+
+
+def test_l2_dispatch_still_validates_against_the_owning_worker():
+    """L2's ``_submit_l2_locked`` has no provenance guard, so this is the only one."""
+    buffer = _RecordingBuffer()
+    dt = DeviceTensor(buffer.base, (4,), torch.float32, buffer=buffer)
+    worker = _worker(2)
     owner = MagicMock(name="pypto_owner")
 
     from pypto.runtime.tensor_arg import bind_tensor_arg_owner, make_tensor_arg  # noqa: PLC0415
@@ -62,62 +189,84 @@ def test_device_tensor_derives_wire_tensor_from_retained_buffer():
         make_tensor_arg(worker, dt)
 
     owner._require_owned_resident_tensor.assert_called_once_with(dt, "Tensor argument")
-    assert len(captured["tensor_calls"]) == 1
-    call = captured["tensor_calls"][0]
-    assert call["shapes"] == (8, 16)
-    assert call["dtype"] == "<dtype:torch.float16>"
 
 
-def test_retained_buffer_is_rejected_without_pypto_owner_binding():
-    class FakeBuffer:
-        base = 0xABCD
+def test_l2_validation_runs_again_on_every_reuse_of_a_cached_descriptor():
+    """The memo must not become a way around the L2 liveness check.
 
-        def tensor(self, *, shapes, dtype):
-            raise AssertionError("an unowned Buffer must be rejected before tensor()")
+    A cached descriptor is exactly as stale as the handle it was built from, so
+    validation has to precede the cache lookup rather than sit behind it.
+    """
+    buffer = _RecordingBuffer()
+    dt = DeviceTensor(buffer.base, (4,), torch.float32, buffer=buffer)
+    worker = _worker(2)
+    owner = MagicMock(name="pypto_owner")
+
+    from pypto.runtime.tensor_arg import bind_tensor_arg_owner, make_tensor_arg  # noqa: PLC0415
+
+    bind_tensor_arg_owner(worker, owner)
+
+    with patch(
+        "pypto.runtime.task_interface.torch_dtype_to_datatype",
+        side_effect=lambda d: f"<dtype:{d}>",
+    ):
+        make_tensor_arg(worker, dt)
+        owner._require_owned_resident_tensor.side_effect = ValueError("not a live allocation")
+        with pytest.raises(ValueError, match="not a live allocation"):
+            make_tensor_arg(worker, dt)
+
+    assert owner._require_owned_resident_tensor.call_count == 2
+    assert len(buffer.tensor_calls) == 1
+
+
+def test_unrecognizable_worker_level_falls_back_to_validating():
+    """A Worker whose level cannot be read must fail closed into checking."""
+    buffer = _RejectingBuffer()
+    dt = DeviceTensor(buffer.base, (4,), torch.float32, buffer=buffer)
 
     from pypto.runtime.tensor_arg import make_tensor_arg  # noqa: PLC0415
 
-    buffer = FakeBuffer()
-    dt = DeviceTensor(buffer.base, (4,), torch.float32, buffer=buffer)
+    # No ``level`` an int check accepts, and no owner binding: the fallback path
+    # rejects rather than silently converting.
     with pytest.raises(TypeError, match="one-shot or raw simpler Worker"):
         make_tensor_arg(MagicMock(name="unbound_worker"), dt)
 
 
-def test_owner_liveness_failure_prevents_wire_tensor_creation():
-    class FakeBuffer:
-        base = 0xABCD
+def test_l2_retained_buffer_is_rejected_without_pypto_owner_binding():
+    buffer = _RejectingBuffer()
+    dt = DeviceTensor(buffer.base, (4,), torch.float32, buffer=buffer)
 
-        def tensor(self, *, shapes, dtype):
-            raise AssertionError("a stale Buffer must be rejected before tensor()")
+    from pypto.runtime.tensor_arg import make_tensor_arg  # noqa: PLC0415
+
+    with pytest.raises(TypeError, match="one-shot or raw simpler Worker"):
+        make_tensor_arg(_worker(2, "unbound_worker"), dt)
+
+
+def test_l2_owner_liveness_failure_prevents_wire_tensor_creation():
+    buffer = _RejectingBuffer()
+    dt = DeviceTensor(buffer.base, (4,), torch.float32, buffer=buffer)
+    worker = _worker(2)
+    owner = MagicMock(name="pypto_owner")
+    owner._require_owned_resident_tensor.side_effect = ValueError("not a live allocation")
 
     from pypto.runtime.tensor_arg import bind_tensor_arg_owner, make_tensor_arg  # noqa: PLC0415
 
-    worker = MagicMock(name="worker")
-    owner = MagicMock(name="pypto_owner")
-    owner._require_owned_resident_tensor.side_effect = ValueError("not a live allocation")
     bind_tensor_arg_owner(worker, owner)
-    buffer = FakeBuffer()
-    dt = DeviceTensor(buffer.base, (4,), torch.float32, buffer=buffer)
 
     with pytest.raises(ValueError, match="not a live allocation"):
         make_tensor_arg(worker, dt)
 
 
-def test_stale_raw_backend_is_rejected_before_owner_validation():
-    class FakeBuffer:
-        base = 0xABCD
-
-        def tensor(self, *, shapes, dtype):
-            raise AssertionError("a stale backend must be rejected before tensor()")
+def test_l2_stale_raw_backend_is_rejected_before_owner_validation():
+    buffer = _RejectingBuffer()
+    dt = DeviceTensor(buffer.base, (4,), torch.float32, buffer=buffer)
+    old_worker = _worker(2, "old_worker")
+    owner = MagicMock(name="pypto_owner")
 
     from pypto.runtime.tensor_arg import bind_tensor_arg_owner, make_tensor_arg  # noqa: PLC0415
 
-    old_worker = MagicMock(name="old_worker")
-    owner = MagicMock(name="pypto_owner")
     bind_tensor_arg_owner(old_worker, owner)
     owner._tensor_arg_worker = MagicMock(name="replacement_worker")
-    buffer = FakeBuffer()
-    dt = DeviceTensor(buffer.base, (4,), torch.float32, buffer=buffer)
 
     with pytest.raises(ValueError, match="stale simpler Worker backend"):
         make_tensor_arg(old_worker, dt)
@@ -128,7 +277,7 @@ def test_raw_pointer_device_tensor_is_rejected_for_wire_dispatch():
     from pypto.runtime.tensor_arg import make_tensor_arg  # noqa: PLC0415
 
     with pytest.raises(TypeError, match="raw-pointer DeviceTensor"):
-        make_tensor_arg(MagicMock(name="worker"), DeviceTensor(0x1000, (4,), torch.float32))
+        make_tensor_arg(_worker(3), DeviceTensor(0x1000, (4,), torch.float32))
 
 
 def test_wire_tensor_passes_through():
@@ -139,13 +288,13 @@ def test_wire_tensor_passes_through():
 
     wire = FakeWireTensor()
     with patch("pypto.runtime.task_interface.Tensor", FakeWireTensor):
-        assert make_tensor_arg(MagicMock(name="worker"), wire) is wire
+        assert make_tensor_arg(_worker(3), wire) is wire
 
 
 def test_host_tensor_delegates_to_simpler():
     host = torch.zeros(4, 4, dtype=torch.float32)
     sentinel = MagicMock(name="Tensor(host)")
-    worker = MagicMock(name="worker")
+    worker = _worker(3)
 
     with patch("simpler_setup.torch_interop.make_tensor_arg", return_value=sentinel) as impl:
         from pypto.runtime.tensor_arg import make_tensor_arg  # noqa: PLC0415


### PR DESCRIPTION
## Summary

Generated `host_orch` converts every tensor parameter once per rank per dispatch, and each conversion re-proved the `DeviceTensor`'s liveness by scanning the owning Worker's whole allocation table. On DP8 decode that is 142 tensors × 8 ranks against a table holding all 1136 shards, so host-side argument packing grew quadratically in the allocation count and each rank entered its submit later than the one before it.

The runtime already validates every device argument at submit, and more strictly than this path could: `_child_prov_check_dispatch_locked` keys on `CanonicalIdentity` (so it rejects the pointer-reuse/ABA case an address-keyed check cannot see), compares the wire descriptor field-for-field against the registered one, and holds `_child_prov_lock` across the native submit — making authorization and dispatch one transaction, where a check at conversion time releases its evidence before the submit it was meant to protect. L3 therefore stops re-deriving a weaker answer. L2 keeps its check, because `_submit_l2_locked` has no equivalent guard.

Callers see no API change. Host-side packing for a DP8 decode step drops from 37.981 ms to 0.512 ms, and the rank-0-to-rank-7 entry skew from 36.77 ms to 0.45 ms.

Fixes #2532

## Changes

- `python/pypto/runtime/tensor_arg.py`: `make_tensor_arg` no longer validates liveness when the dispatching Worker's own submit path does (L3+). A Worker whose level cannot be read falls back to checking rather than skipping. The address-free wire `Tensor` is now built once per handle instead of once per rank per dispatch — it is a pure function of the handle's `(Buffer, shape, dtype)`, all immutable on a frozen `DeviceTensor`. It is memoized on the handle itself rather than in a table: `DeviceTensor` excludes `buffer` from `__eq__`/`__hash__`, so a freed handle and a fresh allocation reusing its address compare equal and would otherwise share one cache entry. On L2 the check runs ahead of the memo, so a cached descriptor never becomes a way around it.
- `python/pypto/runtime/runtime_base.py`: ownership validation no longer scans either. simpler stamps `owner_worker_id` on every allocation it hands out, making the owning key derivable rather than searched. The scan remains only for a Buffer that names no placement, since the `DeviceTensor` contract asks for `base` and `tensor(...)` alone and a custom Worker's `_buffer_for_ptr` may return such a handle.
- `tests/ut/runtime/test_tensor_arg.py`: covers the L2/L3 split, per-handle memoization, and the fail-closed fallback. `test_memo_is_per_handle_so_pointer_reuse_cannot_share_a_descriptor` asserts that two handles which compare and hash equal still receive distinct descriptors; `test_l2_validation_runs_again_on_every_reuse_of_a_cached_descriptor` pins that the memo cannot bypass the L2 check.
- `tests/ut/runtime/test_runtime_base.py`: `test_ownership_check_never_scans_the_buffer_table` validates 8 workers × 16 allocations through a `dict` subclass that counts whole-table traversals, and asserts the count stays zero. Sibling tests keep the freed-handle, pointer-reuse, and placeless-Buffer behaviors pinned.

## Behavior changes

`bind_tensor_arg_owner` and the owner backlink stay: L2 still needs them, and the fail-closed path must find a binding rather than reject a legitimate dispatch. No public API, signature, or migration step changes.

One consequence worth naming: the memo caches the descriptor built on first use, so a caller that mutates a public `Buffer` handle between dispatches would have the runtime compare the pre-mutation descriptor against the allocation-time snapshot and pass, where an uncached rebuild would fail the comparison. PyPTO never mutates the handle.

## Follow-up (not in this change)

`_submit_l2_locked` has no device-argument guard: it records touched identities (which serves `release_buffer`, not argument liveness) and materializes args through an `ImportRegistry` whose map-once cache `Worker.free` does not invalidate. PyPTO's L2 check is therefore the only thing standing between a freed `DeviceTensor` and a use-after-free there, and it is kept for that reason. Adding the L3 guard's equivalent to the runtime's L2 submit would let PyPTO drop that check too.

## Verification

- `ruff check python/pypto/runtime/ tests/ut/runtime/`: exit 0, all checks passed.
- `ruff format --check` on the four changed files: exit 0, already formatted.
- `python -m pytest tests/ut/runtime/ -n 2 -q`: exit 0, 732 passed. Run by the push transaction's validation runner at the pushed commit.
- Host-side packing benchmark (8 ranks × 142 tensors, 1136 resident allocations, real `Buffer` objects built by `wrap_device_malloc`, no device or simulator), same script run against this branch and its base:

  | | base | this change |
  |---|---:|---:|
  | packing per step | 37.981 ms | 0.512 ms |
  | rank0→rank7 skew | 36.77 ms | 0.45 ms |
  | per argument | 33.43 µs | 0.45 µs |

  The base's per-rank increments (2.24, 3.24, 4.27, 5.26, 6.25, 7.23, 8.28 ms) show the quadratic term directly; after the change the increment is a flat 0.06 ms. The benchmark script is not part of this change.