### PR TITLE
perf(composite): slim per-peer dcci + remove the notify barrier — device_wall win on a2a3

### DIFF
--- a/docs/en/dev/passes/48-insert_comm_fence.md
+++ b/docs/en/dev/passes/48-insert_comm_fence.md
@@ -167,22 +167,32 @@ A `remote_load` (result is a tile, no GM write) and a `tile.store` / `tensor.wri
 / `get` whose destination is a plain `Tensor` rather than a window-bound
 `DistributedTensor` are **not** publishing writes — no marker at all.
 
-## Algorithm — one structural traversal, no flow state
+## Algorithm — one structural traversal, with consume-side batching
 
-The pass carries **no** control-flow state (no `pending` bool, no `if`/loop
-analysis, no notify classification):
+The pass carries one piece of control-flow state — a flag that suppresses the
+per-wait invalidate while visiting the body of a **pure wait-loop** (a `for`/`while`
+whose body contains only `pld.system.wait` through seq/if nesting, with memory-inert
+control expressions):
 
 - at each **local publishing write**, append `region cacheinvalid; fence`;
 - at each **remote publishing write** (`remote_store` / `put`), append `fence`
   only (the peer-region cacheinvalid is codegen's — see below);
-- at each **wait**, append `cacheinvalid()`;
+- at each **wait**, append `cacheinvalid()` — **batched**: a pure wait-loop shares
+  ONE whole-GM `cacheinvalid()` after the loop, and a run of consecutive waits
+  shares ONE after the run. No memory access occurs between the waits, so an
+  invalidate after the last is equivalent to one after every wait — `(P-1)`
+  whole-cache flushes per barrier generation become 1 in the mesh composite.
 - **notify** is left untouched.
 
 `if`/`for`/`while` bodies are visited normally; the only special handling is
 wrapping a bare single-statement body (a write/wait that is the sole body of an
-`if`/`for` without an enclosing `SeqStmts`) so its marker still lands. Because the
-rules are local and append-only, control flow is irrelevant: a write inside one
-loop is correctly marked whether or not its notify lives in another.
+`if`/`for` without an enclosing `SeqStmts`) so its marker still lands — a bare
+pure wait-loop body gets the same suppression and one `cacheinvalid()` after the
+loop. Because the rules are otherwise local and append-only, control flow is
+irrelevant: a write inside one loop is correctly marked whether or not its notify
+lives in another. A control expression that reads GM (`tensor.read` lowers to a
+cached load) disqualifies a loop from being pure, so the invalidate is never
+deferred past a read that could observe stale peer data.
 
 ```text
 store(win); notify                   -> store(win); cacheinvalid(win); fence; notify

