### PR TITLE
fix(ir): reject a full-width operand under an auto-halved vector op

### DIFF
--- a/docs/en/dev/passes/21-lower_auto_vector_split.md
+++ b/docs/en/dev/passes/21-lower_auto_vector_split.md
@@ -587,6 +587,207 @@ synthesize. Move the operation outside the automatically-halved split region.
 Singleton split dimensions and already-half-width explicit-boundary regions
 remain unchanged.
 
+Halving a result is sound only under **two conditions**, asked in this order
+because the first subsumes the second wherever it can speak:
+
+| # | Condition | Decided by | Catches |
+| - | --------- | ---------- | ------- |
+| 1 | the halved node still type-checks against its own arguments | the operator's own `f_deduce_type` — no metadata | a full-width `tile.add` operand, a rank-1 bias on the split axis, `row_argmax`'s shape-matched `tmp`, `tile.transpose_view`'s axis permutation |
+| 2 | an operand condition 1 is **blind** to is lane-local, broadcast along the split axis, or **declared** lane-invariant | a registry declaration | `tile.sel`'s full-width `mask`, which its result deduction never reads |
+
+### Condition 1 — the halved node still type-checks
+
+After rewriting the arguments, the pass re-deduces the result from the arguments
+the trailing `Substitute` will install (each tracked operand swapped for its
+halved replacement) and compares the deduced *physical* shape against the halved
+result type. Valid shape is excluded: `HalveTileShape` localizes it per lane,
+which deduction cannot reproduce. A deduction that rejects the halved arguments
+outright counts as a mismatch too — the operator is refusing the very node it
+would receive.
+
+This asks the operator itself, so it needs no per-operator metadata and cannot go
+stale as operators are added or their contracts change. It is what rejects the
+ordinary case:
+
+```python
+def split_auto(vec: pl.Tile[[256, 128], pl.FP32, pl.Mem.Vec], ...):
+    vec_h = pl.tile.add(vec, vec)   # rejected: `vec` is full width
+```
+
+`vec` is a full-width `InCore` parameter, so nothing inside the region partitions
+it. Halving only the result would emit
+`tile.add([256, 128], [256, 128]) -> [128, 128]`, a node whose declared shape
+contradicts type inference over its own arguments; it does not survive
+print→parse and misleads every later consumer that re-derives types from
+operands. Derive the per-lane half first (`tile.load` / `tile.slice` inside the
+region, or an explicit `pl.tile.aiv_shard`), or keep a value both lanes share
+outside the region.
+
+The same check decides cases a shape heuristic gets wrong in both directions.
+Operands align to the result **from the right**, matching `BroadcastShapes`:
+
+| `tile.add([256, 128], bias)` | `UP_DOWN` (dim 0) | `LEFT_RIGHT` (dim 1) |
+| ---------------------------- | ----------------- | -------------------- |
+| `bias: [128]` | accepted — broadcasts over the split axis | rejected — `BroadcastShapes([256, 64], [128])` fails |
+| `bias: [1, 128]` | accepted — singleton on the split axis | rejected — its dim 1 is full width |
+| `bias: [256, 128]` | rejected | rejected |
+
+and it covers an axis-permuting operator, which no right-alignment rule
+describes:
+
+```python
+def split_auto(data: pl.Tile[[1, 256], pl.FP32, pl.Mem.Vec], ...):
+    viewed = pl.tile.transpose_view(data)   # rejected: [128, 1] vs the [256, 1] deduced
+```
+
+`tile.transpose_view` swaps the trailing two dims, so the halved `[128, 1]`
+result contradicts the `[256, 1]` its own operand deduces. Unlike
+`tile.transpose`, this is a pure view and is outside `FindTransposeSplitHazard`,
+which matches `tile.transpose` only.
+
+The shape-describing ops (`tile.full`, `tile.create`, `tile.slice`,
+`tile.reshape`, `tile.reinterpret_view`) rewrite their own operands before this
+check runs, and each has a defined full-width-source meaning.
+
+`tile.reshape` and `tile.reinterpret_view` get that from an earlier rewrite: an
+offsetless view over an untracked source is emitted at full width and followed by
+a per-subblock `tile.slice`, so each lane reads its own half instead of both
+reading the first one. That slice can only be materialized from a **static** half
+extent, so a dynamic split extent over a full-width source is rejected rather
+than left to fall through to plain result halving.
+
+### Condition 2 — operands type deduction is blind to
+
+A deducer that never reads an operand's extent says nothing by accepting it. The
+pass detects that per call, with no metadata: it re-deduces once more with the
+operand **doubled** on the split axis. If deduction throws or the result changes,
+the deducer *pins* that operand and condition 1 already decided it. If the answer
+is unchanged, the operand is *blind*, and only a declaration can say whether full
+width is in contract.
+
+```python
+picked = pl.tile.sel(mask, lhs, rhs, tmp)   # rejected when `mask` is full width
+```
+
+`tile.sel` deduces its result from `BroadcastShapes(lhs, rhs)` alone and checks
+only that `mask` is a `TileType`, so a full-width mask over halved lhs/rhs
+re-deduces perfectly cleanly — yet both lanes would read mask rows `0..127`.
+`tile.sels` is the same shape of trap: it validates that the mask *covers* src's
+valid rows, and an oversized mask satisfies coverage. Both declare only their
+`tmp` position, so their masks are rejected. An operand nobody has classified is
+treated as lane data, which is the safe default.
+
+Restricting this to blind operands is what keeps it in its lane. Without it,
+every operator with a legal full-width operand would need a registry declaration
+purely to suppress a check that had no business running — which is how
+`tile.rsqrt` came to declare a scratch its own deducer requires to match the
+input exactly. `tests/ut/ir/operators/test_lane_invariant_arg_coverage.py`
+measures which operands are blind, fails on a declaration the deducer makes
+unreachable, and pins the blind set so a new operator or a loosened deducer has
+to be classified rather than silently falling through.
+
+The test for a declaration is *positional correspondence*: does output element
+`i` read operand element `i`? Two kinds of operand answer no.
+
+**Hardware scratch.** A full-width workspace is in contract, and each lane simply
+declares the whole thing:
+
+```python
+scratch = pl.tile.create([256, 128], dtype=pl.FP32, target_memory=pl.Mem.Vec)
+sums = pl.tile.row_sum(v, scratch)      # accepted: [128, 128] x [256, 128] -> [128, 1]
+```
+
+`tile.row_sum` documents its `tmp_tile` as scratch *at least as large as* the
+input, never reads it in `DeduceTileRowReductionType`, and declares it with
+`set_lane_invariant_arg(1)`. `tile.create` is registered `CoreAffinity::SHARED`,
+so [the affinity gate](#the-affinity-gate) deliberately passes it through full
+width and never tracks it — matching on the extent alone would reject the whole
+rms-norm reduction shape.
+
+Its sibling `tile.row_argmax` needs a tmp shaped *exactly* like the source, and
+`DeduceTileRowReductionType` enforces that with `require_exact_tmp_shape`. It
+therefore carries **no** declaration: condition 1 rejects a full-width tmp on its
+own, and a declaration would claim a contract the operator does not grant.
+
+**An operand addressed at absolute indices.**
+
+```python
+indices = pl.tile.load(idx, [0, 0], [256, 128], target_memory=pl.Mem.Vec)
+picked = pl.tile.gather(src, indices, tmp)   # accepted: src stays [256, 128]
+```
+
+`tile.gather` computes `out[i] = src[indices[i]]` and takes its result shape from
+`indices`. The index values are absolute into `src`, so halving `indices` already
+gives each lane its own half of the **output** while both read the whole table —
+that is the correct lowering, not a missing shard. `tile.gatherb` is the
+byte-offset form of the same shape. `tile.scatter` and `tile.scatter_update` are
+the write-side dual, addressing a *destination* by absolute index.
+
+**The declaration permits a full-width operand; it does not keep one.** Nothing
+stops the operand's own producer from being halved, and the kinds differ on what
+that means — which is why the registry records *which* kind applies:
+
+| Kind | Full width | Producer partitioned | Example |
+| ---- | ---------- | -------------------- | ------- |
+| `Scratch` | allowed | fine — a halved input takes a halved scratch with it | `row_sum`'s `tmp_tile` |
+| `IndexAddressedSource` | allowed | **rejected** — indices stay absolute, so lane 1 reads the wrong half | `gather`'s `src` |
+| `AbsoluteIndexedDestination` | allowed | **rejected** — the write side of the same defect | `scatter`'s `dst` |
+
+`tile.scatter` writes `dst.flat[indexes[i, j]] = src[i, j]` with *flattened*
+offsets into the whole destination, so a column write encoding `i * dst_cols + c`
+stops matching the moment the row stride halves.
+
+```python
+src = pl.tile.load(tbl, [0, 0], [256, 128], target_memory=pl.Mem.Vec)
+picked = pl.tile.gather(src, indices, tmp)   # rejected: the table was halved
+```
+
+This is the ordinary path rather than a corner: `pl.gather` over a tensor lowers
+to a `tile.load` of the table feeding `tile.gather`, so an author who gathers
+inside a split region hits it by default. Neither condition above sees it — the
+operand is tracked, so condition 2 skips it, and `tile.gather` deduces its result
+from `indices` alone, so condition 1 is satisfied. That is why the absolute-index
+kinds stay declared even where the deducer *does* read the operand: the property
+is not type-expressible in either direction. Produce the table **outside** the
+split region and pass it in; keeping such a producer at full width automatically
+is not implemented.
+
+The absolute-index check runs **before** the halving path, not beside it, because
+the trailing `Substitute` rewrites the argument even where nothing is halved:
+
+- a **singleton result** returns early — `gather` with `[1, N]` indices yields a
+  `[1, N]` result, so the result is untouched while the table under it is still
+  halved;
+- a **tuple result** skips the block entirely. `tile.gather_compare` returns
+  `Tuple[dst, cdst]`, which the generic path (single `TileType` only) cannot
+  halve — so it would keep declaring full-width elements over a halved input.
+  A tuple-returning op that consumes a partitioned operand is rejected;
+  per-element split mapping for tuple results is not implemented.
+
+A position that is scratch only in *some* arities cannot be declared:
+`tile.mrgsort_format2`'s `tmp_or_src2` is a third sorted input in a 3/4-way merge
+and workspace in a 2-way one, and the arity is the positional argument count.
+Such a position stays unclassified and a full-width one is rejected.
+
+### Carries and dropped axes
+
+Two places rewrite state *around* the halving rather than in it, and both must
+follow the same axis and tracking rules or the conditions above misfire:
+
+- **Loop carries.** An `iter_arg` inherits its init value's tracking, so a halved
+  init makes the carry lane-local; the loop-exit `return_var` inherits it in turn
+  so a later `tile.store` gets the per-lane offset. Both the explicit and the
+  AUTO affinity-gated arms share `RepairIterArgs` / `RepairReturnVars` — the AUTO
+  arm recurses through its own walk and cannot reach the explicit path's `ForStmt`
+  branch, so without this a legal tile accumulator has its carry reported as a
+  full-width operand.
+- **`tile.slice` with `drop_dims`.** `shape` / `offset` / `valid_shape` are
+  indexed in the **pre-drop** rank, while the split dim indexes the result.
+  `drop_dims` erases axes afterwards and pads back to 2D by *prepending* unit
+  axes, so `slice([1, 256, 128], drop_dims=[0]) -> [256, 128]` puts the result's
+  dim 0 on the source's dim 1. The result axis is mapped back before any tuple is
+  touched.
+
 ## The affinity gate
 
 Only **vector** work is halved; cube work stays full. Affinity is decided by

--- a/docs/zh/dev/passes/21-lower_auto_vector_split.md
+++ b/docs/zh/dev/passes/21-lower_auto_vector_split.md
@@ -500,6 +500,169 @@ out_store = pl.tile.store(popped, [0 + aiv_id * 7, 0], out_0)
 状态，而本 pass 不会合成这些调整。请将算子移到会自动折半的拆分区域之外。单元素拆分维与
 已有显式边界的半宽区域仍保持不变。
 
+折半结果的可靠性由**两个条件**共同保证。它们按下面的顺序提问，因为第一个条件凡是能开口
+的地方都已经把第二个包住了：
+
+| # | 条件 | 由谁决定 | 拦住的情形 |
+| - | ---- | -------- | ---------- |
+| 1 | 折半后的节点仍能与其自身实参通过类型检查 | 算子自己的 `f_deduce_type`，无需任何元数据 | 全宽的 `tile.add` 操作数、落在拆分轴上的 rank-1 bias、`row_argmax` 形状匹配的 `tmp`、`tile.transpose_view` 的轴置换 |
+| 2 | 条件 1 **看不见**的操作数必须 lane 局部、沿拆分轴广播、或被**显式声明** | 注册表声明 | `tile.sel` 的全宽 `mask`——其结果推导根本不读它 |
+
+### 条件 1 —— 折半后的节点仍能通过类型检查
+
+改写完实参之后，pass 会用尾部 `Substitute` 将要装入的实参（每个被跟踪的操作数换成其折半
+替身）重新推导一次结果，并把推导出的**物理** shape 与折半后的结果类型比对。valid shape 不
+参与比较：`HalveTileShape` 会按 lane 做本地化，而类型推导无法复现这一点。若重新推导对折半
+后的实参直接报错，同样计为不一致——算子正在拒绝它将要收到的那个节点。
+
+这一问是问算子本身，因此不需要任何逐算子元数据，也不会随着算子新增或契约变化而过时。
+最常见的情形正是由它拦下的：
+
+```python
+def split_auto(vec: pl.Tile[[256, 128], pl.FP32, pl.Mem.Vec], ...):
+    vec_h = pl.tile.add(vec, vec)   # 被拒绝：`vec` 是全宽的
+```
+
+`vec` 是全宽的 `InCore` 参数，区域内无人切分它。仅折半结果会产生
+`tile.add([256, 128], [256, 128]) -> [128, 128]`：该节点声明的 shape 与对其自身实参做类型
+推导的结果相矛盾，无法通过 print→parse，并会误导后续所有依据操作数重新推导类型的消费者。
+请先得到 per-lane 的一半（在区域内使用 `tile.load` / `tile.slice`，或显式写
+`pl.tile.aiv_shard`），或把两条 lane 共享的值放在区域之外。
+
+同一个检查也能正确处理形状启发式两个方向都会判错的情形。操作数与结果**从右对齐**
+（与 `BroadcastShapes` 一致）：
+
+| `tile.add([256, 128], bias)` | `UP_DOWN`（维 0） | `LEFT_RIGHT`（维 1） |
+| ---------------------------- | ----------------- | -------------------- |
+| `bias: [128]` | 接受——在拆分轴上是广播 | 拒绝——`BroadcastShapes([256, 64], [128])` 不成立 |
+| `bias: [1, 128]` | 接受——拆分轴上是单元素维 | 拒绝——其维 1 是全宽 |
+| `bias: [256, 128]` | 拒绝 | 拒绝 |
+
+它同样覆盖轴置换类算子，而后者是任何右对齐规则都描述不了的：
+
+```python
+def split_auto(data: pl.Tile[[1, 256], pl.FP32, pl.Mem.Vec], ...):
+    viewed = pl.tile.transpose_view(data)   # 被拒绝：[128, 1] 与推导出的 [256, 1] 矛盾
+```
+
+`tile.transpose_view` 交换末两维，于是折半后的 `[128, 1]` 结果与其操作数自身推导出的
+`[256, 1]` 相矛盾。与 `tile.transpose` 不同，它是纯视图，不在 `FindTransposeSplitHazard`
+的覆盖范围内（后者只匹配 `tile.transpose`）。
+
+描述 shape 的算子（`tile.full`、`tile.create`、`tile.slice`、`tile.reshape`、
+`tile.reinterpret_view`）在该检查之前就改写了自己的操作数，且全宽源在其语义中有明确含义。
+
+`tile.reshape` 与 `tile.reinterpret_view` 的这一点来自一次更早的改写：对未被跟踪的源，
+其无偏移视图会先以全宽发出，再跟一个 per-subblock 的 `tile.slice`，使每条 lane 读到自己
+的那一半，而不是两条都读第一半。该 slice 只能由**静态**的半宽 extent 物化，因此全宽源上
+动态的拆分 extent 会被直接拒绝，而不是落到普通的结果折半上。
+
+### 条件 2 —— 类型推导看不见的操作数
+
+推导器若从不读某个操作数的 extent，那么它"接受"这件事本身什么也不能说明。pass 会逐调用
+就地判定这一点，同样无需元数据：把该操作数在拆分轴上**加倍**再推导一次。若推导报错或结果
+发生变化，说明推导器**盯着**这个操作数，条件 1 已经替它做过判断；若答案不变，说明推导器对
+它**视而不见**，此时只有声明才能回答全宽是否符合契约。
+
+```python
+picked = pl.tile.sel(mask, lhs, rhs, tmp)   # `mask` 为全宽时被拒绝
+```
+
+`tile.sel` 仅从 `BroadcastShapes(lhs, rhs)` 推导结果，对 `mask` 只检查它是不是 `TileType`；
+于是"全宽 mask + 折半 lhs/rhs"能干干净净地重新推导通过——可两条 lane 都会去读 mask 的第
+`0..127` 行。`tile.sels` 是同一类陷阱：它只校验 mask *覆盖* src 的有效行，而超宽的 mask
+恰好满足覆盖。两者都只声明了自己的 `tmp` 位置，因此它们的 mask 会被拒绝。无人分类过的操作
+数一律按 lane 数据对待——这是安全的默认值。
+
+把这道关卡限定在"推导器看不见"的操作数上，正是它不越界的关键。否则每个带有合法全宽操作数
+的算子都得写一条注册表声明，只为压掉一个本就不该运行的检查——`tile.rsqrt` 就是这么给一个
+"推导器要求与输入逐维相等"的 scratch 加上声明的。
+`tests/ut/ir/operators/test_lane_invariant_arg_coverage.py` 会度量哪些操作数处于盲区，
+对推导器已经能决定、因而永远走不到的声明直接判失败，并钉住盲区集合，使新增算子或放松的
+推导器必须被分类，而不是悄悄漏过。
+
+是否需要声明的判据是*位置对应关系*：输出的第 `i` 个元素是否读取操作数的第 `i` 个元素？
+有两类操作数的答案是否。
+
+**硬件 scratch。** 全宽工作区符合契约，两条 lane 各自声明整块即可：
+
+```python
+scratch = pl.tile.create([256, 128], dtype=pl.FP32, target_memory=pl.Mem.Vec)
+sums = pl.tile.row_sum(v, scratch)      # 接受：[128, 128] x [256, 128] -> [128, 1]
+```
+
+`tile.row_sum` 把 `tmp_tile` 定义为*至少与输入一样大*的 scratch，`DeduceTileRowReductionType`
+从不读它，并通过 `set_lane_invariant_arg(1)` 声明。`tile.create` 注册为
+`CoreAffinity::SHARED`，[亲和性门控](#亲和性门控)因此刻意让它以全宽通过、也从不跟踪它——
+仅凭 extent 匹配会把整个 rms-norm 归约形状都拒掉。
+
+它的同族 `tile.row_argmax` 需要与源*完全同形*的 tmp，`DeduceTileRowReductionType` 用
+`require_exact_tmp_shape` 强制了这一点。因此它**不带**任何声明：条件 1 自己就会拒绝全宽
+tmp，而一条声明反而会宣称一个算子并未给出的契约。
+
+**由绝对索引寻址的操作数。**
+
+```python
+indices = pl.tile.load(idx, [0, 0], [256, 128], target_memory=pl.Mem.Vec)
+picked = pl.tile.gather(src, indices, tmp)   # 接受：src 保持 [256, 128]
+```
+
+`tile.gather` 计算 `out[i] = src[indices[i]]`，结果 shape 取自 `indices`。索引值是相对
+`src` 的**绝对**偏移，因此折半 `indices` 本身就让每条 lane 拿到**输出**的各自一半，而两条
+lane 读同一张完整表——这正是正确的降级结果，而不是漏掉的切分。`tile.gatherb` 是同一形态的
+字节偏移版本。`tile.scatter` 与 `tile.scatter_update` 是其写侧对偶，用绝对索引寻址**目的地**。
+
+**声明只是"允许"操作数保持全宽，并不能"保证"它全宽。** 没有任何机制阻止该操作数自己的
+生产者被折半，而各类声明对此的含义不同——这正是注册表需要记录**是哪一类**的原因：
+
+| 类别 | 全宽 | 生产者被折半 | 例子 |
+| ---- | ---- | ------------ | ---- |
+| `Scratch` | 允许 | 无害——输入折半时 scratch 一起折半仍然成立 | `row_sum` 的 `tmp_tile` |
+| `IndexAddressedSource` | 允许 | **拒绝**——索引仍是绝对值，lane 1 读错半区 | `gather` 的 `src` |
+| `AbsoluteIndexedDestination` | 允许 | **拒绝**——同一缺陷的写侧 | `scatter` 的 `dst` |
+
+`tile.scatter` 执行 `dst.flat[indexes[i, j]] = src[i, j]`，索引是相对整块目的地的**扁平**
+偏移，因此按列写入所编码的 `i * dst_cols + c` 一旦行 stride 折半就不再成立。
+
+```python
+src = pl.tile.load(tbl, [0, 0], [256, 128], target_memory=pl.Mem.Vec)
+picked = pl.tile.gather(src, indices, tmp)   # 被拒绝：表被折半了
+```
+
+这是常规路径而非角落：张量层的 `pl.gather` 会降级为"`tile.load` 表 + `tile.gather`"，
+所以在拆分区域内做 gather 的作者默认就会撞上。上面两个条件都看不见它——操作数被跟踪，
+条件 2 会跳过；而 `tile.gather` 仅从 `indices` 推导结果，条件 1 也满足。这正是绝对索引这
+两类即便推导器*确实*读了该操作数也仍要保留声明的原因：这个性质在两个方向上都无法用类型
+表达。请把表放在拆分区域**之外**产生再传入；自动保持这类生产者全宽的重写尚未实现。
+
+绝对索引检查跑在折半路径**之前**而非与之并列，因为即使什么都没被折半，尾部的 `Substitute`
+依然会改写实参：
+
+- **结果为单元素维**时会提前返回——`indices` 为 `[1, N]` 的 gather 结果也是 `[1, N]`，
+  结果原封不动，而其下的表仍被折半；
+- **结果为 tuple** 时会整段跳过。`tile.gather_compare` 返回 `Tuple[dst, cdst]`，通用路径
+  （只理解单个 `TileType`）无法折半它——于是它会在已折半的输入之上继续声明全宽元素。
+  消费了被折半操作数的 tuple 返回算子会被拒绝；对 tuple 结果逐元素映射拆分轴尚未实现。
+
+只在*部分* arity 下才是 scratch 的位置无法声明：`tile.mrgsort_format2` 的 `tmp_or_src2`
+在 3/4 路归并里是第三个已排序输入、在 2 路里才是工作区，而 arity 由位置实参个数决定。
+这类位置保持未分类，全宽时按拒绝处理。
+
+### 循环携带值与被丢弃的轴
+
+有两处是在折半**周围**改写状态而非折半本身，它们必须遵循同样的轴映射与跟踪规则，
+否则上面的条件会误判：
+
+- **循环携带值。** `iter_arg` 继承其 init 的跟踪信息，因此 init 被折半时携带值也变为
+  lane 局部；循环出口的 `return_var` 再继承之，使后续 `tile.store` 拿到 per-lane 偏移。
+  显式路径与 AUTO 亲和性门控路径共用 `RepairIterArgs` / `RepairReturnVars`——AUTO 走的是
+  自己的遍历，够不到显式路径的 `ForStmt` 分支，缺了这一步就会把合法的 tile 累加器的携带值
+  当成全宽操作数报错。
+- **带 `drop_dims` 的 `tile.slice`。** `shape` / `offset` / `valid_shape` 按**丢弃前**的
+  rank 索引，而拆分维按结果索引。`drop_dims` 之后才擦除轴，并通过在前面补单元素轴回到 2D，
+  因此 `slice([1, 256, 128], drop_dims=[0]) -> [256, 128]` 的结果维 0 对应源的维 1。
+  在改写任何 tuple 之前，结果轴会先被反向映射回去。
+
 ## 亲和性门控
 
 仅折半**向量**工作，cube 工作保持全尺寸。亲和性由

--- a/include/pypto/ir/op_registry.h
+++ b/include/pypto/ir/op_registry.h
@@ -231,6 +231,102 @@ struct OpArgEffectSpec {
 };
 
 /**
+ * @brief Arguments that carry no lane-indexed data
+ *
+ * Automatic AIV vector splitting (`LowerAutoVectorSplit`) halves an op's RESULT
+ * to the per-lane extent and relies on every tile operand being lane-local
+ * already. An operand that is still full width normally means nothing sharded
+ * it, and the two lanes would read the same rows.
+ *
+ * **Most operands need no declaration at all.** The pass decides them by
+ * re-deducing the halved call and refusing to emit a node whose declared result
+ * contradicts type inference over its own arguments. That answer comes from the
+ * operator itself, so it needs no metadata and cannot go stale — and it already
+ * rejects a full-width operand for every operator whose `f_deduce_type` reads
+ * that operand's extent, which is most of them.
+ *
+ * This spec covers the remainder: operands the deducer **never looks at**, where
+ * accepting the halved call proves nothing. `tile.sel` deduces its result from
+ * `lhs`/`rhs` alone, yet its `mask` is per-element data that must be sharded
+ * with them; `tile.sels` validates only that the mask COVERS `src`, so an
+ * over-wide mask passes deduction while feeding lane 1 lane 0's rows. For those,
+ * and only those, the registry is the source of truth.
+ *
+ * The test is *positional correspondence*: does output element `i` read operand
+ * element `i`? Two kinds of operand answer no, and both may stay full width.
+ *
+ * 1. **Hardware scratch.** `tile.row_sum(tile, tmp_tile)` uses `tmp_tile` as
+ *    workspace whose contract is "at least as large as the input", never as
+ *    per-lane data. Each lane declaring the whole buffer is what the
+ *    SHARED-affinity `tile.create` that feeds it already does.
+ *
+ * 2. **A lane-shared source addressed by a separate index operand.**
+ *    `tile.gather(src, indices, tmp)` computes `out[i] = src[indices[i]]`, and
+ *    the index values are absolute into `src`. Halving `indices` therefore gives
+ *    each lane its own half of the OUTPUT while both read the same whole table —
+ *    which is the correct lowering, not a missing shard. `tile.gatherb` is the
+ *    byte-offset form of the same shape.
+ *
+ *    The scatter family is the dual: `tile.scatter` and `tile.scatter_update`
+ *    address a *destination* by absolute index, so halving it while the indices
+ *    stay absolute writes the wrong rows.
+ *
+ * The kinds are NOT interchangeable, which is why `LaneInvariantArg` records
+ * which one applies. They differ on what a *partitioned producer* means. Scratch
+ * may be halved freely: the contract is a size relation to the input, and a
+ * halved input takes a halved scratch with it. An absolutely-addressed operand
+ * may not: if it comes from a `tile.load` inside the region, the split halves
+ * that load and lane 1 addresses the wrong rows while the indices stay absolute.
+ * Since `tensor.gather` lowers to exactly `tile.load` + `tile.gather`, that is
+ * the ordinary path, not a corner — so the split guard rejects a partitioned
+ * producer for those kinds rather than accepting it. That property is not
+ * type-expressible in either direction, so those two kinds stay declared even
+ * where the deducer does read the operand.
+ *
+ * Absent (`std::nullopt`) means the operator declares no such argument, so the
+ * split guard treats a tile operand type deduction cannot decide as lane-indexed
+ * data — the safe answer for an operand nobody has classified.
+ *
+ * Two shapes of argument cannot be declared here:
+ *
+ * * one the deducer already pins. `tile.rsqrt`'s `tmp` must match the input
+ *   rank and every dimension, so a declaration claiming full width is legal
+ *   could never be reached and would read as a contract the operator does not
+ *   grant. `tests/ut/ir/operators/test_lane_invariant_arg_coverage.py` measures
+ *   this and fails on such a declaration;
+ * * one that is scratch only in *some* arities. `tile.mrgsort_format2`'s
+ *   `tmp_or_src2` is a third sorted input in a 3/4-way merge and workspace in a
+ *   2-way one, and the arity is the positional argument count, not a kwarg. Such
+ *   a position stays unclassified, so the split guard treats it as data and
+ *   rejects a full-width one — the safe direction.
+ */
+/// Why an argument carries no lane-indexed data. The two kinds behave
+/// differently when the operand's PRODUCER is partitioned, so they cannot share
+/// one flag.
+enum class LaneInvariantArg : uint8_t {
+  /// Hardware workspace. Full width and halved are both correct: the contract is
+  /// a size relation to the input ("at least as large as"), and a halved input
+  /// takes a halved scratch with it.
+  Scratch = 0,
+  /// A source addressed by a separate index/offset operand, whose values are
+  /// ABSOLUTE into it. Only full width is correct. Halving it while the indices
+  /// stay absolute makes lane 1 read the wrong rows and can index out of bounds,
+  /// so a partitioned producer must be rejected rather than accepted.
+  IndexAddressedSource = 1,
+  /// The write-side dual: a DESTINATION addressed by absolute (often flattened)
+  /// indices, as in `tile.scatter`'s `dst.flat[indexes[i, j]] = src[i, j]`.
+  /// Halving it is the same defect on the write side -- lane 1 writes to the
+  /// wrong half, and a flat index encoding `i * dst_cols + c` no longer matches
+  /// the halved row stride at all.
+  AbsoluteIndexedDestination = 2,
+};
+
+struct OpLaneInvariantArgSpec {
+  /// Argument indices that carry no lane-indexed data, and why.
+  std::map<size_t, LaneInvariantArg> args;
+};
+
+/**
  * @brief Type-erased operator registration entry
  *
  * This class represents a registered operator in the registry system. It stores
@@ -729,6 +825,33 @@ class OpRegistryEntry {
     return *this;
   }
 
+  /// Declare that argument `arg_index` carries no lane-indexed data, so
+  /// automatic AIV vector splitting may leave it full width under a halved
+  /// result. See `OpLaneInvariantArgSpec`: this covers hardware scratch and an
+  /// operand addressed at absolute indices, and it is a claim about the DATA the
+  /// operand carries, not about whether the result shape is deduced from it.
+  ///
+  /// Declare a `Scratch` argument only when the operator's own `f_deduce_type`
+  /// does NOT read its extent — otherwise the split pass decides it without
+  /// metadata and the declaration is unreachable.
+  inline OpRegistryEntry& set_lane_invariant_arg(size_t arg_index,
+                                                 LaneInvariantArg kind = LaneInvariantArg::Scratch) {
+    // This metadata decides whether the split guard protects an operand, so a
+    // declaration that names nothing must fail at registration rather than
+    // silently leave the real operand unguarded. Arguments are declared before
+    // this call in every registration, so the count is already known here.
+    CHECK(arguments_.has_value() && arg_index < arguments_->size())
+        << "Operator '" << name_ << "' declares argument " << arg_index << " lane-invariant, but it has "
+        << (arguments_.has_value() ? std::to_string(arguments_->size()) : std::string("no"))
+        << " declared argument(s); add_argument() must come first and the index must name one of them";
+    auto& args = EnsureLaneInvariantArgs().args;
+    auto [it, inserted] = args.emplace(arg_index, kind);
+    CHECK(inserted || it->second == kind)
+        << "Operator '" << name_ << "' declares argument " << arg_index
+        << " lane-invariant twice with different kinds; a single position has one meaning";
+    return *this;
+  }
+
   /// Declare that this operator writes through none of its arguments. Use it to
   /// classify an operator whose name or side-effect-only signature would
   /// otherwise leave a reader wondering — `pld.system.wait` polls a signal it
@@ -799,6 +922,24 @@ class OpRegistryEntry {
     if (resolver != arg_effects_->kwarg_dependent.end()) return resolver->second(kwargs);
     if (arg_index >= arg_effects_->per_arg.size()) return ArgEffect::Read;
     return arg_effects_->per_arg[arg_index];
+  }
+
+  /// True when argument `arg_index` carries no lane-indexed data for a call
+  /// carrying `kwargs`, so automatic AIV splitting may leave it full width.
+  /// False for every argument the operator did not name — an unclassified
+  /// operand is treated as per-lane data, which is the safe answer.
+  [[nodiscard]] bool IsLaneInvariantArg(size_t arg_index) const {
+    return GetLaneInvariantArgKind(arg_index).has_value();
+  }
+
+  /// Why argument `arg_index` is lane-invariant, or `nullopt` when the operator
+  /// did not declare it. The kind decides what a PARTITIONED producer means:
+  /// harmless for `Scratch`, a miscompile for `IndexAddressedSource`.
+  [[nodiscard]] std::optional<LaneInvariantArg> GetLaneInvariantArgKind(size_t arg_index) const {
+    if (!lane_invariant_args_.has_value()) return std::nullopt;
+    auto it = lane_invariant_args_->args.find(arg_index);
+    if (it == lane_invariant_args_->args.end()) return std::nullopt;
+    return it->second;
   }
 
   /// True when this operator may write through argument `arg_index` under some
@@ -876,6 +1017,13 @@ class OpRegistryEntry {
     return *arg_effects_;
   }
 
+  /// The lane-invariance spec, creating it on first declaration. Same
+  /// single-site engagement rule as `EnsureArgEffects`.
+  OpLaneInvariantArgSpec& EnsureLaneInvariantArgs() {
+    if (!lane_invariant_args_.has_value()) return lane_invariant_args_.emplace();
+    return *lane_invariant_args_;
+  }
+
   /**
    * @brief Set the operator name
    *
@@ -902,6 +1050,8 @@ class OpRegistryEntry {
       deduce_type_;                               ///< Type deduction function
   std::optional<OpMemorySpaceSpec> memory_spec_;  ///< Memory space specification
   std::optional<OpArgEffectSpec> arg_effects_;    ///< Per-argument execution effects; nullopt = unclassified
+  std::optional<OpLaneInvariantArgSpec>
+      lane_invariant_args_;     ///< Args carrying no lane-indexed data; nullopt = none declared
   bool is_inplace_safe_{true};  ///< Whether the op supports in-place execution (src == dst buffer)
   ExecutionMemoryAccessEvidence execution_memory_access_evidence_{ExecutionMemoryAccessEvidence::Unknown};
   std::set<size_t> forbid_output_alias_args_;  ///< Input args whose buffer the output must not reuse

--- a/include/pypto/ir/transforms/utils/split_axis_utils.h
+++ b/include/pypto/ir/transforms/utils/split_axis_utils.h
@@ -340,6 +340,23 @@ TransposeSplitHazard FindTransposeSplitHazard(const StmtPtr& body, int split_dim
  *        keeps the default box partition.
  * @return The rewritten statement list.
  */
+/// Propagate split tracking from each iter_arg's init value onto the carry
+/// itself, rebuilding its type at the per-lane extent. Call BEFORE lowering the
+/// body: an operation on an untracked full-width carry is otherwise reported as
+/// carrying a full-width operand even though its init was correctly halved.
+std::vector<IterArgPtr> RepairIterArgs(const std::vector<IterArgPtr>& iter_args,
+                                       std::unordered_map<const Var*, TileInfo>& tile_vars,
+                                       std::unordered_map<const Var*, VarPtr>& var_replacements,
+                                       const ExprPtr& subblock_idx, const ExprPtr& lane_stride);
+
+/// Give each loop-exit return_var the tile info of its iter_arg, so a later
+/// tile.store on it gets the per-lane offset. Call AFTER lowering the body.
+std::vector<VarPtr> RepairReturnVars(const std::vector<VarPtr>& return_vars,
+                                     const std::vector<IterArgPtr>& new_iter_args,
+                                     std::unordered_map<const Var*, TileInfo>& tile_vars,
+                                     std::unordered_map<const Var*, VarPtr>& var_replacements,
+                                     const ExprPtr& subblock_idx, const ExprPtr& lane_stride);
+
 std::vector<StmtPtr> ProcessStmts(const std::vector<StmtPtr>& stmts, SplitMode mode, int split_dim,
                                   std::unordered_map<const Var*, TileInfo>& tile_vars, bool is_aiv,
                                   const ExprPtr& subblock_idx,

--- a/python/bindings/modules/ir.cpp
+++ b/python/bindings/modules/ir.cpp
@@ -986,6 +986,24 @@ void BindIR(nb::module_& m) {
       },
       nb::arg("op_name"), "The hardware path an operator's writes travel, or None when it declared none");
 
+  nb::enum_<LaneInvariantArg>(ir, "LaneInvariantArg",
+                              "Why an argument carries no lane-indexed data under automatic AIV splitting")
+      .value("Scratch", LaneInvariantArg::Scratch,
+             "Hardware workspace; full width and halved are both correct")
+      .value("IndexAddressedSource", LaneInvariantArg::IndexAddressedSource,
+             "Lookup table read at absolute indices; only full width is correct")
+      .value("AbsoluteIndexedDestination", LaneInvariantArg::AbsoluteIndexedDestination,
+             "Destination written at absolute indices; only full width is correct");
+
+  ir.def(
+      "get_op_lane_invariant_arg",
+      [](const std::string& op_name, size_t arg_index) -> nb::object {
+        auto kind = OpRegistry::GetInstance().GetEntry(op_name).GetLaneInvariantArgKind(arg_index);
+        return kind.has_value() ? nb::cast(*kind) : nb::none();
+      },
+      nb::arg("op_name"), nb::arg("arg_index"),
+      "Why one positional argument carries no lane-indexed data, or None when the operator declared none");
+
   // Var - const shared_ptr
   auto var_class = nb::class_<Var, Expr>(ir, "Var", "Variable reference expression");
 

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -3327,6 +3327,39 @@ def get_op_write_channel(op_name: str) -> WriteChannel | None:
         Exception: If operator is not registered
     """
 
+class LaneInvariantArg(enum.Enum):
+    """Why an argument carries no lane-indexed data under automatic AIV splitting.
+
+    Declared only for the arguments an operator's own ``f_deduce_type`` cannot
+    speak about; ``LowerAutoVectorSplit`` decides every other operand by
+    re-deducing the halved call. See ``docs/en/dev/passes/21-lower_auto_vector_split.md``.
+    """
+
+    Scratch = ...
+    """Hardware workspace. Full width and halved are both correct."""
+
+    IndexAddressedSource = ...
+    """Lookup table read at absolute indices. Only full width is correct."""
+
+    AbsoluteIndexedDestination = ...
+    """Destination written at absolute indices. Only full width is correct."""
+
+def get_op_lane_invariant_arg(op_name: str, arg_index: int) -> LaneInvariantArg | None:
+    """Why one positional argument carries no lane-indexed data.
+
+    Args:
+        op_name: Name of the operator
+        arg_index: Positional argument index
+
+    Returns:
+        The declared kind, or None when the operator did not declare this
+        argument — automatic AIV splitting then treats it as per-lane data
+        whenever type deduction cannot decide for itself.
+
+    Raises:
+        Exception: If operator is not registered
+    """
+
 def get_op_output_arity(op_name: str) -> int:
     """Number of values an operator produces.
 

--- a/src/ir/op/tile_ops/broadcast.cpp
+++ b/src/ir/op/tile_ops/broadcast.cpp
@@ -308,6 +308,7 @@ REGISTER_OP("tile.row_expand_add")
     // On A2/A3 PTOAS writes tmp while writing dst; keep those allocations
     // distinct. On A5 tmp is a placeholder, and the stricter rule is safe.
     .forbid_output_alias(2)
+    .set_lane_invariant_arg(2)
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTileRowExpandAddType(args, kwargs, "tile.row_expand_add");

--- a/src/ir/op/tile_ops/elementwise.cpp
+++ b/src/ir/op/tile_ops/elementwise.cpp
@@ -537,6 +537,7 @@ REGISTER_OP("tile.rem")
     .set_input_memory(2, MemorySpace::Vec)
     .set_output_memory(MemorySpace::Vec)
     .not_inplace_safe()
+    .set_lane_invariant_arg(2)
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTileRemainderType(args, kwargs, "tile.rem", true);
@@ -679,6 +680,7 @@ REGISTER_OP("tile.rems")
     .set_input_memory(2, MemorySpace::Vec)
     .set_output_memory(MemorySpace::Vec)
     .not_inplace_safe()
+    .set_lane_invariant_arg(2)
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTileScalarRemainderType(args, kwargs, "tile.rems", true);
@@ -989,6 +991,7 @@ REGISTER_OP("tile.xor")
     .set_input_memory(1, MemorySpace::Vec)
     .set_input_memory(2, MemorySpace::Vec)
     .set_output_memory(MemorySpace::Vec)
+    .set_lane_invariant_arg(2)
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTileOpTernaryType(args, kwargs, "tile.xor", true);
@@ -1004,6 +1007,7 @@ REGISTER_OP("tile.xors")
     .set_input_memory(2, MemorySpace::Vec)
     .set_output_memory(MemorySpace::Vec)
     .not_inplace_safe()
+    .set_lane_invariant_arg(2)
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTileOpXorScalarType(args, kwargs, "tile.xors");
@@ -1084,6 +1088,7 @@ REGISTER_OP("tile.prelu")
     .set_input_memory(2, MemorySpace::Vec)
     .set_output_memory(MemorySpace::Vec)
     .not_inplace_safe()
+    .set_lane_invariant_arg(2)
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTilePreluType(args, kwargs, "tile.prelu");
@@ -1225,6 +1230,7 @@ REGISTER_OP("tile.sel")
     // allow; mask/tmp stay forbidden via registry (see 34-memory_reuse.md).
     .forbid_output_alias(0)
     .forbid_output_alias(3)
+    .set_lane_invariant_arg(3)
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTileSelType(args, kwargs, "tile.sel");
@@ -1316,6 +1322,7 @@ REGISTER_OP("tile.sels")
     .set_input_memory(2, MemorySpace::Vec)
     .set_output_memory(MemorySpace::Vec)
     .forbid_output_alias(0)
+    .set_lane_invariant_arg(2)
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTileSelsType(args, kwargs, "tile.sels");

--- a/src/ir/op/tile_ops/gather.cpp
+++ b/src/ir/op/tile_ops/gather.cpp
@@ -110,6 +110,20 @@ REGISTER_OP("tile.gather")
     .set_input_memory(2, MemorySpace::Vec)
     .set_output_memory(MemorySpace::Vec)
     .not_inplace_safe()
+    // src is a lookup table addressed by absolute index, not positionally: the
+    // halved `indices` already give each lane its own slice of the OUTPUT while
+    // both read the whole table. Declaring the KIND matters -- a partitioned
+    // producer must be rejected, because the indices stay absolute. tmp is plain
+    // workspace, where halving is harmless.
+    .set_lane_invariant_arg(0, LaneInvariantArg::IndexAddressedSource)
+    // tmp IS exempt, because whether an oversized one is out of contract is a
+    // TARGET question this pass cannot answer: A5 does not read tmp in the index
+    // form at all, so a full-width external tmp beside halved indices is legal
+    // there, while A2/A3 requires tmp to match the indices' element type and
+    // valid shape. That A2/A3 rule is already enforced where the target is
+    // known -- the PTOAS verifier -- so rejecting here would only break the
+    // legal A5 form to duplicate a check this pass cannot make accurately.
+    .set_lane_invariant_arg(2)
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTileGatherType(args, kwargs, "tile.gather");
@@ -217,6 +231,9 @@ REGISTER_OP("tile.gatherb")
     .set_input_memory(1, MemorySpace::Vec)
     .set_output_memory(MemorySpace::Vec)
     .not_inplace_safe()
+    // Byte-offset form of tile.gather: src is the shared table, `offset` carries
+    // the per-lane addressing and the result shape.
+    .set_lane_invariant_arg(0, LaneInvariantArg::IndexAddressedSource)
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTileGatherbType(args, kwargs, "tile.gatherb");
@@ -472,6 +489,7 @@ REGISTER_OP("tile.gather_compare")
     // Vec to every TileType element inside the TupleType.
     .set_output_memory(MemorySpace::Vec)
     .not_inplace_safe()
+    .set_lane_invariant_arg(2)
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTileGatherCompareType(args, kwargs, "tile.gather_compare");

--- a/src/ir/op/tile_ops/memory.cpp
+++ b/src/ir/op/tile_ops/memory.cpp
@@ -1648,6 +1648,10 @@ REGISTER_OP("tile.ci")
     // InitMemRef never synthesizes this operand for A5.
     .forbid_output_alias(2)
     .set_output_memory(MemorySpace::Vec)
+    // NOT declared lane-invariant, for two independent reasons: automatic AIV
+    // splitting refuses tile.ci outright (IsUnsupportedAutoSplitGenerator), and
+    // DeduceTileCiType pins the tmp extent anyway, so the type-consistency check
+    // decides it without metadata.
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTileCiType(args, kwargs, "tile.ci");

--- a/src/ir/op/tile_ops/quant_mx.cpp
+++ b/src/ir/op/tile_ops/quant_mx.cpp
@@ -454,6 +454,7 @@ REGISTER_OP("tile.tmov_x2zz")
     .set_arg_effect(1, ArgEffect::Write)
     .not_inplace_safe()
     .functional_execution_memory_access()
+    .set_lane_invariant_arg(1)
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTileTMovX2ZzType(args, kwargs);

--- a/src/ir/op/tile_ops/reduction.cpp
+++ b/src/ir/op/tile_ops/reduction.cpp
@@ -192,6 +192,7 @@ REGISTER_OP("tile.row_sum")
     // TROW* reads the full input row + tmp scratch while writing the reduced
     // output, so the output must not share a buffer with either input.
     .not_inplace_safe()
+    .set_lane_invariant_arg(1)
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTileRowReductionType(args, kwargs, "tile.row_sum");
@@ -208,6 +209,7 @@ REGISTER_OP("tile.row_max")
     // TROW* reads the full input row + tmp scratch while writing the reduced
     // output, so the output must not share a buffer with either input.
     .not_inplace_safe()
+    .set_lane_invariant_arg(1)
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTileRowReductionType(args, kwargs, "tile.row_max");
@@ -224,6 +226,7 @@ REGISTER_OP("tile.row_min")
     // TROW* reads the full input row + tmp scratch while writing the reduced
     // output, so the output must not share a buffer with either input.
     .not_inplace_safe()
+    .set_lane_invariant_arg(1)
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       auto result_type = DeduceTileRowReductionType(args, kwargs, "tile.row_min");
@@ -251,6 +254,7 @@ REGISTER_OP("tile.row_prod")
     // TROW* reads the full input row + tmp scratch while writing the reduced
     // output, so the output must not share a buffer with either input.
     .not_inplace_safe()
+    .set_lane_invariant_arg(1)
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTileRowReductionType(args, kwargs, "tile.row_prod");
@@ -270,6 +274,7 @@ REGISTER_OP("tile.col_sum")
     .set_input_memory(0, MemorySpace::Vec)
     .set_input_memory(1, MemorySpace::Vec)
     .set_output_memory(MemorySpace::Vec)
+    .set_lane_invariant_arg(1)
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       CHECK(args.size() == 1 || args.size() == 2)
@@ -341,6 +346,10 @@ REGISTER_OP("tile.row_argmax")
     // The TROWARGMAX path reads the full source/tmp while producing a smaller
     // index output, so the output must not alias an input (mirrors row_max).
     .not_inplace_safe()
+    // NOT declared lane-invariant, and it must not be: the deducer below runs
+    // with require_exact_tmp_shape, so it already rejects a full-width tmp beside
+    // a halved input. Automatic AIV splitting consults a declaration only where
+    // type deduction is silent, so one here could never be reached.
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTileRowReductionType(args, kwargs, "tile.row_argmax", DataType(DataType::INT32), true);
@@ -355,6 +364,10 @@ REGISTER_OP("tile.row_argmin")
     .set_input_memory(1, MemorySpace::Vec)
     .set_output_memory(MemorySpace::Vec)
     .not_inplace_safe()
+    // NOT declared lane-invariant, and it must not be: the deducer below runs
+    // with require_exact_tmp_shape, so it already rejects a full-width tmp beside
+    // a halved input. Automatic AIV splitting consults a declaration only where
+    // type deduction is silent, so one here could never be reached.
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTileRowReductionType(args, kwargs, "tile.row_argmin", DataType(DataType::INT32), true);
@@ -372,6 +385,13 @@ REGISTER_OP("tile.col_argmax")
     // output must not alias an input (the tmp-bearing column variants share the
     // row-reduction in-place hazard, unlike the 1-arg col_max/col_min).
     .not_inplace_safe()
+    // NOT declared lane-invariant: argmax/argmin need a tmp shaped EXACTLY like
+    // the source (the TROWARGMAX/TCOLARGMAX kernels read the column count from
+    // the tmp/src extent), so a wider tmp walks past the valid columns and can
+    // return the wrong index per column. Unlike the row forms,
+    // DeduceTileColReductionType never inspects args[1] (gh#2615), so type
+    // deduction is BLIND here -- leaving it undeclared is what makes automatic
+    // AIV splitting treat it as per-lane data and reject a full-width one.
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       CHECK(args.size() == 2) << "The operator tile.col_argmax requires 2 arguments, but got " << args.size();
@@ -387,6 +407,13 @@ REGISTER_OP("tile.col_argmin")
     .set_input_memory(1, MemorySpace::Vec)
     .set_output_memory(MemorySpace::Vec)
     .not_inplace_safe()
+    // NOT declared lane-invariant: argmax/argmin need a tmp shaped EXACTLY like
+    // the source (the TROWARGMAX/TCOLARGMAX kernels read the column count from
+    // the tmp/src extent), so a wider tmp walks past the valid columns and can
+    // return the wrong index per column. Unlike the row forms,
+    // DeduceTileColReductionType never inspects args[1] (gh#2615), so type
+    // deduction is BLIND here -- leaving it undeclared is what makes automatic
+    // AIV splitting treat it as per-lane data and reject a full-width one.
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       CHECK(args.size() == 2) << "The operator tile.col_argmin requires 2 arguments, but got " << args.size();

--- a/src/ir/op/tile_ops/scatter.cpp
+++ b/src/ir/op/tile_ops/scatter.cpp
@@ -199,6 +199,12 @@ REGISTER_OP("tile.scatter")
     // DPS: rewrites the indexed positions of `dst` and passes every other
     // position through, so the prior content reaches the result — a read.
     .set_arg_effect(0, ArgEffect::ReadWrite)
+    // `indexes` are FLATTENED absolute offsets into the whole dst
+    // (dst.flat[indexes[i, j]] = src[i, j]), so a partitioned destination is
+    // written at offsets that no longer mean anything: the encoded
+    // `i * dst_cols + c` does not match a halved row stride. Only dst is
+    // declared -- src and indexes are per-lane data and must be sharded.
+    .set_lane_invariant_arg(0, LaneInvariantArg::AbsoluteIndexedDestination)
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTileScatterType(args, kwargs, "tile.scatter");

--- a/src/ir/op/tile_ops/sort.cpp
+++ b/src/ir/op/tile_ops/sort.cpp
@@ -114,6 +114,11 @@ REGISTER_OP("tile.sort32")
     .set_input_memory(2, MemorySpace::Vec)
     .set_output_memory(MemorySpace::Vec)
     .not_inplace_safe()
+    // tmp IS exempt for the same target reason as tile.gather's: the "same dtype
+    // and capacity as src" rule is an A2/A3 one that the PTOAS verifier already
+    // enforces where the target is known. Rejecting here would break the form
+    // A5 accepts to duplicate a check this pass cannot make accurately.
+    .set_lane_invariant_arg(2)
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTileSort32Type(args, kwargs, "tile.sort32");
@@ -191,6 +196,13 @@ REGISTER_OP("tile.mrgsort_format2")
     .set_input_memory(4, MemorySpace::Vec)
     .set_output_memory(MemorySpace::Vec)
     .not_inplace_safe()
+    // NOT declared lane-invariant: in the 5-argument (4-way) form where arg 4 is
+    // the workspace, DeduceTileMrgSortType reads its extent, so a full-width one
+    // beside halved inputs is already rejected by the auto-split pass's
+    // type-consistency check. `tmp_or_src2` / `tmp_or_src3` are unclassifiable
+    // for a different reason: which of them is workspace is decided by the
+    // positional argument COUNT, not by a kwarg, so a per-position declaration
+    // cannot express it. They stay undeclared, and the pass treats them as data.
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTileMrgSortType(args, kwargs, "tile.mrgsort_format2");

--- a/src/ir/op/tile_ops/transform.cpp
+++ b/src/ir/op/tile_ops/transform.cpp
@@ -584,6 +584,14 @@ REGISTER_OP("tile.transpose")
     // buffer, and InitMemRef never inherits the input's buffer for it.
     .set_output_memory_inherit_input()
     .not_inplace_safe()
+    // NOT declared lane-invariant. DeduceTileTransposeType validates the tmp's
+    // dtype and rank but not its extents, so type deduction is blind here and
+    // leaving the argument undeclared is what makes automatic AIV splitting
+    // treat a full-width tmp as per-lane data and reject it. That is the right
+    // answer: pto.ttrans reads the transposed extents out of this buffer, so a
+    // tmp wider than the halved input is out of contract. (A transpose whose
+    // axes touch the split axis is refused earlier still, by
+    // FindTransposeSplitHazard.)
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTileTransposeType(args, kwargs);
@@ -903,6 +911,10 @@ REGISTER_OP("tile.scatter_update")
     .set_output_reuses_input(0)
     // DPS: the indexed rows are rewritten, every other row passes through.
     .set_arg_effect(0, ArgEffect::ReadWrite)
+    // `index` names rows of the WHOLE input, so a partitioned destination is
+    // written at the wrong offsets. Only the destination is declared: `index`
+    // and `src` are ordinary per-lane data and must be sharded.
+    .set_lane_invariant_arg(0, LaneInvariantArg::AbsoluteIndexedDestination)
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTileScatterUpdateType(args, kwargs);

--- a/src/ir/op/tile_ops/unary.cpp
+++ b/src/ir/op/tile_ops/unary.cpp
@@ -273,6 +273,11 @@ REGISTER_OP("tile.rsqrt")
     // writing the output, so the output must not share a buffer with either
     // (same constraint as tile.recip).
     .not_inplace_safe()
+    // NOT declared lane-invariant: DeduceTileRsqrtType requires tmp to match the
+    // input's rank and every dimension, so a full-width tmp beside a halved input
+    // is already rejected by the auto-split pass's type-consistency check. A
+    // declaration here could never be reached, and would read as a contract the
+    // operator itself does not grant.
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTileRsqrtType(args, kwargs, "tile.rsqrt");
@@ -290,6 +295,7 @@ REGISTER_OP("tile.cast")
     .set_input_memory(1, MemorySpace::Vec)
     .set_output_memory(MemorySpace::Vec)
     .forbid_output_alias(1)
+    .set_lane_invariant_arg(1)
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTileCastType(args, kwargs, "tile.cast");

--- a/src/ir/transforms/lower_auto_vector_split_pass.cpp
+++ b/src/ir/transforms/lower_auto_vector_split_pass.cpp
@@ -343,6 +343,14 @@ std::vector<StmtPtr> LowerStmts(const std::vector<StmtPtr>& stmts, SplitMode mod
         continue;
       }
 
+      // Transpose hazard BEFORE halving, matching the explicit-boundary arm
+      // above. FindTransposeSplitHazard is a structural check on the input (the
+      // transpose's axis args and its operand's split-dim extent), so it needs no
+      // lowered form — and running it first keeps its specific diagnostic ahead
+      // of the generic full-width-operand rejection the halving would otherwise
+      // raise on the same statement.
+      ValidateTransposeSplitHazard(region_stmts, rdim, reg->span_);
+
       std::unordered_map<const Var*, TileInfo> r_tile_vars;
       std::unordered_map<const Var*, VarPtr> r_var_repl;
       // Reserve the injected per-region index against every name visible in the
@@ -354,14 +362,13 @@ std::vector<StmtPtr> LowerStmts(const std::vector<StmtPtr>& stmts, SplitMode mod
       auto lowered =
           LowerStmts(inj.body_stmts, rmode, rdim, r_tile_vars, inj.subblock_idx_expr, r_var_repl, used_names);
 
-      // Per-region cube-operand backstop and transpose-hazard check, using THIS
-      // region's split_dim and span so diagnostics point at the region.
+      // Per-region cube-operand backstop, using THIS region's span so the
+      // diagnostic points at the region.
       bool cube_halved = false;
       CheckNoCubeTileHalved(lowered, r_tile_vars, cube_halved);
       INTERNAL_CHECK_SPAN(!cube_halved, reg->span_)
           << "Internal error: LowerAutoVectorSplit halved a CUBE-affinity op inside a pl.split_aiv "
              "region — the vector-sub-region affinity gate leaked into a cube operand.";
-      ValidateTransposeSplitHazard(lowered, rdim, reg->span_);
 
       StmtPtr region_body =
           (lowered.size() == 1) ? lowered[0] : std::make_shared<SeqStmts>(lowered, reg->span_);
@@ -547,12 +554,21 @@ std::vector<StmtPtr> LowerStmts(const std::vector<StmtPtr>& stmts, SplitMode mod
 
     // --- Compound stmts: recurse into the body for vector content. ---
     if (auto for_stmt = std::dynamic_pointer_cast<const ForStmt>(stmt)) {
+      // Repair the loop-carried state around the recursion, exactly as
+      // split_axis::ProcessStmt does for the explicit path. This arm recurses
+      // through LowerStmts (only VECTOR leaves may be halved) rather than
+      // ProcessStmts, so it cannot reach that branch and used to leave every
+      // iter_arg full width and untracked -- a legal tile accumulator whose init
+      // was halved then had its carry reported as a full-width operand.
+      auto new_iter_args = split_axis::RepairIterArgs(for_stmt->iter_args_, tile_vars, var_replacements,
+                                                      subblock_idx, lane_stride);
       auto body = transform_utils::FlattenToStmts(for_stmt->body_);
       auto new_body = LowerStmts(body, mode, split_dim, tile_vars, subblock_idx, var_replacements, used_names,
                                  lane_stride);
-      auto new_for = MutableCopy(for_stmt);
-      new_for->body_ = loop_repair::MakeBody(new_body, for_stmt->span_);
-      result.push_back(new_for);
+      auto new_return_vars = split_axis::RepairReturnVars(for_stmt->return_vars_, new_iter_args, tile_vars,
+                                                          var_replacements, subblock_idx, lane_stride);
+      result.push_back(loop_repair::RebuildForStmt(
+          for_stmt, new_iter_args, loop_repair::MakeBody(new_body, for_stmt->span_), new_return_vars));
       continue;
     }
     if (auto if_stmt = std::dynamic_pointer_cast<const IfStmt>(stmt)) {
@@ -573,12 +589,16 @@ std::vector<StmtPtr> LowerStmts(const std::vector<StmtPtr>& stmts, SplitMode mod
       continue;
     }
     if (auto while_stmt = std::dynamic_pointer_cast<const WhileStmt>(stmt)) {
+      // Same carry repair as the ForStmt arm above.
+      auto new_iter_args = split_axis::RepairIterArgs(while_stmt->iter_args_, tile_vars, var_replacements,
+                                                      subblock_idx, lane_stride);
       auto body = transform_utils::FlattenToStmts(while_stmt->body_);
       auto new_body = LowerStmts(body, mode, split_dim, tile_vars, subblock_idx, var_replacements, used_names,
                                  lane_stride);
-      auto new_while = MutableCopy(while_stmt);
-      new_while->body_ = loop_repair::MakeBody(new_body, while_stmt->span_);
-      result.push_back(new_while);
+      auto new_return_vars = split_axis::RepairReturnVars(while_stmt->return_vars_, new_iter_args, tile_vars,
+                                                          var_replacements, subblock_idx, lane_stride);
+      result.push_back(loop_repair::RebuildWhileStmt(
+          while_stmt, new_iter_args, loop_repair::MakeBody(new_body, while_stmt->span_), new_return_vars));
       continue;
     }
 

--- a/src/ir/transforms/utils/split_axis_utils.cpp
+++ b/src/ir/transforms/utils/split_axis_utils.cpp
@@ -17,6 +17,7 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
+#include <sstream>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -37,6 +38,7 @@
 #include "pypto/ir/tile_view_semantics.h"
 #include "pypto/ir/transforms/base/visitor.h"
 #include "pypto/ir/transforms/printer.h"
+#include "pypto/ir/transforms/structural_comparison.h"
 #include "pypto/ir/transforms/utils/auto_name_utils.h"
 #include "pypto/ir/transforms/utils/core_affinity.h"
 #include "pypto/ir/transforms/utils/loop_state_repair.h"
@@ -105,6 +107,321 @@ bool IsSingletonDim(const ExprPtr& dim_size) {
 
 bool IsUnsupportedAutoSplitGenerator(const CallPtr& call) {
   return IsOp(call, "tile.ci") || IsOp(call, "tile.random");
+}
+
+// Ops allowed to keep a full-width tile operand under a halved result. Each
+// rewrites its own operands in the generic halving block below, and each has a
+// well-defined full-width-source meaning:
+//   * tile.full / tile.create take a shape tuple, not a tile;
+//   * tile.slice reads a per-lane window out of a larger source, so a full-width
+//     src is the normal spelling (AdjustOffsets gives each lane its own half);
+//   * tile.reshape / tile.reinterpret_view over a full-width source are diverted
+//     into a full view + per-lane slice above, and the dynamic half extent that
+//     cannot express that slice is rejected there rather than reaching here.
+bool OperandsMayStayFullWidth(const CallPtr& call) {
+  return IsOp(call, "tile.full") || IsOp(call, "tile.create") || IsOp(call, "tile.slice") ||
+         IsOp(call, "tile.reshape") || IsOp(call, "tile.reinterpret_view");
+}
+
+// A tile operand the generic halving path would carry into the halved call at
+// full width, together with the operand's OWN index for the result's split axis.
+struct FullWidthOperand {
+  ExprPtr arg;
+  size_t arg_index = 0;
+  int split_dim = 0;
+};
+
+// Whether the operator declares that argument ``arg_index`` carries no
+// lane-indexed data (hardware scratch), so leaving it full width is correct.
+//
+// The claim has to come from the REGISTRY, but only for the operands the
+// operator's own type deduction cannot speak about -- see
+// ``OpLaneInvariantArgSpec`` and ``DeducerPinsOperandExtent`` below.
+std::optional<LaneInvariantArg> DeclaredLaneInvariantKind(const CallPtr& call, size_t arg_index) {
+  auto op = std::dynamic_pointer_cast<const Op>(call->op_);
+  if (!op) return std::nullopt;
+  auto& registry = OpRegistry::GetInstance();
+  if (!registry.IsRegistered(op->name_)) return std::nullopt;
+  return registry.GetEntry(op->name_).GetLaneInvariantArgKind(arg_index);
+}
+
+// An absolutely-indexed operand -- tile.gather's source table or tile.scatter's
+// destination -- whose PRODUCER was partitioned, or an empty ``arg`` when there
+// is none.
+//
+// Being declared lane-invariant only says the operand MAY stay full width; it is
+// not a rewrite. Nothing stops the operand's producer from being halved on its
+// own -- and a tile.load inside the region is halved, with the lane offset baked
+// into it. The index values are absolute into the WHOLE operand, so lane 1 then
+// addresses the wrong half and an index past that half is out of bounds.
+//
+// This is the ordinary path rather than a corner: tensor.gather lowers to
+// tile.load + tile.gather (see op_conversion_registry.cpp), so the operand is
+// routinely produced inside the region. Neither other gate sees it -- the
+// operand is tracked, so the full-width check skips it, and the result type is
+// deduced from the index operand (gather) or mirrors the destination (scatter),
+// so the type-consistency check is satisfied either way. Reject it until the
+// pass can keep such a producer at full width, or rebase the indices.
+struct AbsoluteOperand {
+  ExprPtr arg;
+  int split_dim = 0;
+  LaneInvariantArg kind = LaneInvariantArg::IndexAddressedSource;
+};
+
+AbsoluteOperand FindPartitionedAbsoluteOperand(const CallPtr& call,
+                                               const std::unordered_map<const Var*, TileInfo>& tile_vars) {
+  for (size_t i = 0; i < call->args_.size(); ++i) {
+    auto kind = DeclaredLaneInvariantKind(call, i);
+    if (kind != LaneInvariantArg::IndexAddressedSource &&
+        kind != LaneInvariantArg::AbsoluteIndexedDestination) {
+      continue;
+    }
+    auto arg_var = AsVarLike(call->args_[i]);
+    if (!arg_var) continue;
+    auto it = tile_vars.find(arg_var.get());
+    if (it == tile_vars.end()) continue;
+    return {call->args_[i], it->second.split_dim, *kind};
+  }
+  return {};
+}
+
+// Everything needed to ask the operator a follow-up question about the node the
+// pass is about to emit: the argument list the halved call will carry (tracked
+// operands already swapped for their halved replacements) and the halved result
+// type those arguments must reproduce.
+struct HalvedCallProbe {
+  const std::vector<ExprPtr>* args = nullptr;
+  std::shared_ptr<const TileType> expected;
+};
+
+// Whether the operator's own f_deduce_type PINS the extent of argument
+// ``arg_index`` on ``arg_split_dim``.
+//
+// The caller has already established that the halved call type-checks with this
+// operand at full width. That is only *evidence* the operand is legal there if
+// the deducer would have objected to a wrong width -- so ask it: re-deduce with
+// the operand DOUBLED on that axis.
+//
+//   throws, or the deduced result changes -> the deducer reads this operand's
+//       extent, so its silence at full width is a positive answer and the
+//       type-consistency gate has already vouched for the operand;
+//   unchanged                             -> the deducer never looks, its
+//       silence proves nothing, and only a registry declaration can say whether
+//       full width is in contract.
+//
+// Doubling rather than halving is deliberate. A bounded-below scratch contract
+// ("at least as large as the input", tile.sels' mask must COVER src) accepts
+// both widths, and doubling correctly reports that as blind; halving would make
+// such a deducer throw and be misread as a pin.
+//
+// A dynamic extent cannot be doubled into a comparable probe, so it is reported
+// as unpinned -- the conservative direction, since the caller then falls back to
+// requiring a declaration.
+bool DeducerPinsOperandExtent(const CallPtr& call, const HalvedCallProbe& probe, size_t arg_index,
+                              int arg_split_dim) {
+  auto op = std::dynamic_pointer_cast<const Op>(call->op_);
+  if (!op || !probe.args || !probe.expected) return false;
+  if (arg_index >= probe.args->size()) return false;
+  if (!OpRegistry::GetInstance().IsRegistered(op->name_)) return false;
+
+  const auto& arg = (*probe.args)[arg_index];
+  auto arg_tt = std::dynamic_pointer_cast<const TileType>(arg->GetType());
+  if (!arg_tt || arg_split_dim < 0 || arg_split_dim >= static_cast<int>(arg_tt->shape_.size())) return false;
+  auto extent = std::dynamic_pointer_cast<const ConstInt>(arg_tt->shape_[arg_split_dim]);
+  if (!extent) return false;
+
+  std::vector<ExprPtr> widened_shape = arg_tt->shape_;
+  widened_shape[arg_split_dim] =
+      std::make_shared<ConstInt>(extent->value_ * 2, extent->dtype(), extent->span_);
+  auto widened_type = std::make_shared<TileType>(std::move(widened_shape), arg_tt->dtype_, arg_tt->memref_,
+                                                 std::nullopt, arg_tt->memory_space_);
+  std::vector<ExprPtr> widened_args = *probe.args;
+  widened_args[arg_index] = std::make_shared<Var>("__split_probe", widened_type, arg->span_);
+
+  std::shared_ptr<const TileType> deduced;
+  try {
+    auto probe_call = OpRegistry::GetInstance().Create(op->name_, widened_args, call->kwargs_, call->span_);
+    deduced = std::dynamic_pointer_cast<const TileType>(probe_call->GetType());
+  } catch (const pypto::Error&) {
+    return true;  // The deducer refuses the wrong width: it is reading the operand.
+  }
+  if (!deduced || deduced->shape_.size() != probe.expected->shape_.size()) return true;
+  for (size_t d = 0; d < probe.expected->shape_.size(); ++d) {
+    if (!structural_equal(deduced->shape_[d], probe.expected->shape_[d])) return true;
+  }
+  return false;  // Same answer for either width: the deducer is blind to this operand.
+}
+
+// The first tile operand the halved call would carry at full width along the
+// split axis, or an empty ``arg`` when there is none.
+//
+// Halving only the result type is correct exactly when each tile operand was
+// itself partitioned by its producer (so it is in ``tile_vars`` and the later
+// Substitute swaps in the halved var), is broadcast along the split axis, or is
+// lane-invariant by contract.
+//
+// Operands align to the result from the RIGHT -- the alignment BroadcastShapes
+// gives an op like tile.add([M, N], [N]) -> [M, N]. Indexing an operand with the
+// result's absolute split dim is therefore wrong as soon as the ranks differ:
+// under UP_DOWN it reads the [N] bias's only axis as the split axis and rejects
+// a legal shared bias, and under LEFT_RIGHT it finds that index out of range and
+// skips the operand that genuinely does span the split axis. Map the axis onto
+// the operand instead, and treat a missing leading axis as broadcast.
+//
+// ``probe`` decides what this function IS. With a probe it is a GATE, and an
+// operand whose extent the deducer pins is skipped -- the type-consistency check
+// already answered for it, so this heuristic never gets to overrule the
+// operator itself. Without a probe it is only a DIAGNOSTIC refinement, naming
+// the likely operand behind a type-consistency failure; a misjudged axis is
+// then a wrong number in a message rather than a rejected program.
+FullWidthOperand FindFullWidthOperand(const CallPtr& call, int result_split_dim, int result_rank,
+                                      const std::unordered_map<const Var*, TileInfo>& tile_vars,
+                                      const HalvedCallProbe* probe = nullptr) {
+  if (OperandsMayStayFullWidth(call)) return {};
+  for (size_t i = 0; i < call->args_.size(); ++i) {
+    const auto& arg = call->args_[i];
+    auto arg_tt = std::dynamic_pointer_cast<const TileType>(arg->GetType());
+    if (!arg_tt) continue;
+    // Declared as carrying no lane-indexed data (hardware scratch, or a table
+    // addressed by a separate index operand): a full-width operand is in
+    // contract. FindPartitionedAbsoluteOperand covers the converse case.
+    if (DeclaredLaneInvariantKind(call, i).has_value()) continue;
+    const int arg_rank = static_cast<int>(arg_tt->shape_.size());
+    const int arg_split_dim = arg_rank - (result_rank - result_split_dim);
+    // Out of range below: the operand is shorter than the result's leading axes,
+    // so it has no axis here at all and is replicated along the whole split axis.
+    if (arg_split_dim < 0 || arg_split_dim >= arg_rank) continue;
+    // A singleton split axis is replicated, not partitioned: both lanes read it
+    // whole, so leaving it full width is correct.
+    if (IsSingletonDim(arg_tt->shape_[arg_split_dim])) continue;
+    auto arg_var = AsVarLike(arg);
+    if (arg_var && tile_vars.count(arg_var.get()) != 0) continue;
+    if (probe != nullptr && DeducerPinsOperandExtent(call, *probe, i, arg_split_dim)) continue;
+    return {arg, i, arg_split_dim};
+  }
+  return {};
+}
+
+// Map a tile.slice RESULT axis back to the axis its shape / offset / valid_shape
+// tuples are indexed by. Those tuples carry the pre-drop rank; drop_dims erases
+// axes from the result afterwards and then pads back up to 2D by PREPENDING unit
+// axes, so the two ranks disagree whenever drop_dims is non-empty.
+//
+// Reuses the deducer's own ParseSliceDropDims so the mapping cannot drift from
+// the rule it is inverting. A result axis that is one of the synthetic padded
+// unit axes has no pre-drop counterpart; it is singleton, so the halving path
+// never asks about it, and returning the identity keeps callers total.
+int MapResultAxisToSliceArgAxis(const CallPtr& call, int result_axis) {
+  if (call->args_.size() < 5) return result_axis;
+  auto shape_tuple = std::dynamic_pointer_cast<const MakeTuple>(call->args_[1]);
+  if (!shape_tuple) return result_axis;
+  std::vector<int64_t> drop_dims;
+  try {
+    drop_dims = ParseSliceDropDims(call->args_[4], shape_tuple->elements_, "tile.slice");
+  } catch (const pypto::Error&) {
+    return result_axis;
+  }
+  if (drop_dims.empty()) return result_axis;
+
+  // ParseSliceDropDims returns the axes ASCENDING, in range and each at most
+  // once, so the surviving axes fall out of a single merge against them -- no
+  // per-axis lookup into drop_dims. Walking the two in step also makes the
+  // ordering assumption explicit at the one place that depends on it.
+  std::vector<int> kept;
+  kept.reserve(shape_tuple->elements_.size());
+  size_t next_drop = 0;
+  for (int d = 0; d < static_cast<int>(shape_tuple->elements_.size()); ++d) {
+    if (next_drop < drop_dims.size() && drop_dims[next_drop] == static_cast<int64_t>(d)) {
+      ++next_drop;
+      continue;
+    }
+    kept.push_back(d);
+  }
+  // Sub-2D results are clamped back to 2D with leading unit axes, which shifts
+  // every surviving axis right by that padding.
+  const int pad = static_cast<int>(kept.size()) < 2 ? 2 - static_cast<int>(kept.size()) : 0;
+  const int kept_index = result_axis - pad;
+  if (kept_index < 0 || kept_index >= static_cast<int>(kept.size())) return result_axis;
+  return kept[kept_index];
+}
+
+std::string DescribeSplitExtent(const ExprPtr& dim_size) {
+  auto ci = std::dynamic_pointer_cast<const ConstInt>(dim_size);
+  return ci ? std::to_string(ci->value_) : std::string("a runtime extent");
+}
+
+// The rejection text both operand gates share -- what is wrong, and every
+// spelling that is in contract. One builder so the two gates cannot drift into
+// giving different advice about the same mistake.
+std::string FullWidthOperandDiagnostic(const std::string& op_name, const FullWidthOperand& full) {
+  auto full_var = AsVarLike(full.arg);
+  auto full_tt = std::dynamic_pointer_cast<const TileType>(full.arg->GetType());
+  std::ostringstream os;
+  os << "LowerAutoVectorSplit: '" << op_name
+     << "' inside the automatically split vector region carries a full-width operand"
+     << (full_var ? " '" + full_var->name_hint_ + "'" : " at argument " + std::to_string(full.arg_index))
+     << " (extent "
+     << (full_tt ? DescribeSplitExtent(full_tt->shape_[full.split_dim]) : std::string("unknown"))
+     << " on its dim " << full.split_dim
+     << ", the region's split axis), but this pass halves the op's RESULT to the per-lane extent. "
+        "Nothing partitions that operand, so the two lanes would both read the whole tile under a "
+        "per-lane result type. Derive the per-lane half first -- load or slice the value inside the "
+        "split region, or write an explicit pl.tile.aiv_shard(...) -- and feed that to this op. If the "
+        "value is meant to be shared by both lanes, keep it outside the split region or give its split "
+        "axis a singleton extent so it broadcasts.";
+  return os.str();
+}
+
+// The argument list the halved call will actually carry: ``new_args`` (shape
+// tuples already halved for the ops that describe their own shape) with each
+// tracked operand swapped for the halved replacement the trailing Substitute
+// installs.
+std::vector<ExprPtr> BuildHalvedCallArgs(const std::vector<ExprPtr>& new_args,
+                                         const std::unordered_map<const Var*, VarPtr>& var_replacements) {
+  std::vector<ExprPtr> probe_args;
+  probe_args.reserve(new_args.size());
+  for (const auto& arg : new_args) {
+    auto arg_var = AsVarLike(arg);
+    auto it = arg_var ? var_replacements.find(arg_var.get()) : var_replacements.end();
+    probe_args.push_back(it != var_replacements.end() ? it->second : arg);
+  }
+  return probe_args;
+}
+
+// Whether the halved call still agrees with type inference over the arguments it
+// will actually carry. This is the pass's PRIMARY correctness gate for halving:
+// it asks the operator itself, needs no per-operator metadata, and therefore
+// cannot go stale as operators are added or their contracts change.
+//
+// Compare the deduced PHYSICAL shape only: HalveTileShape also localizes
+// valid_shape per lane, which deduction has no way to reproduce and which is not
+// what this guards. A deduction that throws is a mismatch too -- the operator is
+// refusing the very arguments the halved node would carry.
+//
+// What it covers, measured against the operators registered today: for every
+// operand whose extent the deducer reads, this check alone rejects the
+// full-width form -- tile.add's operands (the gh#2203 report), a rank-1 bias on
+// the split axis, tile.row_argmax's shape-matched tmp, and an axis-permuting
+// tile.transpose_view over a source no lane owns a half of. The declared
+// exemptions exist only for the operands it is BLIND to; see
+// FindFullWidthOperand's ``probe`` and OpLaneInvariantArgSpec.
+bool HalvedCallStaysTypeConsistent(const CallPtr& call, const HalvedCallProbe& probe) {
+  auto op = std::dynamic_pointer_cast<const Op>(call->op_);
+  if (!op || !probe.args || !probe.expected) return false;
+  if (!OpRegistry::GetInstance().IsRegistered(op->name_)) return true;
+
+  std::shared_ptr<const TileType> deduced;
+  try {
+    auto probe_call = OpRegistry::GetInstance().Create(op->name_, *probe.args, call->kwargs_, call->span_);
+    deduced = std::dynamic_pointer_cast<const TileType>(probe_call->GetType());
+  } catch (const pypto::Error&) {
+    return false;
+  }
+  if (!deduced || deduced->shape_.size() != probe.expected->shape_.size()) return false;
+  for (size_t d = 0; d < probe.expected->shape_.size(); ++d) {
+    if (!structural_equal(deduced->shape_[d], probe.expected->shape_[d])) return false;
+  }
+  return true;
 }
 
 // Whether a split-axis extent is statically ODD, i.e. the two AIV lanes hold
@@ -684,6 +1001,54 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_dim,
                                 "); partial reduction in a split kernel is not supported");
       }
 
+      // An absolutely-indexed operand is unsafe the moment its producer is
+      // partitioned, whatever happens to the RESULT. Both of the checks below
+      // therefore run here rather than beside the halving: the trailing
+      // Substitute rewrites the argument even on the paths that halve nothing,
+      // so gating them on a halveable TileType result would let exactly those
+      // paths through.
+      //   * a singleton result returns early below -- a gather whose `indices`
+      //     are [1, N] yields a [1, N] result, so nothing is halved while the
+      //     table underneath it still is;
+      //   * a TupleType result skips the whole block -- see the check after this
+      //     one.
+      if (auto absolute = FindPartitionedAbsoluteOperand(call, tile_vars); absolute.arg) {
+        auto absolute_var = AsVarLike(absolute.arg);
+        const bool is_dst = absolute.kind == LaneInvariantArg::AbsoluteIndexedDestination;
+        CHECK_SPAN(false, call->span_)
+            << "LowerAutoVectorSplit: '" << op_name << "' addresses its "
+            << (is_dst ? "destination" : "source") << " operand"
+            << (absolute_var ? " '" + absolute_var->name_hint_ + "'" : "")
+            << " at ABSOLUTE indices, so both AIV lanes must see it whole -- but that operand was "
+               "partitioned along dim "
+            << absolute.split_dim
+            << " by its producer inside the split region. The index values are not rebased, so each lane "
+            << (is_dst ? "writes to the wrong half (and past the end of it once an index exceeds the "
+                         "halved extent)."
+                       : "reads the wrong half (and out of bounds once an index exceeds the halved "
+                         "extent).")
+            << " Produce it OUTSIDE the automatically split region and pass it in, so it stays full "
+               "width while the index operand is halved. Note that pl.gather / pl.scatter over a tensor "
+               "lower to a tile.load feeding the tile op, so loading it inside the region hits this too.";
+      }
+
+      // A TupleType result cannot be halved by the generic path below, which
+      // only understands a single TileType. Left alone that would be harmless --
+      // except the trailing Substitute still rewrites this call's arguments, so
+      // a halved operand ends up under a result type nobody re-derived:
+      // tile.gather_compare over a halved [128, 128] src keeps declaring
+      // Tuple[[256, out_cols], [1, 256]]. That is illegal IR and misallocates.
+      // Reject it; per-element split mapping for tuple results is not implemented.
+      if (auto tuple_type = std::dynamic_pointer_cast<const TupleType>(call->GetType()); tuple_type) {
+        CHECK_SPAN(in_split_dim < 0, call->span_)
+            << "LowerAutoVectorSplit: '" << op_name
+            << "' returns a tuple of tiles, which this pass cannot halve, but it consumes an operand the "
+               "split already partitioned. The call's declared result type is not re-derived, so it "
+               "would keep describing full-width tiles over a per-lane input -- IR that no later "
+               "consumer can trust. Move the operation outside the automatically split region, or feed "
+               "it only values that are shared by both lanes.";
+      }
+
       auto tt = std::dynamic_pointer_cast<const TileType>(call->GetType());
 
       // An explicit reinterpret shape may redistribute bytes across dimensions.
@@ -737,11 +1102,18 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_dim,
           auto input_var = AsVarLike(call->args_[0]);
           bool input_is_split = input_var && tile_vars.count(input_var.get()) != 0;
           auto half_const = std::dynamic_pointer_cast<const ConstInt>(half_dim_size);
-          if (!input_is_split && IsOp(call, "tile.reinterpret_view")) {
+          // The per-lane slice is what partitions a full-width source, and it can
+          // only be materialized from a STATIC half extent. Without it both views
+          // fall through to plain result-halving, which is precisely the silent
+          // "lane 1 reuses lane 0's data" miscompile above -- so the dynamic case
+          // is rejected for reshape exactly as it is for reinterpret_view, rather
+          // than left to a later consumer.
+          if (!input_is_split) {
             CHECK_SPAN(half_const != nullptr, call->span_)
-                << "SplitVectorKernel: tile.reinterpret_view over a full-width source requires a static "
-                   "split extent so the pass can materialize a per-lane slice. Split/load the source "
-                   "before reinterpret_view, or move reinterpret_view outside the split scope.";
+                << "SplitVectorKernel: " << op_name
+                << " over a full-width source requires a static split extent so the pass can "
+                   "materialize a per-lane slice. Split/load the source before "
+                << op_name << ", or move " << op_name << " outside the split scope.";
           }
           if (!input_is_split && half_const != nullptr) {
             auto full_var =
@@ -794,6 +1166,7 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_dim,
         }
 
         auto new_result_type = HalveTileShape(call->GetType(), result_split_dim, subblock_idx, lane_stride);
+
         const ExprPtr lane_step = LaneStep(lane_stride, half_dim_size);
         std::vector<ExprPtr> new_args = call->args_;
         if ((IsOp(call, "tile.full") || IsOp(call, "tile.create")) && call->args_.size() >= 1) {
@@ -810,7 +1183,17 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_dim,
           // tstore expects (half), the qk_pv strided sub-slice miscompile that
           // motivated the explicit-AIV-split RFC. Halve the shape tuple so it
           // tracks the halved result type.
-          new_args[1] = HalveTupleElement(call->args_[1], result_split_dim);
+          //
+          // shape / offset / valid_shape are all indexed in the PRE-DROP rank,
+          // while result_split_dim indexes the result. drop_dims erases axes
+          // after those tuples are built and then pads back up to 2D by
+          // PREPENDING unit axes, so the two disagree as soon as drop_dims is
+          // non-empty: slice([1, 128, 128], drop_dims=[0]) -> [128, 128] puts the
+          // result's dim 0 on the source's dim 1. Map the axis back before
+          // touching any of them, or the wrong source axis is halved and the
+          // type-consistency check then rejects a legal split.
+          const int slice_split_dim = MapResultAxisToSliceArgAxis(call, result_split_dim);
+          new_args[1] = HalveTupleElement(call->args_[1], slice_split_dim);
 
           // Offset (arg[2]) localization mirrors the reshape->slice path above:
           // only add the per-subblock base when the SOURCE tile is NOT already
@@ -821,7 +1204,7 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_dim,
           auto slice_src = AsVarLike(call->args_[0]);
           bool slice_src_is_split = slice_src && tile_vars.count(slice_src.get()) != 0;
           if (!slice_src_is_split) {
-            new_args[2] = AdjustOffsets(call->args_[2], result_split_dim, lane_step, subblock_idx);
+            new_args[2] = AdjustOffsets(call->args_[2], slice_split_dim, lane_step, subblock_idx);
           }
 
           // Optional explicit valid_shape (arg[3]) must stay consistent with the
@@ -832,7 +1215,7 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_dim,
           // LocalizeTupleElementForSplit is a no-op on a tuple whose split_dim
           // is out of range.
           if (call->args_.size() >= 4) {
-            new_args[3] = LocalizeTupleElementForSplit(call->args_[3], result_split_dim,
+            new_args[3] = LocalizeTupleElementForSplit(call->args_[3], slice_split_dim,
                                                        tt->shape_[result_split_dim], lane_step, subblock_idx);
           }
         } else if (IsOp(call, "tile.set_validshape") && call->args_.size() == 3) {
@@ -854,6 +1237,64 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_dim,
                 call->args_[operand_idx], tt->shape_[result_split_dim], lane_step, subblock_idx);
           }
         }
+
+        // Halving only the RESULT is sound under two conditions, asked in this
+        // order because the first subsumes the second wherever it can speak.
+        //
+        // (1) TYPE CONSISTENCY -- the operator's own answer, no metadata.
+        // Re-deduce from the arguments the halved node will actually carry and
+        // refuse to emit one whose declared result contradicts them. That is the
+        // gh#2203 defect verbatim -- `tile.add([256,128],[256,128]) -> [128,128]`
+        // fails print->parse and misleads every later consumer that re-derives
+        // types from operands -- and it equally catches a rank-1 bias on the
+        // split axis, a shape-matched scratch left at full width, and an
+        // axis-permuting tile.transpose_view over a source no lane owns a half
+        // of. (tile.transpose is caught earlier by the transpose hazard check;
+        // transpose_view is a pure view and is not.)
+        //
+        // When it fails, name the full-width operand if there is one: that is
+        // the cause in nearly every real program, and the generic wording below
+        // is only for the axis-mapping case. FindFullWidthOperand runs WITHOUT a
+        // probe here -- purely to refine the message, so a misjudged axis costs a
+        // wrong number in the text rather than a rejected program.
+        const int result_rank = static_cast<int>(tt->shape_.size());
+        const auto probe_args = BuildHalvedCallArgs(new_args, var_replacements);
+        const HalvedCallProbe probe{&probe_args, std::dynamic_pointer_cast<const TileType>(new_result_type)};
+        if (!HalvedCallStaysTypeConsistent(call, probe)) {
+          auto full = FindFullWidthOperand(call, result_split_dim, result_rank, tile_vars);
+          CHECK_SPAN(false, call->span_)
+              << (full.arg ? FullWidthOperandDiagnostic(op_name, full)
+                           : "LowerAutoVectorSplit: halving '" + op_name +
+                                 "' to the per-lane extent along dim " + std::to_string(result_split_dim) +
+                                 " would emit a node whose declared result no longer matches type "
+                                 "inference over its own arguments, so it cannot be lowered for two AIV "
+                                 "lanes. This happens when the op maps its axes in a way the split cannot "
+                                 "follow -- an axis-permuting view such as tile.transpose_view over a "
+                                 "source no lane owns a half of is the usual case. Derive the per-lane "
+                                 "half before the op (load or slice the value inside the split region, or "
+                                 "write an explicit pl.tile.aiv_shard), or move the op outside the "
+                                 "automatically split region.");
+        }
+
+        // (2) BLIND OPERANDS -- the backstop for what (1) cannot see. A deducer
+        // that never reads an operand's extent says nothing by accepting it, so
+        // a full-width operand it ignores still has to be either lane-local or
+        // declared lane-invariant. tile.sel deduces its result from lhs/rhs
+        // alone, yet its mask is per-element data that must be sharded with
+        // them; tile.sels validates only that the mask COVERS src, so an
+        // over-wide mask passes deduction while feeding lane 1 lane 0's rows.
+        //
+        // Passing the probe is what keeps this heuristic in its lane: an operand
+        // whose extent the deducer pins is skipped, because (1) already decided
+        // it. Without that, every operator with a legal full-width operand would
+        // need a registry declaration purely to suppress a check that had no
+        // business running -- which is how tile.rsqrt came to declare a scratch
+        // its own deducer requires to match the input exactly.
+        if (auto blind = FindFullWidthOperand(call, result_split_dim, result_rank, tile_vars, &probe);
+            blind.arg) {
+          CHECK_SPAN(false, call->span_) << FullWidthOperandDiagnostic(op_name, blind);
+        }
+
         auto new_call = std::make_shared<Call>(call->op_, std::move(new_args), call->kwargs_, new_result_type,
                                                call->span_);
         auto new_var = std::make_shared<Var>(assign->var_->name_hint_, new_result_type, assign->var_->span_);
@@ -908,47 +1349,9 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_dim,
     // deferred to the final Substitute pass, it can create a second IterArg
     // instance whose pointer diverges from the one referenced by the rebuilt
     // loop body, breaking structural equality.
-    std::vector<IterArgPtr> new_iter_args;
-    new_iter_args.reserve(for_stmt->iter_args_.size());
+    std::vector<IterArgPtr> new_iter_args =
+        RepairIterArgs(for_stmt->iter_args_, tile_vars, var_replacements, subblock_idx, lane_stride);
     std::vector<VarPtr> new_return_vars = for_stmt->return_vars_;
-
-    // Propagate tile_vars from init values to iter_args BEFORE processing body.
-    // Iter_args carry the init_value into the loop; if the init is a tracked
-    // halved tile, the iter_arg must also be tracked so that operations on it
-    // inside the loop body are correctly recognized.
-    for (const auto& ia : for_stmt->iter_args_) {
-      auto new_init_value = ia->initValue_;
-      if (new_init_value && !var_replacements.empty()) {
-        new_init_value = transform_utils::Substitute(new_init_value, var_replacements);
-      }
-      TypePtr new_type = ia->GetType();
-      bool has_tracked_tile = false;
-      TileInfo tracked_info;
-      if (ia->initValue_) {
-        if (auto init_var = AsVarLike(ia->initValue_)) {
-          auto it = tile_vars.find(init_var.get());
-          if (it != tile_vars.end()) {
-            has_tracked_tile = true;
-            tracked_info = it->second;
-            tile_vars[ia.get()] = it->second;
-            new_type = ApplyTrackedTileShape(ia->GetType(), it->second.split_dim, it->second.half_dim_size,
-                                             subblock_idx, lane_stride);
-          }
-        }
-      }
-
-      if (new_type != ia->GetType() || new_init_value != ia->initValue_) {
-        auto new_iter_arg = std::make_shared<IterArg>(ia->name_hint_, new_type, new_init_value, ia->span_);
-        new_iter_args.push_back(new_iter_arg);
-        var_replacements[ia.get()] = new_iter_arg;
-        if (has_tracked_tile) {
-          tile_vars[new_iter_arg.get()] = tracked_info;
-        }
-      } else {
-        new_iter_args.push_back(ia);
-      }
-    }
-
     auto flat = std::vector<StmtPtr>();
     if (auto seq = std::dynamic_pointer_cast<const SeqStmts>(for_stmt->body_)) {
       flat = seq->stmts_;
@@ -969,22 +1372,8 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_dim,
     INTERNAL_CHECK_SPAN(for_stmt->iter_args_.size() == for_stmt->return_vars_.size(), for_stmt->span_)
         << "Internal error: ForStmt iter_args and return_vars sizes must match, got "
         << for_stmt->iter_args_.size() << " vs " << for_stmt->return_vars_.size();
-    for (size_t i = 0; i < new_iter_args.size() && i < new_return_vars.size(); ++i) {
-      auto it = tile_vars.find(new_iter_args[i].get());
-      if (it != tile_vars.end()) {
-        tile_vars[new_return_vars[i].get()] = it->second;
-        auto new_type = ApplyTrackedTileShape(new_return_vars[i]->GetType(), it->second.split_dim,
-                                              it->second.half_dim_size, subblock_idx, lane_stride);
-        if (new_type != new_return_vars[i]->GetType()) {
-          auto new_return_var =
-              std::make_shared<Var>(new_return_vars[i]->name_hint_, new_type, new_return_vars[i]->span_);
-          new_return_vars[i] = new_return_var;
-          tile_vars[new_return_var.get()] = it->second;
-          var_replacements[for_stmt->return_vars_[i].get()] = new_return_var;
-        }
-      }
-    }
-
+    new_return_vars = RepairReturnVars(for_stmt->return_vars_, new_iter_args, tile_vars, var_replacements,
+                                       subblock_idx, lane_stride);
     return loop_repair::RebuildForStmt(for_stmt, new_iter_args, new_body, new_return_vars);
   }
 
@@ -1039,6 +1428,78 @@ std::string ReserveFreshName(std::unordered_set<std::string>& used_names, const 
 }
 
 }  // namespace
+
+// Shared loop/branch carry repair. Extracted so the AUTO affinity-gated path in
+// lower_auto_vector_split_pass.cpp gets the same treatment as ProcessStmts: it
+// recurses into compound bodies itself (only VECTOR leaves may be halved), so it
+// cannot reach ProcessStmt's ForStmt branch and previously left every iter_arg
+// full width and untracked. A legal tile accumulator -- halved init, tile.add on
+// the carry -- was then reported as carrying a full-width operand.
+std::vector<IterArgPtr> RepairIterArgs(const std::vector<IterArgPtr>& iter_args,
+                                       std::unordered_map<const Var*, TileInfo>& tile_vars,
+                                       std::unordered_map<const Var*, VarPtr>& var_replacements,
+                                       const ExprPtr& subblock_idx, const ExprPtr& lane_stride) {
+  std::vector<IterArgPtr> new_iter_args;
+  new_iter_args.reserve(iter_args.size());
+  // Propagate tile_vars from init values to iter_args BEFORE processing the body:
+  // an iter_arg carries its init into the loop, so a tracked halved init makes the
+  // carry lane-local too, and operations on it inside the body must see that.
+  for (const auto& ia : iter_args) {
+    auto new_init_value = ia->initValue_;
+    if (new_init_value && !var_replacements.empty()) {
+      new_init_value = transform_utils::Substitute(new_init_value, var_replacements);
+    }
+    TypePtr new_type = ia->GetType();
+    bool has_tracked_tile = false;
+    TileInfo tracked_info;
+    if (ia->initValue_) {
+      if (auto init_var = AsVarLike(ia->initValue_)) {
+        auto it = tile_vars.find(init_var.get());
+        if (it != tile_vars.end()) {
+          has_tracked_tile = true;
+          tracked_info = it->second;
+          tile_vars[ia.get()] = it->second;
+          new_type = ApplyTrackedTileShape(ia->GetType(), it->second.split_dim, it->second.half_dim_size,
+                                           subblock_idx, lane_stride);
+        }
+      }
+    }
+    if (new_type != ia->GetType() || new_init_value != ia->initValue_) {
+      auto new_iter_arg = std::make_shared<IterArg>(ia->name_hint_, new_type, new_init_value, ia->span_);
+      new_iter_args.push_back(new_iter_arg);
+      var_replacements[ia.get()] = new_iter_arg;
+      if (has_tracked_tile) tile_vars[new_iter_arg.get()] = tracked_info;
+    } else {
+      new_iter_args.push_back(ia);
+    }
+  }
+  return new_iter_args;
+}
+
+// Loop-exit versions of the carries: a return_var inherits its iter_arg's tile
+// info so a downstream tile.store gets the per-lane offset.
+std::vector<VarPtr> RepairReturnVars(const std::vector<VarPtr>& return_vars,
+                                     const std::vector<IterArgPtr>& new_iter_args,
+                                     std::unordered_map<const Var*, TileInfo>& tile_vars,
+                                     std::unordered_map<const Var*, VarPtr>& var_replacements,
+                                     const ExprPtr& subblock_idx, const ExprPtr& lane_stride) {
+  std::vector<VarPtr> new_return_vars = return_vars;
+  for (size_t i = 0; i < new_iter_args.size() && i < new_return_vars.size(); ++i) {
+    auto it = tile_vars.find(new_iter_args[i].get());
+    if (it == tile_vars.end()) continue;
+    tile_vars[new_return_vars[i].get()] = it->second;
+    auto new_type = ApplyTrackedTileShape(new_return_vars[i]->GetType(), it->second.split_dim,
+                                          it->second.half_dim_size, subblock_idx, lane_stride);
+    if (new_type != new_return_vars[i]->GetType()) {
+      auto new_return_var =
+          std::make_shared<Var>(new_return_vars[i]->name_hint_, new_type, new_return_vars[i]->span_);
+      new_return_vars[i] = new_return_var;
+      tile_vars[new_return_var.get()] = it->second;
+      var_replacements[return_vars[i].get()] = new_return_var;
+    }
+  }
+  return new_return_vars;
+}
 
 std::vector<StmtPtr> ProcessStmts(const std::vector<StmtPtr>& stmts, SplitMode mode, int split_dim,
                                   std::unordered_map<const Var*, TileInfo>& tile_vars, bool is_aiv,

--- a/tests/ut/ir/operators/test_lane_invariant_arg_coverage.py
+++ b/tests/ut/ir/operators/test_lane_invariant_arg_coverage.py
@@ -1,0 +1,297 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Keep ``LaneInvariantArg`` declarations aligned with what type deduction can decide.
+
+``LowerAutoVectorSplit`` decides whether an operand may stay full width under a halved result by
+re-deducing the halved call (``HalvedCallStaysTypeConsistent``). That answer needs no metadata and
+cannot go stale, so a registry declaration is only load-bearing for the operands the operator's own
+``f_deduce_type`` never reads.
+
+This module measures which operands those are, the same way the pass does: widen one tile operand on
+one axis and ask the deducer again.
+
+* deduction throws, or the deduced result changes -> the deducer **pins** that operand's extent, and
+  the pass's type-consistency gate already decides it;
+* deduction is unchanged -> the deducer is **blind** to it, and only a declaration can say whether
+  full width is in contract.
+
+Two things are then checked:
+
+1. Every declared ``LaneInvariantArg.Scratch`` position names a blind operand. A declaration on a
+   pinned operand is inert and actively misleading — it reads as "full width is fine here" while the
+   operator's own deducer rejects that width. ``tile.rsqrt`` carried exactly such a declaration.
+2. The blind positions match ``EXPECTED_BLIND_ARGS`` below. Adding an operator or loosening a
+   deducer moves a position into that set, and the diff forces the question the model turns on: is
+   this operand hardware scratch (declare it) or per-lane data (leave it undeclared, so the pass
+   requires it to be sharded)?
+"""
+
+import itertools
+import re
+from pathlib import Path
+
+import pytest
+from pypto.pypto_core import DataType, ir
+
+SPAN = ir.Span.unknown()
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+
+# Probe shapes. Rectangular on purpose: a square tile cannot tell "the deducer reads dim 0" from
+# "the deducer reads dim 1". The degenerate forms let the search satisfy operators whose second
+# operand is a row or column vector (the row_expand / col_expand families).
+BASE_SHAPE = [64, 32]
+_SHAPE_CANDIDATES = ([64, 32], [64, 1], [1, 32])
+
+# Kwargs an operator requires before its deducer will produce any result at all. Values are chosen to
+# be neutral: they must not themselves depend on a tile operand's extent, or the probe would read the
+# kwarg's influence as the operand's.
+_KWARGS: dict[str, dict] = {
+    "tile.cast": {"target_type": DataType.INT32, "mode": 0},
+    "tile.cmp": {"cmp_type": 0},
+    "tile.gather_compare": {"cmp_mode": 0, "out_cols": 32},
+    "tile.mrgsort_format2": {"exhausted": False},
+    "tile.scatter_mask": {"mask_pattern": 1},
+    "tile.tmov_x2zz": {"group_axis": 1},
+    "tile.tquant_mx_raw": {"group_axis": 1},
+}
+
+_DTYPES = [
+    DataType.FP32,
+    DataType.FP16,
+    DataType.INT32,
+    DataType.UINT32,
+    DataType.INT16,
+    DataType.UINT16,
+    DataType.INT8,
+    DataType.UINT8,
+]
+
+# Operators the uniform-dtype, per-argument-shape search cannot build a baseline call for. Each is
+# excluded explicitly rather than being silently reported as having no blind operands, and the set is
+# asserted below so it cannot grow unnoticed.
+UNSEEDED_OPS = {
+    # Its third argument is a TensorType (a GM destination), and `idx` must be INT32 beside a
+    # non-INT32 data tile — a dtype PAIR the uniform search does not express.
+    ir.get_op("tile.mscatter").name,
+    # Deduction relates the two tiles to each other (`dst.shape[1] == src.shape[1] * mask_pattern`),
+    # which no assignment of independent probe shapes satisfies. That relation is itself the deducer
+    # reading both operands, so both would be pinned.
+    ir.get_op("tile.scatter_mask").name,
+    # Raw UINT8 src/tmp plus a `dst_rows`/`dst_cols` pair that must agree with the source's static
+    # valid shape.
+    ir.get_op("tile.tmov_x2zz").name,
+}
+
+# (operator, argument index) pairs whose extent the operator's own type deduction never reads, so
+# `HalvedCallStaysTypeConsistent` cannot decide them and the registry declaration is what the split
+# pass consults. Keep sorted.
+EXPECTED_BLIND_ARGS = {
+    # --- declared Scratch: hardware workspace, legal at full width beside a halved input ---
+    ("tile.cast", 1),
+    ("tile.col_sum", 1),
+    ("tile.gather", 2),
+    ("tile.gather_compare", 2),
+    ("tile.prelu", 2),
+    ("tile.rem", 2),
+    ("tile.rems", 2),
+    ("tile.row_expand_add", 2),
+    ("tile.row_max", 1),
+    ("tile.row_min", 1),
+    ("tile.row_prod", 1),
+    ("tile.row_sum", 1),
+    ("tile.sel", 3),
+    ("tile.sels", 2),
+    ("tile.sort32", 2),
+    ("tile.xor", 2),
+    ("tile.xors", 2),
+    # --- declared IndexAddressedSource: a lane-shared table read at absolute indices ---
+    ("tile.gather", 0),
+    ("tile.gatherb", 0),
+    # --- undeclared: per-lane data, so the pass requires it to be sharded ---
+    ("tile.col_argmax", 1),
+    ("tile.col_argmin", 1),
+    ("tile.col_expand", 1),
+    ("tile.col_expand_add", 1),
+    ("tile.col_expand_div", 1),
+    ("tile.col_expand_expdif", 1),
+    ("tile.col_expand_max", 1),
+    ("tile.col_expand_min", 1),
+    ("tile.col_expand_mul", 1),
+    ("tile.col_expand_sub", 1),
+    ("tile.gather_compare", 0),
+    ("tile.mrgsort_format2", 0),
+    ("tile.mrgsort_format2", 1),
+    ("tile.mrgsort_format2", 2),
+    ("tile.mrgsort_format2", 3),
+    ("tile.scatter_update", 1),
+    ("tile.scatter_update", 2),
+    ("tile.sel", 0),
+    ("tile.sels", 0),
+    ("tile.sort32", 1),
+}
+
+
+def _registered_tile_ops():
+    """Every ``tile.*`` operator, read from the registrations themselves.
+
+    Scanning the sources rather than listing names keeps the coverage check growing with the
+    codebase: a new tile operator enters the probe the moment it is registered.
+    """
+    names = set()
+    for source in sorted((_REPO_ROOT / "src/ir/op").rglob("*.cpp")):
+        for name in re.findall(r'REGISTER_OP\("(tile\.[^"]+)"\)', source.read_text()):
+            names.add(name)
+    return sorted(names)
+
+
+def _tile(name, shape, dtype):
+    return ir.Var(name, ir.TileType(shape, dtype, memory_space=ir.MemorySpace.Vec), SPAN)
+
+
+def _scalar(name, dtype):
+    return ir.Var(name, ir.ScalarType(dtype), SPAN)
+
+
+def _deduce(op_name, args):
+    return ir.create_op_call(op_name, args, _KWARGS.get(op_name, {}), SPAN).type
+
+
+def _result_shape(result_type):
+    try:
+        return [str(d) for d in result_type.shape]
+    except Exception:  # noqa: BLE001 - a non-shaped result is still a distinguishable answer
+        return None
+
+
+def _vector_tile_args(op_name):
+    """Positional indices of this operator's Vec-constrained tile arguments."""
+    spec = ir.get_op_memory_spec(op_name)
+    if spec is None:
+        return []
+    constraints = spec.get("input_constraints") or []
+    vec = str(ir.MemorySpace.Vec)
+    return [i for i, allowed in enumerate(constraints) if allowed and all(str(a) == vec for a in allowed)]
+
+
+def _find_baseline(op_name, n_args, tile_idx):
+    """First (args, result) the deducer accepts.
+
+    Searches one dtype across all tiles (mixed-dtype operators are rare and are listed in
+    ``UNSEEDED_OPS``) crossed with a per-argument shape from ``_SHAPE_CANDIDATES``, which is what
+    lets the row/col-expand families — whose second operand is a vector — reach a baseline.
+    """
+    ordered = sorted(tile_idx)
+    for dtype in _DTYPES:
+        for shapes in itertools.product(_SHAPE_CANDIDATES, repeat=len(ordered)):
+            per_arg = dict(zip(ordered, shapes, strict=True))
+            for scalar_dtype in _DTYPES:
+                args = [
+                    _tile(f"a{i}", per_arg[i], dtype) if i in per_arg else _scalar(f"s{i}", scalar_dtype)
+                    for i in range(n_args)
+                ]
+                try:
+                    return args, _deduce(op_name, args)
+                except Exception:  # noqa: BLE001 - searching for any accepted combination
+                    continue
+    return None, None
+
+
+def _deducer_pins(op_name, args, baseline, idx, axis):
+    """Whether widening ``args[idx]`` on ``axis`` changes the deducer's answer."""
+    shape = [int(str(d)) for d in args[idx].type.shape]
+    shape[axis] *= 2
+    probe = list(args)
+    probe[idx] = _tile("probe", shape, args[idx].type.dtype)
+    try:
+        widened = _deduce(op_name, probe)
+    except Exception:  # noqa: BLE001 - a refusal is the deducer reading the operand
+        return True
+    return _result_shape(widened) != _result_shape(baseline)
+
+
+def _measure_blind_args():
+    """{(op, arg_index)} the deducer never reads, plus the ops no baseline could be built for."""
+    blind = set()
+    unseeded = set()
+    for op_name in _registered_tile_ops():
+        tile_idx = _vector_tile_args(op_name)
+        if len(tile_idx) < 2:
+            continue
+        n_args = ir.get_op_argument_count(op_name)
+        args, baseline = _find_baseline(op_name, n_args, set(tile_idx))
+        if args is None:
+            unseeded.add(op_name)
+            continue
+        for idx in tile_idx:
+            if idx >= len(args):
+                continue
+            if not any(_deducer_pins(op_name, args, baseline, idx, axis) for axis in (0, 1)):
+                blind.add((op_name, idx))
+    return blind, unseeded
+
+
+@pytest.fixture(scope="module")
+def measured():
+    return _measure_blind_args()
+
+
+def test_probe_covers_every_multi_tile_vector_operator(measured):
+    """The inventory below is only meaningful if the probe reached the operators it claims to."""
+    _, unseeded = measured
+    assert unseeded == UNSEEDED_OPS, (
+        "operators the deduction probe could not build a baseline for changed; a new entry means an "
+        "operator dropped out of the coverage check and needs either a probe seed or a documented "
+        f"reason.\n  now unseeded but expected seeded: {sorted(unseeded - UNSEEDED_OPS)}\n"
+        f"  now seeded but expected unseeded: {sorted(UNSEEDED_OPS - unseeded)}"
+    )
+
+
+def test_blind_operand_inventory_is_unchanged(measured):
+    """Every operand type deduction cannot decide is accounted for.
+
+    A position entering this set is one the split pass can no longer decide for itself: declare it
+    ``set_lane_invariant_arg(i)`` when it is hardware workspace, or leave it undeclared when it
+    carries per-lane data and must be sharded.
+    """
+    blind, _ = measured
+    assert blind == EXPECTED_BLIND_ARGS, (
+        "the set of operands type deduction is blind to changed.\n"
+        f"  newly blind (classify these): {sorted(blind - EXPECTED_BLIND_ARGS)}\n"
+        f"  no longer blind (the deducer now decides; drop any Scratch declaration): "
+        f"{sorted(EXPECTED_BLIND_ARGS - blind)}"
+    )
+
+
+def test_declared_scratch_names_an_operand_deduction_cannot_decide(measured):
+    """A ``Scratch`` declaration on a pinned operand is inert and misleading.
+
+    The split pass consults the declaration only where its type-consistency gate is blind, so
+    declaring a scratch whose shape the deducer pins claims "full width is fine here" while the
+    operator itself rejects that width. Delete such a declaration rather than leaving it to be read
+    as a contract.
+    """
+    blind, unseeded = measured
+    inert = []
+    for op_name in _registered_tile_ops():
+        if op_name in unseeded:
+            continue
+        for idx in range(ir.get_op_argument_count(op_name)):
+            if ir.get_op_lane_invariant_arg(op_name, idx) != ir.LaneInvariantArg.Scratch:
+                continue
+            if (op_name, idx) not in blind:
+                inert.append((op_name, idx))
+    assert not inert, (
+        "these arguments declare LaneInvariantArg.Scratch, but their operator's own f_deduce_type "
+        f"pins the extent, so the declaration can never be reached: {inert}"
+    )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -18,6 +18,7 @@ import pytest
 from pypto import DataType, InternalError, backend, ir, passes
 from pypto.backend import BackendType
 from pypto.ir import IRBuilder
+from pypto.ir.instruments import make_roundtrip_instrument
 from pypto.ir.op import tensor as tensor_ops
 from pypto.ir.op import tile as tile_ops
 from pypto.language.parser.text_parser import parse
@@ -6499,22 +6500,26 @@ class TestConvertCrossCoreSplitOps:
         # LowerAutoVectorSplit rewrites into tile.aic_gather. Built at the tile
         # level for the same reason as the shard oracle above.
         #
-        # The gather source is VECTOR-PRODUCED (tile.add), not a parameter: the
+        # The gather source is VECTOR-PRODUCED (load -> add), not a parameter: the
         # pass's precondition is that the V->C boundary source has already been
         # halved by the affinity gate, so the gather doubles HALF -> FULL. Sourcing
-        # it from a param instead would leave it full-width and over-double
-        # ([256, 128] -> [512, 128]) while the placement move kept its original
-        # [256, 128] result type — an ill-typed move that misrepresents the pass.
-        # Hence the [256, 128] param: add halves it to the [128, 128] per-lane
-        # half, and the gather doubles that back to the [256, 128] FULL tile the
-        # explicit path also produces.
+        # it from a full-width Vec param instead is out of contract — nothing
+        # inside the region partitions it, so halving the add's result alone would
+        # emit tile.add([256, 128], [256, 128]) -> [128, 128], and the pass now
+        # rejects that (see
+        # test_lower_auto_vector_split.py::test_vector_op_rejects_unsharded_full_width_operand).
+        # Hence the [256, 128] tensor + tile.load: the load halves to the
+        # [128, 128] per-lane half, add carries it, and the gather doubles that
+        # back to the [256, 128] FULL tile the explicit path also produces.
         #
         # The gathered tile is then CONSUMED (move -> Left, matmul, store of the
         # Acc result — tile.store takes only {Vec, Acc}, never Mat). Leaving it
         # dead would let a future DCE drop the synthesized gather.
-        vec = ir.Var("vec", ir.TileType([256, 128], DataType.FP32, None, None, MemorySpace.Vec), span)
+        vec_t = ir.Var("vec_t", ir.TensorType([256, 128], DataType.FP32), span)
         rhs = ir.Var("rhs", ir.TileType([128, 128], DataType.FP32, None, None, MemorySpace.Right), span)
         out_0 = ir.Var("out_0", ir.TensorType([256, 128], DataType.FP32), span)
+        load = tile_ops.load(vec_t, [0, 0], [256, 128], [256, 128], target_memory=MemorySpace.Vec, span=span)
+        vec = ir.Var("vec", load.type, span)
         add = tile_ops.add(vec, vec, span)
         vec_h = ir.Var("vec_h", add.type, span)
         move = tile_ops.move(vec_h, MemorySpace.Mat, span=span)
@@ -6529,13 +6534,14 @@ class TestConvertCrossCoreSplitOps:
         auto_func = ir.Function(
             "split_auto",
             [
-                (vec, ir.ParamDirection.In),
+                (vec_t, ir.ParamDirection.In),
                 (rhs, ir.ParamDirection.In),
                 (out_0, ir.ParamDirection.Out),
             ],
             [out_0.type],
             ir.SeqStmts(
                 [
+                    ir.AssignStmt(vec, load, span),
                     ir.AssignStmt(vec_h, add, span),
                     ir.AssignStmt(gathered, move, span),
                     ir.AssignStmt(left, to_left, span),
@@ -6550,17 +6556,17 @@ class TestConvertCrossCoreSplitOps:
             attrs={"split": ir.SplitMode.UP_DOWN},
         )
         auto_program = ir.Program([auto_func], "auto", span)
-        # Property verification stays ON; only the print->parse roundtrip is dropped.
-        # LowerAutoVectorSplit halves the `tile.add` RESULT to the per-lane [128, 128]
-        # but leaves its operand `vec` at the full [256, 128] param width, so the pass
-        # output is not re-parsable ("annotation for 'vec_h' has shape dimension
-        # 0 = 128 but expression has shape dimension 0 = 256"). That is the same V->C
-        # boundary defect family documented in test_lower_auto_vector_split.py; this
-        # test only compares the resulting `tile.aic_gather` TYPE against the explicit
-        # path, which is unaffected. Tracked by hw-native-sys/pypto#2203 — re-enable
-        # the roundtrip once the pass shards or rejects a full-width source instead
-        # of silently halving only the result.
-        with passes.PassContext([passes.VerificationInstrument(passes.VerificationMode.BEFORE_AND_AFTER)]):
+        # Property verification AND the print->parse roundtrip are both on: every
+        # value the halving touches is lane-local here, so the pass output is
+        # well-typed and re-parsable. The roundtrip is what caught the defect this
+        # fixture used to encode (a halved result over a full-width operand), so it
+        # stays enabled to keep that regression visible.
+        with passes.PassContext(
+            [
+                passes.VerificationInstrument(passes.VerificationMode.BEFORE_AND_AFTER),
+                make_roundtrip_instrument(),
+            ]
+        ):
             auto_lowered = passes.lower_auto_vector_split()(auto_program)
         auto_call = _find_first_call_to(
             _require_function(auto_lowered, "split_auto"), ir.get_op("tile.aic_gather").name

--- a/tests/ut/ir/transforms/test_lower_auto_vector_split.py
+++ b/tests/ut/ir/transforms/test_lower_auto_vector_split.py
@@ -70,6 +70,7 @@ from pypto import DataType, ir, passes
 from pypto import backend as _backend
 from pypto.ir.instruments import make_roundtrip_instrument
 from pypto.ir.op import tile_ops as T
+from pypto.ir.pass_manager import OptimizationStrategy, PassManager
 from pypto.runtime import RunConfig
 
 MS = ir.MemorySpace
@@ -1381,6 +1382,988 @@ def test_vc_boundary_rejects_unhalved_vector_operand():
 
     with pytest.raises(ValueError, match="full-width vector operand"):
         _lower(Before)
+
+
+def test_vector_op_rejects_unsharded_full_width_operand():
+    """A vector op whose operand no lane owns a half of is rejected, not halved.
+
+    ``vec`` is a full-width Vec parameter, so nothing inside the region
+    partitions it. Halving only the ``tile.add`` RESULT would emit
+    ``tile.add([256, 128], [256, 128]) -> [128, 128]`` — a node whose declared
+    shape contradicts type inference over its own arguments, which fails
+    print->parse and misleads every later consumer that re-derives types from
+    operands. This is the elementwise mirror of
+    ``test_vc_boundary_rejects_unhalved_vector_operand`` above: the guard that
+    already existed one boundary later now also covers ordinary vector ops.
+    """
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def split_auto(
+            vec: pl.Tile[[256, 128], pl.FP32, pl.Mem.Vec],
+            rhs: pl.Tile[[128, 128], pl.FP32, pl.Mem.Right],
+            out_0: pl.Out[pl.Tensor[[256, 128], pl.FP32]],
+        ) -> pl.Tensor[[256, 128], pl.FP32]:
+            vec_h = pl.tile.add(vec, vec)
+            gathered_mat = pl.tile.move(vec_h, target_memory=pl.Mem.Mat)
+            left = pl.tile.move(gathered_mat, target_memory=pl.Mem.Left)
+            acc = pl.tile.matmul(left, rhs)
+            out_store = pl.tile.store(acc, [0, 0], out_0)
+            return out_store
+
+    with pytest.raises(ValueError, match="carries a full-width operand") as exc_info:
+        _lower(Before)
+    # The diagnostic names the operand and the in-contract spellings, so the
+    # author can act on it without reading the pass.
+    message = str(exc_info.value)
+    assert "'vec'" in message
+    assert "aiv_shard" in message
+
+
+def test_declared_scratch_operand_stays_full_width():
+    """A full-width operand the operator DECLARES as scratch is kept.
+
+    ``tile.row_sum(tile, tmp_tile)`` uses ``tmp_tile`` as hardware workspace whose
+    contract is "at least as large as the input", never as per-lane data, so it
+    declares ``set_lane_invariant_arg(1)``. The buffer comes from ``tile.create``,
+    registered ``CoreAffinity::SHARED``, so the affinity gate deliberately passes
+    it through full width for both lanes to declare — it is never tracked, and
+    matching on the extent alone would reject the whole rms-norm reduction shape
+    (gh#1864's runtime parity probe).
+
+    The exemption is a registry declaration on purpose. See
+    ``test_sel_full_width_mask_is_rejected`` for why "the result shape is not
+    deduced from this operand" is a different property and cannot stand in.
+    """
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def split_auto(
+            x: pl.Tensor[[256, 128], pl.FP32],
+            rhs: pl.Tile[[128, 128], pl.FP32, pl.Mem.Right],
+            out_0: pl.Out[pl.Tensor[[256, 128], pl.FP32]],
+        ) -> pl.Tensor[[256, 128], pl.FP32]:
+            v = pl.tile.load(x, [0, 0], [256, 128], target_memory=pl.Mem.Vec)
+            scratch = pl.tile.create([256, 128], dtype=pl.FP32, target_memory=pl.Mem.Vec)
+            sums = pl.tile.row_sum(v, scratch)
+            vec_h = pl.tile.row_expand_mul(v, sums)
+            gathered_mat = pl.tile.move(vec_h, target_memory=pl.Mem.Mat)
+            left = pl.tile.move(gathered_mat, target_memory=pl.Mem.Left)
+            acc = pl.tile.matmul(left, rhs)
+            out_store = pl.tile.store(acc, [0, 0], out_0)
+            return out_store
+
+    @pl.program
+    class Expected:
+        @pl.function(
+            type=pl.FunctionType.InCore,
+            attrs={"split": pl.SplitMode.UP_DOWN, "split_aiv": True},
+        )
+        def split_auto(
+            x: pl.Tensor[[256, 128], pl.FP32],
+            rhs: pl.Tile[[128, 128], pl.FP32, pl.Mem.Right],
+            out_0: pl.Out[pl.Tensor[[256, 128], pl.FP32]],
+        ) -> pl.Tensor[[256, 128], pl.FP32]:
+            subblock_idx = pl.tile.get_subblock_idx()
+            v = pl.tile.load(x, [0 + subblock_idx * 128, 0], [128, 128], [128, 128], target_memory=pl.Mem.Vec)
+            # Untouched: the scratch is SHARED, so both lanes declare it whole.
+            scratch = pl.tile.create([256, 128], dtype=pl.FP32, target_memory=pl.Mem.Vec)
+            sums = pl.tile.row_sum(v, scratch)
+            vec_h = pl.tile.row_expand_mul(v, sums)
+            gathered_mat_mat = pl.tile.aic_gather(vec_h, split=1)
+            gathered_mat = pl.tile.move(gathered_mat_mat, target_memory=pl.Mem.Mat)
+            left = pl.tile.move(gathered_mat, target_memory=pl.Mem.Left)
+            acc = pl.tile.matmul(left, rhs)
+            out_store = pl.tile.store(acc, [0, 0], out_0)
+            return out_store
+
+    # _lower keeps the print->parse roundtrip instrument on, so this also pins the
+    # invariant the guard protects: the accepted node still re-parses.
+    ir.assert_structural_equal(_lower(Before), Expected)
+
+
+def test_dynamic_full_width_reshape_is_rejected():
+    """A full-width reshape source needs a STATIC half extent to be partitioned.
+
+    ``tile.reshape`` over an untracked source is diverted into a full view plus a
+    per-lane ``tile.slice``, and that slice can only be materialized from a static
+    half extent. A dynamic one used to fall through to plain result halving, which
+    is the offsetless-view miscompile the diversion exists to prevent: both lanes
+    read the first half, so lane 1 silently reuses lane 0's data. Reject it, as
+    the sibling ``tile.reinterpret_view`` already does.
+    """
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def split_auto(
+            cube_seed: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat],
+            data: pl.Tile[[16, 16], pl.FP32, pl.Mem.Vec],
+            rows: pl.Scalar[pl.INDEX],
+            out_0: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+        ) -> pl.Tensor[[16, 16], pl.FP32]:
+            seed_vec = pl.tile.move(cube_seed, target_memory=pl.Mem.Vec)  # noqa: F841
+            reshaped = pl.tile.reshape(data, [rows, 16])
+            out_store = pl.tile.store(reshaped, [0, 0], out_0)
+            return out_store
+
+    with pytest.raises(ValueError, match="requires a static split extent") as exc_info:
+        _lower(Before)
+    message = str(exc_info.value)
+    assert "tile.reshape" in message
+
+
+# ---------------------------------------------------------------------------
+# Halving is gated on TWO independently necessary conditions. Neither implies
+# the other, so each needs its own coverage:
+#   (1) every tile operand is lane-local, split-axis-singleton, or DECLARED
+#       scratch  -- violated by tile.sel's full-width mask, which the operator's
+#       type deduction never reads;
+#   (2) the halved node still type-checks against its own arguments -- violated
+#       by tile.transpose_view, whose axis permutation the broadcast
+#       right-alignment in (1) is not entitled to describe.
+# ---------------------------------------------------------------------------
+
+
+def test_sel_full_width_mask_is_rejected():
+    """A per-element operand outside the result deduction is still lane data.
+
+    ``tile.sel(mask, lhs, rhs, tmp)`` deduces its result from ``BroadcastShapes``
+    over lhs/rhs alone and validates only that ``mask`` is a ``TileType``. So with
+    lhs/rhs halved and a full-width ``mask``, the halved node re-deduces cleanly —
+    condition (2) is satisfied and cannot catch this. Both lanes would then read
+    mask rows 0..127 and silently compute the wrong halves.
+
+    Only condition (1) rejects it, and only because ``tile.sel`` declares arg 3
+    (``tmp``) lane-invariant and NOT arg 0.
+    """
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def split_auto(
+            x: pl.Tensor[[256, 128], pl.FP32],
+            mask: pl.Tile[[256, 128], pl.FP32, pl.Mem.Vec],
+            tmp: pl.Tile[[1, 16], pl.UINT32, pl.Mem.Vec],
+            rhs: pl.Tile[[128, 128], pl.FP32, pl.Mem.Right],
+            out_0: pl.Out[pl.Tensor[[256, 128], pl.FP32]],
+        ) -> pl.Tensor[[256, 128], pl.FP32]:
+            v = pl.tile.load(x, [0, 0], [256, 128], target_memory=pl.Mem.Vec)
+            w = pl.tile.load(x, [0, 0], [256, 128], target_memory=pl.Mem.Vec)
+            picked = pl.tile.sel(mask, v, w, tmp)
+            gathered_mat = pl.tile.move(picked, target_memory=pl.Mem.Mat)
+            left = pl.tile.move(gathered_mat, target_memory=pl.Mem.Left)
+            acc = pl.tile.matmul(left, rhs)
+            out_store = pl.tile.store(acc, [0, 0], out_0)
+            return out_store
+
+    with pytest.raises(ValueError, match="carries a full-width operand") as exc_info:
+        _lower(Before)
+    message = str(exc_info.value)
+    assert "'mask'" in message
+
+
+def test_sels_full_width_mask_is_rejected():
+    """An oversized mask satisfies ``tile.sels``' coverage rule and is still wrong.
+
+    ``tile.sels`` validates that the mask's carrier rows *cover* src's valid rows,
+    which a full-width mask over a halved src passes. Coverage is not partition:
+    each lane would read the mask from row 0.
+    """
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def split_auto(
+            x: pl.Tensor[[256, 128], pl.FP32],
+            mask: pl.Tile[[256, 128], pl.INT32, pl.Mem.Vec],
+            tmp: pl.Tile[[256, 128], pl.FP32, pl.Mem.Vec],
+            rhs: pl.Tile[[128, 128], pl.FP32, pl.Mem.Right],
+            out_0: pl.Out[pl.Tensor[[256, 128], pl.FP32]],
+        ) -> pl.Tensor[[256, 128], pl.FP32]:
+            v = pl.tile.load(x, [0, 0], [256, 128], target_memory=pl.Mem.Vec)
+            picked = pl.tile.sels(mask, v, tmp, pl.const(0.0, pl.FP32))
+            gathered_mat = pl.tile.move(picked, target_memory=pl.Mem.Mat)
+            left = pl.tile.move(gathered_mat, target_memory=pl.Mem.Left)
+            acc = pl.tile.matmul(left, rhs)
+            out_store = pl.tile.store(acc, [0, 0], out_0)
+            return out_store
+
+    with pytest.raises(ValueError, match="carries a full-width operand") as exc_info:
+        _lower(Before)
+    assert "'mask'" in str(exc_info.value)
+
+
+def test_declared_scratch_is_exempt_on_the_left_right_split_axis():
+    """The declaration, not the extent, is what exempts a scratch operand.
+
+    ``tile.sel``'s ``tmp`` is ``[1, 16]``: singleton on dim 0, so ``UP_DOWN`` would
+    skip it for the wrong reason. Under ``LEFT_RIGHT`` the split axis is dim 1,
+    where it is full width — and it must still be accepted, while every real
+    operand is lane-local via ``tile.load``.
+    """
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.LEFT_RIGHT})
+        def split_auto(
+            x: pl.Tensor[[256, 128], pl.FP32],
+            tmp: pl.Tile[[1, 16], pl.UINT32, pl.Mem.Vec],
+            rhs: pl.Tile[[128, 128], pl.FP32, pl.Mem.Right],
+            out_0: pl.Out[pl.Tensor[[256, 128], pl.FP32]],
+        ) -> pl.Tensor[[256, 128], pl.FP32]:
+            m = pl.tile.load(x, [0, 0], [256, 128], target_memory=pl.Mem.Vec)
+            v = pl.tile.load(x, [0, 0], [256, 128], target_memory=pl.Mem.Vec)
+            w = pl.tile.load(x, [0, 0], [256, 128], target_memory=pl.Mem.Vec)
+            picked = pl.tile.sel(m, v, w, tmp)
+            gathered_mat = pl.tile.move(picked, target_memory=pl.Mem.Mat)
+            left = pl.tile.move(gathered_mat, target_memory=pl.Mem.Left)
+            acc = pl.tile.matmul(left, rhs)
+            out_store = pl.tile.store(acc, [0, 0], out_0)
+            return out_store
+
+    lowered = _lower(Before)
+    # The tmp operand survives at its declared full width, and the sel result is
+    # halved on the LEFT_RIGHT axis.
+    printed = lowered.as_python()
+    assert "pl.tile.sel(" in printed
+    assert "[256, 64]" in printed
+
+
+def test_gather_full_width_table_is_lane_shared():
+    """A lookup table addressed by absolute index is shared, not un-sharded.
+
+    ``tile.gather`` computes ``out[i] = src[indices[i]]`` and takes its result
+    shape from ``indices``. The index values are absolute into ``src``, so halving
+    ``indices`` already gives each lane its own half of the OUTPUT while both read
+    the whole table — the correct lowering, not a missing shard.
+
+    Positional correspondence is what the guard is really about, and ``src`` has
+    none with the result, so ``tile.gather`` declares it lane-invariant alongside
+    its ``tmp``. See ``test_scatter_update_full_width_index_is_rejected`` for the
+    dual, which must stay rejected.
+    """
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def split_auto(
+            idx: pl.Tensor[[256, 128], pl.INT32],
+            scratch: pl.Tensor[[256, 128], pl.INT32],
+            src: pl.Tile[[256, 128], pl.FP32, pl.Mem.Vec],
+            rhs: pl.Tile[[128, 128], pl.FP32, pl.Mem.Right],
+            out_0: pl.Out[pl.Tensor[[256, 128], pl.FP32]],
+        ) -> pl.Tensor[[256, 128], pl.FP32]:
+            indices = pl.tile.load(idx, [0, 0], [256, 128], target_memory=pl.Mem.Vec)
+            # tmp is shape-MATCHED to indices on A2/A3, so it is loaded inside the
+            # region and halves with them. Only `src` is lane-shared.
+            tmp = pl.tile.load(scratch, [0, 0], [256, 128], target_memory=pl.Mem.Vec)
+            picked = pl.tile.gather(src, indices, tmp)
+            gathered_mat = pl.tile.move(picked, target_memory=pl.Mem.Mat)
+            left = pl.tile.move(gathered_mat, target_memory=pl.Mem.Left)
+            acc = pl.tile.matmul(left, rhs)
+            out_store = pl.tile.store(acc, [0, 0], out_0)
+            return out_store
+
+    @pl.program
+    class Expected:
+        @pl.function(
+            type=pl.FunctionType.InCore,
+            attrs={"split": pl.SplitMode.UP_DOWN, "split_aiv": True},
+        )
+        def split_auto(
+            idx: pl.Tensor[[256, 128], pl.INT32],
+            scratch: pl.Tensor[[256, 128], pl.INT32],
+            src: pl.Tile[[256, 128], pl.FP32, pl.Mem.Vec],
+            rhs: pl.Tile[[128, 128], pl.FP32, pl.Mem.Right],
+            out_0: pl.Out[pl.Tensor[[256, 128], pl.FP32]],
+        ) -> pl.Tensor[[256, 128], pl.FP32]:
+            subblock_idx = pl.tile.get_subblock_idx()
+            indices = pl.tile.load(
+                idx, [0 + subblock_idx * 128, 0], [128, 128], [128, 128], target_memory=pl.Mem.Vec
+            )
+            tmp = pl.tile.load(
+                scratch, [0 + subblock_idx * 128, 0], [128, 128], [128, 128], target_memory=pl.Mem.Vec
+            )
+            # `src` stays whole; indices, tmp and the result are all halved.
+            picked = pl.tile.gather(src, indices, tmp)
+            gathered_mat_mat = pl.tile.aic_gather(picked, split=1)
+            gathered_mat = pl.tile.move(gathered_mat_mat, target_memory=pl.Mem.Mat)
+            left = pl.tile.move(gathered_mat, target_memory=pl.Mem.Left)
+            acc = pl.tile.matmul(left, rhs)
+            out_store = pl.tile.store(acc, [0, 0], out_0)
+            return out_store
+
+    ir.assert_structural_equal(_lower(Before), Expected)
+
+
+def test_gatherb_full_width_table_is_lane_shared():
+    """The byte-offset form of the same shape: `offset` carries the addressing."""
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def split_auto(
+            off_t: pl.Tensor[[256, 128], pl.UINT32],
+            src: pl.Tile[[256, 128], pl.FP32, pl.Mem.Vec],
+            rhs: pl.Tile[[128, 128], pl.FP32, pl.Mem.Right],
+            out_0: pl.Out[pl.Tensor[[256, 1024], pl.FP32]],
+        ) -> pl.Tensor[[256, 1024], pl.FP32]:
+            offset = pl.tile.load(off_t, [0, 0], [256, 128], target_memory=pl.Mem.Vec)
+            picked = pl.tile.gatherb(src, offset, output_dtype=pl.FP32)
+            seed = pl.tile.move(rhs, target_memory=pl.Mem.Mat)  # noqa: F841
+            out_store = pl.tile.store(picked, [0, 0], out_0)
+            return out_store
+
+    lowered = _lower(Before)
+    printed = lowered.as_python()
+    # The table stays [256, 128] while the gathered result halves to [128, 1024].
+    assert "pl.tile.gatherb(src, offset" in printed
+    assert "[128, 1024]" in printed
+
+
+def test_gather_partitioned_table_producer_is_rejected():
+    """Declaring the table lane-shared permits full width; it does not keep it so.
+
+    Nothing stops the operand's own producer from being halved: a ``tile.load``
+    inside the region is halved with the lane offset baked in. The index values
+    are absolute into the WHOLE table, so lane 1 reads the wrong rows and an index
+    past the halved extent is out of bounds.
+
+    Neither other gate sees this. The operand is tracked, so condition (1) skips
+    it; and ``tile.gather`` deduces its result from ``indices`` alone, so
+    condition (2) is satisfied. It needs its own check.
+    """
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def split_auto(
+            tbl: pl.Tensor[[256, 128], pl.FP32],
+            idx: pl.Tensor[[256, 128], pl.INT32],
+            tmp: pl.Tile[[256, 128], pl.INT32, pl.Mem.Vec],
+            rhs: pl.Tile[[128, 128], pl.FP32, pl.Mem.Right],
+            out_0: pl.Out[pl.Tensor[[256, 128], pl.FP32]],
+        ) -> pl.Tensor[[256, 128], pl.FP32]:
+            # The lookup table is LOADED inside the region, so the pass halves it.
+            src = pl.tile.load(tbl, [0, 0], [256, 128], target_memory=pl.Mem.Vec)
+            indices = pl.tile.load(idx, [0, 0], [256, 128], target_memory=pl.Mem.Vec)
+            picked = pl.tile.gather(src, indices, tmp)
+            gathered_mat = pl.tile.move(picked, target_memory=pl.Mem.Mat)
+            left = pl.tile.move(gathered_mat, target_memory=pl.Mem.Left)
+            acc = pl.tile.matmul(left, rhs)
+            out_store = pl.tile.store(acc, [0, 0], out_0)
+            return out_store
+
+    with pytest.raises(ValueError, match="ABSOLUTE indices") as exc_info:
+        _lower(Before)
+    message = str(exc_info.value)
+    assert "'src'" in message
+    # The remedy names where the table has to come from.
+    assert "OUTSIDE the automatically split region" in message
+
+
+def test_gatherb_partitioned_table_producer_is_rejected():
+    """The byte-offset form carries the same absolute-addressing hazard."""
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def split_auto(
+            tbl: pl.Tensor[[256, 128], pl.FP32],
+            off_t: pl.Tensor[[256, 128], pl.UINT32],
+            rhs: pl.Tile[[128, 128], pl.FP32, pl.Mem.Right],
+            out_0: pl.Out[pl.Tensor[[256, 1024], pl.FP32]],
+        ) -> pl.Tensor[[256, 1024], pl.FP32]:
+            src = pl.tile.load(tbl, [0, 0], [256, 128], target_memory=pl.Mem.Vec)
+            offset = pl.tile.load(off_t, [0, 0], [256, 128], target_memory=pl.Mem.Vec)
+            picked = pl.tile.gatherb(src, offset, output_dtype=pl.FP32)
+            seed = pl.tile.move(rhs, target_memory=pl.Mem.Mat)  # noqa: F841
+            out_store = pl.tile.store(picked, [0, 0], out_0)
+            return out_store
+
+    with pytest.raises(ValueError, match="ABSOLUTE indices") as exc_info:
+        _lower(Before)
+    assert "'src'" in str(exc_info.value)
+
+
+def test_scratch_with_partitioned_producer_is_still_accepted():
+    """Halving is harmless for scratch, so the two declared kinds must differ.
+
+    ``tile.row_sum``'s ``tmp_tile`` contract is a size relation to the input
+    ("at least as large as"), and a halved input takes a halved scratch with it.
+    Rejecting every partitioned lane-invariant operand would break this, which is
+    why ``LaneInvariantArg`` records *why* an operand is lane-invariant rather
+    than just that it is.
+    """
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def split_auto(
+            x: pl.Tensor[[256, 128], pl.FP32],
+            s: pl.Tensor[[256, 128], pl.FP32],
+            rhs: pl.Tile[[128, 128], pl.FP32, pl.Mem.Right],
+            out_0: pl.Out[pl.Tensor[[256, 128], pl.FP32]],
+        ) -> pl.Tensor[[256, 128], pl.FP32]:
+            v = pl.tile.load(x, [0, 0], [256, 128], target_memory=pl.Mem.Vec)
+            # Scratch produced INSIDE the region, so the pass halves it too.
+            scratch = pl.tile.load(s, [0, 0], [256, 128], target_memory=pl.Mem.Vec)
+            sums = pl.tile.row_sum(v, scratch)
+            vec_h = pl.tile.row_expand_mul(v, sums)
+            gathered_mat = pl.tile.move(vec_h, target_memory=pl.Mem.Mat)
+            left = pl.tile.move(gathered_mat, target_memory=pl.Mem.Left)
+            acc = pl.tile.matmul(left, rhs)
+            out_store = pl.tile.store(acc, [0, 0], out_0)
+            return out_store
+
+    printed = _lower(Before).as_python()
+    # Both the input and its scratch halve together; the reduction follows.
+    assert printed.count("[128, 128], pl.FP32, pl.Mem.Vec") >= 2
+    assert "pl.tile.row_sum(v, scratch)" in printed
+
+
+def test_gather_partitioned_table_is_rejected_even_with_a_singleton_result():
+    """The absolute-index check cannot hang off the halving path.
+
+    With ``indices`` shaped ``[1, N]`` the gather result is ``[1, N]`` too, so the
+    result's split axis is singleton and the halving path returns early — nothing
+    about the RESULT is rewritten. The table underneath it is still halved by its
+    own producer, and the trailing ``Substitute`` still swaps the halved var in,
+    so the absolute indices address the wrong half regardless. The check
+    therefore runs before the singleton early-return, not beside the halving.
+    """
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def split_auto(
+            tbl: pl.Tensor[[256, 128], pl.FP32],
+            idx: pl.Tensor[[1, 128], pl.INT32],
+            tmp: pl.Tile[[1, 128], pl.INT32, pl.Mem.Vec],
+            rhs: pl.Tile[[128, 128], pl.FP32, pl.Mem.Right],
+            out_0: pl.Out[pl.Tensor[[1, 128], pl.FP32]],
+        ) -> pl.Tensor[[1, 128], pl.FP32]:
+            src = pl.tile.load(tbl, [0, 0], [256, 128], target_memory=pl.Mem.Vec)
+            indices = pl.tile.load(idx, [0, 0], [1, 128], target_memory=pl.Mem.Vec)
+            picked = pl.tile.gather(src, indices, tmp)
+            seed = pl.tile.move(rhs, target_memory=pl.Mem.Mat)  # noqa: F841
+            out_store = pl.tile.store(picked, [0, 0], out_0)
+            return out_store
+
+    with pytest.raises(ValueError, match="ABSOLUTE indices") as exc_info:
+        _lower(Before)
+    assert "source operand 'src'" in str(exc_info.value)
+
+
+def test_tuple_result_op_over_a_partitioned_operand_is_rejected():
+    """A tuple result is not halveable, and its operands are substituted anyway.
+
+    ``tile.gather_compare`` returns ``Tuple[dst[rows, out_cols], cdst[1, rows]]``,
+    so the generic path — which only understands a single ``TileType`` — skips it
+    entirely: no full-width check, no type consistency, no halving. But the
+    trailing ``Substitute`` still rewrites its arguments, so the call ends up
+    declaring full-width tuple elements over a halved ``[128, 128]`` input. That
+    is illegal IR and would misallocate, so it is rejected; per-element split
+    mapping for tuple results is not implemented.
+    """
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def split_auto(
+            t: pl.Tensor[[256, 128], pl.FP32],
+            tmp: pl.Tile[[256, 128], pl.FP32, pl.Mem.Vec],
+            rhs: pl.Tile[[128, 128], pl.FP32, pl.Mem.Right],
+            out_0: pl.Out[pl.Tensor[[256, 16], pl.INT32]],
+        ) -> pl.Tensor[[256, 16], pl.INT32]:
+            src = pl.tile.load(t, [0, 0], [256, 128], target_memory=pl.Mem.Vec)
+            dst, cdst = pl.tile.gather_compare(src, pl.const(1.0, pl.FP32), tmp, cmp_mode="eq", out_cols=16)
+            seed = pl.tile.move(rhs, target_memory=pl.Mem.Mat)  # noqa: F841
+            out_store = pl.tile.store(dst, [0, 0], out_0)
+            return out_store
+
+    with pytest.raises(ValueError, match="returns a tuple of tiles") as exc_info:
+        _lower(Before)
+    assert "tile.gather_compare" in str(exc_info.value)
+
+
+def test_scatter_with_every_operand_partitioned_is_rejected():
+    """All three operands being tracked does not make absolute indices safe.
+
+    ``tile.scatter`` writes ``dst.flat[indexes[i, j]] = src[i, j]``, where the
+    indexes are FLATTENED offsets into the whole ``dst`` (a column write encodes
+    ``i * dst_cols + c``). Loading dst, src and indexes all inside the region
+    tracks every one of them, so the full-width check skips them all and type
+    consistency passes — yet the index values were never rebased, so the halved
+    row stride no longer matches and lane 1 writes past its destination.
+    """
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def split_auto(
+            d: pl.Tensor[[256, 128], pl.FP32],
+            s: pl.Tensor[[256, 128], pl.FP32],
+            i: pl.Tensor[[256, 128], pl.INT32],
+            rhs: pl.Tile[[128, 128], pl.FP32, pl.Mem.Right],
+            out_0: pl.Out[pl.Tensor[[256, 128], pl.FP32]],
+        ) -> pl.Tensor[[256, 128], pl.FP32]:
+            dst = pl.tile.load(d, [0, 0], [256, 128], target_memory=pl.Mem.Vec)
+            src = pl.tile.load(s, [0, 0], [256, 128], target_memory=pl.Mem.Vec)
+            indexes = pl.tile.load(i, [0, 0], [256, 128], target_memory=pl.Mem.Vec)
+            res = pl.tile.scatter(dst, src, indexes)
+            seed = pl.tile.move(rhs, target_memory=pl.Mem.Mat)  # noqa: F841
+            out_store = pl.tile.store(res, [0, 0], out_0)
+            return out_store
+
+    with pytest.raises(ValueError, match="ABSOLUTE indices") as exc_info:
+        _lower(Before)
+    assert "destination operand 'dst'" in str(exc_info.value)
+
+
+def test_shape_matched_scratch_is_not_exempt_at_full_width():
+    """A scratch whose shape the deducer pins is rejected with no metadata involved.
+
+    ``tile.row_argmax`` needs a tmp shaped *exactly* like the source — the
+    TROWARGMAX kernel reads the column count from the tmp/src extent, so a wider
+    tmp walks past the valid columns and can return the wrong index per column.
+    Nothing in the registry says so: ``DeduceTileRowReductionType`` runs with
+    ``require_exact_tmp_shape``, so re-deducing the halved call throws and the
+    type-consistency gate refuses it. The operator answers for itself.
+
+    That is why ``tile.row_sum`` needs a declaration and this one must not have
+    one — see ``test_declared_scratch_operand_stays_full_width`` for the sibling
+    whose deducer never looks at ``tmp_tile``, and
+    ``tests/ut/ir/operators/test_lane_invariant_arg_coverage.py`` for the check
+    that keeps the two apart as deducers change.
+    """
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def split_auto(
+            x: pl.Tensor[[256, 128], pl.FP32],
+            tmp: pl.Tile[[256, 128], pl.FP32, pl.Mem.Vec],
+            rhs: pl.Tile[[128, 128], pl.FP32, pl.Mem.Right],
+            out_0: pl.Out[pl.Tensor[[256, 1], pl.INT32]],
+        ) -> pl.Tensor[[256, 1], pl.INT32]:
+            v = pl.tile.load(x, [0, 0], [256, 128], target_memory=pl.Mem.Vec)
+            picked = pl.tile.row_argmax(v, tmp)
+            seed = pl.tile.move(rhs, target_memory=pl.Mem.Mat)  # noqa: F841
+            out_store = pl.tile.store(picked, [0, 0], out_0)
+            return out_store
+
+    with pytest.raises(ValueError, match="carries a full-width operand") as exc_info:
+        _lower(Before)
+    assert "'tmp'" in str(exc_info.value)
+
+
+def test_scratch_the_deducer_pins_needs_no_declaration():
+    """The registry is consulted only where type deduction is silent.
+
+    ``DeduceTileRsqrtType`` requires ``tmp`` to match the input's rank and every
+    dimension, so a full-width ``tmp`` beside a halved input is already refused by
+    re-deducing the halved call. ``tile.rsqrt`` therefore carries NO
+    ``set_lane_invariant_arg`` — one would claim full width is in contract while
+    the operator itself rejects that width, and could never be reached.
+
+    Pinning it here keeps the two halves of the model honest: this is the case a
+    declaration must *not* cover, and
+    ``tests/ut/ir/operators/test_lane_invariant_arg_coverage.py`` fails if one is
+    ever added back.
+    """
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def split_auto(
+            x: pl.Tensor[[256, 128], pl.FP32],
+            tmp: pl.Tile[[256, 128], pl.FP32, pl.Mem.Vec],
+            rhs: pl.Tile[[128, 128], pl.FP32, pl.Mem.Right],
+            out_0: pl.Out[pl.Tensor[[256, 128], pl.FP32]],
+        ) -> pl.Tensor[[256, 128], pl.FP32]:
+            v = pl.tile.load(x, [0, 0], [256, 128], target_memory=pl.Mem.Vec)
+            scaled = pl.tile.rsqrt(v, tmp=tmp)
+            gathered_mat = pl.tile.move(scaled, target_memory=pl.Mem.Mat)
+            left = pl.tile.move(gathered_mat, target_memory=pl.Mem.Left)
+            acc = pl.tile.matmul(left, rhs)
+            out_store = pl.tile.store(acc, [0, 0], out_0)
+            return out_store
+
+    with pytest.raises(ValueError, match="carries a full-width operand") as exc_info:
+        _lower(Before)
+    assert "'tmp'" in str(exc_info.value)
+
+
+def test_target_dependent_scratch_stays_exempt():
+    """Whether an oversized scratch is out of contract can be a TARGET question.
+
+    ``tile.gather``'s index form does not read ``tmp`` at all on A5, so a
+    full-width external tmp beside halved indices is legal there; A2/A3 requires
+    it to match the indices, and the PTOAS verifier already enforces that where
+    the target is known. Rejecting here would break the legal A5 form to
+    duplicate a check this pass cannot make accurately, so the exemption stays.
+    """
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def split_auto(
+            idx: pl.Tensor[[256, 128], pl.INT32],
+            src: pl.Tile[[256, 128], pl.FP32, pl.Mem.Vec],
+            tmp: pl.Tile[[256, 128], pl.INT32, pl.Mem.Vec],
+            rhs: pl.Tile[[128, 128], pl.FP32, pl.Mem.Right],
+            out_0: pl.Out[pl.Tensor[[256, 128], pl.FP32]],
+        ) -> pl.Tensor[[256, 128], pl.FP32]:
+            indices = pl.tile.load(idx, [0, 0], [256, 128], target_memory=pl.Mem.Vec)
+            picked = pl.tile.gather(src, indices, tmp)
+            gathered_mat = pl.tile.move(picked, target_memory=pl.Mem.Mat)
+            left = pl.tile.move(gathered_mat, target_memory=pl.Mem.Left)
+            acc = pl.tile.matmul(left, rhs)
+            out_store = pl.tile.store(acc, [0, 0], out_0)
+            return out_store
+
+    printed = _lower(Before).as_python()
+    assert "pl.tile.gather(src, indices, tmp)" in printed
+    # tmp keeps its declared full width; only `indices` and the result are halved.
+    assert "tmp: pl.Tile[[256, 128], pl.INT32" in printed
+    assert "picked: pl.Tile[[128, 128]" in printed
+
+
+def test_loop_carried_tile_accumulator_is_tracked():
+    """The AUTO path must repair loop carries, or it rejects a legal accumulator.
+
+    The AUTO arm recurses through its own affinity-gated walk rather than
+    ``ProcessStmts``, so it never reached the ``ForStmt`` carry repair. The
+    ``iter_arg`` then stayed full width and untracked while its init was halved,
+    and the ``tile.add`` on the carry was reported as a full-width operand — a
+    legal program failing to compile. Existing loop coverage carried only
+    ``Tensor`` iter_args, which are never halved and so never showed this.
+    """
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def split_auto(
+            cube_seed: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat],
+            data: pl.Tensor[[128, 128], pl.FP32],
+            out_0: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+        ) -> pl.Tensor[[128, 128], pl.FP32]:
+            seed_vec = pl.tile.move(cube_seed, target_memory=pl.Mem.Vec)  # noqa: F841
+            accum = pl.tile.load(data, [0, 0], [128, 128], target_memory=pl.Mem.Vec)
+            for i, (acc_it,) in pl.range(2, init_values=(accum,)):  # noqa: B007
+                acc_next = pl.tile.add(acc_it, acc_it)
+                acc_loop = pl.yield_(acc_next)
+            out_store = pl.tile.store(acc_loop, [0, 0], out_0)
+            return out_store
+
+    printed = _lower(Before).as_python()
+    # The carry and everything derived from it are lane-local.
+    assert "pl.tile.add(acc_it, acc_it)" in printed
+    assert printed.count("[64, 128]") >= 3
+    # The store on the loop-exit var picks up the per-lane offset.
+    assert "subblock_idx * 64" in printed
+
+
+def test_slice_drop_dims_maps_the_result_axis_back_to_the_source_axis():
+    """shape / offset / valid_shape are indexed in the PRE-DROP rank.
+
+    ``drop_dims`` erases axes from the result after those tuples are built, so
+    ``slice([1, 256, 128], drop_dims=[0]) -> [256, 128]`` puts the result's dim 0
+    on the source's dim 1. Halving the source's dim 0 instead left the node
+    disagreeing with its own arguments, and the type-consistency check then
+    rejected a legal split.
+    """
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def split_auto(
+            cube_seed: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat],
+            data: pl.Tensor[[1, 256, 128], pl.FP32],
+            out_0: pl.Out[pl.Tensor[[256, 128], pl.FP32]],
+        ) -> pl.Tensor[[256, 128], pl.FP32]:
+            seed_vec = pl.tile.move(cube_seed, target_memory=pl.Mem.Vec)  # noqa: F841
+            v = pl.tile.load(data, [0, 0, 0], [1, 256, 128], target_memory=pl.Mem.Vec)
+            sl = pl.tile.slice(v, [1, 256, 128], [0, 0, 0], drop_dims=[0])
+            out_store = pl.tile.store(sl, [0, 0], out_0)
+            return out_store
+
+    printed = _lower(Before).as_python()
+    # The halved extent and the lane offset both land on source axis 1, not 0.
+    assert "pl.tile.slice(v, [1, 128, 128], [0, 0 + subblock_idx * 128, 0]" in printed
+
+
+def test_slice_drop_dims_maps_across_two_dropped_axes():
+    """Two dropped axes, so the mapping has to walk past both.
+
+    The mapping consumes ``drop_dims`` with a single cursor, relying on
+    ``ParseSliceDropDims`` returning the axes ascending. One dropped axis cannot
+    tell that cursor apart from one that never advances — both land on the same
+    answer — so the shift only shows up once a second axis is dropped:
+    ``slice([1, 1, 256, 128], drop_dims=[0, 1]) -> [256, 128]`` puts the result's
+    dim 0 on the source's dim 2.
+    """
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def split_auto(
+            cube_seed: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat],
+            data: pl.Tensor[[1, 1, 256, 128], pl.FP32],
+            out_0: pl.Out[pl.Tensor[[256, 128], pl.FP32]],
+        ) -> pl.Tensor[[256, 128], pl.FP32]:
+            seed_vec = pl.tile.move(cube_seed, target_memory=pl.Mem.Vec)  # noqa: F841
+            v = pl.tile.load(data, [0, 0, 0, 0], [1, 1, 256, 128], target_memory=pl.Mem.Vec)
+            sl = pl.tile.slice(v, [1, 1, 256, 128], [0, 0, 0, 0], drop_dims=[0, 1])
+            out_store = pl.tile.store(sl, [0, 0], out_0)
+            return out_store
+
+    printed = _lower(Before).as_python()
+    # Source axis 2 carries the halved extent and the lane offset; 0 and 1 are dropped.
+    assert "pl.tile.slice(v, [1, 1, 128, 128], [0, 0, 0 + subblock_idx * 128, 0]" in printed
+
+
+def test_scatter_update_partitioned_destination_is_rejected():
+    """The scatter dual addresses a DESTINATION by absolute index.
+
+    ``tile.scatter_update`` takes its result from ``input`` and writes rows named
+    by absolute ``index`` values, so a partitioned ``input`` is written at the
+    wrong offsets. The symmetry with ``tile.gather`` is only apparent: gather may
+    keep a full-width source, whereas here the destination is what must stay
+    whole, and ``index`` / ``src`` remain ordinary per-lane data.
+    """
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def split_auto(
+            x: pl.Tensor[[256, 128], pl.FP32],
+            index: pl.Tile[[256, 128], pl.INT32, pl.Mem.Vec],
+            values: pl.Tile[[256, 128], pl.FP32, pl.Mem.Vec],
+            rhs: pl.Tile[[128, 128], pl.FP32, pl.Mem.Right],
+            out_0: pl.Out[pl.Tensor[[256, 128], pl.FP32]],
+        ) -> pl.Tensor[[256, 128], pl.FP32]:
+            base = pl.tile.load(x, [0, 0], [256, 128], target_memory=pl.Mem.Vec)
+            upd = pl.tile.scatter_update(base, index, values, dim=-2)
+            gathered_mat = pl.tile.move(upd, target_memory=pl.Mem.Mat)
+            left = pl.tile.move(gathered_mat, target_memory=pl.Mem.Left)
+            acc = pl.tile.matmul(left, rhs)
+            out_store = pl.tile.store(acc, [0, 0], out_0)
+            return out_store
+
+    with pytest.raises(ValueError, match="ABSOLUTE indices") as exc_info:
+        _lower(Before)
+    message = str(exc_info.value)
+    assert "destination operand 'base'" in message
+    assert "writes to the wrong half" in message
+
+
+@pytest.mark.parametrize("ascend_backend", [_backend.BackendType.Ascend950], indirect=True)
+def test_tensor_gather_in_a_split_region_is_diagnosed_through_the_pipeline(ascend_backend):
+    """The user-level path reaches the guard, not just hand-written tile IR.
+
+    ``pl.gather`` over a tensor lowers to a ``tile.load`` of the table feeding
+    ``tile.gather`` (`op_conversion_registry.cpp`), and only then does
+    ``LowerAutoVectorSplit`` run — so the table is produced *inside* the split
+    region as a matter of course, and this is the ordinary A5 spelling rather
+    than a hand-built corner. Driving the real pipeline is what proves the guard
+    is reachable the way an author would hit it; the tile-level tests above pass
+    the table as a parameter, which is exactly the shape that never gets halved.
+    """
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def main(
+            tbl: pl.Tensor[[256, 128], pl.FP32],
+            idx: pl.Tensor[[256, 128], pl.INT32],
+            w: pl.Tensor[[128, 128], pl.FP32],
+            out_0: pl.Out[pl.Tensor[[256, 128], pl.FP32]],
+        ) -> pl.Tensor[[256, 128], pl.FP32]:
+            picked = pl.gather(tbl, dim=-1, index=idx)
+            acc = pl.matmul(picked, w)
+            out_0[0:256, 0:128] = acc
+            return out_0
+
+    manager = PassManager(OptimizationStrategy.Default)
+    with pytest.raises(ValueError, match="ABSOLUTE indices") as exc_info:
+        with passes.PassContext([]):
+            manager.run_passes(Before)
+    # The operand named is the tile.load the tensor->tile conversion synthesized.
+    assert "tile.gather" in str(exc_info.value)
+
+
+def test_transpose_view_of_full_width_source_is_rejected():
+    """An axis-permuting view does not obey the broadcast right-alignment.
+
+    ``tile.transpose_view`` swaps the trailing two dims, so an untracked
+    ``[1, 256]`` source under ``UP_DOWN`` presents a *singleton* on the axis the
+    right-alignment maps the result's split dim onto — condition (1) accepts it.
+    The halved ``[128, 1]`` result then contradicts the ``[256, 1]`` the operand
+    deduces, and only condition (2) catches that. Unlike ``tile.transpose``, this
+    is a pure view and is outside ``FindTransposeSplitHazard``.
+    """
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def split_auto(
+            cube_seed: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat],
+            data: pl.Tile[[1, 256], pl.FP32, pl.Mem.Vec],
+            out_0: pl.Out[pl.Tensor[[256, 1], pl.FP32]],
+        ) -> pl.Tensor[[256, 1], pl.FP32]:
+            seed_vec = pl.tile.move(cube_seed, target_memory=pl.Mem.Vec)  # noqa: F841
+            viewed = pl.tile.transpose_view(data)
+            out_store = pl.tile.store(viewed, [0, 0], out_0)
+            return out_store
+
+    with pytest.raises(ValueError, match="no longer matches type inference") as exc_info:
+        _lower(Before)
+    assert "tile.transpose_view" in str(exc_info.value)
+
+
+# The full-width-operand guard matches operands to the result from the RIGHT, the
+# alignment BroadcastShapes gives ``tile.add([M, N], [N]) -> [M, N]``. The three
+# tests below pin both answers that alignment produces for the same [128] bias,
+# plus the same-rank singleton it must not be confused with. Indexing the operand
+# with the result's ABSOLUTE split dim gets both directions wrong: it rejects the
+# legal shared bias under UP_DOWN, and under LEFT_RIGHT it reads the index as out
+# of range and skips the operand that does span the split axis.
+
+
+def test_rank1_broadcast_operand_off_the_split_axis_is_shared():
+    """A [128] bias right-aligns to dim 1, so UP_DOWN leaves it whole.
+
+    The bias has no axis of its own on the split dim, so both AIV lanes read it
+    entire while the ``tile.add`` result still halves to [128, 128].
+    """
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def split_auto(
+            x: pl.Tensor[[256, 128], pl.FP32],
+            bias: pl.Tile[[128], pl.FP32, pl.Mem.Vec],
+            rhs: pl.Tile[[128, 128], pl.FP32, pl.Mem.Right],
+            out_0: pl.Out[pl.Tensor[[256, 128], pl.FP32]],
+        ) -> pl.Tensor[[256, 128], pl.FP32]:
+            v = pl.tile.load(x, [0, 0], [256, 128], target_memory=pl.Mem.Vec)
+            vec_h = pl.tile.add(v, bias)
+            gathered_mat = pl.tile.move(vec_h, target_memory=pl.Mem.Mat)
+            left = pl.tile.move(gathered_mat, target_memory=pl.Mem.Left)
+            acc = pl.tile.matmul(left, rhs)
+            out_store = pl.tile.store(acc, [0, 0], out_0)
+            return out_store
+
+    @pl.program
+    class Expected:
+        @pl.function(
+            type=pl.FunctionType.InCore,
+            attrs={"split": pl.SplitMode.UP_DOWN, "split_aiv": True},
+        )
+        def split_auto(
+            x: pl.Tensor[[256, 128], pl.FP32],
+            bias: pl.Tile[[128], pl.FP32, pl.Mem.Vec],
+            rhs: pl.Tile[[128, 128], pl.FP32, pl.Mem.Right],
+            out_0: pl.Out[pl.Tensor[[256, 128], pl.FP32]],
+        ) -> pl.Tensor[[256, 128], pl.FP32]:
+            subblock_idx = pl.tile.get_subblock_idx()
+            v = pl.tile.load(x, [0 + subblock_idx * 128, 0], [128, 128], [128, 128], target_memory=pl.Mem.Vec)
+            vec_h = pl.tile.add(v, bias)
+            gathered_mat_mat = pl.tile.aic_gather(vec_h, split=1)
+            gathered_mat = pl.tile.move(gathered_mat_mat, target_memory=pl.Mem.Mat)
+            left = pl.tile.move(gathered_mat, target_memory=pl.Mem.Left)
+            acc = pl.tile.matmul(left, rhs)
+            out_store = pl.tile.store(acc, [0, 0], out_0)
+            return out_store
+
+    ir.assert_structural_equal(_lower(Before), Expected)
+
+
+def test_rank1_broadcast_operand_on_the_split_axis_is_rejected():
+    """The SAME [128] bias right-aligns onto dim 1, which LEFT_RIGHT splits.
+
+    Nothing partitions the bias, so halving only the add's result would emit
+    ``tile.add([128, 64], [128]) -> [128, 64]``. The operand must be reported on
+    its OWN axis 0, not skipped as out of range.
+    """
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.LEFT_RIGHT})
+        def split_auto(
+            x: pl.Tensor[[256, 128], pl.FP32],
+            bias: pl.Tile[[128], pl.FP32, pl.Mem.Vec],
+            rhs: pl.Tile[[128, 128], pl.FP32, pl.Mem.Right],
+            out_0: pl.Out[pl.Tensor[[256, 128], pl.FP32]],
+        ) -> pl.Tensor[[256, 128], pl.FP32]:
+            v = pl.tile.load(x, [0, 0], [256, 128], target_memory=pl.Mem.Vec)
+            vec_h = pl.tile.add(v, bias)
+            gathered_mat = pl.tile.move(vec_h, target_memory=pl.Mem.Mat)
+            left = pl.tile.move(gathered_mat, target_memory=pl.Mem.Left)
+            acc = pl.tile.matmul(left, rhs)
+            out_store = pl.tile.store(acc, [0, 0], out_0)
+            return out_store
+
+    with pytest.raises(ValueError, match="carries a full-width operand") as exc_info:
+        _lower(Before)
+    message = str(exc_info.value)
+    assert "'bias'" in message
+    # Reported on the OPERAND's own axis, which is 0 here, not the result's 1.
+    assert "on its dim 0" in message
+
+
+def test_same_rank_singleton_operand_is_shared():
+    """A same-rank [1, 128] bias is replicated, not partitioned.
+
+    This is the other accepting branch and must not be confused with the
+    right-alignment one: the axis exists, it is simply singleton.
+    """
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def split_auto(
+            x: pl.Tensor[[256, 128], pl.FP32],
+            bias: pl.Tile[[1, 128], pl.FP32, pl.Mem.Vec],
+            rhs: pl.Tile[[128, 128], pl.FP32, pl.Mem.Right],
+            out_0: pl.Out[pl.Tensor[[256, 128], pl.FP32]],
+        ) -> pl.Tensor[[256, 128], pl.FP32]:
+            v = pl.tile.load(x, [0, 0], [256, 128], target_memory=pl.Mem.Vec)
+            vec_h = pl.tile.add(v, bias)
+            gathered_mat = pl.tile.move(vec_h, target_memory=pl.Mem.Mat)
+            left = pl.tile.move(gathered_mat, target_memory=pl.Mem.Left)
+            acc = pl.tile.matmul(left, rhs)
+            out_store = pl.tile.store(acc, [0, 0], out_0)
+            return out_store
+
+    @pl.program
+    class Expected:
+        @pl.function(
+            type=pl.FunctionType.InCore,
+            attrs={"split": pl.SplitMode.UP_DOWN, "split_aiv": True},
+        )
+        def split_auto(
+            x: pl.Tensor[[256, 128], pl.FP32],
+            bias: pl.Tile[[1, 128], pl.FP32, pl.Mem.Vec],
+            rhs: pl.Tile[[128, 128], pl.FP32, pl.Mem.Right],
+            out_0: pl.Out[pl.Tensor[[256, 128], pl.FP32]],
+        ) -> pl.Tensor[[256, 128], pl.FP32]:
+            subblock_idx = pl.tile.get_subblock_idx()
+            v = pl.tile.load(x, [0 + subblock_idx * 128, 0], [128, 128], [128, 128], target_memory=pl.Mem.Vec)
+            vec_h = pl.tile.add(v, bias)
+            gathered_mat_mat = pl.tile.aic_gather(vec_h, split=1)
+            gathered_mat = pl.tile.move(gathered_mat_mat, target_memory=pl.Mem.Mat)
+            left = pl.tile.move(gathered_mat, target_memory=pl.Mem.Left)
+            acc = pl.tile.matmul(left, rhs)
+            out_store = pl.tile.store(acc, [0, 0], out_0)
+            return out_store
+
+    ir.assert_structural_equal(_lower(Before), Expected)
 
 
 def test_vc_boundary_gathers_on_the_migrated_split_axis():


