### PR TITLE
fix(runtime): forward ring config through execute_compiled

### DIFF
--- a/docs/en/dev/05-runtime-ring-sizing.md
+++ b/docs/en/dev/05-runtime-ring-sizing.md
@@ -4,7 +4,7 @@ PyPTO exposes Simpler's per-task ring sizing as three optional overrides on
 [`RunConfig`](../../../python/pypto/runtime/runner.py). They let you size the
 runtime's per-task ring resources for a single dispatch without touching the
 compiled artifact or any global state. This works on both the L2 single-chip
-path (`run()` / `ChipWorker.run()`) and the L3 distributed path
+path (`run()` / `execute_compiled()` / `ChipWorker.run()`) and the L3 distributed path
 (`DistributedWorker.run()` / the one-shot `compiled(...)`).
 
 The runtime keeps its task-launch resources in *ring buffers*. Each override
@@ -57,7 +57,7 @@ than raising an opaque `TypeError` from the power-of-two check.
 
 ## Usage
 
-### L2 single-chip (`run`)
+### L2 single-chip (`run` / `execute_compiled`)
 
 ```python
 from pypto.runtime import run, RunConfig
@@ -73,6 +73,26 @@ compiled = run(
     ),
 )
 ```
+
+The directory-driven entry point accepts the same per-dispatch config. Its
+existing explicit `platform`, `device_id`, DFX, and AICPU arguments keep their
+current precedence; `config` carries the ring overrides that previously had no
+route to `CallConfig.runtime_env`:
+
+```python
+from pypto.runtime import RunConfig, execute_compiled
+
+execute_compiled(
+    work_dir,
+    [a, b, c],
+    platform="a2a3",
+    device_id=0,
+    config=RunConfig(platform="a2a3", ring_heap=512 * 1024 * 1024),
+)
+```
+
+The same ring sizing is used for worker prewarm, the device dispatch, and the
+dependency-capture subprocess used by onboard swimlane collection.
 
 ### L3 distributed (`DistributedWorker` / `compiled(...)`)
 

--- a/docs/en/dev/05-runtime-ring-sizing.md
+++ b/docs/en/dev/05-runtime-ring-sizing.md
@@ -18,9 +18,15 @@ applied per dispatch on top of the program's `DistributedConfig` baseline
 
 | `RunConfig` field | `CallConfig.runtime_env` member | Controls | Constraint |
 | ----------------- | ------------------------------- | -------- | ---------- |
-| `ring_task_window: int \| None` | `ring_task_window` | Number of in-flight task slots in the task ring | power of 2, `>= 4` |
-| `ring_heap: int \| None` | `ring_heap` | Bytes of the per-ring task-output heap | power of 2, `>= 1024` |
-| `ring_dep_pool: int \| None` | `ring_dep_pool` | Dependency-edge pool capacity | `[4, INT32_MAX]` |
+| `ring_task_window: int \| list[int] \| tuple[int, ...] \| None` | `ring_task_window` | Number of in-flight task slots in the task ring | power of 2, `>= 4` |
+| `ring_heap: int \| list[int] \| tuple[int, ...] \| None` | `ring_heap` | Bytes of the per-ring task-output heap | power of 2, `>= 1024` |
+| `ring_dep_pool: int \| list[int] \| tuple[int, ...] \| None` | `ring_dep_pool` | Dependency-edge pool capacity | `[4, INT32_MAX]` |
+
+Each field accepts either a scalar, which is broadcast to every scope-depth
+ring, or a list/tuple of exactly four entries for rings 0 through 3. In the
+per-ring form, `0` leaves that ring at its runtime default; every nonzero entry
+must satisfy the constraint in the table. Scalar `0` is invalid—use `None` to
+leave the entire field unset.
 
 `None` (the default) leaves the field **unset** (`0` on `CallConfig`). PyPTO
 writes the value into `CallConfig.runtime_env` only when it is not `None`, so an

--- a/docs/zh/dev/05-runtime-ring-sizing.md
+++ b/docs/zh/dev/05-runtime-ring-sizing.md
@@ -16,9 +16,14 @@ Simpler 的 `CallConfig.runtime_env` 上的同名字段一一对应，并且按 
 
 | `RunConfig` 字段 | `CallConfig.runtime_env` 成员 | 作用 | 约束 |
 | ---------------- | ----------------------------- | ---- | ---- |