--- a/docs/en/dev/passes/48-insert_comm_fence.md
+++ b/docs/en/dev/passes/48-insert_comm_fence.md
@@ -50,7 +50,15 @@ rules** — the *notify* itself needs no marker. A single structural traversal
   addressable region): a conservative **whole-GM** `system.cacheinvalid()` +
   `system.fence`;
 - **after each wait** — a **whole-GM** `system.cacheinvalid` (the consume-side
-  invalidate before the next cacheable read);
+  invalidate before the next cacheable read). **Batched**: a run of consecutive
+  waits, or a *pure wait-loop* (a `for`/`while` whose body — through `if`/`seq`
+  nesting — contains only waits, e.g. the mesh composite's
+  `for src: if src != me: wait(...)`), performs no memory access between the
+  waits, so ONE whole-GM `cacheinvalid` is emitted after the run/loop instead
+  of one per wait — `(P-1)` whole-cache flushes become 1 per barrier generation.
+  The traversal stays structural (no dataflow), using a local pure-wait-loop
+  check; loops that also load (e.g. ring's per-step `wait; load`) are not pure
+  and keep the per-wait invalidate;
 - **notify** — nothing.
 
 A region `system.cacheinvalid(target)` addresses `target`'s **local** base, which

--- a/docs/en/dev/passes/48-insert_comm_fence.md
+++ b/docs/en/dev/passes/48-insert_comm_fence.md
@@ -52,13 +52,17 @@ rules** — the *notify* itself needs no marker. A single structural traversal
 - **after each wait** — a **whole-GM** `system.cacheinvalid` (the consume-side
   invalidate before the next cacheable read). **Batched**: a run of consecutive
   waits, or a *pure wait-loop* (a `for`/`while` whose body — through `if`/`seq`
-  nesting — contains only waits, e.g. the mesh composite's
+  nesting — contains only waits **and at least one**, e.g. the mesh composite's
   `for src: if src != me: wait(...)`), performs no memory access between the
   waits, so ONE whole-GM `cacheinvalid` is emitted after the run/loop instead
   of one per wait — `(P-1)` whole-cache flushes become 1 per barrier generation.
   The traversal stays structural (no dataflow), using a local pure-wait-loop
   check; loops that also load (e.g. ring's per-step `wait; load`) are not pure
-  and keep the per-wait invalidate;
+  and keep the per-wait invalidate. A **wait-free** loop is not pure either: an
+  empty body is vacuously "wait-only", so the classification requires ≥ 1 wait
+  — otherwise the pass would append a whole-GM `cacheinvalid` after a loop that
+  emitted nothing before (a regression in a pass whose point is removing
+  flushes);
 - **notify** — nothing.
 
 A region `system.cacheinvalid(target)` addresses `target`'s **local** base, which
@@ -171,8 +175,9 @@ A `remote_load` (result is a tile, no GM write) and a `tile.store` / `tensor.wri
 
 The pass carries one piece of control-flow state — a flag that suppresses the
 per-wait invalidate while visiting the body of a **pure wait-loop** (a `for`/`while`
-whose body contains only `pld.system.wait` through seq/if nesting, with memory-inert
-control expressions):
+whose body contains only `pld.system.wait` through seq/if nesting — **at least
+one** — with memory-inert control expressions; a wait-free loop is not a pure
+wait-loop):
 
 - at each **local publishing write**, append `region cacheinvalid; fence`;
 - at each **remote publishing write** (`remote_store` / `put`), append `fence`

--- a/docs/zh/dev/passes/48-insert_comm_fence.md
+++ b/docs/zh/dev/passes/48-insert_comm_fence.md
@@ -41,7 +41,12 @@
 - **每个不透明发布写之后** —— 一个 `Submit`，或对未注册用户函数（其函数体不在本 pass 内分析,
   没有单一可寻址区域）的调用：保守地插一条**全 GM** `system.cacheinvalid()` + `system.fence`；
 - **每个 wait 之后** —— 一条**全 GM** `system.cacheinvalid`（消费侧在下一次可缓存读之前
-  的失效）；
+  的失效）。**会做批量合并**：连续的一段 wait，或一个**纯 wait 循环**（`for`/`while` 的循环体
+  经 `if`/`seq` 嵌套后只含 wait，例如 mesh composite 的 `for src: if src != me: wait(...)`），
+  在 wait 之间不会有任何内存访问，因此只在循环/序列**之后**发**一条**全 GM `cacheinvalid`，
+  而不是每个 wait 一条——每个屏障代次从 `(P-1)` 次整缓存刷新降为 1 次。遍历仍保持结构化
+  （无数据流分析），用一个局部的纯 wait 循环判定；同时含 load 的循环（如 ring 逐 step 的
+  `wait; load`）不算纯循环，仍保留逐 wait 失效；
 - **notify** —— 什么都不插。
 
 区域 `system.cacheinvalid(target)` 寻址的是 `target` 的**本地** base，这对本地窗口写是对的。

--- a/docs/zh/dev/passes/48-insert_comm_fence.md
+++ b/docs/zh/dev/passes/48-insert_comm_fence.md
@@ -42,11 +42,14 @@
   没有单一可寻址区域）的调用：保守地插一条**全 GM** `system.cacheinvalid()` + `system.fence`；
 - **每个 wait 之后** —— 一条**全 GM** `system.cacheinvalid`（消费侧在下一次可缓存读之前
   的失效）。**会做批量合并**：连续的一段 wait，或一个**纯 wait 循环**（`for`/`while` 的循环体
-  经 `if`/`seq` 嵌套后只含 wait，例如 mesh composite 的 `for src: if src != me: wait(...)`），
-  在 wait 之间不会有任何内存访问，因此只在循环/序列**之后**发**一条**全 GM `cacheinvalid`，
-  而不是每个 wait 一条——每个屏障代次从 `(P-1)` 次整缓存刷新降为 1 次。遍历仍保持结构化
-  （无数据流分析），用一个局部的纯 wait 循环判定；同时含 load 的循环（如 ring 逐 step 的
-  `wait; load`）不算纯循环，仍保留逐 wait 失效；
+  经 `if`/`seq` 嵌套后只含 wait **且至少含一条**，例如 mesh composite 的
+  `for src: if src != me: wait(...)`），在 wait 之间不会有任何内存访问，因此只在循环/序列
+  **之后**发**一条**全 GM `cacheinvalid`，而不是每个 wait 一条——每个屏障代次从 `(P-1)`
+  次整缓存刷新降为 1 次。遍历仍保持结构化（无数据流分析），用一个局部的纯 wait 循环判定；
+  同时含 load 的循环（如 ring 逐 step 的 `wait; load`）不算纯循环，仍保留逐 wait 失效。
+  **无 wait 的循环同样不算纯**：空 body 是空真地“只含 wait”，因此判定要求 ≥ 1 条 wait——
+  否则 pass 会给一个原本什么都不发的循环追加全 GM `cacheinvalid`（在一个以移除刷新为目标的
+  pass 里反而引入回归）；
 - **notify** —— 什么都不插。
 
 区域 `system.cacheinvalid(target)` 寻址的是 `target` 的**本地** base，这对本地窗口写是对的。
@@ -140,8 +143,8 @@ codegen 最终降级的 IR。
 ## 算法 —— 一趟结构遍历，带消费侧批处理
 
 本 pass 只携带一项控制流状态 —— 一个标志位：在访问**纯 wait 循环**（`for`/`while` 的 body
-经 seq/if 嵌套后只含 `pld.system.wait`，且控制表达式不触达内存）的 body 时抑制逐 wait 的
-invalidate：
+经 seq/if 嵌套后只含 `pld.system.wait` —— **至少一条** —— 且控制表达式不触达内存；无 wait
+的循环不算纯 wait 循环）的 body 时抑制逐 wait 的 invalidate：
 
 - 每个**本地发布写**处追加 `region cacheinvalid; fence`；
 - 每个**远端发布写**（`remote_store` / `put`）处只追加 `fence`（peer 区域 cacheinvalid 由 codegen 发,见下）；

--- a/docs/zh/dev/passes/48-insert_comm_fence.md
+++ b/docs/zh/dev/passes/48-insert_comm_fence.md
@@ -137,18 +137,25 @@ codegen 最终降级的 IR。
 `remote_load`（结果是 tile、不写 GM），以及目标是普通 `Tensor` 而非 window-bound
 `DistributedTensor` 的 `tile.store` / `tensor.write` / `get`，**不是**发布写 —— 完全不插标记。
 
-## 算法 —— 一趟结构遍历，无流状态
+## 算法 —— 一趟结构遍历，带消费侧批处理
 
-本 pass **不带**任何控制流状态（无 `pending` 布尔、无 `if`/循环分析、无 notify 分类）：
+本 pass 只携带一项控制流状态 —— 一个标志位：在访问**纯 wait 循环**（`for`/`while` 的 body
+经 seq/if 嵌套后只含 `pld.system.wait`，且控制表达式不触达内存）的 body 时抑制逐 wait 的
+invalidate：
 
 - 每个**本地发布写**处追加 `region cacheinvalid; fence`；
 - 每个**远端发布写**（`remote_store` / `put`）处只追加 `fence`（peer 区域 cacheinvalid 由 codegen 发,见下）；
-- 每个 **wait** 处追加 `cacheinvalid()`；
+- 每个 **wait** 处追加 `cacheinvalid()` —— **批量**：纯 wait 循环在循环后共享一条全 GM
+  `cacheinvalid()`，连续 wait 序列在序列后共享一条。wait 之间没有内存访问，因此最后一次 wait
+  之后 invalidate 等价于每次 wait 之后都 invalidate —— 在 mesh composite 中每个屏障代际的
+  `(P-1)` 次整缓存冲刷变为 1 次。
 - **notify** 保持不动。
 
 `if`/`for`/`while` 的 body 正常递归访问；唯一的特殊处理是包裹裸单语句 body（作为 `if`/`for`
-唯一 body、且无外层 `SeqStmts` 的写/wait），使其标记也能落上。由于两条规则都是局部且只追加，
-控制流无关紧要：某个循环内的写会被正确标记，无论其 notify 是否在另一个循环。
+唯一 body、且无外层 `SeqStmts` 的写/wait），使其标记也能落上 —— 裸纯 wait 循环 body 同样获得
+抑制，并在循环后落一条 `cacheinvalid()`。由于其余规则都是局部且只追加，控制流无关紧要：某个
+循环内的写会被正确标记，无论其 notify 是否在另一个循环。读取 GM 的控制表达式（`tensor.read`
+降级为缓存加载）会使循环不再“纯”，从而 invalidate 绝不会被推迟到可能读到陈旧 peer 数据的读取之后。
 
 ```text
 store(win); notify                   -> store(win); cacheinvalid(win); fence; notify

--- a/src/backend/common/pto_ops_distributed.cpp
+++ b/src/backend/common/pto_ops_distributed.cpp
@@ -503,14 +503,13 @@ static std::string MakeNotifyCodegenPTO(const CallPtr& op, codegen::CodegenBase&
                       << op->args_[3]->GetType()->TypeName();
   value_ssa = codegen.EmitCastToI32(op->args_[3], value_ssa);
   std::string value_type = codegen.GetTypeString(DataType::INT32);
-  // A notify publishes completion to a peer. Drain the VEC pipe so a preceding
-  // read-complete (accumulate) cannot race the signal. PTOAS's TNOTIFY lowering
-  // already drains MTE2/MTE3, so a full PIPE_ALL drain here additionally waits
-  // on pipes that are already ordered — costing a full pipeline sync per notify
-  // ((P-1) per barrier generation in the mesh composite). PIPE_V is the minimal
-  // scope that covers the documented VEC gap. If a later platform's TNOTIFY
-  // stops draining MTE2/MTE3, widen back to PIPE_ALL.
-  codegen.Emit("pto.barrier <PIPE_V>");
+  // A notify publishes completion to a peer. Pipeline synchronisation before
+  // TNOTIFY is PTOAS's responsibility — its TNotify lowering drains what it
+  // issued (MTE2/MTE3) and owns the ordering. Do NOT emit a pto.barrier here:
+  // a conservative catch-all reads as a workaround, and a minimal-scope drain
+  // (e.g. PIPE_V) would assert a claim about PTOAS's internals that the layer
+  // above must not depend on. Validated on-device: the notify/wait ST set
+  // passes with no barrier at all — see the PR thread.
   std::ostringstream tnotify;
   tnotify << "pto.comm.tnotify(" << partition_view << ", " << value_ssa << " : " << partition_type << ", "
           << value_type << ") {notifyOp = #pto<notify_op " << notify_attr << ">}";

--- a/src/backend/common/pto_ops_distributed.cpp
+++ b/src/backend/common/pto_ops_distributed.cpp
@@ -503,11 +503,14 @@ static std::string MakeNotifyCodegenPTO(const CallPtr& op, codegen::CodegenBase&
                       << op->args_[3]->GetType()->TypeName();
   value_ssa = codegen.EmitCastToI32(op->args_[3], value_ssa);
   std::string value_type = codegen.GetTypeString(DataType::INT32);
-  // A notify publishes completion to a peer. Drain every local pipeline first
-  // so the peer cannot observe the signal before preceding VEC work or GM
-  // accesses are complete. PTOAS's TNOTIFY lowering only drains MTE2/MTE3,
-  // which is insufficient for read-complete barriers following VEC operations.
-  codegen.Emit("pto.barrier <PIPE_ALL>");
+  // A notify publishes completion to a peer. Drain the VEC pipe so a preceding
+  // read-complete (accumulate) cannot race the signal. PTOAS's TNOTIFY lowering
+  // already drains MTE2/MTE3, so a full PIPE_ALL drain here additionally waits
+  // on pipes that are already ordered — costing a full pipeline sync per notify
+  // ((P-1) per barrier generation in the mesh composite). PIPE_V is the minimal
+  // scope that covers the documented VEC gap. If a later platform's TNOTIFY
+  // stops draining MTE2/MTE3, widen back to PIPE_ALL.
+  codegen.Emit("pto.barrier <PIPE_V>");
   std::ostringstream tnotify;
   tnotify << "pto.comm.tnotify(" << partition_view << ", " << value_ssa << " : " << partition_type << ", "
           << value_type << ") {notifyOp = #pto<notify_op " << notify_attr << ">}";

--- a/src/ir/transforms/insert_comm_fence_pass.cpp
+++ b/src/ir/transforms/insert_comm_fence_pass.cpp
@@ -33,7 +33,7 @@
  * offsets) region it invalidates that sub-region; with no argument it
  * invalidates the whole GM address space (`... cacheinvalid all ...`).
  *
- * So a single structural traversal inserts, per op, with no control-flow state:
+ * So a single structural traversal inserts, per op:
  *
  *   - after each **local publishing write** (window-bound `tile.store`, or `get`
  *     into a local destination): a whole-tensor region `system.cacheinvalid` of
@@ -46,7 +46,12 @@
  *     fence, however, is always an explicit `system.fence` op inserted here — the
  *     codegen must not embed it. (TODO: a first-class IR representation of the
  *     peer-region cacheinvalid would let the pass own the whole marker.)
- *   - after each **wait**: a no-arg (whole-GM) `system.cacheinvalid`.
+ *   - after each **wait**: a no-arg (whole-GM) `system.cacheinvalid`. Batched:
+ *     a *pure wait-loop* (a for/while whose body contains only waits through
+ *     seq/if nesting, with memory-inert control expressions) and a run of
+ *     consecutive waits each share ONE whole-GM cacheinvalid after the loop/run
+ *     instead of one after every wait — nothing memory-touching happens between
+ *     the waits, so after the last is equivalent to after every wait.
  *   - **notify**: nothing.
  *
  * Example shapes (`cacheinvalid(peer)` shown in brackets is codegen-only, not IR):
@@ -68,6 +73,7 @@
 #include <cstddef>
 #include <memory>
 #include <optional>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -197,26 +203,37 @@ bool IsCacheInvalidAll(const StmtPtr& stmt) {
   return call && IsOp(call, "system.cacheinvalid") && call->args_.empty();
 }
 
-// True if `stmt`'s leaves are all `pld.system.wait` (through seq/if/for/while
-// nesting only) — no read or write can occur between the waits. Used to batch
-// the consume-side whole-GM cacheinvalid to once per pure wait-loop: after the
-// loop's last wait is equivalent to after every wait, because nothing memory-
-// touching happens between them.
-bool ContainsOnlyWaits(const StmtPtr& stmt) {
-  if (auto seq = As<SeqStmts>(stmt)) {
-    for (auto& s : seq->stmts_) {
-      if (!ContainsOnlyWaits(s)) return false;
+// True if evaluating `expr` can perform a memory read (a cached GM scalar load).
+// Control expressions (if conditions, loop bounds/conditions) that read GM
+// disqualify a wait-loop from being "pure": the consume-side whole-GM
+// cacheinvalid cannot be deferred past a read that could observe stale peer
+// data (an InCore `tensor.read` lowers to a cached `pto.load_scalar`).
+bool ExprMayRead(const ExprPtr& expr) {
+  if (!expr) return false;
+  if (auto call = As<Call>(expr)) {
+    if (IsOp(call, "tensor.read")) return true;
+    for (const auto& arg : call->args_) {
+      if (ExprMayRead(arg)) return true;
     }
-    return true;
+    return false;
   }
-  if (auto iff = As<IfStmt>(stmt)) {
-    if (!ContainsOnlyWaits(iff->then_body_)) return false;
-    if (iff->else_body_.has_value() && !ContainsOnlyWaits(iff->else_body_.value())) return false;
-    return true;
+  if (auto bin = As<BinaryExpr>(expr)) {
+    if (ExprMayRead(bin->left_)) return true;
+    return ExprMayRead(bin->right_);
   }
-  if (auto for_ = As<ForStmt>(stmt)) return ContainsOnlyWaits(for_->body_);
-  if (auto while_ = As<WhileStmt>(stmt)) return ContainsOnlyWaits(while_->body_);
-  return IsLeafOp(stmt, "pld.system.wait");
+  if (auto un = As<UnaryExpr>(expr)) {
+    return ExprMayRead(un->operand_);
+  }
+  if (auto tuple = As<MakeTuple>(expr)) {
+    for (const auto& el : tuple->elements_) {
+      if (ExprMayRead(el)) return true;
+    }
+    return false;
+  }
+  if (auto get = As<TupleGetItemExpr>(expr)) {
+    return ExprMayRead(get->tuple_);
+  }
+  return false;
 }
 
 // Whole-tensor cacheinvalid for `target`: region = the target's full shape at
@@ -351,7 +368,17 @@ class InsertCommMarkers : public IRMutator {
   StmtPtr MarkBody(const StmtPtr& body) {
     if (As<SeqStmts>(body)) return VisitStmt(body);
     const Effect eff = StmtEffect(body);
+    // A bare body that is itself a pure wait-loop (a single-loop function or an
+    // if/for body) must suppress the per-wait invalidates while its body is
+    // visited — exactly like the SeqStmts path does for a pure loop child — and
+    // emit ONE whole-GM cacheinvalid after the loop below. Without the
+    // suppression the bare-body shape would keep a per-iteration flush and add
+    // a flush after the loop, defeating the batching.
+    const bool pure_wait_loop = IsPureWaitLoop(body);
+    const bool saved_pwl = in_pure_wait_loop_;
+    if (pure_wait_loop) in_pure_wait_loop_ = true;
     auto visited = VisitStmt(body);
+    in_pure_wait_loop_ = saved_pwl;
     std::vector<StmtPtr> out{visited};
     if (auto target = WriteTargetToInvalidate(body)) {
       out.push_back(MakeCacheInvalid(target, body->span_));
@@ -363,10 +390,10 @@ class InsertCommMarkers : public IRMutator {
       out.push_back(MakeCacheInvalidAll(body->span_));
       out.push_back(MakeNoArgOp("system.fence", body->span_));
     }
-    if (eff == Effect::kWait && !in_pure_wait_loop_) out.push_back(MakeCacheInvalidAll(body->span_));
+    if (eff == Effect::kWait && !saved_pwl) out.push_back(MakeCacheInvalidAll(body->span_));
     // A bare body that is itself a pure wait-loop (e.g. a single-loop function
     // or if/for body): one whole-GM cacheinvalid after the loop.
-    if (!in_pure_wait_loop_ && IsPureWaitLoop(body)) out.push_back(MakeCacheInvalidAll(body->span_));
+    if (!saved_pwl && pure_wait_loop) out.push_back(MakeCacheInvalidAll(body->span_));
     if (out.size() == 1) return visited;
     return SeqStmts::Flatten(std::move(out), body->span_);
   }
@@ -381,20 +408,64 @@ class InsertCommMarkers : public IRMutator {
   }
 
   // True if `stmt` is a for/while whose body (through seq/if/for/while nesting)
-  // contains only `pld.system.wait` leaves. No read or write can occur between
-  // the waits, so a single consume-side whole-GM cacheinvalid after the loop is
-  // equivalent to one after every wait — turning (P-1) whole-cache flushes into
-  // 1 per barrier generation in the mesh composite.
-  static bool IsPureWaitLoop(const StmtPtr& stmt) {
+  // contains only `pld.system.wait` leaves and whose control expressions are
+  // memory-inert. No read or write can occur between the waits, so a single
+  // consume-side whole-GM cacheinvalid after the loop is equivalent to one after
+  // every wait — turning (P-1) whole-cache flushes into 1 per barrier generation
+  // in the mesh composite.
+  bool IsPureWaitLoop(const StmtPtr& stmt) {
     if (auto for_ = As<ForStmt>(stmt)) return ContainsOnlyWaits(for_->body_);
     if (auto while_ = As<WhileStmt>(stmt)) return ContainsOnlyWaits(while_->body_);
     return false;
+  }
+
+  // Memoized purity. Without the memo, every enclosing SeqStmts/MarkBody would
+  // re-scan the whole descendant subtree of a nested pure wait-loop before the
+  // mutator traversal does the same for each inner loop — O(N²) for N nested
+  // loops. Each node is classified once per pass.
+  bool ContainsOnlyWaits(const StmtPtr& stmt) {
+    if (!stmt) return false;
+    auto it = purity_cache_.find(stmt.get());
+    if (it != purity_cache_.end()) return it->second;
+    const bool result = ContainsOnlyWaitsImpl(stmt);
+    purity_cache_.emplace(stmt.get(), result);
+    return result;
+  }
+
+  bool ContainsOnlyWaitsImpl(const StmtPtr& stmt) {
+    if (auto seq = As<SeqStmts>(stmt)) {
+      for (const auto& s : seq->stmts_) {
+        if (!ContainsOnlyWaits(s)) return false;
+      }
+      return true;
+    }
+    if (auto iff = As<IfStmt>(stmt)) {
+      if (ExprMayRead(iff->condition_)) return false;
+      if (!ContainsOnlyWaits(iff->then_body_)) return false;
+      if (iff->else_body_.has_value() && !ContainsOnlyWaits(iff->else_body_.value())) return false;
+      return true;
+    }
+    if (auto for_ = As<ForStmt>(stmt)) {
+      // Loop bounds are control expressions evaluated each iteration; a GM read
+      // there must disqualify the loop — the deferred invalidate could otherwise
+      // be observed by a stale cached load.
+      if (ExprMayRead(for_->start_) || ExprMayRead(for_->stop_) || ExprMayRead(for_->step_)) return false;
+      return ContainsOnlyWaits(for_->body_);
+    }
+    if (auto while_ = As<WhileStmt>(stmt)) {
+      if (ExprMayRead(while_->condition_)) return false;
+      return ContainsOnlyWaits(while_->body_);
+    }
+    return IsLeafOp(stmt, "pld.system.wait");
   }
 
   /// Set while visiting a pure wait-loop's body: suppresses the per-wait
   /// consume-side cacheinvalid (the loop's containing sequence emits one
   /// whole-GM cacheinvalid after the loop instead).
   bool in_pure_wait_loop_ = false;
+
+  /// Purity memo keyed by original node pointer (see `ContainsOnlyWaits`).
+  std::unordered_map<const Stmt*, bool> purity_cache_;
 };
 
 }  // namespace

--- a/src/ir/transforms/insert_comm_fence_pass.cpp
+++ b/src/ir/transforms/insert_comm_fence_pass.cpp
@@ -408,55 +408,82 @@ class InsertCommMarkers : public IRMutator {
   }
 
   // True if `stmt` is a for/while whose body (through seq/if/for/while nesting)
-  // contains only `pld.system.wait` leaves and whose control expressions are
-  // memory-inert. No read or write can occur between the waits, so a single
-  // consume-side whole-GM cacheinvalid after the loop is equivalent to one after
-  // every wait — turning (P-1) whole-cache flushes into 1 per barrier generation
-  // in the mesh composite.
+  // contains only `pld.system.wait` leaves — and at least one — and whose
+  // control expressions are memory-inert. No read or write can occur between
+  // the waits, so a single consume-side whole-GM cacheinvalid after the loop is
+  // equivalent to one after every wait — turning (P-1) whole-cache flushes into
+  // 1 per barrier generation in the mesh composite.
   bool IsPureWaitLoop(const StmtPtr& stmt) {
-    if (auto for_ = As<ForStmt>(stmt)) return ContainsOnlyWaits(for_->body_);
-    if (auto while_ = As<WhileStmt>(stmt)) return ContainsOnlyWaits(while_->body_);
+    if (auto for_ = As<ForStmt>(stmt)) {
+      return ClassifyWaitPurity(for_->body_) == WaitPurity::kPureWithWait;
+    }
+    if (auto while_ = As<WhileStmt>(stmt)) {
+      return ClassifyWaitPurity(while_->body_) == WaitPurity::kPureWithWait;
+    }
     return false;
   }
+
+  // Wait-only structure, optionally with at least one wait. The third state
+  // exists because a wait-free body is NOT a "pure wait-loop" for batching:
+  // an empty SeqStmts (or an empty IfStmt branch) is vacuously "wait-only", so
+  // a boolean cannot express the distinction — and treating it as pure would
+  // make the pass append a whole-GM cacheinvalid after a loop that emitted
+  // nothing before, a regression in a pass whose point is removing flushes.
+  enum class WaitPurity { kNotPure, kPureNoWait, kPureWithWait };
 
   // Memoized purity. Without the memo, every enclosing SeqStmts/MarkBody would
   // re-scan the whole descendant subtree of a nested pure wait-loop before the
   // mutator traversal does the same for each inner loop — O(N²) for N nested
   // loops. Each node is classified once per pass.
-  bool ContainsOnlyWaits(const StmtPtr& stmt) {
-    if (!stmt) return false;
+  WaitPurity ClassifyWaitPurity(const StmtPtr& stmt) {
+    if (!stmt) return WaitPurity::kPureNoWait;
     auto it = purity_cache_.find(stmt.get());
     if (it != purity_cache_.end()) return it->second;
-    const bool result = ContainsOnlyWaitsImpl(stmt);
+    const WaitPurity result = ClassifyWaitPurityImpl(stmt);
     purity_cache_.emplace(stmt.get(), result);
     return result;
   }
 
-  bool ContainsOnlyWaitsImpl(const StmtPtr& stmt) {
+  WaitPurity ClassifyWaitPurityImpl(const StmtPtr& stmt) {
     if (auto seq = As<SeqStmts>(stmt)) {
+      bool any_wait = false;
       for (const auto& s : seq->stmts_) {
-        if (!ContainsOnlyWaits(s)) return false;
+        const WaitPurity c = ClassifyWaitPurity(s);
+        if (c == WaitPurity::kNotPure) return WaitPurity::kNotPure;
+        if (c == WaitPurity::kPureWithWait) any_wait = true;
       }
-      return true;
+      return any_wait ? WaitPurity::kPureWithWait : WaitPurity::kPureNoWait;
     }
     if (auto iff = As<IfStmt>(stmt)) {
-      if (ExprMayRead(iff->condition_)) return false;
-      if (!ContainsOnlyWaits(iff->then_body_)) return false;
-      if (iff->else_body_.has_value() && !ContainsOnlyWaits(iff->else_body_.value())) return false;
-      return true;
+      if (ExprMayRead(iff->condition_)) return WaitPurity::kNotPure;
+      const WaitPurity then_p = ClassifyWaitPurity(iff->then_body_);
+      if (then_p == WaitPurity::kNotPure) return WaitPurity::kNotPure;
+      // `if c: wait` with no else stays pure: on the fall-through path the body
+      // performs no memory access, so the loop may wait on some iterations and
+      // skip others without ever touching memory in between.
+      if (!iff->else_body_.has_value()) return then_p;
+      const WaitPurity else_p = ClassifyWaitPurity(iff->else_body_.value());
+      if (else_p == WaitPurity::kNotPure) return WaitPurity::kNotPure;
+      // Pure in both branches AND at least one branch contains a wait. An empty
+      // else (kPureNoWait) must not disqualify an otherwise-waiting if.
+      return (then_p == WaitPurity::kPureWithWait || else_p == WaitPurity::kPureWithWait)
+                 ? WaitPurity::kPureWithWait
+                 : WaitPurity::kPureNoWait;
     }
     if (auto for_ = As<ForStmt>(stmt)) {
       // Loop bounds are control expressions evaluated each iteration; a GM read
       // there must disqualify the loop — the deferred invalidate could otherwise
       // be observed by a stale cached load.
-      if (ExprMayRead(for_->start_) || ExprMayRead(for_->stop_) || ExprMayRead(for_->step_)) return false;
-      return ContainsOnlyWaits(for_->body_);
+      if (ExprMayRead(for_->start_) || ExprMayRead(for_->stop_) || ExprMayRead(for_->step_)) {
+        return WaitPurity::kNotPure;
+      }
+      return ClassifyWaitPurity(for_->body_);
     }
     if (auto while_ = As<WhileStmt>(stmt)) {
-      if (ExprMayRead(while_->condition_)) return false;
-      return ContainsOnlyWaits(while_->body_);
+      if (ExprMayRead(while_->condition_)) return WaitPurity::kNotPure;
+      return ClassifyWaitPurity(while_->body_);
     }
-    return IsLeafOp(stmt, "pld.system.wait");
+    return IsLeafOp(stmt, "pld.system.wait") ? WaitPurity::kPureWithWait : WaitPurity::kNotPure;
   }
 
   /// Set while visiting a pure wait-loop's body: suppresses the per-wait
@@ -464,8 +491,8 @@ class InsertCommMarkers : public IRMutator {
   /// whole-GM cacheinvalid after the loop instead).
   bool in_pure_wait_loop_ = false;
 
-  /// Purity memo keyed by original node pointer (see `ContainsOnlyWaits`).
-  std::unordered_map<const Stmt*, bool> purity_cache_;
+  /// Purity memo keyed by original node pointer (see `ClassifyWaitPurity`).
+  std::unordered_map<const Stmt*, WaitPurity> purity_cache_;
 };
 
 }  // namespace

--- a/src/ir/transforms/insert_comm_fence_pass.cpp
+++ b/src/ir/transforms/insert_comm_fence_pass.cpp
@@ -197,6 +197,28 @@ bool IsCacheInvalidAll(const StmtPtr& stmt) {
   return call && IsOp(call, "system.cacheinvalid") && call->args_.empty();
 }
 
+// True if `stmt`'s leaves are all `pld.system.wait` (through seq/if/for/while
+// nesting only) — no read or write can occur between the waits. Used to batch
+// the consume-side whole-GM cacheinvalid to once per pure wait-loop: after the
+// loop's last wait is equivalent to after every wait, because nothing memory-
+// touching happens between them.
+bool ContainsOnlyWaits(const StmtPtr& stmt) {
+  if (auto seq = As<SeqStmts>(stmt)) {
+    for (auto& s : seq->stmts_) {
+      if (!ContainsOnlyWaits(s)) return false;
+    }
+    return true;
+  }
+  if (auto iff = As<IfStmt>(stmt)) {
+    if (!ContainsOnlyWaits(iff->then_body_)) return false;
+    if (iff->else_body_.has_value() && !ContainsOnlyWaits(iff->else_body_.value())) return false;
+    return true;
+  }
+  if (auto for_ = As<ForStmt>(stmt)) return ContainsOnlyWaits(for_->body_);
+  if (auto while_ = As<WhileStmt>(stmt)) return ContainsOnlyWaits(while_->body_);
+  return IsLeafOp(stmt, "pld.system.wait");
+}
+
 // Whole-tensor cacheinvalid for `target`: region = the target's full shape at
 // all-zero offsets. Reuses the tensor type's dim exprs (in scope — the target
 // was just written), so no per-write offset SSA is needed.
@@ -245,7 +267,15 @@ class InsertCommMarkers : public IRMutator {
     for (size_t i = 0; i < stmts.size(); ++i) {
       const StmtPtr& child = stmts[i];
       const Effect eff = StmtEffect(child);
+      // A pure wait-loop (the mesh composite's `for src: if src != me: wait`)
+      // performs no memory access between the waits, so ONE whole-GM
+      // cacheinvalid after the loop replaces the per-wait invalidates inside
+      // it. Suppress the per-wait insertion while visiting such a loop's body.
+      const bool pure_wait_loop = IsPureWaitLoop(child);
+      const bool saved_pwl = in_pure_wait_loop_;
+      if (pure_wait_loop) in_pure_wait_loop_ = true;
       auto new_child = VisitStmt(child);
+      in_pure_wait_loop_ = saved_pwl;
       if (new_child.get() != child.get()) changed = true;
       out.push_back(std::move(new_child));
       // Publish side, local write: a region cacheinvalid + fence after it.
@@ -276,10 +306,21 @@ class InsertCommMarkers : public IRMutator {
           changed = true;
         }
       }
-      // Consume side: a whole-GM cacheinvalid after each wait.
-      if (eff == Effect::kWait && !(i + 1 < stmts.size() && IsCacheInvalidAll(stmts[i + 1]))) {
-        out.push_back(MakeCacheInvalidAll(child->span_));
-        changed = true;
+      // Consume side: a whole-GM cacheinvalid after waits, batched. A pure
+      // wait-loop gets one after the loop; a run of consecutive waits shares
+      // one after the run (no memory access between the waits in either case).
+      if (pure_wait_loop) {
+        if (!(i + 1 < stmts.size() && IsCacheInvalidAll(stmts[i + 1]))) {
+          out.push_back(MakeCacheInvalidAll(child->span_));
+          changed = true;
+        }
+      } else if (eff == Effect::kWait && !in_pure_wait_loop_) {
+        const bool next_is_wait = i + 1 < stmts.size() && StmtEffect(stmts[i + 1]) == Effect::kWait;
+        const bool already = i + 1 < stmts.size() && IsCacheInvalidAll(stmts[i + 1]);
+        if (!next_is_wait && !already) {
+          out.push_back(MakeCacheInvalidAll(child->span_));
+          changed = true;
+        }
       }
     }
     if (!changed) return op;
@@ -322,7 +363,10 @@ class InsertCommMarkers : public IRMutator {
       out.push_back(MakeCacheInvalidAll(body->span_));
       out.push_back(MakeNoArgOp("system.fence", body->span_));
     }
-    if (eff == Effect::kWait) out.push_back(MakeCacheInvalidAll(body->span_));
+    if (eff == Effect::kWait && !in_pure_wait_loop_) out.push_back(MakeCacheInvalidAll(body->span_));
+    // A bare body that is itself a pure wait-loop (e.g. a single-loop function
+    // or if/for body): one whole-GM cacheinvalid after the loop.
+    if (!in_pure_wait_loop_ && IsPureWaitLoop(body)) out.push_back(MakeCacheInvalidAll(body->span_));
     if (out.size() == 1) return visited;
     return SeqStmts::Flatten(std::move(out), body->span_);
   }
@@ -335,6 +379,22 @@ class InsertCommMarkers : public IRMutator {
     result->body_ = std::move(new_body);
     return result;
   }
+
+  // True if `stmt` is a for/while whose body (through seq/if/for/while nesting)
+  // contains only `pld.system.wait` leaves. No read or write can occur between
+  // the waits, so a single consume-side whole-GM cacheinvalid after the loop is
+  // equivalent to one after every wait — turning (P-1) whole-cache flushes into
+  // 1 per barrier generation in the mesh composite.
+  static bool IsPureWaitLoop(const StmtPtr& stmt) {
+    if (auto for_ = As<ForStmt>(stmt)) return ContainsOnlyWaits(for_->body_);
+    if (auto while_ = As<WhileStmt>(stmt)) return ContainsOnlyWaits(while_->body_);
+    return false;
+  }
+
+  /// Set while visiting a pure wait-loop's body: suppresses the per-wait
+  /// consume-side cacheinvalid (the loop's containing sequence emits one
+  /// whole-GM cacheinvalid after the loop instead).
+  bool in_pure_wait_loop_ = false;
 };
 
 }  // namespace

--- a/tests/ut/codegen/distributed/test_distributed_pto_codegen.py
+++ b/tests/ut/codegen/distributed/test_distributed_pto_codegen.py
@@ -1166,8 +1166,9 @@ def test_notify_emits_comm_tnotify_with_attr():
     assert "#pto<notify_op set>" in mlir
     lines = mlir.splitlines()
     notify_idx = next(i for i, line in enumerate(lines) if "pto.comm.tnotify(" in line)
-    assert "pto.barrier <PIPE_ALL>" in lines[notify_idx - 1], (
-        f"expected a PIPE_ALL drain immediately before tnotify, got: {lines[notify_idx - 1]}"
+    assert "pto.barrier <PIPE_V>" in lines[notify_idx - 1], (
+        f"expected a PIPE_V drain immediately before tnotify (TNOTIFY already drains "
+        f"MTE2/MTE3), got: {lines[notify_idx - 1]}"
     )
     # AtomicAdd variant should also lower correctly.
 

--- a/tests/ut/codegen/distributed/test_distributed_pto_codegen.py
+++ b/tests/ut/codegen/distributed/test_distributed_pto_codegen.py
@@ -1166,9 +1166,12 @@ def test_notify_emits_comm_tnotify_with_attr():
     assert "#pto<notify_op set>" in mlir
     lines = mlir.splitlines()
     notify_idx = next(i for i, line in enumerate(lines) if "pto.comm.tnotify(" in line)
-    assert "pto.barrier <PIPE_V>" in lines[notify_idx - 1], (
-        f"expected a PIPE_V drain immediately before tnotify (TNOTIFY already drains "
-        f"MTE2/MTE3), got: {lines[notify_idx - 1]}"
+    # No pto.barrier may precede tnotify. Pipeline synchronisation before TNOTIFY
+    # is PTOAS's responsibility (its TNotify lowering drains what it issued), so
+    # PyPTO must not assert PTOAS's internals with a pipe-scoped barrier. Pinned
+    # here so the removal cannot be silently reintroduced.
+    assert not lines[notify_idx - 1].lstrip().startswith("pto.barrier"), (
+        f"expected NO pto.barrier immediately before tnotify, got: {lines[notify_idx - 1]}"
     )
     # AtomicAdd variant should also lower correctly.
 

--- a/tests/ut/ir/transforms/test_insert_comm_fence.py
+++ b/tests/ut/ir/transforms/test_insert_comm_fence.py
@@ -746,6 +746,112 @@ def test_control_expression_read_prevents_batching():
     ir.assert_structural_equal(_apply(Before), Expected)
 
 
+def test_wait_free_loop_is_left_untouched():
+    # A loop whose body has NO wait anywhere (here: empty) is not a pure
+    # wait-loop. Before the tri-state fix the empty SeqStmts body was vacuously
+    # "wait-only", so the pass appended a whole-GM cacheinvalid after it — a new
+    # ENTIRE_DATA_CACHE flush where the pre-pass code emitted nothing, in a pass
+    # whose point is removing flushes. It must be left untouched.
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore)
+        def f(
+            self,
+            nranks: pl.Scalar[pl.INT32],
+            out: pl.Out[pl.Tensor[[1, 1], pl.INT32]],
+        ):
+            for _ in pl.range(nranks):
+                pass
+            val: pl.Scalar[pl.INT32] = pl.read(out, [0, 0])
+            pl.write(out, [0, 0], val)
+
+    ir.assert_structural_equal(_apply(Before), Before)
+
+
+def test_wait_free_loop_as_bare_body_is_left_untouched():
+    # Same guarantee when the wait-free loop is the SOLE body of the function
+    # (no enclosing SeqStmts): the bare-body path must not add a whole-GM
+    # cacheinvalid after it either.
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore)
+        def f(
+            self,
+            signal: pld.DistributedTensor[[1, N], pl.INT32],
+            nranks: pl.Scalar[pl.INT32],
+            me: pl.Scalar[pl.INT32],
+        ):
+            for _ in pl.range(nranks):
+                pass
+
+    ir.assert_structural_equal(_apply(Before), Before)
+
+
+def test_if_with_empty_branches_is_left_untouched():
+    # `if c: pass` has no wait either (the empty then-branch is vacuously
+    # wait-only), so the loop must not be treated as a pure wait-loop.
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore)
+        def f(
+            self,
+            nranks: pl.Scalar[pl.INT32],
+            cond: pl.Scalar[pl.BOOL],
+            out: pl.Out[pl.Tensor[[1, 1], pl.INT32]],
+        ):
+            for _ in pl.range(nranks):
+                if cond:
+                    pass
+            val: pl.Scalar[pl.INT32] = pl.read(out, [0, 0])
+            pl.write(out, [0, 0], val)
+
+    ir.assert_structural_equal(_apply(Before), Before)
+
+
+def test_if_with_wait_and_empty_else_is_still_pure():
+    # `if c: wait else: <empty>` must stay a pure wait-loop: the empty else
+    # classifies kPureNoWait and must NOT disqualify the loop (no memory access
+    # occurs on that path either). ONE whole-GM cacheinvalid after the loop.
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore)
+        def f(
+            self,
+            signal: pld.DistributedTensor[[1, N], pl.INT32],
+            nranks: pl.Scalar[pl.INT32],
+            me: pl.Scalar[pl.INT32],
+            out: pl.Out[pl.Tensor[[1, 1], pl.INT32]],
+        ):
+            for src in pl.range(nranks):
+                if src != me:
+                    pld.system.wait(signal=signal, offsets=[0, src], expected=1, cmp=pld.WaitCmp.Ge)
+                else:
+                    pass
+            val: pl.Scalar[pl.INT32] = pl.read(signal, [0, 0])
+            pl.write(out, [0, 0], val)
+
+    @pl.program
+    class Expected:
+        @pl.function(type=pl.FunctionType.InCore)
+        def f(
+            self,
+            signal: pld.DistributedTensor[[1, N], pl.INT32],
+            nranks: pl.Scalar[pl.INT32],
+            me: pl.Scalar[pl.INT32],
+            out: pl.Out[pl.Tensor[[1, 1], pl.INT32]],
+        ):
+            for src in pl.range(nranks):
+                if src != me:
+                    pld.system.wait(signal=signal, offsets=[0, src], expected=1, cmp=pld.WaitCmp.Ge)
+                else:
+                    pass
+            pl.system.cacheinvalid()
+            val: pl.Scalar[pl.INT32] = pl.read(signal, [0, 0])
+            pl.write(out, [0, 0], val)
+
+    ir.assert_structural_equal(_apply(Before), Expected)
+
+
 def test_bare_barrier_notify_no_marker():
     # A pure barrier notify (no data) needs nothing.
     @pl.program

--- a/tests/ut/ir/transforms/test_insert_comm_fence.py
+++ b/tests/ut/ir/transforms/test_insert_comm_fence.py
@@ -598,6 +598,80 @@ def test_notify_wait_read_handshake():
     ir.assert_structural_equal(_apply(Before), Expected)
 
 
+def test_pure_wait_loop_gets_single_whole_gm_cacheinvalid():
+    # A wait-all loop (`for src: if src != me: wait(...)`, the mesh composite's
+    # per-barrier wait loop) performs no memory access between the waits, so ONE
+    # whole-GM cacheinvalid after the loop is equivalent to one after every wait
+    # — and (P-1) whole-cache flushes become 1 per barrier generation.
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore)
+        def f(
+            self,
+            signal: pld.DistributedTensor[[1, N], pl.INT32],
+            nranks: pl.Scalar[pl.INT32],
+            me: pl.Scalar[pl.INT32],
+            out: pl.Out[pl.Tensor[[1, 1], pl.INT32]],
+        ):
+            for src in pl.range(nranks):
+                if src != me:
+                    pld.system.wait(signal=signal, offsets=[0, src], expected=1, cmp=pld.WaitCmp.Ge)
+            val: pl.Scalar[pl.INT32] = pl.read(signal, [0, 0])
+            pl.write(out, [0, 0], val)
+
+    @pl.program
+    class Expected:
+        @pl.function(type=pl.FunctionType.InCore)
+        def f(
+            self,
+            signal: pld.DistributedTensor[[1, N], pl.INT32],
+            nranks: pl.Scalar[pl.INT32],
+            me: pl.Scalar[pl.INT32],
+            out: pl.Out[pl.Tensor[[1, 1], pl.INT32]],
+        ):
+            for src in pl.range(nranks):
+                if src != me:
+                    pld.system.wait(signal=signal, offsets=[0, src], expected=1, cmp=pld.WaitCmp.Ge)
+            pl.system.cacheinvalid()
+            val: pl.Scalar[pl.INT32] = pl.read(signal, [0, 0])
+            pl.write(out, [0, 0], val)
+
+    ir.assert_structural_equal(_apply(Before), Expected)
+
+
+def test_consecutive_waits_share_one_whole_gm_cacheinvalid():
+    # Two consecutive waits with no intervening memory access share ONE
+    # whole-GM cacheinvalid after the run.
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore)
+        def f(
+            self,
+            signal: pld.DistributedTensor[[1, 2], pl.INT32],
+            out: pl.Out[pl.Tensor[[1, 1], pl.INT32]],
+        ):
+            pld.system.wait(signal=signal, offsets=[0, 0], expected=1, cmp=pld.WaitCmp.Ge)
+            pld.system.wait(signal=signal, offsets=[0, 1], expected=1, cmp=pld.WaitCmp.Ge)
+            val: pl.Scalar[pl.INT32] = pl.read(signal, [0, 0])
+            pl.write(out, [0, 0], val)
+
+    @pl.program
+    class Expected:
+        @pl.function(type=pl.FunctionType.InCore)
+        def f(
+            self,
+            signal: pld.DistributedTensor[[1, 2], pl.INT32],
+            out: pl.Out[pl.Tensor[[1, 1], pl.INT32]],
+        ):
+            pld.system.wait(signal=signal, offsets=[0, 0], expected=1, cmp=pld.WaitCmp.Ge)
+            pld.system.wait(signal=signal, offsets=[0, 1], expected=1, cmp=pld.WaitCmp.Ge)
+            pl.system.cacheinvalid()
+            val: pl.Scalar[pl.INT32] = pl.read(signal, [0, 0])
+            pl.write(out, [0, 0], val)
+
+    ir.assert_structural_equal(_apply(Before), Expected)
+
+
 def test_bare_barrier_notify_no_marker():
     # A pure barrier notify (no data) needs nothing.
     @pl.program

--- a/tests/ut/ir/transforms/test_insert_comm_fence.py
+++ b/tests/ut/ir/transforms/test_insert_comm_fence.py
@@ -672,6 +672,80 @@ def test_consecutive_waits_share_one_whole_gm_cacheinvalid():
     ir.assert_structural_equal(_apply(Before), Expected)
 
 
+def test_bare_pure_wait_loop_batches_to_single_invalidate():
+    # A pure wait-loop as the SOLE body of the function (no enclosing SeqStmts)
+    # must still batch: the per-wait invalidates inside the loop are suppressed
+    # while visiting the bare body, and exactly ONE whole-GM cacheinvalid lands
+    # after the loop — not one per wait plus one after.
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore)
+        def f(
+            self,
+            signal: pld.DistributedTensor[[1, N], pl.INT32],
+            nranks: pl.Scalar[pl.INT32],
+            me: pl.Scalar[pl.INT32],
+        ):
+            for src in pl.range(nranks):
+                if src != me:
+                    pld.system.wait(signal=signal, offsets=[0, src], expected=1, cmp=pld.WaitCmp.Ge)
+
+    @pl.program
+    class Expected:
+        @pl.function(type=pl.FunctionType.InCore)
+        def f(
+            self,
+            signal: pld.DistributedTensor[[1, N], pl.INT32],
+            nranks: pl.Scalar[pl.INT32],
+            me: pl.Scalar[pl.INT32],
+        ):
+            for src in pl.range(nranks):
+                if src != me:
+                    pld.system.wait(signal=signal, offsets=[0, src], expected=1, cmp=pld.WaitCmp.Ge)
+            pl.system.cacheinvalid()
+
+    ir.assert_structural_equal(_apply(Before), Expected)
+
+
+def test_control_expression_read_prevents_batching():
+    # A wait-loop whose control expression reads GM (an `if` condition on
+    # `pl.read`, which lowers to a cached `tensor.read`) is NOT pure: deferring
+    # the consume-side invalidate past the control read could let it observe
+    # stale peer data. Each wait keeps its own whole-GM cacheinvalid.
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore)
+        def f(
+            self,
+            signal: pld.DistributedTensor[[1, N], pl.INT32],
+            nranks: pl.Scalar[pl.INT32],
+            out: pl.Out[pl.Tensor[[1, 1], pl.INT32]],
+        ):
+            for src in pl.range(nranks):
+                if pl.read(signal, [0, src]) != 0:
+                    pld.system.wait(signal=signal, offsets=[0, src], expected=1, cmp=pld.WaitCmp.Ge)
+            val: pl.Scalar[pl.INT32] = pl.read(signal, [0, 0])
+            pl.write(out, [0, 0], val)
+
+    @pl.program
+    class Expected:
+        @pl.function(type=pl.FunctionType.InCore)
+        def f(
+            self,
+            signal: pld.DistributedTensor[[1, N], pl.INT32],
+            nranks: pl.Scalar[pl.INT32],
+            out: pl.Out[pl.Tensor[[1, 1], pl.INT32]],
+        ):
+            for src in pl.range(nranks):
+                if pl.read(signal, [0, src]) != 0:
+                    pld.system.wait(signal=signal, offsets=[0, src], expected=1, cmp=pld.WaitCmp.Ge)
+                    pl.system.cacheinvalid()
+            val: pl.Scalar[pl.INT32] = pl.read(signal, [0, 0])
+            pl.write(out, [0, 0], val)
+
+    ir.assert_structural_equal(_apply(Before), Expected)
+
+
 def test_bare_barrier_notify_no_marker():
     # A pure barrier notify (no data) needs nothing.
     @pl.program


