### PR TITLE
feat(language): accept deps= on every pl.spmd form, not just `as tid`

### DIFF
--- a/docs/en/dev/language/02-manual_dependencies.md
+++ b/docs/en/dev/language/02-manual_dependencies.md
@@ -32,7 +32,7 @@ shape (single kernel call, outlined `pl.at` region, or dependency-only fan-in).
 | `result, tid = pl.submit(kernel, *args, deps=[...], allow_early_resolve=False)` | single kernel call | The trailing `tid` is the producer `pl.Scalar[pl.TASK_ID]`. A parser construct (like `pl.range`), not a runtime function. `allow_early_resolve=True` opts this task in as a speculative early-dispatch producer (lets the scheduler pre-stage its consumers; lowers to `Arg::set_allow_early_resolve(true)`). Also accepts `predicate=(t[i] > 0)` — a dispatch predicate the scheduler evaluates at the dispatch point (see [Dispatch predicate](#dispatch-predicate-predicate)). |
 | `result, tid = pl.spmd_submit(kernel, *args, core_num=N, sync_start=False, deps=[...])` | single SPMD task launch | The SPMD sibling of `pl.submit`: dispatches the kernel across `N` blocks (one orchestration task → one `tid`). `core_num` is a required keyword (positive int expr); `sync_start=True` forces atomic launch of all blocks. Callee may be InCore / AIC / AIV / Group. Records the launch spec on `Submit.core_num` / `Submit.sync_start`. Also accepts `allow_early_resolve=True` (same early-dispatch opt-in as `pl.submit`) and `predicate=(t[i] > 0)` (see [Dispatch predicate](#dispatch-predicate-predicate)). |
 | `with pl.at(level=pl.Level.CORE_GROUP, deps=[...]) as tid:` | outlined `pl.at`-block | The whole block is outlined into an `InCore` kernel + `Submit`; `tid` captures the synthesized Submit's TaskId, usable as a dep for later `pl.submit` / `pl.at` sites. Without `as tid` the outliner synthesizes an unused TaskId Var — deps always travel on `Submit::deps_`. Also accepts `allow_early_resolve=True` (same early-dispatch opt-in as `pl.submit`); it forces the `Submit` shape even without `as tid` and lowers to `Arg::set_allow_early_resolve(true)`. |
-| `with pl.spmd(N, deps=[...]) as tid:` | outlined SPMD dispatch | The SPMD sibling of the `pl.at ... as tid` form. The inline body is auto-outlined into an `InCore` kernel and dispatched across `N` blocks; `tid` captures the grid-wide producer TaskId. `deps=` accepted only with `as tid`. `core_num` / `sync_start` ride on the lowered `Submit`'s own `core_num` / `sync_start` fields (the launch spec belongs to the launch site, not the outlined callee); codegen reads them from there. Also accepts `allow_early_resolve=True` (same early-dispatch opt-in as `pl.submit` / `pl.at`; valid on all three `pl.spmd` forms, forcing the `Submit` shape even without `as tid`) and `predicate=(t[i] > 0)` (see [Dispatch predicate](#dispatch-predicate-predicate); also valid on all three forms and also forces the `Submit` shape). Cannot nest inside `pl.cluster()`. |
+| `with pl.spmd(N, deps=[...]) as tid:` | outlined SPMD dispatch | The SPMD sibling of the `pl.at ... as tid` form. The inline body is auto-outlined into an `InCore` kernel and dispatched across `N` blocks; `tid` captures the grid-wide producer TaskId. `deps=` is accepted on all three spmd forms; without `as tid` the outliner synthesizes an unused TaskId Var, exactly as on `pl.at`. `core_num` / `sync_start` ride on the lowered `Submit`'s own `core_num` / `sync_start` fields (the launch spec belongs to the launch site, not the outlined callee); codegen reads them from there. Also accepts `allow_early_resolve=True` (same early-dispatch opt-in as `pl.submit` / `pl.at`; valid on all three `pl.spmd` forms, forcing the `Submit` shape even without `as tid`) and `predicate=(t[i] > 0)` (see [Dispatch predicate](#dispatch-predicate-predicate); also valid on all three forms and also forces the `Submit` shape). Cannot nest inside `pl.cluster()`. |
 | `barrier = pl.system.task_dummy(deps=[...])` | dependency-only barrier | Submits no kernel. The returned TaskId is a compact fan-in point for later `deps=[barrier]`. |
 | `None` (Python literal) | seed / dep entry | The "no producer yet" sentinel. `prev_tid = None` seeds a TaskId loop iter_arg; `None` in `deps=[None]` is dropped (contributes no edge). Lowers to `system.task_invalid` → `TaskId::invalid()`. |
 
@@ -223,14 +223,14 @@ with pl.spmd(4, deps=[g_tid], predicate=(rc[0, 0] > 0)) as tid:  # producer is a
 
 Two things follow from that route:
 
-- **`deps=` needs the `as tid` form.** `deps=` is only accepted on
-  `with pl.spmd(...) as tid:`. A predicate over a tensor produced elsewhere in
-  the same function therefore needs that form — the plain `with` and `for`
-  forms can only carry a predicate over a tensor with no in-function producer
-  (typically a function parameter), which the contract check permits.
-- **No `as tid` is required otherwise.** Like `allow_early_resolve=True`, a
-  predicate forces the scope to lower to a `Submit`; when the scope has no
-  `as tid` the outliner synthesises an unused TaskId Var.
+- **`deps=` needs no `as tid`.** Like `allow_early_resolve=True` and
+  `predicate=`, `deps=` is accepted on all three spmd forms and forces the scope
+  to lower to a `Submit`; when the scope has no `as tid` the outliner synthesises
+  an unused TaskId Var. Capturing the TaskId is only needed when a *later* task
+  must wait on this one.
+- **The contract still binds the predicate.** A predicate over a tensor produced
+  elsewhere in the same function needs that producer in `deps=` — which every
+  form can now express.
 
 A cluster-nested `pl.spmd` is unwrapped into the Group function and never
 produces a `Submit`, so `predicate=` (like `allow_early_resolve=`) is rejected

--- a/docs/en/dev/passes/09-outline_cluster_scopes.md
+++ b/docs/en/dev/passes/09-outline_cluster_scopes.md
@@ -129,8 +129,8 @@ class After:
 
 | Dispatch shape | Carrier |
 | -------------- | ------- |
-| plain `Call` (`with pl.spmd(...)`) | `attrs["core_num"]` (`ExprPtr`) and `attrs["sync_start"]` (`bool`, only when true) |
-| `Submit` (`with pl.spmd(...) as tid`) | the first-class `Submit::core_num_` / `sync_start_` fields |
+| plain `Call` (`with pl.spmd(...)` carrying no Submit-only metadata) | `attrs["core_num"]` (`ExprPtr`) and `attrs["sync_start"]` (`bool`, only when true) |
+| `Submit` (`as tid`, or any of `deps=` / `allow_early_resolve=` / `predicate=`, for which the outliner synthesizes the TaskId Var) | the first-class `Submit::core_num_` / `sync_start_` fields |
 | `Group` from `pl.cluster(): with pl.spmd(...)` | the dispatch, same as above; the Group keeps only the `spmd_unwrapped` marker |
 
 `core_num` is an expression evaluated in the *dispatching* function's scope — it

--- a/docs/en/dev/passes/09-outline_cluster_scopes.md
+++ b/docs/en/dev/passes/09-outline_cluster_scopes.md
@@ -129,8 +129,8 @@ class After:
 
 | Dispatch shape | Carrier |
 | -------------- | ------- |
-| plain `Call` (`with pl.spmd(...)` carrying no Submit-only metadata) | `attrs["core_num"]` (`ExprPtr`) and `attrs["sync_start"]` (`bool`, only when true) |
-| `Submit` (`as tid`, or any of `deps=` / `allow_early_resolve=` / `predicate=`, for which the outliner synthesizes the TaskId Var) | the first-class `Submit::core_num_` / `sync_start_` fields |
+| plain `Call` — a standalone `with pl.spmd(...)` / `for i in pl.spmd(...)` carrying no Submit-only metadata | `attrs["core_num"]` (`ExprPtr`) and `attrs["sync_start"]` (`bool`, only when true) |
+| `Submit` — a standalone `with pl.spmd(...)` / `for i in pl.spmd(...)` with `as tid`, or any of `deps=` / `allow_early_resolve=` / `predicate=` (for which the outliner synthesizes the TaskId Var) | the first-class `Submit::core_num_` / `sync_start_` fields |
 | `Group` from `pl.cluster(): with pl.spmd(...)` | the dispatch, same as above; the Group keeps only the `spmd_unwrapped` marker |
 
 `core_num` is an expression evaluated in the *dispatching* function's scope — it

--- a/docs/en/user/tasks/02-submit.md
+++ b/docs/en/user/tasks/02-submit.md
@@ -158,7 +158,7 @@ like any other. See [Control Flow](../language/02-control-flow.md).
 | **`pl.submit is a DSL parser construct and cannot be called directly`** | Used outside a decorated function body | Move it inside the decorated body |
 | **`unpacks 1 result value(s) but kernel returns 0`** | The kernel writes an `Out` parameter and declares no return type | Unpack only what the kernel returns, or give it a return type |
 | **`deps= entries must be a TaskId variable`** | A TaskId reached by indexing a flat submit result | Bind the TaskId to its own name and pass that |
-| **`pl.spmd(..., deps=[...]) cannot be nested inside pl.cluster()`** | A cluster-nested `pl.spmd` is unwrapped into the Group and never produces a task to hang edges on | Put the `deps=` on the `pl.cluster()` region, or use a standalone `pl.spmd` |
+| **`pl.spmd(..., deps=[...]) cannot be nested inside pl.cluster()`** | A cluster-nested `pl.spmd` is unwrapped into the Group and never produces a task to hang edges on | Drop the `pl.cluster()` wrapper — a standalone `pl.spmd` is its own implicit cluster and does take `deps=` |
 | **`core_num` missing** | It is a required keyword on `pl.spmd_submit` | Pass `core_num=N`; positional slots are the kernel's arguments |
 | **A consumer only waits on the last producer of a loop** | One TaskId was reused instead of collected | Collect into a `pl.array` of `pl.TASK_ID` and pass the array |
 | **Explicit edge seems ignored in auto scope** | It is not — the wait set is the union | Look for a *missing* edge elsewhere, not a discarded one |

--- a/docs/en/user/tasks/02-submit.md
+++ b/docs/en/user/tasks/02-submit.md
@@ -87,9 +87,9 @@ with pl.spmd(4, name_hint="stage2", deps=[first]) as second:
 It accepts `deps=`, `predicate=` and `allow_early_resolve=`, which makes it the one inline
 form that carries a dispatch predicate.
 
-**`deps=` requires the `as` form.** Binding with `as` is what gives you the TaskId; the bare
-`with pl.spmd(4):` and `for i in pl.spmd(4):` forms run the same work without naming it, and
-passing `deps=` to either is rejected with `pl.spmd() does not accept 'deps=' here`.
+All three forms take `deps=`. Binding with `as` is what gives you *this* dispatch's TaskId,
+so you only need it when a later task must wait on this one — `with pl.spmd(4, deps=[...]):`
+and `for i in pl.spmd(4, deps=[...]):` declare edges just as well without naming themselves.
 
 ### `pl.submit`
 
@@ -158,7 +158,7 @@ like any other. See [Control Flow](../language/02-control-flow.md).
 | **`pl.submit is a DSL parser construct and cannot be called directly`** | Used outside a decorated function body | Move it inside the decorated body |
 | **`unpacks 1 result value(s) but kernel returns 0`** | The kernel writes an `Out` parameter and declares no return type | Unpack only what the kernel returns, or give it a return type |
 | **`deps= entries must be a TaskId variable`** | A TaskId reached by indexing a flat submit result | Bind the TaskId to its own name and pass that |
-| **`pl.spmd() does not accept 'deps=' here`** | `deps=` was passed to the bare `with` or the `for` form | Bind the region with `as tid:` — only that form takes `deps=` |
+| **`pl.spmd(..., deps=[...]) cannot be nested inside pl.cluster()`** | A cluster-nested `pl.spmd` is unwrapped into the Group and never produces a task to hang edges on | Put the `deps=` on the `pl.cluster()` region, or use a standalone `pl.spmd` |
 | **`core_num` missing** | It is a required keyword on `pl.spmd_submit` | Pass `core_num=N`; positional slots are the kernel's arguments |
 | **A consumer only waits on the last producer of a loop** | One TaskId was reused instead of collected | Collect into a `pl.array` of `pl.TASK_ID` and pass the array |
 | **Explicit edge seems ignored in auto scope** | It is not — the wait set is the union | Look for a *missing* edge elsewhere, not a discarded one |

--- a/docs/zh/dev/language/02-manual_dependencies.md
+++ b/docs/zh/dev/language/02-manual_dependencies.md
@@ -29,7 +29,7 @@ DSL 暴露**两套正交的机制**，用户可任意组合：
 | `result, tid = pl.submit(kernel, *args, deps=[...], allow_early_resolve=False)` | 单个 kernel 调用 | 尾部 `tid` 是 producer `pl.Scalar[pl.TASK_ID]`。它是 parser construct（类似 `pl.range`），不是 runtime 函数。`allow_early_resolve=True` 将该 task 标记为推测式 early-dispatch producer（让调度器提前预置其 consumer；lower 为 `Arg::set_allow_early_resolve(true)`）。同样接受 `predicate=(t[i] > 0)` —— 调度器在 dispatch 点求值的调度谓词（参见[调度谓词](#调度谓词predicate)）。 |
 | `result, tid = pl.spmd_submit(kernel, *args, core_num=N, sync_start=False, deps=[...])` | 单个 SPMD task launch | `pl.submit` 的 SPMD 版本：将 kernel 在 `N` 个 block 上分发（一个 orchestration task → 一个 `tid`）。`core_num` 是必填关键字参数（正整数表达式）；`sync_start=True` 强制所有 block 原子启动。callee 可以是 InCore / AIC / AIV / Group。launch spec 记录在 `Submit.core_num` / `Submit.sync_start` 上。同样接受 `allow_early_resolve=True`（与 `pl.submit` 相同的 early-dispatch 选项）和 `predicate=(t[i] > 0)`（参见[调度谓词](#调度谓词predicate)）。 |
 | `with pl.at(level=pl.Level.CORE_GROUP, deps=[...]) as tid:` | outlined `pl.at`-块 | 整块被 outline 成 InCore kernel + `Submit`；`tid` 捕获被合成的 Submit 的 TaskId，可作为后续 `pl.submit` / `pl.at` 的 dep。不写 `as tid` 时 outliner 会合成一个未使用的 TaskId Var——deps 始终走 `Submit::deps_`。同样接受 `allow_early_resolve=True`（与 `pl.submit` 相同的 early-dispatch 选项）；即使不写 `as tid` 也会强制走 `Submit` 形态，并 lower 为 `Arg::set_allow_early_resolve(true)`。 |
-| `with pl.spmd(N, deps=[...]) as tid:` | outlined SPMD 分发 | `pl.at ... as tid` 形式的 SPMD 版本。内联 body 自动外包成 InCore kernel 并在 `N` 个 block 上分发；`tid` 捕获 grid 级 producer TaskId。`deps=` 仅在带 `as tid` 时可用。`core_num` / `sync_start` 记录在 lower 出的 `Submit` 自身的 `core_num` / `sync_start` 字段上（launch spec 属于启动点，而非外包出的被调函数）；codegen 直接从那里读取。同样接受 `allow_early_resolve=True`（与 `pl.submit` / `pl.at` 相同的 early-dispatch 选项；`pl.spmd` 三种形式均可用，即使不写 `as tid` 也会强制走 `Submit` 形态）和 `predicate=(t[i] > 0)`（参见[调度谓词](#调度谓词predicate)；同样三种形式均可用，同样强制走 `Submit` 形态）。不能嵌套在 `pl.cluster()` 内。 |
+| `with pl.spmd(N, deps=[...]) as tid:` | outlined SPMD 分发 | `pl.at ... as tid` 形式的 SPMD 版本。内联 body 自动外包成 InCore kernel 并在 `N` 个 block 上分发；`tid` 捕获 grid 级 producer TaskId。`deps=` 在 `pl.spmd` 三种形式上均可用；不写 `as tid` 时 outliner 会合成一个未使用的 TaskId Var，与 `pl.at` 一致。`core_num` / `sync_start` 记录在 lower 出的 `Submit` 自身的 `core_num` / `sync_start` 字段上（launch spec 属于启动点，而非外包出的被调函数）；codegen 直接从那里读取。同样接受 `allow_early_resolve=True`（与 `pl.submit` / `pl.at` 相同的 early-dispatch 选项；`pl.spmd` 三种形式均可用，即使不写 `as tid` 也会强制走 `Submit` 形态）和 `predicate=(t[i] > 0)`（参见[调度谓词](#调度谓词predicate)；同样三种形式均可用，同样强制走 `Submit` 形态）。不能嵌套在 `pl.cluster()` 内。 |
 | `barrier = pl.system.task_dummy(deps=[...])` | dependency-only barrier | 不提交 kernel。返回的 TaskId 是一个紧凑的 fan-in 点，可供后续 `deps=[barrier]` 使用。 |
 | `None`（Python 字面量） | 种子 / dep 条目 | "暂无 producer" 的哨兵。`prev_tid = None` 用作 TaskId 循环 iter_arg 的种子；`deps=[None]` 中的 `None` 被丢弃（不贡献任何边）。下沉为 `system.task_invalid` → `TaskId::invalid()`。 |
 
@@ -201,12 +201,12 @@ with pl.spmd(4, deps=[g_tid], predicate=(rc[0, 0] > 0)) as tid:  # producer 是�
 
 由这条路径引出两点：
 
-- **`deps=` 需要 `as tid` 形式。** `deps=` 只在 `with pl.spmd(...) as tid:` 上被接受。
-  因此，若谓词读取的张量由同一函数内的其他任务产出，就必须用该形式；普通 `with` 与
-  `for` 形式只能对没有函数内 producer 的张量（通常是函数参数）加谓词——这种情况契约
-  检查会放行。
-- **其余情况不要求 `as tid`。** 与 `allow_early_resolve=True` 一样，谓词会强制该作用域
-  lower 为 `Submit`；当作用域没有 `as tid` 时，outliner 会合成一个未被使用的 TaskId Var。
+- **`deps=` 不需要 `as tid`。** 与 `allow_early_resolve=True`、`predicate=` 一样，
+  `deps=` 在三种形式上均可用，并会强制该作用域 lower 为 `Submit`；当作用域没有
+  `as tid` 时，outliner 会合成一个未被使用的 TaskId Var。只有当*后续*任务需要等待本次
+  派发时，才需要捕获 TaskId。
+- **谓词契约依旧成立。** 若谓词读取的张量由同一函数内的其他任务产出，该 producer 必须
+  出现在 `deps=` 中——现在三种形式都能表达这一点。
 
 嵌套在 `pl.cluster()` 内的 `pl.spmd` 会被展开进 Group 函数、永远不会产生 `Submit`，
 因此 `predicate=`（与 `allow_early_resolve=` 一样）会在解析期被拒绝，而不是被静默丢弃。

--- a/docs/zh/dev/passes/09-outline_cluster_scopes.md
+++ b/docs/zh/dev/passes/09-outline_cluster_scopes.md
@@ -126,8 +126,8 @@ class After:
 
 | 调度形态 | 载体 |
 | -------- | ---- |
-| 普通 `Call`（`with pl.spmd(...)`，且不带任何 Submit 专属元数据） | `attrs["core_num"]`（`ExprPtr`）与 `attrs["sync_start"]`（`bool`，仅为真时发出） |
-| `Submit`（`as tid`，或带 `deps=` / `allow_early_resolve=` / `predicate=` 之一——此时 outliner 会合成 TaskId Var） | 一等字段 `Submit::core_num_` / `sync_start_` |
+| 普通 `Call`——独立的 `with pl.spmd(...)` / `for i in pl.spmd(...)`，且不带任何 Submit 专属元数据 | `attrs["core_num"]`（`ExprPtr`）与 `attrs["sync_start"]`（`bool`，仅为真时发出） |
+| `Submit`——独立的 `with pl.spmd(...)` / `for i in pl.spmd(...)`，带 `as tid`，或带 `deps=` / `allow_early_resolve=` / `predicate=` 之一（此时 outliner 会合成 TaskId Var） | 一等字段 `Submit::core_num_` / `sync_start_` |
 | `pl.cluster(): with pl.spmd(...)` 产生的 `Group` | 同上，挂在调度点；Group 上只保留 `spmd_unwrapped` 标记 |
 
 `core_num` 是在*调度方*函数作用域中求值的表达式，可能引用调用者的局部标量（例如

--- a/docs/zh/dev/passes/09-outline_cluster_scopes.md
+++ b/docs/zh/dev/passes/09-outline_cluster_scopes.md
@@ -126,8 +126,8 @@ class After:
 
 | 调度形态 | 载体 |
 | -------- | ---- |
-| 普通 `Call`（`with pl.spmd(...)`） | `attrs["core_num"]`（`ExprPtr`）与 `attrs["sync_start"]`（`bool`，仅为真时发出） |
-| `Submit`（`with pl.spmd(...) as tid`） | 一等字段 `Submit::core_num_` / `sync_start_` |
+| 普通 `Call`（`with pl.spmd(...)`，且不带任何 Submit 专属元数据） | `attrs["core_num"]`（`ExprPtr`）与 `attrs["sync_start"]`（`bool`，仅为真时发出） |
+| `Submit`（`as tid`，或带 `deps=` / `allow_early_resolve=` / `predicate=` 之一——此时 outliner 会合成 TaskId Var） | 一等字段 `Submit::core_num_` / `sync_start_` |
 | `pl.cluster(): with pl.spmd(...)` 产生的 `Group` | 同上，挂在调度点；Group 上只保留 `spmd_unwrapped` 标记 |
 
 `core_num` 是在*调度方*函数作用域中求值的表达式，可能引用调用者的局部标量（例如

--- a/docs/zh/user/tasks/02-submit.md
+++ b/docs/zh/user/tasks/02-submit.md
@@ -73,7 +73,7 @@ with pl.spmd(4, name_hint="stage2", deps=[first]) as second:
 
 它接受 `deps=`、`predicate=` 与 `allow_early_resolve=`，这使它成为唯一带派发谓词的内联写法。
 
-**`deps=` 只有 `as` 形式接受。** 用 `as` 绑定才拿得到 TaskId；裸 `with pl.spmd(4):` 与 `for i in pl.spmd(4):` 照样执行同样的工作但不给它命名，向这两种形式传 `deps=` 会被拒绝并报 `pl.spmd() does not accept 'deps=' here`。
+**三种形式都接受 `deps=`。** 用 `as` 绑定拿到的是*本次*派发的 TaskId，只有当后续任务需要等待它时才需要；裸 `with pl.spmd(4, deps=[...]):` 与 `for i in pl.spmd(4, deps=[...]):` 同样可以声明依赖边，只是不给自己命名。
 
 ### `pl.submit`
 
@@ -129,7 +129,7 @@ out, _ = pl.submit(self.consumer, data, out, deps=[tids])
 | **`pl.submit is a DSL parser construct and cannot be called directly`** | 在被装饰函数体外使用 | 移进被装饰的函数体内 |
 | **`unpacks 1 result value(s) but kernel returns 0`** | kernel 写的是 `Out` 参数且没声明返回类型 | 只解包 kernel 真正返回的东西，或给它加上返回类型 |
 | **`deps= entries must be a TaskId variable`** | TaskId 是对扁平 submit 结果做下标得到的 | 把 TaskId 绑定到独立的名字再传 |
-| **`pl.spmd() does not accept 'deps=' here`** | 向裸 `with` 或 `for` 形式传了 `deps=` | 用 `as tid:` 绑定该区域 —— 只有这种形式接受 `deps=` |
+| **`pl.spmd(..., deps=[...]) cannot be nested inside pl.cluster()`** | 嵌套在 cluster 内的 `pl.spmd` 会被展开进 Group 函数，不会产生可挂依赖边的任务 | 把 `deps=` 放到 `pl.cluster()` 区域上，或改用独立的 `pl.spmd` |
 | **`core_num` 缺失** | 它是 `pl.spmd_submit` 的必需关键字 | 传 `core_num=N`；位置槽是 kernel 的实参 |
 | **消费者只等到了循环的最后一个生产者** | 复用了一个 TaskId 而没有收集 | 收进 `pl.TASK_ID` 的 `pl.array` 并把数组传入 |
 | **auto 作用域里显式边似乎被忽略** | 并没有 —— 等待集合是并集 | 去别处找**缺失**的边，而不是被丢弃的边 |

--- a/docs/zh/user/tasks/02-submit.md
+++ b/docs/zh/user/tasks/02-submit.md
@@ -129,7 +129,7 @@ out, _ = pl.submit(self.consumer, data, out, deps=[tids])
 | **`pl.submit is a DSL parser construct and cannot be called directly`** | 在被装饰函数体外使用 | 移进被装饰的函数体内 |
 | **`unpacks 1 result value(s) but kernel returns 0`** | kernel 写的是 `Out` 参数且没声明返回类型 | 只解包 kernel 真正返回的东西，或给它加上返回类型 |
 | **`deps= entries must be a TaskId variable`** | TaskId 是对扁平 submit 结果做下标得到的 | 把 TaskId 绑定到独立的名字再传 |
-| **`pl.spmd(..., deps=[...]) cannot be nested inside pl.cluster()`** | 嵌套在 cluster 内的 `pl.spmd` 会被展开进 Group 函数，不会产生可挂依赖边的任务 | 把 `deps=` 放到 `pl.cluster()` 区域上，或改用独立的 `pl.spmd` |
+| **`pl.spmd(..., deps=[...]) cannot be nested inside pl.cluster()`** | 嵌套在 cluster 内的 `pl.spmd` 会被展开进 Group 函数，不会产生可挂依赖边的任务 | 去掉 `pl.cluster()` 包装 —— 独立的 `pl.spmd` 自带隐式 cluster，且接受 `deps=` |
 | **`core_num` 缺失** | 它是 `pl.spmd_submit` 的必需关键字 | 传 `core_num=N`；位置槽是 kernel 的实参 |
 | **消费者只等到了循环的最后一个生产者** | 复用了一个 TaskId 而没有收集 | 收进 `pl.TASK_ID` 的 `pl.array` 并把数组传入 |
 | **auto 作用域里显式边似乎被忽略** | 并没有 —— 等待集合是并集 | 去别处找**缺失**的边，而不是被丢弃的边 |

--- a/python/pypto/language/dsl_api.py
+++ b/python/pypto/language/dsl_api.py
@@ -770,7 +770,10 @@ def spmd(
     | --- | --- |
     | `with pl.spmd(n):` | Dispatch or inline block (no captured TaskId). |
     | `for i in pl.spmd(n):` | Loop-style; `i` = per-block index, body is auto-outlined to InCore. |
-    | `with pl.spmd(n) as tid:` | Same body as form 1, plus TaskId in `tid` (optionally pass `deps=[...]`). |
+    | `with pl.spmd(n) as tid:` | Same body as form 1, plus the dispatch TaskId in `tid`. |
+
+    ``deps=[...]`` works on all three: capturing the TaskId is only needed when a
+    *later* task must wait on this one.
 
     Usage forms:
 
@@ -786,7 +789,8 @@ def spmd(
        sole body statement *is* the InCore carrier and is not wrapped again; with
        such a body ``optimizations=`` must go on that ``pl.at(...)`` rather than on
        the ``pl.spmd(...)`` line. Captures no producer TaskId (use form 3 for
-       that). Can stand alone (implicit cluster) or nest inside ``pl.cluster()``.
+       that), but still accepts ``deps=``. Can stand alone (implicit cluster) or
+       nest inside ``pl.cluster()``.
 
     2. ``for i in pl.spmd(n):`` — loop-style. The iteration variable binds
        the per-block index (equivalent to ``pl.tile.get_block_idx()``); the
@@ -799,7 +803,7 @@ def spmd(
        ``tid`` (mirroring ``with pl.at(...) as tid:``), usable as a ``deps=`` edge
        on later tasks, stored into a ``pl.array.create(N, pl.TASK_ID)``, or
        crossing into ``pl.manual_scope``. TaskId capture is the only thing this
-       adds over form 1 — it is orthogonal to the inline body.
+       adds over form 1 — it is orthogonal to both the inline body and ``deps=``.
 
     Optional ``optimizations=[pl.split(mode)]`` applies to the inner InCore scope
     (auto-generated for the for-form and the ``as tid`` form, wrapped around the
@@ -824,9 +828,14 @@ def spmd(
         optimizations: Optional list literal containing only ``pl.split(mode)``
             entries (the parser inspects the AST).
         deps: Optional explicit producer-edge list (TaskId Vars and/or ``None``
-            sentinels), accepted only with the ``as tid`` form. Lowered to the
-            outlined Submit's ``manual_dep_edges``; codegen packs it into a
+            sentinels), accepted on all three forms. Lowered to the outlined
+            Submit's ``manual_dep_edges``; codegen packs it into a
             ``set_dependencies(...)`` invocation (union'd with auto-deps).
+            Like ``allow_early_resolve`` it forces the dispatch to lower to an
+            ``ir.Submit`` even without ``as tid`` — the Spmd outliner synthesises
+            the (unused) producer TaskId Var that shape needs. Rejected on a
+            ``pl.cluster()``-nested ``pl.spmd``, which is unwrapped into the Group
+            function and never produces a Submit.
         allow_early_resolve: Opt the grid dispatch in as a speculative
             early-dispatch producer (simpler#1065). Same hint as
             ``pl.submit(..., allow_early_resolve=True)`` / ``pl.at(...,
@@ -852,9 +861,7 @@ def spmd(
             ``pl.cluster()``-nested ``pl.spmd``.
 
             **Contract:** the operand tensor's producing task must be one of
-            ``deps=`` — otherwise the predicate may read a stale value. ``deps=``
-            is only available on the ``as tid`` form, so a predicate over a
-            tensor produced in the same function needs that form. The parser
+            ``deps=`` — otherwise the predicate may read a stale value. The parser
             makes a best-effort check (see ``pl.spmd_submit``); getting ``deps=``
             right remains the author's responsibility.
 

--- a/python/pypto/language/dsl_api.py
+++ b/python/pypto/language/dsl_api.py
@@ -790,7 +790,10 @@ def spmd(
        such a body ``optimizations=`` must go on that ``pl.at(...)`` rather than on
        the ``pl.spmd(...)`` line. Captures no producer TaskId (use form 3 for
        that), but still accepts ``deps=``. Can stand alone (implicit cluster) or
-       nest inside ``pl.cluster()``.
+       nest inside ``pl.cluster()`` — but only a scope carrying no Submit-only
+       metadata may nest: ``deps=`` / ``allow_early_resolve=`` / ``predicate=``
+       require the standalone form (a cluster-nested pl.spmd is unwrapped into
+       the Group function and never produces the ``Submit`` that carries them).
 
     2. ``for i in pl.spmd(n):`` — loop-style. The iteration variable binds
        the per-block index (equivalent to ``pl.tile.get_block_idx()``); the

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -4590,6 +4590,42 @@ class ASTParser:
             hint=f"Use a standalone `with pl.spmd(..., {kwarg}):` (implicit cluster) to keep it.",
         )
 
+    @staticmethod
+    def _build_spmd_scope_attrs(
+        dep_vars: "list[ir.Var]",
+        allow_early_resolve: bool,
+        predicate: "ir.Expr | None",
+        task_id_var: "ir.Var | None" = None,
+    ) -> "list[tuple[str, Any]]":
+        """Build a ``SpmdScopeStmt``'s attr list in canonical order.
+
+        The single source of the ordering shared by all three ``pl.spmd`` forms:
+        ``manual_dep_edges``, ``task_id_var`` (``as tid`` only), then
+        ``allow_early_resolve``, then ``predicate`` — mirroring
+        :meth:`_parse_at_meta` for ``pl.at`` scopes.
+
+        **The order is load-bearing.** ``structural_equal`` compares scope attrs
+        positionally, so a print -> reparse cycle only round-trips while this
+        matches the printer's emission order (``PrintScopeDepsAttr`` ->
+        ``PrintScopeTaskIdVarSuffix`` -> ``PrintScopeAllowEarlyResolveAttr`` ->
+        ``PrintScopePredicateAttr`` in ``python_printer.cpp``). Keeping it in one
+        place is what makes adding a kwarg a two-file change instead of a
+        four-site one.
+
+        Each entry is omitted when unset, so a plain ``with pl.spmd(n):`` yields
+        an empty list (the caller passes ``attrs=... or None``).
+        """
+        attrs: list[tuple[str, Any]] = []
+        if dep_vars:
+            attrs.append(("manual_dep_edges", dep_vars))
+        if task_id_var is not None:
+            attrs.append(("task_id_var", task_id_var))
+        if allow_early_resolve:
+            attrs.append(("allow_early_resolve", True))
+        if predicate is not None:
+            attrs.append(("predicate", predicate))
+        return attrs
+
     def _reject_submit_dispatch_metadata_in_cluster(
         self,
         *,
@@ -4958,17 +4994,9 @@ class ASTParser:
         # of them would be silently dropped — reject them here (mirrors the
         # ``as tid`` cluster rejection in _parse_spmd_scope_with_tid).
         self._reject_spmd_submit_only_kwargs_in_cluster(dep_vars, allow_early_resolve, predicate, span)
-        # Canonical attr order: manual_dep_edges, then allow_early_resolve, then
-        # predicate (the ``as tid`` form inserts task_id_var between the first two)
-        # so a print -> reparse compares equal under structural_equal's positional
-        # attr check.
-        spmd_attrs: list[tuple[str, Any]] = []
-        if dep_vars:
-            spmd_attrs.append(("manual_dep_edges", dep_vars))
-        if allow_early_resolve:
-            spmd_attrs.append(("allow_early_resolve", True))
-        if predicate is not None:
-            spmd_attrs.append(("predicate", predicate))
+        # No task_id_var — this form captures none; the rest of the canonical
+        # order is shared with the other two forms.
+        spmd_attrs = self._build_spmd_scope_attrs(dep_vars, allow_early_resolve, predicate)
 
         # No ``as tid``: the plain with-form. Any ``deps=`` rides on the scope as
         # ``manual_dep_edges`` and the Spmd outliner synthesises the TaskId Var it
@@ -5039,26 +5067,13 @@ class ASTParser:
                 hint="Use `with pl.spmd(...) as tid:` (single name; nested tuples are not allowed).",
             )
 
-        # Canonical attr order (deps, task_id_var, allow_early_resolve,
-        # predicate) mirrors _parse_at_meta so a print -> reparse cycle compares
-        # equal under structural_equal's positional attr check.
-        scope_attrs: list[tuple[str, Any]] = []
-        if dep_vars:
-            scope_attrs.append(("manual_dep_edges", dep_vars))
+        # ``task_id_var`` is the only attr unique to this form. The Spmd outliner
+        # reads each one off the scope and threads it onto the synthesised Submit;
+        # ``predicate`` in particular carries live SSA Vars (the operand tensor and
+        # its indices), which ConvertToSSA versions via SubstScopeAttrs.
         tid_var = self.builder.var(optional_vars.id, ir.ScalarType(DataType.TASK_ID), span=span)
         self.scope_manager.define_var(optional_vars.id, tid_var, span=span)
-        scope_attrs.append(("task_id_var", tid_var))
-        # ``allow_early_resolve`` last (canonical order) — the Spmd outliner reads
-        # it off the scope and threads it onto the synthesised Submit, exactly as
-        # _parse_at_meta does for pl.at scopes.
-        if allow_early_resolve:
-            scope_attrs.append(("allow_early_resolve", True))
-        # ``predicate`` after it — an Expr (not a flag), read off the scope by the
-        # Spmd outliner and moved onto ``Submit.predicate``. It carries live SSA
-        # Vars (the operand tensor and its indices), which ConvertToSSA versions
-        # via SubstScopeAttrs.
-        if predicate is not None:
-            scope_attrs.append(("predicate", predicate))
+        scope_attrs = self._build_spmd_scope_attrs(dep_vars, allow_early_resolve, predicate, tid_var)
 
         # Emit the transient ``AssignStmt(tid, system.task_invalid())`` placeholder
         # one stmt BEFORE the scope so ConvertToSSA has a def for the tid Var; the
@@ -5184,14 +5199,8 @@ class ASTParser:
         # A cluster-nested pl.spmd is unwrapped into the Group and never produces
         # a Submit, so reject them there (mirrors the with-form / as-tid guards).
         self._reject_spmd_submit_only_kwargs_in_cluster(dep_vars, allow_early_resolve, predicate, span)
-        # Canonical attr order — see the with-form.
-        spmd_attrs: list[tuple[str, Any]] = []
-        if dep_vars:
-            spmd_attrs.append(("manual_dep_edges", dep_vars))
-        if allow_early_resolve:
-            spmd_attrs.append(("allow_early_resolve", True))
-        if predicate is not None:
-            spmd_attrs.append(("predicate", predicate))
+        # No task_id_var — the for-form captures none (see the with-form).
+        spmd_attrs = self._build_spmd_scope_attrs(dep_vars, allow_early_resolve, predicate)
         # Merge forward-sticky pl.dump_tag tensors onto the auto-outlined InCore
         # scope — the kernel the loop body lowers to. The with-form (pl.at /
         # pl.spmd / pl.cluster) routes through _parse_scope_body for this; the

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -4395,25 +4395,30 @@ class ASTParser:
         return kw.value.value
 
     # ``pl.spmd()`` keywords whose *value* the caller interprets. ``deps`` is
-    # conditionally legal (see _validate_spmd_kwarg_name).
+    # legal on every form: declaring edges is orthogonal to capturing the
+    # dispatch TaskId with ``as tid`` (see _parse_spmd_kwargs).
     _SPMD_KWARGS = frozenset(
-        {"core_num", "sync_start", "name_hint", "optimizations", "allow_early_resolve", "predicate"}
+        {
+            "core_num",
+            "sync_start",
+            "name_hint",
+            "optimizations",
+            "deps",
+            "allow_early_resolve",
+            "predicate",
+        }
     )
 
-    def _validate_spmd_kwarg_name(
-        self, kw: ast.keyword, anchor: ast.AST, *, usage_hint: str, allow_deps: bool
-    ) -> None:
+    def _validate_spmd_kwarg_name(self, kw: ast.keyword, anchor: ast.AST, *, usage_hint: str) -> None:
         """Reject a ``pl.spmd()`` keyword that is not legal in this context.
 
         Split out of :meth:`_parse_spmd_kwargs` so that method handles only what
         each keyword's *value* means, while "is this keyword name accepted here"
-        lives in one place. Covers three rejections:
+        lives in one place. Covers two rejections:
 
         * ``**kwargs`` unpacking (``kw.arg is None``) — the parser must see each
           keyword literally.
-        * ``deps=`` outside the ``as tid`` capture form, where there is no TaskId
-          to hang the edges on.
-        * any unrecognised name, whose hint lists the keywords valid *here*.
+        * any unrecognised name, whose hint lists the keywords valid here.
         """
         if kw.arg is None:
             # `pl.spmd(**cfg)` — ast.keyword.arg is None for **kwargs unpacking.
@@ -4423,24 +4428,13 @@ class ASTParser:
                 span=self.span_tracker.get_span(kw.value),
                 hint=usage_hint,
             )
-        if kw.arg == "deps" and not allow_deps:
-            raise ParserSyntaxError(
-                "pl.spmd() does not accept 'deps=' here",
-                span=self.span_tracker.get_span(kw.value),
-                hint="Use `with pl.spmd(n, deps=[...]) as tid:` (the with-form) to "
-                "declare explicit TaskId deps, or `out, tid = pl.spmd_submit(..., "
-                "deps=[...])` for the single-call form.",
-            )
-        if kw.arg == "deps" or kw.arg in self._SPMD_KWARGS:
+        if kw.arg in self._SPMD_KWARGS:
             return
-        supported = "'sync_start', 'name_hint', 'optimizations', "
-        if allow_deps:
-            supported += "'deps', "
-        supported += "'allow_early_resolve', 'predicate'"
         raise ParserSyntaxError(
             f"pl.spmd() got unexpected keyword argument '{kw.arg}'",
             span=self.span_tracker.get_span(anchor),
-            hint=f"Supported keywords: {supported}",
+            hint="Supported keywords: 'sync_start', 'name_hint', 'optimizations', 'deps', "
+            "'allow_early_resolve', 'predicate'",
         )
 
     def _parse_spmd_kwargs(
@@ -4449,7 +4443,6 @@ class ASTParser:
         call: ast.Call,
         *,
         usage_hint: str,
-        allow_deps: bool = False,
     ) -> tuple[
         "ir.Expr", bool, str, "ir.SplitMode | None", "int | None", "list[ir.Var]", bool, "ir.Expr | None"
     ]:
@@ -4466,11 +4459,14 @@ class ASTParser:
         ``optimizations=[...]`` accepts only ``pl.split(MODE)`` — see
         :meth:`_parse_spmd_optimizations_list`.
 
-        ``deps=[...]`` is accepted only when ``allow_deps`` is True (the
-        ``with pl.spmd(...) as tid:`` form). It takes the same shapes as
+        ``deps=[...]`` is accepted on every form. It takes the same shapes as
         ``pl.submit(..., deps=)`` / ``pl.at(..., deps=)`` — producer TaskId
         ``Scalar[TASK_ID]`` Vars, an ``Array[N, TASK_ID]`` carry, or the ``None``
-        sentinel — resolved via :meth:`_parse_submit_deps_kwarg`.
+        sentinel — resolved via :meth:`_parse_submit_deps_kwarg`. Capturing the
+        dispatch TaskId with ``as tid`` is orthogonal: a scope that declares
+        edges without capturing one still lowers to a ``Submit`` (the Spmd
+        outliner synthesises the unused TaskId Var), exactly as
+        ``pl.at(..., deps=[...])`` already does without an ``as`` clause.
 
         ``allow_early_resolve=True/False`` is a speculative early-dispatch hint
         (same as ``pl.submit`` / ``pl.at``); it is always accepted here (it needs
@@ -4481,10 +4477,10 @@ class ASTParser:
         the same validation as ``pl.spmd_submit(..., predicate=)``, shared via
         :meth:`_parse_submit_predicate_kwarg`. It rides on the ``SpmdScopeStmt``
         until ``OutlineSpmdScopes`` moves it onto the synthesised ``Submit``.
-        Like ``allow_early_resolve`` it needs no ``as tid`` (the outliner
-        synthesises a TaskId Var when the scope has none) and is rejected by the
-        same cluster-nesting guard. The producer-in-``deps=`` contract is checked
-        below, once ``dep_vars`` is resolved.
+        Like ``allow_early_resolve`` and ``deps=`` it needs no ``as tid`` (the
+        outliner synthesises a TaskId Var when the scope has none) and is
+        rejected by the same cluster-nesting guard. The producer-in-``deps=``
+        contract is checked below, once ``dep_vars`` is resolved.
         """
         if len(call.args) > 1:
             raise ParserSyntaxError(
@@ -4503,7 +4499,7 @@ class ASTParser:
         allow_early_resolve: bool = False
         predicate: ir.Expr | None = None
         for kw in call.keywords:
-            self._validate_spmd_kwarg_name(kw, anchor, usage_hint=usage_hint, allow_deps=allow_deps)
+            self._validate_spmd_kwarg_name(kw, anchor, usage_hint=usage_hint)
             if kw.arg == "name_hint":
                 name_hint = self._parse_scope_name_hint(kw.value, "pl.spmd()")
             elif kw.arg == "core_num":
@@ -4539,18 +4535,11 @@ class ASTParser:
         # Producer-in-deps contract, checked once dep_vars is known. Same
         # best-effort spot check as pl.spmd_submit: the scheduler reads the
         # operand at the dispatch point, so its producing task must be a
-        # dependency or the read may observe a stale value. On the plain /
-        # for-forms deps= is unavailable, so a tracked producer reports here and
-        # the error steers the author to the ``as tid`` form.
+        # dependency or the read may observe a stale value. Every pl.spmd form
+        # accepts deps=, so the remediation hint is always "add the producer".
         if predicate is not None:
             self._validate_predicate_deps(
-                "pl.spmd()",
-                predicate,
-                dep_vars,
-                self.span_tracker.get_span(anchor),
-                # allow_deps is False on the plain / for-forms, where deps= is
-                # rejected outright — the hint must not tell the author to add one.
-                deps_accepted=allow_deps,
+                "pl.spmd()", predicate, dep_vars, self.span_tracker.get_span(anchor)
             )
         return (
             core_num,
@@ -4564,23 +4553,30 @@ class ASTParser:
         )
 
     def _reject_spmd_submit_only_kwargs_in_cluster(
-        self, allow_early_resolve: bool, predicate: "ir.Expr | None", span: "ir.Span"
+        self,
+        dep_vars: "list[ir.Var]",
+        allow_early_resolve: bool,
+        predicate: "ir.Expr | None",
+        span: "ir.Span",
     ) -> None:
         """Reject Submit-only ``pl.spmd()`` kwargs on a ``pl.cluster()``-nested scope.
 
-        Covers ``allow_early_resolve=True`` and ``predicate=(...)``: both are
-        carried by ``Submit`` fields with no plain-``Call`` equivalent. A
-        cluster-nested Spmd scope is unwrapped into the Group function by
-        ``OutlineClusterScopes`` (``UnwrapNestedSpmd``) and never lowers to a
-        ``Submit``, so either would be silently dropped. Raise a clear parse-time
-        error instead, mirroring the ``as tid`` cluster rejection in
-        :meth:`_parse_spmd_scope_with_tid`. ``UnwrapNestedSpmd`` re-asserts this
-        for hand-built / deserialized IR.
+        Covers ``deps=[...]``, ``allow_early_resolve=True`` and
+        ``predicate=(...)``: each is carried by a ``Submit`` field (``deps_`` /
+        ``allow_early_resolve_`` / ``predicate_``) with no plain-``Call``
+        equivalent. A cluster-nested Spmd scope is unwrapped into the Group
+        function by ``OutlineClusterScopes`` (``UnwrapNestedSpmd``) and never
+        lowers to a ``Submit``, so any of them would be silently dropped. Raise a
+        clear parse-time error instead, mirroring the ``as tid`` cluster
+        rejection in :meth:`_parse_spmd_scope_with_tid`. ``UnwrapNestedSpmd``
+        re-asserts this for hand-built / deserialized IR.
         """
         if not self._is_inside_scope(ir.ScopeKind.Cluster):
             return
         # Report the kwarg the user actually wrote, so the message names it.
-        if allow_early_resolve:
+        if dep_vars:
+            kwarg, lost = "deps=[...]", "the dependency edges"
+        elif allow_early_resolve:
             kwarg, lost = "allow_early_resolve=True", "the early-dispatch hint"
         elif predicate is not None:
             kwarg, lost = "predicate=(...)", "the dispatch predicate"
@@ -4903,31 +4899,27 @@ class ASTParser:
         Two forms, differing only in whether the grid dispatch's producer TaskId is
         captured — the body shape is identical (see :meth:`_emit_spmd_body`):
 
-        * ``with pl.spmd(n):`` — no captured TaskId, no ``deps=``. Accepts either a
-          dispatch body calling a pre-defined kernel (direct dispatch) or an inline
-          body auto-outlined into an InCore kernel (like ``for i in pl.spmd(n):``,
+        * ``with pl.spmd(n):`` — no captured TaskId. Accepts either a dispatch
+          body calling a pre-defined kernel (direct dispatch) or an inline body
+          auto-outlined into an InCore kernel (like ``for i in pl.spmd(n):``,
           minus the auto-bound loop var — read the per-block index inside via
           ``pl.tile.get_block_idx()``).
         * ``with pl.spmd(n, deps=[...]) as tid:`` — same body shapes, and
           additionally captures the producer ``Scalar[TASK_ID]`` (mirrors
           ``with pl.at(...) as tid:``) so it can feed a ``deps=`` edge.
 
-        TaskId capture and inline bodies are orthogonal: the inline body is outlined
-        the same way with or without ``as tid``; ``as tid`` only adds the
-        ``task_id_var`` attr that makes the dispatch lower to an ``ir.Submit``.
+        TaskId capture, ``deps=`` and inline bodies are all orthogonal: the inline
+        body is outlined the same way with or without ``as tid``; ``as tid`` only
+        adds the ``task_id_var`` attr. ``deps=`` alone is enough to force the
+        ``ir.Submit`` shape — the Spmd outliner synthesises an unused TaskId Var
+        for a scope that declares edges without capturing one, the same way
+        ``pl.at(..., deps=[...])`` works without an ``as`` clause.
         """
         with_hint = (
             "Use 'with pl.spmd(4):' with a body that dispatches a 'self.<kernel>(...)' call "
             "or reads 'pl.tile.get_block_idx()', or 'with pl.spmd(4) as tid:' to also "
             "capture the dispatch TaskId."
         )
-        # ``deps=`` is accepted ONLY with ``as tid`` — gate it by keyword presence,
-        # not by the resolved list being non-empty. _parse_submit_deps_kwarg
-        # normalizes ``deps=[]`` / ``deps=[None]`` to ``[]``, so a truthiness check
-        # would silently accept those unsupported forms on the plain with-form.
-        # Passing allow_deps=(optional_vars is not None) makes _parse_spmd_kwargs
-        # reject any ``deps=`` on the non-capturing form (and keeps its "supported
-        # keywords" hint accurate).
         (
             core_num,
             sync_start,
@@ -4937,9 +4929,7 @@ class ASTParser:
             dep_vars,
             allow_early_resolve,
             predicate,
-        ) = self._parse_spmd_kwargs(
-            stmt, context_expr, usage_hint=with_hint, allow_deps=optional_vars is not None
-        )
+        ) = self._parse_spmd_kwargs(stmt, context_expr, usage_hint=with_hint)
         scope_kind = scope_kind_map["spmd"]
         span = self.span_tracker.get_span(stmt)
 
@@ -4960,26 +4950,31 @@ class ASTParser:
             )
             return
 
-        # ``allow_early_resolve`` opts the grid dispatch into speculative
-        # early-dispatch and ``predicate`` gates it at the dispatch point (both
-        # mirror pl.submit / pl.spmd_submit). A cluster-nested pl.spmd is
-        # unwrapped into the Group function by OutlineClusterScopes and never
-        # lowers to a Submit, so either would be silently dropped — reject them
-        # here (mirrors the ``as tid`` cluster rejection in
-        # _parse_spmd_scope_with_tid).
-        self._reject_spmd_submit_only_kwargs_in_cluster(allow_early_resolve, predicate, span)
-        spmd_attrs: list[tuple[str, Any]] = [("allow_early_resolve", True)] if allow_early_resolve else []
-        # Canonical attr order: allow_early_resolve then predicate (matches the
-        # ``as tid`` form) so a print -> reparse compares equal under
-        # structural_equal's positional attr check.
+        # ``deps=`` declares explicit producer edges, ``allow_early_resolve`` opts
+        # the grid dispatch into speculative early-dispatch, and ``predicate``
+        # gates it at the dispatch point (all three mirror pl.submit /
+        # pl.spmd_submit). A cluster-nested pl.spmd is unwrapped into the Group
+        # function by OutlineClusterScopes and never lowers to a Submit, so any
+        # of them would be silently dropped — reject them here (mirrors the
+        # ``as tid`` cluster rejection in _parse_spmd_scope_with_tid).
+        self._reject_spmd_submit_only_kwargs_in_cluster(dep_vars, allow_early_resolve, predicate, span)
+        # Canonical attr order: manual_dep_edges, then allow_early_resolve, then
+        # predicate (the ``as tid`` form inserts task_id_var between the first two)
+        # so a print -> reparse compares equal under structural_equal's positional
+        # attr check.
+        spmd_attrs: list[tuple[str, Any]] = []
+        if dep_vars:
+            spmd_attrs.append(("manual_dep_edges", dep_vars))
+        if allow_early_resolve:
+            spmd_attrs.append(("allow_early_resolve", True))
         if predicate is not None:
             spmd_attrs.append(("predicate", predicate))
 
-        # No ``as tid``: the plain with-form. ``deps=`` was already rejected above
-        # (allow_deps=False), so dep_vars is empty here. The shared helper leaves a
-        # dispatch body unwrapped and outlines an inline body into a synthetic
-        # InCore kernel — identical to the ``as tid`` form, minus the captured
-        # TaskId.
+        # No ``as tid``: the plain with-form. Any ``deps=`` rides on the scope as
+        # ``manual_dep_edges`` and the Spmd outliner synthesises the TaskId Var it
+        # needs to emit a Submit. The shared helper leaves a dispatch body
+        # unwrapped and outlines an inline body into a synthetic InCore kernel —
+        # identical to the ``as tid`` form, minus the captured TaskId.
         self._emit_spmd_body(
             stmt,
             span,
@@ -5166,29 +5161,35 @@ class ASTParser:
                     hint=spmd_hint,
                 )
 
-        # The for-form does not capture a TaskId, so it rejects deps= (allow_deps
-        # defaults False): use the with-form `with pl.spmd(n, deps=[...]) as tid:`
-        # to wire explicit deps. dep_vars is therefore always empty here.
+        # The for-form captures no TaskId, but ``deps=`` does not need one: the
+        # edges ride on the SpmdScopeStmt and the Spmd outliner synthesises the
+        # TaskId Var required to emit a Submit. Use the with-form
+        # `with pl.spmd(n, deps=[...]) as tid:` when the dispatch must also be
+        # nameable as a later task's dependency.
         (
             core_num,
             sync_start,
             name_hint,
             split_mode,
             split_slot_num,
-            _,
+            dep_vars,
             allow_early_resolve,
             predicate,
         ) = self._parse_spmd_kwargs(stmt, iter_call, usage_hint=spmd_hint)
         spmd_name_hint, incore_name_hint = _split_spmd_for_loop_name_hints(name_hint)
 
         span = self.span_tracker.get_span(stmt)
-        # ``allow_early_resolve`` / ``predicate`` ride on the SpmdScopeStmt (read
-        # by the Spmd outliner onto the synthesised Submit). A cluster-nested
-        # pl.spmd is unwrapped into the Group and never produces a Submit, so
-        # reject them there (mirrors the with-form / as-tid guards).
-        self._reject_spmd_submit_only_kwargs_in_cluster(allow_early_resolve, predicate, span)
-        spmd_attrs: list[tuple[str, Any]] = [("allow_early_resolve", True)] if allow_early_resolve else []
+        # ``deps=`` / ``allow_early_resolve`` / ``predicate`` ride on the
+        # SpmdScopeStmt (read by the Spmd outliner onto the synthesised Submit).
+        # A cluster-nested pl.spmd is unwrapped into the Group and never produces
+        # a Submit, so reject them there (mirrors the with-form / as-tid guards).
+        self._reject_spmd_submit_only_kwargs_in_cluster(dep_vars, allow_early_resolve, predicate, span)
         # Canonical attr order — see the with-form.
+        spmd_attrs: list[tuple[str, Any]] = []
+        if dep_vars:
+            spmd_attrs.append(("manual_dep_edges", dep_vars))
+        if allow_early_resolve:
+            spmd_attrs.append(("allow_early_resolve", True))
         if predicate is not None:
             spmd_attrs.append(("predicate", predicate))
         # Merge forward-sticky pl.dump_tag tensors onto the auto-outlined InCore
@@ -7553,8 +7554,6 @@ class ASTParser:
         predicate: ir.Expr,
         dep_vars: list[ir.Var],
         span: ir.Span,
-        *,
-        deps_accepted: bool = True,
     ) -> None:
         """Enforce that a ``predicate=`` operand's producer is one of ``deps=``.
 
@@ -7570,12 +7569,6 @@ class ASTParser:
         parameter, say) has no tracked producer, and an ``Array[N, TASK_ID]``
         dep entry does not name its producers individually — both are skipped
         rather than risk rejecting a correct program.
-
-        ``deps_accepted`` tailors the remediation hint. The plain
-        ``with pl.spmd(...):`` and ``for i in pl.spmd(...):`` forms do not take
-        ``deps=`` at all, so telling their author to add one would send them
-        into a second, different error; there the fix is to switch to the
-        ``as tid`` capture form.
         """
         if not isinstance(predicate, self._PREDICATE_CMP_TYPES):
             return
@@ -7596,17 +7589,10 @@ class ASTParser:
         if any(d is producer_tid for d in dep_vars) and current_gen == producer_gen:
             return
         tid_name = producer_tid.name_hint
-        why = (
-            "Without it the scheduler may evaluate the predicate before the producing task has "
-            "written the tensor."
-        )
         hint = (
-            f"Add the producer to the dependency list: deps=[{tid_name}]. {why}"
-            if deps_accepted
-            else (
-                f"This form does not accept deps=. Capture the TaskId instead: "
-                f"`with pl.spmd(n, deps=[{tid_name}], predicate=...) as tid:`. {why}"
-            )
+            f"Add the producer to the dependency list: deps=[{tid_name}]. Without it the "
+            "scheduler may evaluate the predicate before the producing task has written the "
+            "tensor."
         )
         raise ParserSyntaxError(
             f"'{method_name}' predicate reads '{operand.name_hint}', which is produced by the task "

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -2318,6 +2318,10 @@ void IRPythonPrinter::VisitStmt_(const SpmdScopeStmtPtr& op) {
     if (incore) {
       PrintScopeOptimizations(incore->split_, incore);
     }
+    // ``deps=`` needs no ``as tid``: the Spmd outliner synthesises the TaskId Var
+    // it needs to emit a Submit, so the for-form carries edges too and must print
+    // them or the round-trip drops the dependency.
+    PrintScopeDepsAttr(op);
     PrintScopeAllowEarlyResolveAttr(op);
     PrintScopePredicateAttr(op);
     stream_ << "):\n";
@@ -2355,6 +2359,9 @@ void IRPythonPrinter::VisitStmt_(const SpmdScopeStmtPtr& op) {
   if (!op->name_hint_.empty()) {
     stream_ << ", name_hint=\"" << op->name_hint_ << "\"";
   }
+  // Same as the for-form above: a plain ``with pl.spmd(...):`` may carry
+  // ``manual_dep_edges`` without a captured TaskId.
+  PrintScopeDepsAttr(op);
   PrintScopeAllowEarlyResolveAttr(op);
   PrintScopePredicateAttr(op);
   stream_ << "):\n";

--- a/tests/ut/codegen/test_spmd_scope_tid_codegen.py
+++ b/tests/ut/codegen/test_spmd_scope_tid_codegen.py
@@ -171,6 +171,56 @@ class TestSpmdScopeTaskIdCodegen:
             f"expected set_dependencies({deps_arr}, ...) tying the dep to {alias!r}\n{code}"
         )
 
+    def test_deps_without_as_tid_emit_set_dependencies(self):
+        """``deps=`` needs no ``as tid``: the Spmd outliner synthesises the producer
+        TaskId Var, so the dispatch still lowers to a Submit and emits
+        ``set_dependencies(...)``.
+
+        Only the *consumer* omits the capture here — the producer keeps ``as tid``
+        because naming it is exactly what ``deps=`` needs. The synthesised TaskId
+        is unconsumed, so codegen must not require it to be bound to anything.
+        """
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class P:
+            @pl.function(type=pl.FunctionType.InCore)
+            def vkernel(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                t = pl.load(a, [0, 0], [512, 128])
+                out = pl.store(pl.add(t, t), [0, 0], out)
+                return out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out1: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+                out2: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                with pl.spmd(4, name_hint="stage1") as tid0:
+                    out1 = self.vkernel(a, out1)
+                # No ``as tid`` — the edge is declared, the TaskId is not needed.
+                with pl.spmd(4, name_hint="stage2", deps=[tid0]):
+                    out2 = self.vkernel(a, out2)
+                return out2
+
+        transformed = self._mixed_spmd_pipeline(P)
+        code = self._codegen(transformed)
+        m = re.search(r"TaskId (\w+) = task_0_outs\.task_id\(\);", code)
+        assert m is not None, f"first dispatch's producer TaskId not captured\n{code}"
+        alias = m.group(1)
+        m2 = re.search(rf"(\w+)\[[^\]]*\] = {re.escape(alias)};", code)
+        assert m2 is not None, f"captured TaskId {alias!r} not wired into a deps array\n{code}"
+        deps_arr = m2.group(1)
+        assert re.search(rf"\.set_dependencies\({re.escape(deps_arr)},", code) is not None, (
+            f"expected set_dependencies({deps_arr}, ...) on the uncaptured consumer\n{code}"
+        )
+
     def test_mixed_spmd_in_equals_out_aliases_shared_buffer(self):
         """A MIXED (split=) ``pl.spmd`` dispatch passing one buffer as both an
         input AND the output must codegen — and both lanes of the aliased buffer

--- a/tests/ut/language/parser/test_scope_parsing.py
+++ b/tests/ut/language/parser/test_scope_parsing.py
@@ -1434,37 +1434,129 @@ class TestSpmdScopeTaskId:
         Reparsed = pl.parse_program(printed)
         ir.assert_structural_equal(Original, Reparsed)
 
+    def test_deps_without_tid_round_trip(self):
+        """``deps=`` needs no ``as tid``: capturing the TaskId and declaring edges
+        are orthogonal, and the uncaptured form round-trips.
+
+        The Spmd outliner synthesises the (unused) producer TaskId Var such a scope
+        needs to lower to a ``Submit``, exactly as ``pl.at(..., deps=[...])``
+        already works without an ``as`` clause. An inline body prints back as the
+        ``for``-form (its first statement is the block-index read), so this pins
+        the for-form's ``deps=`` printing too.
+        """
+
+        @pl.program
+        class Original:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                with pl.spmd(4, name_hint="s1") as tid0:
+                    i = pl.tile.get_block_idx()
+                    out = pl.store(pl.load(a, [i * 128, 0], [128, 128]), [i * 128, 0], out)
+                with pl.spmd(4, name_hint="s2", deps=[tid0]):  # deps without `as tid`
+                    j = pl.tile.get_block_idx()
+                    out = pl.store(pl.load(out, [j * 128, 0], [128, 128]), [j * 128, 0], out)
+                return out
+
+        printed = Original.as_python()
+        assert "deps=[tid0]" in printed
+        assert "s2_spmd" in printed and " as " not in printed.split("s2_spmd")[1].split("\n")[0]
+        Reparsed = pl.parse_program(printed)
+        ir.assert_structural_equal(Original, Reparsed)
+
+    def test_dispatch_body_deps_without_tid_round_trip(self):
+        """A direct-dispatch body (no InCore wrapper, so the plain with-form is
+        what prints back) carries ``deps=`` without ``as tid`` and round-trips."""
+
+        @pl.program
+        class Original:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                out = pl.store(pl.load(a, [0, 0], [512, 128]), [0, 0], out)
+                return out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out1: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+                out2: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                with pl.spmd(4, name_hint="s1") as tid0:
+                    out1 = self.kernel(a, out1)
+                with pl.spmd(4, name_hint="s2", deps=[tid0]):
+                    out2 = self.kernel(a, out2)
+                return out2
+
+        printed = Original.as_python()
+        assert "deps=[tid0]" in printed
+        Reparsed = pl.parse_program(printed)
+        ir.assert_structural_equal(Original, Reparsed)
+
+    def test_for_spmd_deps_round_trip(self):
+        """The ``for``-form takes ``deps=`` on the same terms as the with-forms."""
+
+        @pl.program
+        class Original:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                with pl.spmd(4, name_hint="s1") as tid0:
+                    i = pl.tile.get_block_idx()
+                    out = pl.store(pl.load(a, [i * 128, 0], [128, 128]), [i * 128, 0], out)
+                for j in pl.spmd(4, name_hint="s2", deps=[tid0]):
+                    out = pl.store(pl.load(out, [j * 128, 0], [128, 128]), [j * 128, 0], out)
+                return out
+
+        printed = Original.as_python()
+        assert "deps=[tid0]" in printed
+        Reparsed = pl.parse_program(printed)
+        ir.assert_structural_equal(Original, Reparsed)
+
+    def test_empty_deps_without_tid_is_a_no_op(self):
+        """``deps=[]`` normalizes to no edges — accepted, and leaves no attr behind."""
+
+        @pl.program
+        class Original:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                out = pl.store(pl.load(a, [0, 0], [512, 128]), [0, 0], out)
+                return out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                with pl.spmd(4, deps=[]):
+                    out = self.kernel(a, out)
+                return out
+
+        printed = Original.as_python()
+        assert "deps=" not in printed
+        ir.assert_structural_equal(Original, pl.parse_program(printed))
+
     # ── Rejections ──────────────────────────────────────────────────────────
 
-    def test_deps_without_tid_rejected(self):
-        """``deps=`` on the plain ``with pl.spmd(n):`` form (no ``as tid``) is rejected."""
-        with pytest.raises(ParserSyntaxError, match="does not accept 'deps='"):
-
-            @pl.program
-            class Bad:
-                @pl.function(type=pl.FunctionType.Orchestration)
-                def main(
-                    self,
-                    a: pl.Tensor[[512, 128], pl.FP32],
-                    out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
-                ) -> pl.Tensor[[512, 128], pl.FP32]:
-                    with pl.spmd(4, name_hint="s1") as tid0:
-                        i = pl.tile.get_block_idx()
-                        out = pl.store(pl.load(a, [i * 128, 0], [128, 128]), [i * 128, 0], out)
-                    with pl.spmd(4, deps=[tid0]):  # type: ignore[call-arg]  # deps without `as tid`
-                        j = pl.tile.get_block_idx()
-                        out = pl.store(pl.load(out, [j * 128, 0], [128, 128]), [j * 128, 0], out)
-                    return out
-
-    def test_empty_deps_without_tid_rejected(self):
-        """``deps=[]`` (empty / normalized to []) without ``as tid`` is rejected too.
-
-        Gating is by keyword *presence* (allow_deps=optional_vars is not None), not by
-        the resolved dep list being non-empty — so even an empty/None-only ``deps=``
-        on the non-capturing with-form surfaces a clear error rather than silently
-        passing.
-        """
-        with pytest.raises(ParserSyntaxError, match="does not accept 'deps='"):
+    def test_deps_nested_in_cluster_rejected(self):
+        """``deps=`` on a cluster-nested pl.spmd is rejected: the scope is unwrapped
+        into the Group function and never produces a Submit to carry the edges."""
+        with pytest.raises(ParserSyntaxError, match=r"`pl.spmd\(\.\.\., deps=\[\.\.\.\]\)` cannot be nested"):
 
             @pl.program
             class Bad:
@@ -1481,21 +1573,15 @@ class TestSpmdScopeTaskId:
                 def main(
                     self,
                     a: pl.Tensor[[512, 128], pl.FP32],
-                    out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+                    out1: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+                    out2: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
                 ) -> pl.Tensor[[512, 128], pl.FP32]:
-                    with pl.spmd(4, deps=[]):  # type: ignore[call-arg]  # empty deps, no `as tid`
-                        out = self.kernel(a, out)
-                    return out
-
-    def test_for_spmd_deps_rejected(self):
-        """The for-form does not accept ``deps=`` — steer to the ``as tid`` with-form."""
-        with pytest.raises(ParserSyntaxError, match="does not accept 'deps='"):
-
-            @pl.function
-            def bad(a: pl.Tensor[[512, 128], pl.FP32]) -> pl.Tensor[[512, 128], pl.FP32]:
-                for i in pl.spmd(4, deps=[]):  # type: ignore[call-arg]
-                    _ = i
-                return a
+                    with pl.spmd(4, name_hint="s1") as tid0:
+                        out1 = self.kernel(a, out1)
+                    with pl.cluster():
+                        with pl.spmd(4, deps=[tid0]):
+                            out2 = self.kernel(a, out2)
+                    return out2
 
     def test_as_tid_tuple_target_rejected(self):
         """The ``as`` target must be a plain name, not a tuple."""

--- a/tests/ut/language/parser/test_submit_predicate.py
+++ b/tests/ut/language/parser/test_submit_predicate.py
@@ -620,20 +620,18 @@ def test_scope_producer_tracking_survives_tid_rebinding():
 
 
 def test_scope_predicate_deps_hint_matches_the_form():
-    """The remediation hint must be reachable from the form the author wrote.
+    """The remediation hint is the same on every spmd form: add the producer.
 
-    Scope-producer tracking made this case reachable: on the plain / for-forms
-    ``deps=`` is rejected outright, so a hint saying "add deps=[tid]" would send
-    the author into a second, different error. Those forms are told to switch to
-    the ``as tid`` capture form instead.
+    ``deps=`` is accepted on all three spellings (capturing the TaskId is
+    orthogonal to declaring edges), so "add deps=[g_tid]" is actionable whichever
+    form the author wrote — no form has to be steered to a different one first.
     """
-    # as-tid form: deps= is available, so "add it" is the right advice.
+    # as-tid form.
     with pytest.raises(ParserSyntaxError) as as_tid:
         _scope_program("rc[0, 0] > 0", deps_src="")
     assert "deps=[g_tid]" in as_tid.value.hint, as_tid.value.hint
 
-    # plain with-form: deps= is not accepted; the hint must say so and point at
-    # the capture form rather than at a kwarg that would itself be rejected.
+    # plain with-form: same advice, and following it now parses.
     plain_src = (
         _SCOPE_HEAD
         + f"""
@@ -650,9 +648,10 @@ def test_scope_predicate_deps_hint_matches_the_form():
     )
     with pytest.raises(ParserSyntaxError) as plain:
         pl.parse_program(plain_src)
-    hint = plain.value.hint
-    assert "does not accept deps=" in hint, hint
-    assert "as tid" in hint, hint
+    assert "deps=[g_tid]" in plain.value.hint, plain.value.hint
+
+    # Taking the hint's advice on the plain form resolves the error.
+    pl.parse_program(plain_src.replace("pl.spmd(1, predicate=", "pl.spmd(1, deps=[g_tid], predicate="))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

`deps=` now works on all three `pl.spmd` spellings:

```python
with pl.spmd(4, deps=[tid0]):          # was: "pl.spmd() does not accept 'deps=' here"
    ...
for i in pl.spmd(4, deps=[tid0]):      # was: same rejection
    ...
with pl.spmd(4, deps=[tid0]) as tid1:  # unchanged
    ...
```

## Why

Declaring dependency edges and capturing the dispatch TaskId are orthogonal concerns, but `pl.spmd` conflated them — `deps=` was gated on the `as tid` capture form, so an author who only wanted to order a dispatch had to name it anyway. `pl.at(..., deps=[...])` has never required an `as` clause, so the restriction was also inconsistent between the two scope forms.

Nothing in the lowering needed it. The Spmd outliner already synthesizes an unused TaskId Var for a scope carrying `manual_dep_edges` without `task_id_var` — the same path `pl.at` takes — so the `Submit` shape the edges require is produced either way:

> A scope with deps but no `as tid` binding gets a synthetic TaskId Var so the dispatch is still a Submit — a plain GlobalVar Call must never carry `manual_dep_edges` (ManualDepsOnSubmitOnly invariant).
> — `src/ir/transforms/utils/scope_outline_utils.cpp`

Only the parser gate and the printer were blocking the spelling.

## Changes

- **`ast_parser.py`** — dropped the `allow_deps` gate: `deps` joins `_SPMD_KWARGS`, and both non-capturing forms attach `manual_dep_edges` to the `SpmdScopeStmt` in the canonical attr order the `as tid` form already uses. `_validate_predicate_deps` loses its `deps_accepted` branch (every form can now act on "add the producer to `deps=`").
- **`python_printer.cpp`** — the for-form and plain with-form branches print `deps=`, so the new spellings survive print → reparse.
- **Cluster guard** — `deps=` on a `pl.cluster()`-nested `pl.spmd` is now rejected at parse time, alongside the existing `allow_early_resolve=` / `predicate=` rejections. Such a scope is unwrapped into the Group function and never produces a `Submit`, which `UnwrapNestedSpmd`'s `INTERNAL_CHECK` already asserted for hand-built / deserialized IR.
- **Docs** (en + zh) and the `pl.spmd` docstring updated.

No IR definition or pass logic changed — this is a parser/printer surface change over an already-supported IR shape.

## Reviewer notes

**One pre-existing test asserted the removed restriction.** `test_scope_predicate_deps_hint_matches_the_form` (`tests/ut/language/parser/test_submit_predicate.py`) pinned the two-way predicate hint: "add `deps=[tid]`" for the `as tid` form, "this form does not accept `deps=`, switch to `as tid`" for the others. That second branch existed only because of the gate this PR removes, so the test now pins the unified hint and additionally asserts that following its advice on the plain form parses.

**New / converted tests:**

| Test | Covers |
| ---- | ------ |
| `test_deps_without_tid_round_trip` | plain with-form, inline body (prints back as the for-form) |
| `test_dispatch_body_deps_without_tid_round_trip` | direct-dispatch body — the plain with-form printer branch |
| `test_for_spmd_deps_round_trip` | `for i in pl.spmd(n, deps=[...])` |
| `test_empty_deps_without_tid_is_a_no_op` | `deps=[]` normalizes to no edges, leaves no attr |
| `test_deps_nested_in_cluster_rejected` | the new cluster-nesting rejection |
| `test_deps_without_as_tid_emit_set_dependencies` | codegen: an uncaptured consumer still emits `set_dependencies(...)` |

The first three replace the three `does not accept 'deps='` rejection tests.

## Verification

- `tests/ut/` + `tests/lint/`: 10833 passed, 3 skipped, 1 xfailed
- `ctest`: 1/1 passed
- pre-commit: all hooks clean (clang-format, cpplint, markdownlint, ruff, pyright, en/zh doc parity)

Round-trip verification ran under the repo conftest's default `PYPTO_VERIFY_LEVEL=roundtrip` instrument, so every pass boundary re-checked print → parse → `structural_equal` on the new attr shape.