-| `ring_task_window: int \| None` | `ring_task_window` | task ring 中在途 task slot 的数量 | 2 的幂，`>= 4` |
-| `ring_heap: int \| None` | `ring_heap` | 每个 ring 的 task 输出堆字节数 | 2 的幂，`>= 1024` |
-| `ring_dep_pool: int \| None` | `ring_dep_pool` | 依赖边池容量 | `[4, INT32_MAX]` |
+| `ring_task_window: int \| list[int] \| tuple[int, ...] \| None` | `ring_task_window` | task ring 中在途 task slot 的数量 | 2 的幂，`>= 4` |
+| `ring_heap: int \| list[int] \| tuple[int, ...] \| None` | `ring_heap` | 每个 ring 的 task 输出堆字节数 | 2 的幂，`>= 1024` |
+| `ring_dep_pool: int \| list[int] \| tuple[int, ...] \| None` | `ring_dep_pool` | 依赖边池容量 | `[4, INT32_MAX]` |
+
+每个字段都可传入标量（广播到所有 scope-depth ring），或包含恰好四项的 list/tuple
+（依次配置 ring 0 到 ring 3）。在逐 ring 形式中，`0` 表示该 ring 保持运行时默认值；
+每个非零项必须满足表中的约束。标量 `0` 无效——若要让整个字段保持未设置，请使用
+`None`。
 
 `None`（默认值）表示该字段 **未设置**（在 `CallConfig` 上为 `0`）。PyPTO 仅在值
 不为 `None` 时才写入 `CallConfig.runtime_env`，因此未设置的字段完全交由运行时

--- a/docs/zh/dev/05-runtime-ring-sizing.md
+++ b/docs/zh/dev/05-runtime-ring-sizing.md
@@ -3,7 +3,7 @@
 PyPTO 通过 [`RunConfig`](../../../python/pypto/runtime/runner.py) 上的三个可选
 覆盖项暴露 Simpler 的单任务 ring 尺寸配置。它们让你在单次派发中为运行时的
 单任务 ring 资源设置尺寸，而无需改动已编译产物或任何全局状态。该能力同时适用于
-L2 单 chip 路径（`run()` / `ChipWorker.run()`）和 L3 分布式路径
+L2 单 chip 路径（`run()` / `execute_compiled()` / `ChipWorker.run()`）和 L3 分布式路径
 （`DistributedWorker.run()` / 一次性的 `compiled(...)`）。
 
 运行时把任务启动相关资源保存在 *ring buffer*（环形缓冲）中。每个覆盖项与
@@ -53,7 +53,7 @@ RunConfig(platform="a2a3", ring_heap=1000)
 
 ## 用法
 
-### L2 单 chip（`run`）
+### L2 单 chip（`run` / `execute_compiled`）
 
 ```python
 from pypto.runtime import run, RunConfig
@@ -69,6 +69,25 @@ compiled = run(
     ),
 )
 ```
+
+目录驱动的入口同样接受单次派发配置。它原有的显式 `platform`、`device_id`、DFX 和
+AICPU 参数保持现有优先级；`config` 用来携带此前无法到达
+`CallConfig.runtime_env` 的 ring 覆盖项：
+
+```python
+from pypto.runtime import RunConfig, execute_compiled
+
+execute_compiled(
+    work_dir,
+    [a, b, c],
+    platform="a2a3",
+    device_id=0,
+    config=RunConfig(platform="a2a3", ring_heap=512 * 1024 * 1024),
+)
+```
+
+worker 预热、正式设备派发，以及板端 swimlane 收集使用的依赖捕获子进程，都会使用
+相同的 ring 尺寸。
 
 ### L3 分布式（`DistributedWorker` / `compiled(...)`）
 

--- a/python/pypto/ir/compiled_program.py
+++ b/python/pypto/ir/compiled_program.py
@@ -696,6 +696,7 @@ def _invoke_compiled(
         device_id=config.device_id,
         dfx=_DfxOpts.from_run_config(config),
         aicpu_thread_num=config.aicpu_thread_num,
+        config=config,
     )
 
     if not return_style:

--- a/python/pypto/runtime/_dep_gen_capture.py
+++ b/python/pypto/runtime/_dep_gen_capture.py
@@ -124,6 +124,10 @@ def main(argv: list[str]) -> int:
     if aicpu_thread_num is None:
         aicpu_thread_num = runtime_config.get("aicpu_thread_num")
 
+    from .runner import RunConfig  # noqa: PLC0415
+
+    config = RunConfig(platform=platform, **spec.get("ring_overrides", {}))
+
     dfx_dir.mkdir(parents=True, exist_ok=True)
     execute_on_device(
         chip_callable,
@@ -136,6 +140,7 @@ def main(argv: list[str]) -> int:
         enable_sdma=enable_sdma,
         output_prefix=str(dfx_dir),
         enable_dep_gen=True,
+        config=config,
     )
     return 0
 