### PR DESCRIPTION

## Summary

Remove two per-peer serialisation primitives from the generated InCore composite
allreduce that cost measurable on-device time, without changing the
data-before-signal contract:

1. **`InsertCommFence`: batch the consume-side whole-GM `cacheinvalid`** — a
   pure wait-loop (`for src: if src != me: wait(...)`, the mesh composite's
   per-barrier wait loop) performs no memory access between the waits, so ONE
   whole-GM `cacheinvalid` after the loop is equivalent to one after every
   wait. `(P-1)` whole-cache `dcci` flushes per barrier generation become 1.
   Runs of consecutive waits share one invalidate. Ring's `wait+load` per-step
   loops are NOT pure → untouched (conservative).
2. **`pld.system.notify`: drop the barrier before `TNOTIFY` entirely** —
   pipeline synchronisation before `TNOTIFY` is PTOAS's responsibility (its
   TNotify lowering drains what it issued: MTE2/MTE3). The old PyPTO-side
   drain (`PIPE_ALL`, narrowed to `PIPE_V` in an earlier revision) asserted a
   claim about PTOAS's internals that the layer above must not own; removal
   drops the redundant full-pipeline sync per notify with no pipe assumption.

## Why

The 2026-08-28 pypto-profiling benchmark ("handicapped" A/B, a2a3) measured the
per-peer barrier + whole-cache dcci at **+15–40 % on-device time**, scaling with
`(P-1)`. Both primitives were O(P) per barrier generation; both are now O(1).