### PR DESCRIPTION
## Summary

`LowerAutoVectorSplit` halved a VECTOR-affine op's result type to the per-lane extent without checking that the op's tile operands were already lane-local. When an operand was still full width — typically an `InCore` parameter nothing inside the split region shards — the pass emitted `tile.add([256, 128], [256, 128]) -> [128, 128]`: a node whose declared shape contradicts type inference over its own arguments. That IR does not survive print→parse and misleads every later consumer that re-derives types from operands. Authors now get an actionable diagnostic at the offending statement instead of silently miscompiled IR.

**This revision replaces the earlier declaration-first design** (see #2612). The gate is now the operator's own `f_deduce_type`, and registry metadata is consulted only where that check is provably blind.

Behavior change: a split region that previously produced ill-typed IR from a full-width operand is now rejected at compile time with a `ValueError`, as is a `tile.reshape` whose full-width source carries a dynamic split extent. No in-contract program changes behavior. No interface or migration step.

## The model

| | Decided by | Covers |
| - | ---------- | ------ |
| **1. Type consistency** | the operator's own `f_deduce_type` — no metadata | 57 of the 77 operators with >1 tile operand |
| **2. Blind-operand backstop** | a registry declaration, reached only where (1) is silent | the remaining 20 |
| **3. Absolute indexing** | a registry declaration, always | `gather`/`gatherb` src, `scatter`/`scatter_update` dst |

**(1)** Re-deduce the result from the arguments the halved node will actually carry — each tracked operand swapped for its halved replacement — and refuse to emit one whose declared result contradicts them. This asks the operator, so it needs no per-operator metadata and cannot go stale. It rejects the `tile.add` case above, a rank-1 bias that broadcasts over the split axis under `UP_DOWN` but spans it under `LEFT_RIGHT`, `tile.row_argmax`'s shape-matched `tmp`, and an axis-permuting `tile.transpose_view`.

**(2)** A deducer that never reads an operand's extent says nothing by accepting it. `tile.sel` deduces its result from `lhs`/`rhs` alone and checks only that `mask` is a `TileType`, so a full-width mask over halved lhs/rhs re-deduces cleanly while both lanes read mask rows `0..127`; `tile.sels` validates only that the mask *covers* `src`. The pass detects that per call, again without metadata: re-deduce once more with the operand **doubled** on the split axis. Throws or a changed result ⇒ the deducer pins the operand and (1) already decided it; unchanged ⇒ blind, and only a declaration can say whether full width is in contract. Doubling rather than halving is what makes a bounded-below contract read as blind instead of as a pin.

**(3)** Being lane-invariant is not a rewrite: nothing stops the operand's own producer from being halved. For `gather`'s table and `scatter`'s destination the index values are absolute, so a partitioned producer is the defect. `tensor.gather` lowers to exactly `tile.load` + `tile.gather`, so that is the ordinary path — and no other gate sees it, since the operand is tracked and the result type is deduced from the index operand. Not type-expressible in either direction, so these stay declared.

### Why the order matters

Running the full-width check over *every* operand is what made it need a declaration on each operand that is legally full width, purely to suppress a check that had no business running. Restricting it to blind operands removes that class of false rejection outright — and makes a wrong declaration detectable instead of load-bearing.

Three declarations turned out to be unreachable and are dropped:

| Declaration | Why it could never fire |
| ----------- | ----------------------- |
| `tile.rsqrt` arg 1 | `DeduceTileRsqrtType` requires `tmp` to match the input rank and every dimension — the declaration claimed "full width is fine here" while the operator rejects that width |
| `tile.ci` arg 2 | the auto-split path refuses `tile.ci` outright, and its deducer pins the tmp anyway |
| `tile.mrgsort_format2` arg 4 | the deducer reads it in the 5-argument form where it exists |

## Changes

- `src/ir/transforms/utils/split_axis_utils.cpp`:
  - `HalvedCallStaysTypeConsistent` becomes the primary gate, running before the operand check rather than after it. On failure it names the full-width operand when there is one; `FindFullWidthOperand` runs **without** a probe there, purely to refine the message, so a misjudged axis costs a wrong number in the text rather than a rejected program.
  - `DeducerPinsOperandExtent` — the doubling probe. `FindFullWidthOperand` takes it as an optional argument: with it the function is a gate, without it a diagnostic.
  - One `FullWidthOperandDiagnostic` builder shared by both rejection paths.
  - Reject a dynamic split extent on a `tile.reshape` over a full-width source, as `tile.reinterpret_view` already did. The per-lane slice that partitions such a source can only be materialized from a static half extent; without it the reshape fell through to plain result halving — the offsetless-view miscompile the full view + slice diversion exists to prevent.
  - Map a `tile.slice` result axis back through `drop_dims` before halving `shape` / `offset` / `valid_shape`: those carry the pre-drop rank, and `drop_dims` erases axes afterwards and pads back to 2D by *prepending* unit axes. The mapping walks `drop_dims` with a single merge cursor rather than a per-axis `std::find` — `ParseSliceDropDims` returns the axes ascending, in range and each at most once, so that is O(R + D) and makes the ordering assumption explicit. Both ranks are bounded by the tile rank, so this was never a throughput problem; it is the repeated-linear-lookup shape the pass-complexity rule rules out.
  - `RepairIterArgs` / `RepairReturnVars` extracted and shared, so the AUTO affinity-gated arm gets the loop-carry repair too. It recurses through its own walk and cannot reach `ProcessStmt`'s `ForStmt` branch, so it used to leave every `iter_arg` full width and untracked — a legal tile accumulator then had its carry reported as a full-width operand.
- `src/ir/transforms/lower_auto_vector_split_pass.cpp`: run the per-region transpose-hazard check before halving rather than after, so its more specific diagnostic still wins on a statement that is also an un-sharded operand.
- `include/pypto/ir/op_registry.h`: `LaneInvariantArg`, `OpLaneInvariantArgSpec`, `set_lane_invariant_arg`, documented as covering *only* what type deduction cannot decide.
- `python/bindings/modules/ir.cpp`, `python/pypto/pypto_core/ir.pyi`: `get_op_lane_invariant_arg` + the `LaneInvariantArg` enum.
- `src/ir/op/tile_ops/*.cpp`: the declarations, and a comment at each place one is deliberately absent saying which check decides it instead.
- `tests/ut/ir/operators/test_lane_invariant_arg_coverage.py` (new): runs the measurement over every registered tile operator and asserts three things — the probe still reaches the operators it claims to, the set of blind operands is unchanged, and no `Scratch` declaration names an operand the deducer pins. A new operator or a loosened deducer therefore has to be classified rather than falling through silently. This is the coverage check #2612 asks for.
- `tests/ut/ir/transforms/test_lower_auto_vector_split.py`: `test_vector_op_rejects_unsharded_full_width_operand`, the three right-alignment cases, `test_scratch_the_deducer_pins_needs_no_declaration` (pins the case a declaration must *not* cover), `test_sel_full_width_mask_is_rejected` / `test_sels_...`, the gather/scatter partitioned-producer cases, the tuple-result case, `test_dynamic_full_width_reshape_is_rejected`, and the `drop_dims` axis mapping.
- `tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py`: the `tile.aic_gather` oracle fixture encoded the defect and had to suppress the print→parse roundtrip to pass. Source its vector value from a `tile.load` inside the region, and re-enable the roundtrip.
- `docs/{en,zh}/dev/passes/21-lower_auto_vector_split.md`: the two conditions, what each decides, and when a declaration is required.

## Verification

Run at the pushed commit (`ddb6820`, rebased onto `777e222`), in a worktree-local build:

- `pytest tests/ut/ -q -n 16 -p no:randomly`: 11053 passed, 8 skipped, 1 xfailed, 1 failed. The single failure is `tests/ut/language/test_unified_ops.py::TestUnifiedSlicePadValue::test_symlinked_import_path_still_names_the_caller`, which fails identically on an unmodified checkout of this machine: the editable install's meta-path finder hijacks the subprocess's symlinked `import pypto`. It touches no code in this range.
- `pytest tests/ut/ir/transforms/ tests/ut/ir/operators/ tests/ut/codegen/ -q -n 16 -p no:randomly`: 6043 passed, 2 skipped.
- 12 `tests/lint/` checks (headers, english-only, broad-raises, op-name-literals, emitter-check-classification, docs en↔zh parity, docs nav, function-attr-key parity, IR-property parity, property-set doc parity, op-docstring parity, docs symbol coverage): all passed.
- `clang-format --dry-run --Werror` and `ruff check` / `ruff format --check` on the changed sources: passed.

Two measurements back the design rather than assert it:

- Disabling the full-width operand check and leaving only type consistency turns 339 passing tests into 5 failures — and **3 of the 5 are still rejected**, by the type-consistency check, with different wording (`tile.add` under both split modes, and `row_argmax`'s tmp). Only `tile.sel` / `tile.sels`' masks genuinely escape, which is exactly the blind class condition 2 exists for.
- Probing all 77 operators with more than one tile operand (double one operand on one axis, ask the deducer again) finds 39 blind `(operator, argument)` positions across 20 operators; 74 operators reach a baseline, and the 3 that do not are named with a reason. That inventory is now the checked-in expectation in the new test.

No system tests were run locally; CI covers them.

Closes #2203