--- a/python/pypto/runtime/debug/replay.py
+++ b/python/pypto/runtime/debug/replay.py
@@ -215,6 +215,7 @@ def replay(
             platform=config.platform,
             device_id=config.device_id,
             dfx=_DfxOpts.from_run_config(config),
+            config=config,
         )
 
     if named_tensors is not None:

--- a/python/pypto/runtime/device_runner.py
+++ b/python/pypto/runtime/device_runner.py
@@ -42,7 +42,7 @@ from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from importlib import import_module
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import torch
 
@@ -64,6 +64,9 @@ from .task_interface import (
     CoreCallable,  # pyright: ignore[reportAttributeAccessIssue]
     Worker,  # pyright: ignore[reportAttributeAccessIssue]
 )
+
+if TYPE_CHECKING:
+    from .runner import RunConfig
 
 logger = logging.getLogger(__name__)
 
@@ -689,6 +692,7 @@ def execute_on_device(  # noqa: PLR0913
     enable_pmu: int = 0,
     enable_dep_gen: bool = False,
     enable_scope_stats: bool = False,
+    config: RunConfig | None = None,
     runtime_env: dict[str, str] | None = None,
 ) -> None:
     """Execute *chip_callable* on device via Simpler's unified ``Worker``.
@@ -741,6 +745,11 @@ def execute_on_device(  # noqa: PLR0913
         enable_scope_stats: Capture per-scope ring-fill peaks
             (``scope_stats/scope_stats.jsonl``). Mirrors
             ``--enable-scope-stats``.
+        config: Optional per-dispatch :class:`pypto.runtime.RunConfig`.
+            Its ``ring_task_window``, ``ring_heap``, and ``ring_dep_pool``
+            overrides are copied to ``CallConfig.runtime_env`` before worker
+            prewarm and dispatch. Existing explicit arguments above retain
+            their current behavior and precedence.
         runtime_env: Optional per-example environment variable overrides.
             Applied around the device ``run`` call. When an active
             :class:`pypto.runtime.ChipWorker` is reused, ``init()`` has already
@@ -802,6 +811,10 @@ def execute_on_device(  # noqa: PLR0913
     cfg.enable_scope_stats = enable_scope_stats
     if output_prefix:
         cfg.output_prefix = output_prefix
+    if config is not None:
+        from .runner import _apply_ring_overrides  # noqa: PLC0415
+
+        _apply_ring_overrides(cfg, config)
 
     env = runtime_env or {}
     active = _PyptoWorker.current(

--- a/python/pypto/runtime/runner.py
+++ b/python/pypto/runtime/runner.py
@@ -1448,6 +1448,7 @@ def execute_compiled(  # noqa: PLR0913
     level: int = 2,
     aicpu_thread_num: int | None = None,
     analyze_auto_scopes_for_deps: bool = False,
+    config: RunConfig | None = None,
 ) -> None:
     """Execute a pre-compiled program with user-provided tensors and scalars.
 