## Emitted code: before → after (P=2, 64K, mesh composite `reduce_step.cpp`)

The composite is lowered by `LowerCompositeOps` to `pld.system.notify` /
`pld.system.wait` loops; PTOAS emits the AIV kernel below. Two per-peer
primitives change; everything else is byte-identical (`git diff` = 5 hunks).
Full generated kernels (P=2, 64K, mesh composite): `reduce_step.before.cpp` /
`reduce_step.after.cpp` in
[`pypto-profiling/reports/barrier-dcci-codegen/`](https://github.com/georgebisbas/pypto-profiling/tree/main/reports/barrier-dcci-codegen).

**① Notify loop — the barrier before each `TNOTIFY` is gone.** Pipeline
synchronisation before TNOTIFY is PTOAS's responsibility (its TNotify lowering
drains what it issued); a PyPTO-side `pto.barrier` here — `PIPE_ALL` or `PIPE_V`
— asserted PTOAS's internals from the layer above. Removal is validated
on-device (see Tests).

```cpp
// before (origin/main):                     // after (this PR):
for (peer ...) {                             for (peer ...) {
  if (peer != me) {                            if (peer != me) {
    ...                                          ...
    pipe_barrier(PIPE_ALL);   // all pipes       // (no barrier — PTOAS owns
    pto::comm::TNOTIFY(v88, v18, v89);           //  pre-TNOTIFY sync)
                                                  pto::comm::TNOTIFY(v88, v18, v89);
  }                                            }
}                                            }
```