@@ -1482,6 +1483,11 @@ def execute_compiled(  # noqa: PLR0913
             Accepted here so callers that reuse one config dictionary for
             compile and execute can pass it through safely. It has no effect
             after the program has already been compiled.
+        config: Optional per-dispatch :class:`RunConfig`. Its ring-sizing
+            fields are forwarded to ``CallConfig.runtime_env``. The existing
+            explicit ``platform``, ``device_id``, ``dfx``, and
+            ``aicpu_thread_num`` arguments keep their current behavior and
+            precedence.
 
     Device results are written back into the host tensors in *args* in
     place; per-run timing is no longer returned — read it from the runtime's
@@ -1531,6 +1537,7 @@ def execute_compiled(  # noqa: PLR0913
             enable_pmu=pass_dfx.enable_pmu,
             enable_dep_gen=pass_dfx.enable_dep_gen,
             enable_scope_stats=pass_dfx.enable_scope_stats,
+            config=config,
         )
 
     def _capture_deps() -> None:
@@ -1549,6 +1556,11 @@ def execute_compiled(  # noqa: PLR0913
                 "dfx_dir": str(dfx_dir),
                 "level": level,
                 "aicpu_thread_num": effective_aicpu_thread_num,
+                "ring_overrides": {
+                    "ring_task_window": config.ring_task_window if config is not None else None,
+                    "ring_heap": config.ring_heap if config is not None else None,
+                    "ring_dep_pool": config.ring_dep_pool if config is not None else None,
+                },
             },
             dfx_dir,
             run_id,

--- a/tests/ut/ir/test_compiled_program.py
+++ b/tests/ut/ir/test_compiled_program.py
@@ -336,7 +336,13 @@ class TestCompiledProgramCall:
         prog = _make_program_with_orchestration()
         cp = CompiledProgram(prog, str(tmp_path), platform="a2a3sim")
         args = (torch.zeros(128, 128), torch.zeros(128, 128), torch.zeros(128, 128))
-        config = RunConfig(platform="a2a3", device_id=3, enable_pmu=2, aicpu_thread_num=7)
+        config = RunConfig(
+            platform="a2a3",
+            device_id=3,
+            enable_pmu=2,
+            aicpu_thread_num=7,
+            ring_heap=512 * 1024 * 1024,
+        )
 
         with patch("pypto.runtime.runner.execute_compiled") as mock_exec:
             cp(*args, config=config)
@@ -345,6 +351,7 @@ class TestCompiledProgramCall:
         assert mock_exec.call_args.kwargs["device_id"] == 3
         assert mock_exec.call_args.kwargs["dfx"].enable_pmu == 2
         assert mock_exec.call_args.kwargs["aicpu_thread_num"] == 7
+        assert mock_exec.call_args.kwargs["config"] is config
 
     def test_no_config_uses_compiled_platform(self, tmp_path):
         prog = _make_program_with_orchestration()

--- a/tests/ut/runtime/test_replay.py
+++ b/tests/ut/runtime/test_replay.py
@@ -126,14 +126,16 @@ def test_replay_routes_to_execute_compiled(tmp_path: Path) -> None:
     work_dir = _make_build_output(tmp_path)
     a = torch.zeros(2)
     b = torch.zeros(2)
+    config = RunConfig(platform="a2a3sim", device_id=3, ring_heap=512 * 1024 * 1024)
     with patch.object(replay_module, "execute_compiled") as ec:
-        replay(work_dir, a, b, config=RunConfig(platform="a2a3sim", device_id=3))
+        replay(work_dir, a, b, config=config)
     ec.assert_called_once()
     call_args = ec.call_args
     assert call_args.args[0] == work_dir
     assert call_args.args[1] == [a, b]
     assert call_args.kwargs["platform"] == "a2a3sim"
     assert call_args.kwargs["device_id"] == 3
+    assert call_args.kwargs["config"] is config
 
 
 def test_replay_forwards_dfx_flags(tmp_path: Path) -> None:

--- a/tests/ut/runtime/test_run_config.py
+++ b/tests/ut/runtime/test_run_config.py
@@ -688,6 +688,7 @@ class TestRunConfigCompileForwarding:
 
     def test_execute_compiled_accepts_auto_scope_deps_switch(self, tmp_path, monkeypatch):
         captured: dict = {}
+        config = RunConfig(platform="a2a3sim", ring_heap=1024 * 1024)
 
         def fake_compile_and_assemble(_work_dir, platform):
             captured["compile"] = {"platform": platform}
@@ -708,11 +709,59 @@ class TestRunConfigCompileForwarding:
             platform="a2a3sim",
             device_id=0,
             analyze_auto_scopes_for_deps=True,
+            config=config,
         )
 
         assert captured["compile"]["platform"] == "a2a3sim"
         assert captured["execute"]["args"][3] == "fake_runtime"
         assert captured["execute"]["kwargs"]["aicpu_thread_num"] is None
+        assert captured["execute"]["kwargs"]["config"] is config
+
+    def test_execute_compiled_serializes_ring_config_for_dep_capture(self, tmp_path, monkeypatch):
+        captured: dict = {}
+
+        def fake_compile_and_assemble(_work_dir, _platform):
+            return object(), "fake_runtime", {}
+
+        def fake_execute_on_device(*_args, **kwargs):
+            captured["execute_config"] = kwargs["config"]
+
+        fake_device_runner = types.SimpleNamespace(
+            compile_and_assemble=fake_compile_and_assemble,
+            execute_on_device=fake_execute_on_device,
+        )
+        monkeypatch.setitem(sys.modules, "pypto.runtime.device_runner", fake_device_runner)
+
+        import pypto.runtime.runner as runner_mod  # noqa: PLC0415
+
+        monkeypatch.setattr(
+            runner_mod,
+            "_capture_deps_subprocess",
+            lambda spec, *_args: captured.update(spec=spec),
+        )
+        monkeypatch.setattr(runner_mod, "_collect_dfx_artifacts", lambda *_args: None)
+
+        config = RunConfig(
+            platform="a2a3",
+            ring_task_window=[16, 32, 64, 128],
+            ring_heap=512 * 1024 * 1024,
+            ring_dep_pool=[64, 0, 0, 256],
+        )
+        execute_compiled(
+            tmp_path,
+            [],
+            platform="a2a3",
+            device_id=0,
+            dfx=_DfxOpts(enable_chip_swimlane=True),
+            config=config,
+        )
+
+        assert captured["execute_config"] is config
+        assert captured["spec"]["ring_overrides"] == {
+            "ring_task_window": [16, 32, 64, 128],
+            "ring_heap": 512 * 1024 * 1024,
+            "ring_dep_pool": [64, 0, 0, 256],
+        }
 
     @pytest.mark.parametrize(
         ("runtime_config", "expected_enable_sdma"),

--- a/tests/ut/runtime/test_swimlane_two_pass.py
+++ b/tests/ut/runtime/test_swimlane_two_pass.py
@@ -18,11 +18,15 @@ host-register mappings between DFX runs. These tests drive
 """
 
 import ctypes
+import json
+import sys
+import types
 from pathlib import Path
 
 import pypto.runtime.runner as _runner
 import pytest
 import torch
+from pypto.runtime import _dep_gen_capture
 from pypto.runtime.device_tensor import DeviceTensor
 from pypto.runtime.runner import _build_args_spec, _DfxOpts, _execute_dfx_passes, _generate_swimlane
 
@@ -142,6 +146,47 @@ def test_build_args_spec_scalar(tmp_path):
 def test_build_args_spec_rejects_unknown_type(tmp_path):
     with pytest.raises(TypeError):
         _build_args_spec(["not an arg"], tmp_path)  # type: ignore[list-item]  # pyright: ignore[reportArgumentType]
+
+
+def test_dep_capture_reconstructs_ring_config(tmp_path, monkeypatch):
+    captured: dict = {}
+
+    def fake_compile_and_assemble(_work_dir, _platform):
+        return object(), "fake_runtime", {}
+
+    def fake_execute_on_device(*_args, **kwargs):
+        captured.update(kwargs)
+
+    fake_device_runner = types.ModuleType("pypto.runtime.device_runner")
+    fake_device_runner.compile_and_assemble = fake_compile_and_assemble  # type: ignore[attr-defined]
+    fake_device_runner.execute_on_device = fake_execute_on_device  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "pypto.runtime.device_runner", fake_device_runner)
+
+    spec_path = tmp_path / "capture.json"
+    spec_path.write_text(
+        json.dumps(
+            {
+                "mode": "argspec",
+                "args": [],
+                "work_dir": str(tmp_path),
+                "platform": "a2a3",
+                "device_id": 0,
+                "dfx_dir": str(tmp_path / "dfx"),
+                "ring_overrides": {
+                    "ring_task_window": [16, 32, 64, 128],
+                    "ring_heap": 512 * 1024 * 1024,
+                    "ring_dep_pool": [64, 0, 0, 256],
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert _dep_gen_capture.main([str(spec_path)]) == 0
+    config = captured["config"]
+    assert config.ring_task_window == [16, 32, 64, 128]
+    assert config.ring_heap == 512 * 1024 * 1024
+    assert config.ring_dep_pool == [64, 0, 0, 256]
 
 
 def _converter_argv(monkeypatch, work_dir: Path, swimlane_dir: Path) -> list[str]:


### PR DESCRIPTION
## Summary

- let execute_compiled accept and forward an optional RunConfig
- apply ring_task_window, ring_heap, and ring_dep_pool to CallConfig.runtime_env before worker prewarm and dispatch
- preserve the same ring sizing in CompiledProgram, replay, and the dependency-capture subprocess
- document the L2 work-dir API in English and Chinese and add regression coverage

## Compatibility and precedence

Existing explicit execute_compiled arguments remain authoritative for platform, device_id, DFX, and aicpu_thread_num. The forwarded config supplies the previously unreachable ring-sizing fields, so existing callers retain their behavior.

## Testing

- native RelWithDebInfo worktree build completed successfully
- full unit suite: 10849 passed, 63 skipped, 1 xfailed
- targeted runtime/IR regression suite: 245 passed, 5 skipped
- pre-commit hooks, Ruff, formatting, docs parity, Markdown, and Pyright passed

A real device dispatch was not run because the user-site _task_interface binding in this workspace is stale relative to the pinned Simpler checkout; the host-side tests cover forwarding, CallConfig overlay behavior, serialization, and child-process reconstruction.

Fixes #2586