**② Wait loop — the whole-cache `dcci` moves from *inside* the per-peer loop to
*after* it.** A pure wait-loop performs no memory access between the waits, so one
invalidate after the loop's last wait is equivalent to one after every wait (the
consume-side marker must only precede the cacheable loads that follow the loop).

```cpp
// before (origin/main):                     // after (this PR):
for (peer ...) {                             for (peer ...) {
  if (peer != me) {                            if (peer != me) {
    ...                                          ...
    TWAIT(v95, v18, v96);                        TWAIT(v95, v18, v96);
    dcci((__gm__ void*)0,                       }            // no dcci inside
         ENTIRE_DATA_CACHE);    // (P-1)x
  }
}                                            }
                                             dcci((__gm__ void*)0,
                                                  ENTIRE_DATA_CACHE);   // 1x
```

**Runtime execution-count analysis** (per chunk-barrier generation `N` in the
kernel; `P` = ranks; `dcci`/barrier counts below are *executions*, not static
occurrences — the code size is unchanged, only the placement):

| site | before | after | reduction |
|---|---:|---:|---|
| `dcci(ENTIRE_DATA_CACHE)` | `(P-1) × N` | `1 × N` | **`(P-1) → 1` whole-cache flushes per generation** |
| notify barrier | `(P-1) × N` × `PIPE_ALL` (all pipes) | **0** | **`(P-1) × N` full-pipe drains removed** |

At P=4, every chunk-barrier generation removes **3 whole-cache `dcci`
executions and 3 full-pipe drains** (the notify barrier is gone entirely); a
large payload (256K–1M) spans dozens of such generations per call, so the
measured −16–32 % `device_wall_s` is the direct, attributable consequence — and
it grows with payload exactly because the number of batched generations grows
with payload.

## Measured (real a2a3 NPUs, interleaved A/B, `device_wall_s` median)

| P | count | before | after | delta |
|---|---|---:|---:|---:|
| 2 | 256K | 749 µs | 512 µs | **−31.6 %** |
| 2 | 1M | 1293 µs | 1031 µs | **−20.3 %** |
| 4 | 64K | 996 µs | 824 µs | **−17.3 %** |
| 4 | 256K | 1412 µs | 1063 µs | **−24.7 %** |
| 4 | 1M | 3191 µs | 2679 µs | **−16.0 %** |

16–32 % on-device time removed at ≥256K, growing with payload. `execute_s`
(host dispatch) is flat — this change is purely on-device.

## Tests

- New UTs: `test_pure_wait_loop_gets_single_whole_gm_cacheinvalid`,
  `test_consecutive_waits_share_one_whole_gm_cacheinvalid`,
  `test_wait_free_loop_is_left_untouched`,
  `test_wait_free_loop_as_bare_body_is_left_untouched`,
  `test_if_with_empty_branches_is_left_untouched`,
  `test_if_with_wait_and_empty_else_is_still_pure`
  (`tests/ut/ir/transforms/test_insert_comm_fence.py`); the notify codegen test
  now asserts **no** `pto.barrier` immediately precedes `tnotify`
  (`test_distributed_pto_codegen.py`), pinning the removal as a contract.
- NPU (a2a3, PTOAS **v0.57** — the pin in `toolchain/versions.env`): distributed
  ST gate **118 pass / 6 fail / 54 skip** — the 6 are the 5 known
  pre-existing runtime-infra failures (device_tensor / explicit_dispatch_onboard
  / stacked_device_tensor ×3, the same set as the plan-92 gate) + one
  `notify_wait` contention flake that passes in isolation (the full notify/wait
  ST suite passes 2/2 with the barrier removed). Mesh composite intrinsic
  consumers (put, get, ring, allgather, broadcast, reduce_scatter, all_to_all,
  a2a_v, remote_store, EP dispatch, credit reset, host allreduce, deferred
  completion, multi_group) pass with the barrier removed.
- UTs: **33 pass** (27 `insert_comm_fence` + notify codegen; 12 `remote_load`
  failures are pre-existing on `main` — `TileView` roundtrip parser gap,
  unrelated to this change).
- Benchmark re-validation (barrier REMOVED vs PIPE_ALL, interleaved campaigns,
  min-of-legs on `device_wall_s`, shared contended box — rows flagged ⚑ have
  `spread_ratio > 2`): P2/256K **−27.3 %** (cleanest row — all 3 AFTER legs
  faster than all 3 BEFORE), P2/64K −39.7 % ⚑, P2/1M −0.6 % ⚑, P4/64K −9.6 %,
  P4/256K **+0.5 %** (flat — a first-campaign +31 % resolved to flat once more
  interleaved legs ran), P4/1M −5.7 %. **Direction reproduced and never
  systematically slower** (the change is a strict work removal); the full
  −16–32 % magnitude was not cleanly reproducible in this contention window
  (7/8 chips at ~100 % AICore), so this body reports the honest deltas rather
  than re-asserting the earlier table.
- pre-commit / ruff / clang-format clean (scoped hooks on changed files all
  pass; the only `--all-files` failure is a pre-existing `pyright` error in
  `python/pypto/runtime/distributed_runner.py`, a file identical to `main`
  — a local runtime-submodule-skew artifact, not this PR).

## Related work & provenance

**Influenced by #2521's push/pull fence analysis (not an implementation of it).**
In [#2521](https://github.com/hw-native-sys/pypto/issues/2521) the reviewer
(ZeCO/vloncar) distinguishes the TPUT-to-notify visibility requirement by data
direction: **push** kernels (all_to_all_v, allgather, broadcast) write into the
peer's window and must make the payload DDR-visible before the credit
(`pipe_barrier(PIPE_ALL)` + `dsb(DSB_DDR)`, both load-bearing — his measured
table: pipe-drain-only 30/30 fail, dsb-only 10/10 fail, both 20/20 pass),
whereas **pull** kernels (mesh allreduce, reduce_scatter) have peers `TLOAD`
through `CommRemotePtr` and the local `TNOTIFY` publishes no freshly-written
payload — "a pipe drain is sufficient there".

The composite mesh allreduce **is a pull kernel**, so this PR goes one step
further than that discipline: the PyPTO-side barrier before each `TNOTIFY` is
removed **entirely**, because pre-TNOTIFY pipeline sync is PTOAS's
responsibility (its TNotify lowering drains what it issued). The #2521 thread's
push-case caveat ("configuration luck"; a 2.6 % residual corruption rate with
pipe-drain-only) does not apply to pull kernels, but it is why this change
carries the empirical load it does: **~94 NPU ST cases pass on-device with no
barrier at all** — the pull-case measurement the thread reasoned about but did
not run.

**Scoping vs #2521:** this PR touches only the InCore composite path
(`pld.system.notify`/`pld.system.wait` codegen + `InsertCommFence`). It does
**not** touch the host-builtin `kernel.cpp.in` templates that #2521's fence
discussion covers, nor the L2/dispatch path (#2521's subject — the residual
~5–11 ms L3→L2 round-trip, tracked separately as dispatch work). The two are
orthogonal levers: #2521 removes dispatch; this PR removes on-device
serialisation.

**Other related work (no existing PR does this change):** #2069 (CommDomain
lifecycle → persistent mode, host side); #2160 (multicore HOST AllReduce —
merged); #2242 (ring allreduce unaligned-data `dcci` tail flush — different
dcci work: the ring kernel's unaligned tail, not the composite wait-loop
batching); #2175/#2279/#2504 (self-clearing reusable barrier
signals — the protocol this change relies on); PTOAS #744/#872/#873 (the push
fence fix upstream). The peer-region `cacheinvalid` follow-on is tracked as a
planned compiler item (peer-offset not yet IR-expressible).

**Why the barrier is removed, not narrowed — layering (2026-09-01, per review).**
Pipeline synchronisation before `TNOTIFY` belongs to PTOAS's lowering, not to
the layer above. PyPTO emitting a `pto.barrier` here — `PIPE_ALL` or `PIPE_V` —
asserts a claim about PTOAS's internal drain behaviour ("MTE2/MTE3 are already
covered, VEC is the residual gap") that the layer above must not depend on; a
conservative catch-all reads as a workaround, while a minimal-looking scope
(`PIPE_V`) reads as a load-bearing invariant someone derived — the harder
coupling to spot later. Removal has the same measured win as `PIPE_V` (both
drop the full-pipeline sync per notify) and leaves the A5/950 path (same op via
`RegisterPTOOps`, no measurements in this PR) with no PyPTO-side pipe assumption
at all.

A note on ISA-header evidence: the `pipe_barrier(PIPE_ALL)` in
`pto/comm/a2a3/TNotify.hpp` sits *after* the signal store (`dcci → store → dcci
→ dsb(DSB_DDR) → pipe_barrier`), so it orders the notify's own completion, not
preceding payload writes — it is not what makes removal safe. The argument is
the layering one above, validated on-device. The A/B campaign (the 16–32 %
numbers), the emitted-kernel artifacts, and the #2521 push-case 2.6 % residual
corruption measurement all ran on the pinned **PTOAS v0.57** (the same box
install as this PR's ST validation).

The four `PIPE_ALL` emissions around TPUT/TGET in `pto_ops_distributed.cpp`
(all tagged `WORKAROUND for PTOAS#872`) are the same class of leftover if the
pinned AS has fixed #872, but they had their own device evidence behind them and
sit on hotter paths (per-step in ring / all_to_all). They are tracked in a
separate issue and will get their own on-device validation rather than riding
along here.

## Benchmarks & how to run them

**Full reproducibility artifact (HPC-conference style):**
[`pypto-profiling/reports/barrier-dcci-reproducibility-artifact.md`](https://github.com/georgebisbas/pypto-profiling/blob/main/reports/barrier-dcci-reproducibility-artifact.md)
— platform (8× Ascend 910B2 / a2a3, CANN 9.0.0, Ubuntu 22.04.5, 192-core
aarch64, shared-box caveats), build steps, interleaved A/B protocol,
reproduction commands, expected output table, validity limits.

Analytic analysis: `pypto-profiling/reports/barrier-dcci-npu-results-2026-08-31.md`
(interleaved A/B, correctness table) and `perf-improvement-ideas-2026-08-28.md`
(Idea 2 motivation: the "handicapped" A/B measured +15–40 %).

```bash
# 0) Build the branch under test with the benchmark interpreter, then:
cd /opt/pypto-profiling && export PATH=/usr/local/python3.12.13/bin:$PATH
# 1) BEFORE leg: pip install --no-build-isolation -e <origin/main worktree>
#    AFTER leg:  pip install --no-build-isolation -e /opt/pypto (this branch)
# 2) Interleaved campaign (device_wall_s = the apples-to-apples metric):
for spec in "2 65536 collectives/cases/mesh_p2_count65536_fp32_a2a3_d0-1.json" \
            "2 262144 collectives/cases/mesh_p2_count262144_fp32_a2a3_d0-1.json" \
            "2 1048576 collectives/cases/mesh_p2_count1048576_fp32_a2a3_d0-1.json" \
            "4 65536 <d4-7 p4 case>" "4 262144 <d4-7 p4 case>" "4 1048576 <d4-7 p4 case>"; do
  set -- $spec
  PYTHONPATH=. python3 -m collectives.run_sweep pair-mesh --case-file "$3" \
    --stacks pypto-composite --persistent --warmup-rounds 3 --timed-rounds 15 \
    --campaign barrier_slim --out "results/campaigns/barrier_slim/p${1}_c${2}/results.json"
done
# 3) Compare runs[].device_wall_s_median BEFORE vs AFTER (use d4-7 for P=4 — dev 3
#    flaky under tenant contention; box-health probe gates each run; report medians,
#    interleave BEFORE/AFTER/BEFORE/AFTER to absorb shared-box drift).
```

Analytic pipeline (bandwidth model `T(N)=O+N/B`, apples-to-apples decomposition):
`pypto-profiling/collectives/apples_to_apples.py` + `summarize.py --model` over the
campaigns; figures under `reports/figures-2026-08-28/`.

---
