### PR TITLE
refactor(runtime)!: drop the run and compile_program entry points

### DIFF
--- a/docs/en/dev/01-compile-profiling.md
+++ b/docs/en/dev/01-compile-profiling.md
@@ -37,15 +37,12 @@ prof.to_json("profile.json")
 ### Option 4: `RunConfig`
 
 ```python
-from pypto.runtime import run, RunConfig
+from pypto import ir
+from pypto.runtime import RunConfig
 
-result = run(
-    program=MyProgram,
-    tensor_specs=specs,
-    golden=golden_fn,
-    config=RunConfig(compile_profiling=True),
-)
-# result.profile contains the profiling data as a dict
+config = RunConfig(compile_profiling=True)
+compiled = ir.compile(MyProgram, **config.compile_kwargs())
+# The report lands in `<compiled.output_dir>/report/`.
 ```
 
 ## Output
@@ -90,7 +87,8 @@ Total: 2.847s
 
 ## Stage Hierarchy
 
-The profiler records the following stages when using `runtime.run()`:
+These are all the stages the profiler can record. A single run reports only
+those its entry point reaches:
 
 | Stage | Description |
 | ----- | ----------- |

--- a/docs/en/dev/03-runtime-dfx.md
+++ b/docs/en/dev/03-runtime-dfx.md
@@ -148,18 +148,18 @@ a *device-resident* tensor routes the graph, in which case it is approximate.
 ### From Python (`RunConfig`)
 
 ```python
-from pypto.runtime import run, RunConfig
+from pypto import ir
+from pypto.runtime import RunConfig
 
-run(
-    MyProgram, a, b, c,
-    config=RunConfig(
-        platform="a2a3sim",
-        enable_chip_swimlane=4,        # full swimlane -> chip_swimlane_records.json
-                                     # (True is the same level 4; use 1-3 for less)
-        enable_dep_gen=True,         # produces deps.json (render with deps_viewer on demand)
-        enable_pmu=4,                # PMU event = MEMORY
-    ),
+config = RunConfig(
+    platform="a2a3sim",
+    enable_chip_swimlane=4,      # full swimlane -> chip_swimlane_records.json
+                                 # (True is the same level 4; use 1-3 for less)
+    enable_dep_gen=True,         # produces deps.json (render with deps_viewer on demand)
+    enable_pmu=4,                # PMU event = MEMORY
 )
+compiled = ir.compile(MyProgram, **config.compile_kwargs())
+compiled(a, b, c, config=config)
 ```
 
 ### From pytest

--- a/docs/en/dev/03-runtime-replay.md
+++ b/docs/en/dev/03-runtime-replay.md
@@ -8,8 +8,9 @@ To re-run a previously compiled `build_output/<jit_dir>/` after editing
 one or more kernel cpp files — typically to verify a hand-tuned change
 under PMU / swimlane / args-dump — use the debug-only
 [`pypto.runtime.debug.replay`](../../../python/pypto/runtime/debug/replay.py)
-module. It reuses the same `execute_compiled` path as the normal
-`pypto.runtime.run` flow, so DFX flags behave identically.
+module. An L2 build reuses the same `execute_compiled` path as a normal
+`compiled(...)` dispatch; an L3 build is dispatched through
+`execute_distributed_compiled`. Either way DFX flags behave identically.
 
 ```python
 from pypto.runtime.debug import replay

--- a/docs/en/dev/05-runtime-ring-sizing.md
+++ b/docs/en/dev/05-runtime-ring-sizing.md
@@ -4,12 +4,12 @@ PyPTO exposes Simpler's per-task ring sizing as three optional overrides on
 [`RunConfig`](../../../python/pypto/runtime/runner.py). They let you size the
 runtime's per-task ring resources for a single dispatch without touching the
 compiled artifact or any global state. This works on both the L2 single-chip
-path (`run()` / `execute_compiled()` / `ChipWorker.run()`) and the L3 distributed path
+path (`compiled(...)` / `execute_compiled()` / `ChipWorker.run()`) and the L3 distributed path
 (`DistributedWorker.run()` / the one-shot `compiled(...)`).
 
 The runtime keeps its task-launch resources in *ring buffers*. Each override
 maps 1:1 to a field on Simpler's `CallConfig.runtime_env` and is sized **per
-task submission** — per `run()` / `rt.run()` call — so different submissions of
+task submission** — per `compiled(...)` / `rt.run()` call — so different submissions of
 the same kernel can use different ring sizes. On the L3 path the override is
 applied per dispatch on top of the program's `DistributedConfig` baseline
 (`aicpu_thread_num`) and reaches every chip in that dispatch.
@@ -63,21 +63,20 @@ than raising an opaque `TypeError` from the power-of-two check.
 
 ## Usage
 
-### L2 single-chip (`run` / `execute_compiled`)
+### L2 single-chip (`compiled(...)` / `execute_compiled`)
 
 ```python
-from pypto.runtime import run, RunConfig
+from pypto import ir
+from pypto.runtime import RunConfig
 
-compiled = run(
-    MyProgram,
-    a, b, c,
-    config=RunConfig(
-        platform="a2a3",
-        ring_task_window=128,        # 128 in-flight task slots
-        ring_heap=8 * 1024 * 1024,   # 8 MiB output heap per ring
-        ring_dep_pool=256,           # 256 dependency-edge entries
-    ),
+config = RunConfig(
+    platform="a2a3",
+    ring_task_window=128,        # 128 in-flight task slots
+    ring_heap=8 * 1024 * 1024,   # 8 MiB output heap per ring
+    ring_dep_pool=256,           # 256 dependency-edge entries
 )
+compiled = ir.compile(MyProgram, **config.compile_kwargs())
+compiled(a, b, c, config=config)
 ```
 
 The directory-driven entry point accepts the same per-dispatch config. Its

--- a/docs/en/dev/08-entry-points.md
+++ b/docs/en/dev/08-entry-points.md
@@ -1,0 +1,137 @@
+# Compile and Execution Entry Points
+
+Which entry point does what, and which layer it belongs to.
+
+PyPTO has more compile and execution entry points than it has concepts, and
+several share a name across abstraction layers: six different functions are
+called `compile`, and `run` is a method on both the runtime worker handles and
+`PassPipeline`. This page is the map — what each entry point takes, what it
+produces, and when to reach for it.
+
+## The four layers
+
+Every entry point belongs to exactly one of four layers. Confusion arises when
+a name does not say which:
+
+```text
+  define              compile                 artifact                execute
+  ────────────────────────────────────────────────────────────────────────────
+  @pl.program  ──┐                        CompiledProgram      ChipWorker.run()
+  @pl.function   ├─>  ir.compile()   ──>   Distributed-        DistributedWorker.run()
+  @pl.jit      ──┘    kernel.compile()     CompiledProgram     compiled(*args)
+                      kernel.lower()  ──>  ir.Program
+```
+
+Below the artifact layer sits an **assembly layer** — turning `.pto` and `.cpp`
+into loadable binaries. It is internal and has no supported entry point.
+
+## Choosing an entry point
+
+| You have | You want | Use |
+| -------- | -------- | --- |
+| A `@pl.jit` kernel and torch tensors | The result | `kernel(*args, config=...)` |
+| A `@pl.jit` kernel | The artifact, to dispatch repeatedly | `kernel.compile(*args, config=...)` |
+| A `@pl.jit` kernel | The IR, without codegen | `kernel.lower(*args)` |
+| A `@pl.program` class | The artifact | `ir.compile(program, ...)` |
+| A `CompiledProgram` | One dispatch | `compiled(*args, config=...)` |
+| A `CompiledProgram` and device-resident data | Many dispatches | `ChipWorker.run(compiled, *args)` |
+| A `DistributedCompiledProgram` | Many dispatches | `compiled.prepare()` → `DistributedWorker.run(...)` |
+| A build directory on disk | One dispatch, no recompile | `execute_compiled(work_dir, args, ...)` |
+| A `CompiledProgram` | Timed dispatches | `benchmark(compiled, args, ...)` |
+
+## Compile
+
+| Entry | Layer | Location |
+| ----- | ----- | -------- |
+| `ir.compile` | compile driver | [`ir/compile.py`](../../../python/pypto/ir/compile.py) |
+| `JITFunction.compile` | specialize + driver | [`jit/decorator.py`](../../../python/pypto/jit/decorator.py) |
+| `JITFunction.lower` | specialize only, stops at `ir.Program` | same |
+| `device_runner.compile_and_assemble` | assembly | [`runtime/device_runner.py`](../../../python/pypto/runtime/device_runner.py) |
+| `device_runner.compile_single_kernel` / `compile_single_orchestration` | assembly | same |
+| `KernelCompiler.compile_incore` | ptoas invocation | [`runtime/kernel_compiler.py`](../../../python/pypto/runtime/kernel_compiler.py) |
+
+`ir.compile` is the only supported one; the rest of the table is here so a name
+that turns up in a traceback can be placed on a layer. It also shadows the
+Python builtin `compile`, so prefer `from pypto import ir` and call
+`ir.compile` over importing the name directly.
+
+Its parameters are documented in [Compiling](../user/execution/00-compile.md).
+
+## Execute
+
+| Entry | Layer | Takes | Location |
+| ----- | ----- | ----- | -------- |
+| `CompiledProgram.__call__` | artifact | artifact handle | [`ir/compiled_program.py`](../../../python/pypto/ir/compiled_program.py) |
+| `Worker.run` / `ChipWorker.run` / `DistributedWorker.run` | execute | artifact + worker | [`runtime/worker.py`](../../../python/pypto/runtime/worker.py) |
+| `runtime.execute_compiled` | execute | output directory | [`runtime/runner.py`](../../../python/pypto/runtime/runner.py) |
+| `execute_distributed_compiled` | execute | output directory | [`runtime/distributed_runner.py`](../../../python/pypto/runtime/distributed_runner.py) |
+| `device_runner.execute_on_device` | assembly | assembled binaries | [`runtime/device_runner.py`](../../../python/pypto/runtime/device_runner.py) |
+| `execute_artifact_dir` / `execute_batch_manifest` | CLI | output directory | [`runtime/execute_artifact.py`](../../../python/pypto/runtime/execute_artifact.py) |
+
+`run` does not say which layer you are on; the receiver does. `ChipWorker.run`
+and `DistributedWorker.run` dispatch an artifact, both implementing
+`Worker.run`. `PassPipeline.run` is unrelated — it transforms a `Program` — as
+is `PassManager.run_passes`.
+
+`execute_compiled` and `execute_distributed_compiled` are the L2 and L3
+directory-driven paths. They skip the PyPTO compile entirely, which is what
+makes [replay](03-runtime-replay.md) possible.
+
+## Driving both phases from one config
+
+`RunConfig` carries compile-time and dispatch-time settings together.
+`compile_kwargs()` extracts the compile-time half as `ir.compile` keyword
+arguments, so one config object drives both phases:
+
+```python
+config = RunConfig(platform="a2a3")
+compiled = ir.compile(program, **config.compile_kwargs())
+compiled(*tensors, config=config)
+```
+
+Its fields split three ways:
+
+| Read by | Fields |
+| ------- | ------ |
+| `ir.compile`, via `compile_kwargs()` | `strategy`, `backend_type`, `platform`, `memory_planner`, `dump_passes`, `dump_ptoas_passes`, `compile_profiling`, `diagnostic_phase`, `disabled_diagnostics`, `analyze_auto_scopes_for_deps`, `save_kernels_dir` (as `output_dir`), `distributed_config` |
+| Dispatch | `device_id`, `aicpu_thread_num`, the `ring_*` overrides ([Ring sizing](05-runtime-ring-sizing.md)), the DFX toggles ([DFX](03-runtime-dfx.md)) |
+| The system-test harness only | `rtol`, `atol`, `golden_data_dir`, `save_kernels`, `codegen_only` |
+
+The `@pl.jit` path keeps its own mapping in
+`jit.decorator._run_config_compile_kwargs`, which omits `platform` and
+`backend_type` because that path forwards them separately.
+
+## What is internal
+
+These have no stability guarantee. They are not in any `__all__`, and code
+outside PyPTO should not import them:
+
+- `pypto.ir.compile` — `_ensure_orchestration_headers`
+- `pypto.runtime.device_runner` — `compile_and_assemble`, `compile_single_kernel`,
+  `compile_single_orchestration`, `execute_on_device`
+- `pypto.runtime.kernel_compiler` — `KernelCompiler`, `compile_incore`
+- `pypto.runtime.runner` — `_build_call_config`, `_coerced_to_orch_args`,
+  `_DfxOpts`
+- `pypto.runtime.tensor_arg`, `pypto.runtime.elf_parser`, `pypto.runtime._binary_cache`
+
+`DistributedCompiledProgram` and `DistributedConfig` are public, but are not
+re-exported from `pypto.ir`; import them from
+`pypto.ir.distributed_compiled_program`.
+
+## Command-line entry points
+
+| Command | Purpose |
+| ------- | ------- |
+| `pypto-ir-trace` | Render a pass dump as an interactive lowering trace ([IR lowering trace](07-ir-lower-trace.md)) |
+| `python -m pypto.runtime.execute_artifact` | Execute an artifact directory or a batch manifest |
+| `python -m pypto.runtime.debug.replay` | Re-run a build directory after hand-editing generated code ([Replay](03-runtime-replay.md)) |
+| `python build_output/<dir>/debug/run.py` | The self-contained reproducer emitted with every build |
+| `python -m pypto.tools.memory_map` | Render on-chip memory as HTML ([Memory Map](07-memory-map.md)) |
+| `python -m pypto.tools.clean_sim_trace` | Convert simulator dumps to readable traces ([Trace cleaning](04-simulator-trace-cleaning.md)) |
+
+## See Also
+
+- [Compiling](../user/execution/00-compile.md) — `ir.compile`'s parameters and the artifact directory.
+- [Running](../user/execution/01-run.md) — `CompiledProgram`, `ChipWorker`, `DeviceTensor`.
+- [Runtime DFX Flags](03-runtime-dfx.md) — the five diagnostic sub-features.
+- [Per-Task Ring Sizing](05-runtime-ring-sizing.md) — the three per-dispatch ring overrides.

--- a/docs/en/dev/index.md
+++ b/docs/en/dev/index.md
@@ -31,6 +31,7 @@ PyPTO programs, start with the [User Manual](../user/index.md).
 | [Per-Task Ring Sizing](05-runtime-ring-sizing.md) | The three ring-size overrides on `RunConfig` and when to tune them |
 | [Persistent L3 execution](06-persistent-l3.md) | Reusing one worker across prepared distributed programs |
 | [Memory Map](07-memory-map.md) | Rendering a pass dump into an interactive HTML map of on-chip memory |
+| [Compile and Execution Entry Points](08-entry-points.md) | Every compile and execution entry point, the layer it belongs to, and when to reach for it |
 | [Distributed Operators](distributed_ops.md) | The N6 distributed op family — typed DSL access to collectives and primitives |
 | [PTOAS Op Status Matrix](ptoas-op-status.md) | Which public and compatibility PTOAS ops the compiler currently emits |
 

--- a/docs/en/user/execution/01-run.md
+++ b/docs/en/user/execution/01-run.md
@@ -131,11 +131,12 @@ launch. `close()` releases the registrations and any `DeviceTensor` the caller f
 | `aicpu_thread_num` | AICPU thread count override |
 
 **Some `RunConfig` fields belong to the harness, not to dispatch.** `rtol` / `atol`,
-`golden_data_dir`, `save_kernels` / `save_kernels_dir` and `codegen_only` are read by
-`pypto.runtime.run()`, which compiles, generates a golden and compares. Going through
-`compiled(...)`, `worker.run(...)` or a registration handle, they do nothing — in
-particular **`codegen_only=True` does not stop a dispatch on this path**, so do not rely on
-it to avoid a launch.
+`golden_data_dir`, `save_kernels` and `codegen_only` are read by the system-test harness,
+which compiles, generates a golden and compares. Going through `compiled(...)`,
+`worker.run(...)` or a registration handle, they do nothing — in particular
+**`codegen_only=True` does not stop a dispatch on this path**, so do not rely on it to
+avoid a launch. (`save_kernels_dir` is the exception: `RunConfig.compile_kwargs()`
+forwards it as `ir.compile`'s `output_dir`.)
 
 ## Edge Cases
 

--- a/docs/zh/dev/01-compile-profiling.md
+++ b/docs/zh/dev/01-compile-profiling.md
@@ -36,15 +36,12 @@ prof.to_json("profile.json")
 ### 方式 4：`RunConfig`
 
 ```python
-from pypto.runtime import run, RunConfig
+from pypto import ir
+from pypto.runtime import RunConfig
 
-result = run(
-    program=MyProgram,
-    tensor_specs=specs,
-    golden=golden_fn,
-    config=RunConfig(compile_profiling=True),
-)
-# result.profile 包含 profiling 数据（dict 格式）
+config = RunConfig(compile_profiling=True)
+compiled = ir.compile(MyProgram, **config.compile_kwargs())
+# 报告落在 `<compiled.output_dir>/report/` 下。
 ```
 
 ## 输出格式
@@ -89,7 +86,7 @@ Total: 2.847s
 
 ## 阶段层次结构
 
-使用 `runtime.run()` 时，profiler 记录以下阶段：
+下表是 profiler 能记录的全部阶段。单次运行只会报告其入口实际经过的那些：
 
 | 阶段 | 说明 |
 | ---- | ---- |

--- a/docs/zh/dev/03-runtime-dfx.md
+++ b/docs/zh/dev/03-runtime-dfx.md
@@ -125,18 +125,18 @@ L2 子进程用两种方式重建编排实参：被 pytest harness 驱动时从 
 ### 从 Python（`RunConfig`）
 
 ```python
-from pypto.runtime import run, RunConfig
+from pypto import ir
+from pypto.runtime import RunConfig
 
-run(
-    MyProgram, a, b, c,
-    config=RunConfig(
-        platform="a2a3sim",
-        enable_chip_swimlane=4,        # 全量 swimlane -> chip_swimlane_records.json
-                                     # （True 等价于等级 4；需要更轻量时用 1-3）
-        enable_dep_gen=True,         # 生成 deps.json（按需用 deps_viewer 渲染 HTML）
-        enable_pmu=4,                # PMU 事件 = MEMORY
-    ),
+config = RunConfig(
+    platform="a2a3sim",
+    enable_chip_swimlane=4,      # 全量 swimlane -> chip_swimlane_records.json
+                                 # （True 等价于等级 4；需要更轻量时用 1-3）
+    enable_dep_gen=True,         # 生成 deps.json（按需用 deps_viewer 渲染 HTML）
+    enable_pmu=4,                # PMU 事件 = MEMORY
 )
+compiled = ir.compile(MyProgram, **config.compile_kwargs())
+compiled(a, b, c, config=config)
 ```
 
 ### 从 pytest

--- a/docs/zh/dev/03-runtime-replay.md
+++ b/docs/zh/dev/03-runtime-replay.md
@@ -7,8 +7,8 @@
 需要在改完 kernel cpp 之后重新跑一遍编译产物（典型场景：手调 kernel
 后用 PMU / swimlane / args-dump 验证修改是否正确），使用 debug 专用
 的 [`pypto.runtime.debug.replay`](../../../python/pypto/runtime/debug/replay.py)
-模块。它复用与 `pypto.runtime.run` 相同的 `execute_compiled` 路径,
-因此 DFX 开关的行为完全一致。
+模块。L2 构建复用与普通 `compiled(...)` 派发相同的 `execute_compiled` 路径,
+L3 构建则经由 `execute_distributed_compiled` 派发。两者的 DFX 开关行为完全一致。
 
 ```python
 from pypto.runtime.debug import replay

--- a/docs/zh/dev/05-runtime-ring-sizing.md
+++ b/docs/zh/dev/05-runtime-ring-sizing.md
@@ -3,12 +3,12 @@
 PyPTO 通过 [`RunConfig`](../../../python/pypto/runtime/runner.py) 上的三个可选
 覆盖项暴露 Simpler 的单任务 ring 尺寸配置。它们让你在单次派发中为运行时的
 单任务 ring 资源设置尺寸，而无需改动已编译产物或任何全局状态。该能力同时适用于
-L2 单 chip 路径（`run()` / `execute_compiled()` / `ChipWorker.run()`）和 L3 分布式路径
+L2 单 chip 路径（`compiled(...)` / `execute_compiled()` / `ChipWorker.run()`）和 L3 分布式路径
 （`DistributedWorker.run()` / 一次性的 `compiled(...)`）。
 
 运行时把任务启动相关资源保存在 *ring buffer*（环形缓冲）中。每个覆盖项与
 Simpler 的 `CallConfig.runtime_env` 上的同名字段一一对应，并且按 **每次任务提交**
-生效 —— 即每次 `run()` / `rt.run()` 调用，因此同一 kernel 的不同提交可以使用不同
+生效 —— 即每次 `compiled(...)` / `rt.run()` 调用，因此同一 kernel 的不同提交可以使用不同
 的 ring 尺寸。在 L3 路径上，覆盖项按每次派发生效，叠加在程序的 `DistributedConfig`
 基线（`aicpu_thread_num`）之上，并作用于该次派发的所有 chip。
 
@@ -58,21 +58,20 @@ RunConfig(platform="a2a3", ring_heap=1000)
 
 ## 用法
 
-### L2 单 chip（`run` / `execute_compiled`）
+### L2 单 chip（`compiled(...)` / `execute_compiled`）
 
 ```python
-from pypto.runtime import run, RunConfig
+from pypto import ir
+from pypto.runtime import RunConfig
 
-compiled = run(
-    MyProgram,
-    a, b, c,
-    config=RunConfig(
-        platform="a2a3",
-        ring_task_window=128,        # 128 个在途 task slot
-        ring_heap=8 * 1024 * 1024,   # 每个 ring 8 MiB 输出堆
-        ring_dep_pool=256,           # 256 个依赖边条目
-    ),
+config = RunConfig(
+    platform="a2a3",
+    ring_task_window=128,        # 128 个在途 task slot
+    ring_heap=8 * 1024 * 1024,   # 每个 ring 8 MiB 输出堆
+    ring_dep_pool=256,           # 256 个依赖边条目
 )
+compiled = ir.compile(MyProgram, **config.compile_kwargs())
+compiled(a, b, c, config=config)
 ```
 
 目录驱动的入口同样接受单次派发配置。它原有的显式 `platform`、`device_id`、DFX 和

--- a/docs/zh/dev/08-entry-points.md
+++ b/docs/zh/dev/08-entry-points.md
@@ -1,0 +1,128 @@
+# 编译与执行入口
+
+每个入口做什么，以及它属于哪一层。
+
+PyPTO 的编译与执行入口比它拥有的概念要多，而且好几个名字横跨抽象层：有六个不同的
+函数叫 `compile`，而 `run` 既是运行时 worker 句柄上的方法，也是 `PassPipeline` 上的
+方法。本页是这份地图——每个入口接受什么、产出什么、什么时候该用它。
+
+## 四个层次
+
+每个入口都恰好属于四层中的一层。名字没有表达出它属于哪一层时，混乱就产生了：
+
+```text
+  define              compile                 artifact                execute
+  ────────────────────────────────────────────────────────────────────────────
+  @pl.program  ──┐                        CompiledProgram      ChipWorker.run()
+  @pl.function   ├─>  ir.compile()   ──>   Distributed-        DistributedWorker.run()
+  @pl.jit      ──┘    kernel.compile()     CompiledProgram     compiled(*args)
+                      kernel.lower()  ──>  ir.Program
+```
+
+产物层之下还有一个**装配层（assembly layer）**——把 `.pto` 与 `.cpp` 变成可加载的
+二进制。它是内部实现，没有受支持的入口。
+
+## 如何选择入口
+
+| 你手上有 | 你想要 | 用 |
+| -------- | ------ | -- |
+| 一个 `@pl.jit` 内核和 torch 张量 | 结果 | `kernel(*args, config=...)` |
+| 一个 `@pl.jit` 内核 | 产物，用于反复派发 | `kernel.compile(*args, config=...)` |
+| 一个 `@pl.jit` 内核 | IR，不做 codegen | `kernel.lower(*args)` |
+| 一个 `@pl.program` 类 | 产物 | `ir.compile(program, ...)` |
+| 一个 `CompiledProgram` | 派发一次 | `compiled(*args, config=...)` |
+| 一个 `CompiledProgram` 和常驻设备的数据 | 派发多次 | `ChipWorker.run(compiled, *args)` |
+| 一个 `DistributedCompiledProgram` | 派发多次 | `compiled.prepare()` → `DistributedWorker.run(...)` |
+| 磁盘上的一个构建目录 | 派发一次，不重新编译 | `execute_compiled(work_dir, args, ...)` |
+| 一个 `CompiledProgram` | 计时派发 | `benchmark(compiled, args, ...)` |
+
+## 编译
+
+| 入口 | 层 | 位置 |
+| ---- | -- | ---- |
+| `ir.compile` | 编译驱动 | [`ir/compile.py`](../../../python/pypto/ir/compile.py) |
+| `JITFunction.compile` | 特化 + 驱动 | [`jit/decorator.py`](../../../python/pypto/jit/decorator.py) |
+| `JITFunction.lower` | 只做特化，止于 `ir.Program` | 同上 |
+| `device_runner.compile_and_assemble` | 装配 | [`runtime/device_runner.py`](../../../python/pypto/runtime/device_runner.py) |
+| `device_runner.compile_single_kernel` / `compile_single_orchestration` | 装配 | 同上 |
+| `KernelCompiler.compile_incore` | 调用 ptoas | [`runtime/kernel_compiler.py`](../../../python/pypto/runtime/kernel_compiler.py) |
+
+只有 `ir.compile` 是受支持的入口；表中其余项列在这里，是为了让 traceback 里出现的
+名字能被定位到某一层。它还遮蔽了 Python 内置的 `compile`，因此更推荐
+`from pypto import ir` 后调用 `ir.compile`，而不是直接导入这个名字。
+
+它的参数在[编译](../user/execution/00-compile.md)中有说明。
+
+## 执行
+
+| 入口 | 层 | 接受什么 | 位置 |
+| ---- | -- | -------- | ---- |
+| `CompiledProgram.__call__` | 产物 | 产物句柄 | [`ir/compiled_program.py`](../../../python/pypto/ir/compiled_program.py) |
+| `Worker.run` / `ChipWorker.run` / `DistributedWorker.run` | 执行 | 产物 + worker | [`runtime/worker.py`](../../../python/pypto/runtime/worker.py) |
+| `runtime.execute_compiled` | 执行 | 产物目录 | [`runtime/runner.py`](../../../python/pypto/runtime/runner.py) |
+| `execute_distributed_compiled` | 执行 | 产物目录 | [`runtime/distributed_runner.py`](../../../python/pypto/runtime/distributed_runner.py) |
+| `device_runner.execute_on_device` | 装配 | 已装配的二进制 | [`runtime/device_runner.py`](../../../python/pypto/runtime/device_runner.py) |
+| `execute_artifact_dir` / `execute_batch_manifest` | CLI | 产物目录 | [`runtime/execute_artifact.py`](../../../python/pypto/runtime/execute_artifact.py) |
+
+`run` 本身不说明你在哪一层，接收者才说明。`ChipWorker.run` 与
+`DistributedWorker.run` 派发产物，二者都实现 `Worker.run`。`PassPipeline.run`
+与此无关——它变换一个 `Program`——`PassManager.run_passes` 同理。
+
+`execute_compiled` 与 `execute_distributed_compiled` 分别是 L2 与 L3 的
+"目录驱动"路径。它们完全跳过 PyPTO 编译，[replay](03-runtime-replay.md)
+正是靠这一点成立的。
+
+## 用同一个 config 驱动两个阶段
+
+`RunConfig` 同时承载编译期与派发期的设置。`compile_kwargs()` 把编译期那一半提取为
+`ir.compile` 的关键字参数，因此一个 config 对象可以驱动两个阶段：
+
+```python
+config = RunConfig(platform="a2a3")
+compiled = ir.compile(program, **config.compile_kwargs())
+compiled(*tensors, config=config)
+```
+
+它的字段分三类：
+
+| 由谁读取 | 字段 |
+| -------- | ---- |
+| `ir.compile`，经 `compile_kwargs()` | `strategy`、`backend_type`、`platform`、`memory_planner`、`dump_passes`、`dump_ptoas_passes`、`compile_profiling`、`diagnostic_phase`、`disabled_diagnostics`、`analyze_auto_scopes_for_deps`、`save_kernels_dir`（作为 `output_dir`）、`distributed_config` |
+| 派发 | `device_id`、`aicpu_thread_num`、`ring_*` 覆写项（[Ring 尺寸](05-runtime-ring-sizing.md)）、DFX 开关（[DFX](03-runtime-dfx.md)） |
+| 仅系统测试 harness | `rtol`、`atol`、`golden_data_dir`、`save_kernels`、`codegen_only` |
+
+`@pl.jit` 路径保留了自己的映射 `jit.decorator._run_config_compile_kwargs`，
+它省略了 `platform` 与 `backend_type`，因为该路径会单独转发这两项。
+
+## 哪些是内部实现
+
+以下没有稳定性保证。它们不在任何 `__all__` 中，PyPTO 之外的代码不应导入：
+
+- `pypto.ir.compile` —— `_ensure_orchestration_headers`
+- `pypto.runtime.device_runner` —— `compile_and_assemble`、`compile_single_kernel`、
+  `compile_single_orchestration`、`execute_on_device`
+- `pypto.runtime.kernel_compiler` —— `KernelCompiler`、`compile_incore`
+- `pypto.runtime.runner` —— `_build_call_config`、`_coerced_to_orch_args`、
+  `_DfxOpts`
+- `pypto.runtime.tensor_arg`、`pypto.runtime.elf_parser`、`pypto.runtime._binary_cache`
+
+`DistributedCompiledProgram` 与 `DistributedConfig` 是公开的，但没有从 `pypto.ir`
+重新导出；请从 `pypto.ir.distributed_compiled_program` 导入。
+
+## 命令行入口
+
+| 命令 | 用途 |
+| ---- | ---- |
+| `pypto-ir-trace` | 把 pass dump 渲染成交互式 lowering trace（[IR lowering trace](07-ir-lower-trace.md)） |
+| `python -m pypto.runtime.execute_artifact` | 执行一个产物目录或一份 batch manifest |
+| `python -m pypto.runtime.debug.replay` | 手改生成代码后重跑一个构建目录（[Replay](03-runtime-replay.md)） |
+| `python build_output/<dir>/debug/run.py` | 每次构建都会生成的自包含复现脚本 |
+| `python -m pypto.tools.memory_map` | 把片上内存渲染成 HTML（[Memory Map](07-memory-map.md)） |
+| `python -m pypto.tools.clean_sim_trace` | 把仿真器 dump 转成可读 trace（[Trace 清洗](04-simulator-trace-cleaning.md)） |
+
+## 参见
+
+- [编译](../user/execution/00-compile.md) —— `ir.compile` 的参数与产物目录。
+- [运行](../user/execution/01-run.md) —— `CompiledProgram`、`ChipWorker`、`DeviceTensor`。
+- [运行时 DFX 开关](03-runtime-dfx.md) —— 五个诊断子特性。
+- [每任务 Ring 尺寸](05-runtime-ring-sizing.md) —— 三个逐次派发的 ring 覆写项。

--- a/docs/zh/dev/index.md
+++ b/docs/zh/dev/index.md
@@ -29,6 +29,7 @@ PyPTO 的构成：IR、pass 流水线、代码生成，以及围绕它们的基�
 | [逐任务 Ring Sizing](05-runtime-ring-sizing.md) | `RunConfig` 上的三个 ring 尺寸覆盖项及其调优时机 |
 | [持久化 L3 执行](06-persistent-l3.md) | 在多个已 prepare 的分布式程序间复用同一个 worker |
 | [内存图](07-memory-map.md) | 把 pass dump 渲染成可交互的片上内存 HTML 图 |
+| [编译与执行入口](08-entry-points.md) | 全部编译与执行入口、各自所属的层，以及何时该用哪一个 |
 | [分布式算子](distributed_ops.md) | N6 分布式算子家族 —— 对集合通信与低层原语的类型化 DSL 访问 |
 | [PTOAS 算子状态矩阵](ptoas-op-status.md) | 编译器当前会发射哪些 PTOAS 公开与兼容算子 |
 

--- a/docs/zh/user/execution/01-run.md
+++ b/docs/zh/user/execution/01-run.md
@@ -113,7 +113,7 @@ finally:
 | `ring_task_window` / `ring_heap` / `ring_dep_pool` | 运行时环的尺寸（[内存](../performance/05-memory.md)） |
 | `aicpu_thread_num` | AICPU 线程数覆盖 |
 
-**`RunConfig` 里有些字段属于 harness，不属于派发。** `rtol` / `atol`、`golden_data_dir`、`save_kernels` / `save_kernels_dir` 与 `codegen_only` 是由 `pypto.runtime.run()` 读取的 —— 那条路径会编译、生成 golden 并比对。走 `compiled(...)`、`worker.run(...)` 或注册句柄时，它们不起作用；**尤其是 `codegen_only=True` 在这条路径上并不会阻止派发**，别指望用它来避免一次 launch。
+**`RunConfig` 里有些字段属于 harness，不属于派发。** `rtol` / `atol`、`golden_data_dir`、`save_kernels` 与 `codegen_only` 是由系统测试 harness 读取的 —— 那条路径会编译、生成 golden 并比对。走 `compiled(...)`、`worker.run(...)` 或注册句柄时，它们不起作用；**尤其是 `codegen_only=True` 在这条路径上并不会阻止派发**，别指望用它来避免一次 launch。（`save_kernels_dir` 是例外：`RunConfig.compile_kwargs()` 会把它作为 `ir.compile` 的 `output_dir` 转发。）
 
 ## 边界情况
 
@@ -122,7 +122,7 @@ finally:
 | **worker 在首次派发前就拒绝该程序** | 产物的 `platform` 与 worker 不一致 | 用你要派发的平台去编译 |
 | **`missing inferred tensor metadata for parameter`** | 把 `DeviceTensor` 传给了 `@pl.jit` 入口 | 派发**已编译**的程序；特化器读不到它的 shape/dtype |
 | **设备内存随 launch 增长** | `DeviceTensor` 没释放 | `free_tensor`，或用 `with` 圈住 worker |
-| **`run()` 不给 host/device 拆分** | `execution_time` 是整段墙上时间 | 用 `pypto.runtime.benchmark` 取 `device_wall_us` / `host_wall_us` |
+| **派发不给 host/device 拆分** | `execution_time` 是整段墙上时间 | 用 `pypto.runtime.benchmark` 取 `device_wall_us` / `host_wall_us` |
 
 ## 参见
 

--- a/examples/models/04_paged_attention.py
+++ b/examples/models/04_paged_attention.py
@@ -38,9 +38,10 @@ import struct
 
 import pypto.language as pl
 import torch
+from pypto import ir
 from pypto.backend import BackendType
 from pypto.ir.pass_manager import OptimizationStrategy
-from pypto.runtime import RunConfig, run
+from pypto.runtime import RunConfig
 
 # ── Shared InCore kernels (module-level, reusable across programs) ──────────
 
@@ -613,8 +614,16 @@ def main():
         context_len=context_len,
         scale=scale,
     )
-    run(
-        program,
+    run_config = RunConfig(
+        platform="a2a3",
+        device_id=11,
+        strategy=OptimizationStrategy.Default,
+        dump_passes=True,
+        backend_type=BackendType.Ascend910B,
+        enable_chip_swimlane=args.enable_chip_swimlane,
+    )
+    compiled = ir.compile(program, **run_config.compile_kwargs())
+    compiled(
         query,
         key_cache,
         value_cache,
@@ -622,14 +631,7 @@ def main():
         context_lens,
         out,
         config,
-        config=RunConfig(
-            platform="a2a3",
-            device_id=11,
-            strategy=OptimizationStrategy.Default,
-            dump_passes=True,
-            backend_type=BackendType.Ascend910B,
-            enable_chip_swimlane=args.enable_chip_swimlane,
-        ),
+        config=run_config,
     )
 
     # Golden validation

--- a/examples/models/06_paged_attention_dynamic.py
+++ b/examples/models/06_paged_attention_dynamic.py
@@ -23,9 +23,10 @@ import argparse
 
 import pypto.language as pl
 import torch
+from pypto import ir
 from pypto.backend import BackendType
 from pypto.ir.pass_manager import OptimizationStrategy
-from pypto.runtime import RunConfig, run
+from pypto.runtime import RunConfig
 
 # ---------------------------------------------------------------------------
 # Module-level dynamic variables — used only in InCore kernel type annotations.
@@ -542,22 +543,23 @@ def main():
         max_num_blocks_per_req=max_num_blocks_per_req,
         context_len=context_len,
     )
-    run(
-        program,
+    run_config = RunConfig(
+        platform="a2a3",
+        device_id=11,
+        strategy=OptimizationStrategy.Default,
+        dump_passes=True,
+        backend_type=BackendType.Ascend910B,
+        enable_chip_swimlane=args.enable_chip_swimlane,
+    )
+    compiled = ir.compile(program, **run_config.compile_kwargs())
+    compiled(
         query,
         key_cache,
         value_cache,
         block_table,
         context_lens,
         out,
-        config=RunConfig(
-            platform="a2a3",
-            device_id=11,
-            strategy=OptimizationStrategy.Default,
-            dump_passes=True,
-            backend_type=BackendType.Ascend910B,
-            enable_chip_swimlane=args.enable_chip_swimlane,
-        ),
+        config=run_config,
     )
 
     # Golden validation

--- a/examples/models/07_paged_attention_multi_config.py
+++ b/examples/models/07_paged_attention_multi_config.py
@@ -51,9 +51,10 @@ import argparse
 
 import pypto.language as pl
 import torch
+from pypto import ir
 from pypto.backend import BackendType
 from pypto.ir.pass_manager import OptimizationStrategy
-from pypto.runtime import RunConfig, run
+from pypto.runtime import RunConfig
 
 # ── Constants ────────────────────────────────────────────────────────────────
 Q_TILE = 16
@@ -801,23 +802,24 @@ def main():
         max_num_blocks_per_req=max_num_blocks_per_req,
         context_len=context_len,
     )
-    run(
-        program,
+    run_config = RunConfig(
+        platform="a2a3sim",
+        device_id=11,
+        strategy=OptimizationStrategy.Default,
+        dump_passes=True,
+        backend_type=BackendType.Ascend910B,
+        compile_profiling=True,
+        enable_chip_swimlane=args.enable_chip_swimlane,
+    )
+    compiled = ir.compile(program, **run_config.compile_kwargs())
+    compiled(
         query,
         key_cache,
         value_cache,
         block_table,
         context_lens,
         out,
-        config=RunConfig(
-            platform="a2a3sim",
-            device_id=11,
-            strategy=OptimizationStrategy.Default,
-            dump_passes=True,
-            backend_type=BackendType.Ascend910B,
-            compile_profiling=True,
-            enable_chip_swimlane=args.enable_chip_swimlane,
-        ),
+        config=run_config,
     )
 
     # Golden validation

--- a/examples/models/09_paged_attention_spmd.py
+++ b/examples/models/09_paged_attention_spmd.py
@@ -51,9 +51,10 @@ from collections.abc import Sequence
 
 import pypto.language as pl
 import torch
+from pypto import ir
 from pypto.backend import BackendType
 from pypto.ir.pass_manager import OptimizationStrategy
-from pypto.runtime import RunConfig, run
+from pypto.runtime import RunConfig
 
 
 def _get_default_device_id() -> int:
@@ -799,7 +800,7 @@ def main():
         backend_type=BackendType.Ascend950 if args.platform.startswith("a5") else BackendType.Ascend910B,
         enable_chip_swimlane=args.enable_chip_swimlane,
     )
-    compiled = run(program, config=run_config)
+    compiled = ir.compile(program, **run_config.compile_kwargs())
     output = compiled(*input_tensors, config=run_config)
     if not isinstance(output, torch.Tensor):
         raise TypeError(f"Expected tensor output from compiled program, got {type(output).__name__}")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -301,6 +301,7 @@ nav:
       - en/dev/06-persistent-l3.md
       - en/dev/07-memory-map.md
       - en/dev/07-ir-lower-trace.md
+      - en/dev/08-entry-points.md
       - en/dev/distributed_ops.md
       - en/dev/ptoas-op-status.md
       - IR:

--- a/python/pypto/ir/compile.py
+++ b/python/pypto/ir/compile.py
@@ -42,6 +42,67 @@ def _write_files(files: dict[str, str], output_dir: str) -> None:
             f.write(content)
 
 
+def _ensure_orchestration_headers(output_dir: str) -> None:
+    """Add the ``runtime.h`` / ``<iostream>`` includes the runtime requires.
+
+    The generated orchestration translation unit is compiled by the runtime's
+    CodeRunner, which requires both headers. Emitting them from the code
+    generator would make the compiler back-end aware of a runtime-specific
+    requirement, so they are stamped here instead — once, as part of writing the
+    artifact, so that *every* compile produces a directory the runtime can build.
+
+    Args:
+        output_dir: Root output directory the artifact was written to.
+    """
+    orch_dir = os.path.join(output_dir, "orchestration")
+    if not os.path.isdir(orch_dir):
+        return
+    for name in os.listdir(orch_dir):
+        if name.endswith(".cpp"):
+            _add_headers_to_file(os.path.join(orch_dir, name))
+
+
+def _add_headers_to_file(cpp_file: str) -> None:
+    """Insert the missing ``runtime.h`` / ``<iostream>`` headers into *cpp_file*.
+
+    Idempotent: a file that already carries both headers is left untouched, so
+    re-running this over an existing artifact directory is safe.
+
+    Args:
+        cpp_file: Path to a C++ source file that may be missing the headers.
+    """
+    with open(cpp_file, encoding="utf-8") as f:
+        content = f.read()
+
+    has_runtime_h = '#include "runtime.h"' in content
+    has_iostream = "#include <iostream>" in content
+    if has_runtime_h and has_iostream:
+        return
+
+    headers: list[str] = []
+    if not has_runtime_h:
+        headers.append('#include "runtime.h"')
+    if not has_iostream:
+        headers.append("#include <iostream>")
+
+    # Insert before the first non-comment, non-blank line.
+    lines = content.splitlines(keepends=True)
+    insert_pos = 0
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped and not stripped.startswith(("//", "/*", "*")):
+            insert_pos = i
+            break
+
+    header_block = "\n".join(headers) + "\n"
+    if insert_pos > 0:
+        header_block += "\n"
+
+    lines.insert(insert_pos, header_block)
+    with open(cpp_file, "w", encoding="utf-8") as f:
+        f.write("".join(lines))
+
+
 def _backend_type_for_platform(platform: str | None, fallback: BackendType) -> BackendType:
     """Return the codegen backend selected by a runtime platform string."""
     if platform is None:
@@ -388,6 +449,7 @@ def compile(  # noqa: PLR0913
             _write_files(exc.files, output_dir)
             raise
         _write_files(files, output_dir)
+        _ensure_orchestration_headers(output_dir)
     finally:
         if owns_profiler and prof is not None:
             prof.__exit__(None, None, None)

--- a/python/pypto/runtime/__init__.py
+++ b/python/pypto/runtime/__init__.py
@@ -10,18 +10,28 @@
 """
 PyPTO runtime module.
 
-Provides utilities for compiling a ``@pl.program`` and running it on an
-Ascend NPU (or simulator).
+Provides the execution half of the pipeline: dispatching a program compiled by
+:func:`pypto.ir.compile` onto an Ascend NPU (or simulator), and the device
+memory that outlives a single dispatch.
 
-Example::
+Compilation itself belongs to :func:`pypto.ir.compile`; this module never
+compiles on your behalf. :meth:`RunConfig.compile_kwargs` bridges the two, so
+one config object can drive both phases::
 
     import torch
-    from pypto.runtime import run, RunConfig
+    from pypto import ir
+    from pypto.runtime import RunConfig
+
+    config = RunConfig(platform="a2a3sim")
+    compiled = ir.compile(MyProgram, **config.compile_kwargs())
 
     a = torch.full((128, 128), 2.0)
     b = torch.full((128, 128), 3.0)
     c = torch.zeros(128, 128)
-    compiled = run(MyProgram, a, b, c, config=RunConfig(platform="a2a3sim"))
+    compiled(a, b, c, config=config)
+
+``docs/en/dev/08-entry-points.md`` maps every compile and execution entry point
+to the layer it belongs to.
 """
 
 from .bench import BenchmarkStats, TraceInvocation, TraceSpan, benchmark
@@ -36,7 +46,7 @@ from .log_config import _ensure_configured as _ensure_log_configured
 from .log_config import configure_log
 from .log_config import current_level as log_level
 from .pto_isa import ensure_pto_isa_root, pto_isa_include_dir
-from .runner import RunConfig, RunResult, compile_program, execute_compiled, run
+from .runner import RunConfig, RunResult, execute_compiled
 from .runtime_base import Worker
 from .tensor_spec import ScalarSpec, TensorSpec
 from .worker import ChipWorker, RegistrationHandle
@@ -45,9 +55,7 @@ from .worker import ChipWorker, RegistrationHandle
 _ensure_log_configured()
 
 __all__ = [
-    "run",
     "benchmark",
-    "compile_program",
     "execute_compiled",
     "execute_distributed_compiled",
     "configure_log",

--- a/python/pypto/runtime/bench.py
+++ b/python/pypto/runtime/bench.py
@@ -1307,7 +1307,7 @@ def benchmark(
         compiled: A single-orchestration
             :class:`~pypto.ir.CompiledProgram` (L2) or a
             :class:`~pypto.ir.distributed_compiled_program.DistributedCompiledProgram`
-            (L3) from ``ir.compile`` / ``compile_program``. Multi-orch L2
+            (L3) from ``ir.compile``. Multi-orch L2
             programs must pass ``compiled[<name>]``.
         args: Positional dispatch args, same as ``compiled(*args)``. **L3
             requires shared-memory host** ``torch.Tensor`` **args** (allocated

--- a/python/pypto/runtime/debug/replay.py
+++ b/python/pypto/runtime/debug/replay.py
@@ -12,8 +12,9 @@
 Debug-only entry point for the "I edited a kernel cpp by hand, now re-run
 with DFX (PMU / swimlane / args_dump / dep_gen / scope_stats) enabled" workflow.
 
-Reuses :func:`pypto.runtime.runner.execute_compiled`, so the device-side
-execution path is identical to the normal :func:`pypto.runtime.run` flow.
+An L2 build reuses :func:`pypto.runtime.runner.execute_compiled`, so its
+device-side execution path is identical to a normal ``compiled(...)``
+dispatch; an L3 build goes through ``execute_distributed_compiled``.
 The added value is:
 
 1. A friendlier signature for the replay use case

--- a/python/pypto/runtime/device_runner.py
+++ b/python/pypto/runtime/device_runner.py
@@ -517,7 +517,7 @@ def _compile_and_assemble_locked(
 
     Args:
         work_dir: Root output directory containing ``kernels/``, ``orchestration/``,
-            and ``kernel_config.py`` (produced by :func:`compile_program`).
+            and ``kernel_config.py`` (produced by :func:`pypto.ir.compile`).
         platform: Target execution platform.
 
     Returns:

--- a/python/pypto/runtime/execute_artifact.py
+++ b/python/pypto/runtime/execute_artifact.py
@@ -90,7 +90,7 @@ def execute_artifact_dir(
     caller can validate them separately with the test's real tolerance.
 
     Args:
-        work_dir: A build directory produced by ``compile_program`` +
+        work_dir: A build directory produced by ``ir.compile`` +
             ``compile_and_assemble`` (contains ``kernel_config.py``,
             ``kernels/``, ``orchestration/``, ``golden.py``, ``data/``).
         platform: Target execution platform (e.g. ``"a2a3"``).

--- a/python/pypto/runtime/runner.py
+++ b/python/pypto/runtime/runner.py
@@ -10,18 +10,24 @@
 """
 PyPTO runtime runner.
 
-Provides :func:`run`, the main entry point for compiling a ``@pl.program``
-and executing it on an Ascend NPU (or simulator).
+Provides :class:`RunConfig` — the settings that drive a run — and
+:func:`execute_compiled`, which dispatches an already-compiled artifact
+directory onto an Ascend NPU (or simulator).
 
-Typical usage::
+Compilation is :func:`pypto.ir.compile`'s job; nothing here compiles for you.
+:meth:`RunConfig.compile_kwargs` carries the compile-side settings across::
 
     import torch
-    from pypto.runtime import run, RunConfig
+    from pypto import ir
+    from pypto.runtime import RunConfig
+
+    config = RunConfig(platform="a2a3sim")
+    compiled = ir.compile(MyProgram, **config.compile_kwargs())
 
     a = torch.full((128, 128), 2.0)
     b = torch.full((128, 128), 3.0)
     c = torch.zeros(128, 128)
-    compiled = run(MyProgram, a, b, c, config=RunConfig(platform="a2a3sim"))
+    compiled(a, b, c, config=config)
 """
 
 import functools
@@ -153,7 +159,11 @@ def _normalize_swimlane_level(value: int | bool, source: str) -> int:
 
 @dataclass
 class RunConfig:
-    """Configuration for a :func:`run` invocation or harness test execution.
+    """Configuration for compiling and dispatching a program.
+
+    Carries both halves: :meth:`compile_kwargs` extracts the compile-side
+    fields for :func:`pypto.ir.compile`, and the rest is read at dispatch by
+    :meth:`~pypto.ir.CompiledProgram.__call__` / :meth:`Worker.run`.
 
     When passed to :meth:`pypto.jit.decorator.JITFunction.lower`, only
     ``platform``, ``strategy``, diagnostics, dependency analysis, and
@@ -302,11 +312,10 @@ class RunConfig:
             so a HOST-level ``@pl.jit.host`` kernel compiles to a
             :class:`~pypto.ir.distributed_compiled_program.DistributedCompiledProgram`
             and dispatches per-rank. ``None`` (default) compiles a regular
-            single-chip :class:`~pypto.ir.compiled_program.CompiledProgram`. The
-            ``@pl.program`` :func:`run` entry point does not read this field; it
-            forwards no compile-side overrides, so distributed ``@pl.program``
-            execution is driven by ``ir.compile(..., distributed_config=...)``
-            directly rather than through ``RunConfig``.
+            single-chip :class:`~pypto.ir.compiled_program.CompiledProgram`.
+            :meth:`compile_kwargs` forwards it too, so a ``@pl.program``
+            compiled via ``ir.compile(prog, **config.compile_kwargs())`` picks
+            up the same distributed target.
         analyze_auto_scopes_for_deps: If ``True``, enable compiler-derived task
             dependency analysis for AUTO runtime scopes during compilation.
             Defaults to ``False`` so existing runs keep using TensorMap fallback
@@ -468,6 +477,50 @@ class RunConfig:
             or self.enable_scope_stats
         )
 
+    def compile_kwargs(self) -> dict[str, Any]:
+        """Return the compile-side fields as ``ir.compile()`` keyword arguments.
+
+        A :class:`RunConfig` carries both compile-time and dispatch-time
+        settings. This method extracts the compile-time half so a caller can
+        drive the two phases separately without restating the mapping::
+
+            compiled = ir.compile(program, **config.compile_kwargs())
+            compiled(*tensors, config=config)
+
+        Dispatch-only fields (``device_id``, the DFX toggles, the ring-sizing
+        overrides) are not compile inputs and are consumed by
+        :meth:`~pypto.ir.CompiledProgram.__call__` instead. ``rtol`` / ``atol``
+        and ``golden_data_dir`` reach neither phase: only the system-test
+        harness reads them, to compare a dispatch against its golden.
+
+        ``output_dir``, ``distributed_config`` and ``memory_planner`` are
+        forwarded only when set, so an unset value defers to ``ir.compile()``'s
+        own default. That matters for ``memory_planner`` in particular:
+        ``ir.compile()`` rejects an explicit planner while a ``PassContext`` is
+        active, and an unset value must defer to that context.
+
+        Returns:
+            Keyword arguments accepted by :func:`pypto.ir.compile`.
+        """
+        kwargs: dict[str, Any] = {
+            "strategy": self.strategy,
+            "backend_type": self.backend_type,
+            "platform": self.platform,
+            "dump_passes": self.dump_passes,
+            "dump_ptoas_passes": self.dump_ptoas_passes,
+            "profiling": self.compile_profiling,
+            "diagnostic_phase": self.diagnostic_phase,
+            "disabled_diagnostics": self.disabled_diagnostics,
+            "analyze_auto_scopes_for_deps": self.analyze_auto_scopes_for_deps,
+        }
+        if self.save_kernels_dir is not None:
+            kwargs["output_dir"] = self.save_kernels_dir
+        if self.distributed_config is not None:
+            kwargs["distributed_config"] = self.distributed_config
+        if self.memory_planner is not None:
+            kwargs["memory_planner"] = self.memory_planner
+        return kwargs
+
     @property
     def enable_l2_swimlane(self) -> int:
         """Deprecated alias for :attr:`enable_chip_swimlane`.
@@ -532,7 +585,7 @@ class RunResult:
         passed: ``True`` if the program executed and results matched the golden
             reference within the configured tolerances.
         test_name: Optional test case name.  Set by the harness when running
-            a named test case; ``None`` for direct :func:`run` calls.
+            a named test case; ``None`` outside the harness.
         error: Human-readable error message when ``passed`` is ``False``.
         execution_time: Python wall-clock time in seconds for the full run
             (compile + execute + validate). This mixes host-side compile/golden
@@ -563,121 +616,6 @@ class RunResult:
             if self.error:
                 msg += f": {self.error}"
         return msg + time_str
-
-
-def compile_program(  # noqa: PLR0913
-    program: Any,
-    work_dir: Path,
-    *,
-    strategy: OptimizationStrategy,
-    backend_type: BackendType,
-    dump_passes: bool | PassDumpLevel = False,
-    dump_ptoas_passes: bool = False,
-    diagnostic_phase: DiagnosticPhase | None = None,
-    disabled_diagnostics: DiagnosticCheckSet | None = None,
-    profiling: bool = False,
-    analyze_auto_scopes_for_deps: bool = False,
-    memory_planner: MemoryPlanner | None = None,
-    enable_pypto_l0c_double_buffer: bool | None = None,
-) -> None:
-    """Compile *program* to *work_dir* and patch orchestration headers.
-
-    Runs :func:`ir.compile` then inserts ``runtime.h`` / ``<iostream>`` includes
-    into the generated orchestration C++ files (required by Simpler's CodeRunner).
-
-    Args:
-        program: A ``@pl.program`` decorated class or an ``ir.Program`` object.
-        work_dir: Output directory for generated artefacts.
-        strategy: PyPTO optimisation strategy applied during compilation.
-        backend_type: Code-generation backend.
-        dump_passes: Per-pass IR dump control — a :class:`~pypto.ir.PassDumpLevel`
-            or a ``bool`` (``True`` -> ``CONCISE``, ``False`` -> ``NONE``).
-        dump_ptoas_passes: If ``True``, dump intermediate IR after every ptoas
-            pass under ``<work_dir>/ptoas_passes/<codegen-unit>/``.
-        diagnostic_phase: Override the diagnostic phase gate for compilation.
-        disabled_diagnostics: Set of diagnostic checks to disable.
-        profiling: If ``True``, enable compile profiling.
-        analyze_auto_scopes_for_deps: If ``True``, enable compiler-derived task
-            dependency analysis for AUTO runtime scopes.
-        memory_planner: On-chip memory planner forwarded to :func:`ir.compile`.
-        enable_pypto_l0c_double_buffer: Opt the legacy ``PYPTO`` planner in to
-            chooser-emitted dbC=2. Ignored under ``DSA_RP`` and ``PTOAS``, where
-            chooser dbC is automatic.
-    """
-    from pypto import ir  # noqa: PLC0415
-
-    ir.compile(
-        program,
-        output_dir=str(work_dir),
-        strategy=strategy,
-        dump_passes=dump_passes,
-        dump_ptoas_passes=dump_ptoas_passes,
-        backend_type=backend_type,
-        diagnostic_phase=diagnostic_phase,
-        disabled_diagnostics=disabled_diagnostics,
-        profiling=profiling,
-        analyze_auto_scopes_for_deps=analyze_auto_scopes_for_deps,
-        memory_planner=memory_planner,
-        enable_pypto_l0c_double_buffer=enable_pypto_l0c_double_buffer,
-    )
-    _patch_orchestration_headers(work_dir)
-
-
-def run(
-    program: Any,
-    *tensors: torch.Tensor,
-    config: RunConfig | None = None,
-) -> Any:
-    """Compile *program* and execute it with *tensors* on device.
-
-    This is the user-facing entry point for the compile-and-run workflow.
-    No golden function, no TensorSpec — just define, compile, call.
-
-    Args:
-        program: A ``@pl.program`` decorated class or an ``ir.Program``.
-        *tensors: Positional ``torch.Tensor`` arguments matching the
-            orchestration function's parameter order.  Pass no tensors
-            for compile-only.
-        config: Run configuration (platform, device, profiling, etc.).
-            Uses default :class:`RunConfig` if ``None``.
-
-    Returns:
-        A :class:`~pypto.ir.compiled_program.CompiledProgram` that can
-        be called again with new tensors.
-
-    Example:
-        >>> from pypto.runtime import run, RunConfig
-        >>> a = torch.full((128, 128), 2.0)
-        >>> b = torch.full((128, 128), 3.0)
-        >>> c = torch.zeros(128, 128)
-        >>> compiled = run(MyProgram, a, b, c, config=RunConfig(platform="a2a3sim"))
-        >>> # Re-run with different inputs:
-        >>> compiled(a2, b2, c2)
-    """
-    if config is None:
-        config = RunConfig()
-
-    from pypto import ir  # noqa: PLC0415
-
-    compiled = ir.compile(
-        program,
-        output_dir=config.save_kernels_dir,
-        strategy=config.strategy,
-        backend_type=config.backend_type,
-        dump_passes=config.dump_passes,
-        dump_ptoas_passes=config.dump_ptoas_passes,
-        diagnostic_phase=config.diagnostic_phase,
-        disabled_diagnostics=config.disabled_diagnostics,
-        platform=config.platform,
-        profiling=config.compile_profiling,
-        analyze_auto_scopes_for_deps=config.analyze_auto_scopes_for_deps,
-        memory_planner=config.memory_planner,
-    )
-
-    if tensors and not config.codegen_only:
-        compiled(*tensors, config=config)
-
-    return compiled
 
 
 # ---------------------------------------------------------------------------
@@ -1037,7 +975,7 @@ def _execute_on_device(
 ) -> None:
     """Load inputs, execute on device, and validate against golden.
 
-    Shared execution logic used by both :func:`run` and the test harness
+    Shared execution logic used by both :func:`execute_compiled` and the test harness
     (``test_runner.py``).  The caller is responsible for compiling binaries
     via ``compile_and_assemble`` and passing the result here.
 
@@ -1379,60 +1317,6 @@ def _generate_swimlane(
         )
 
 
-def _patch_orchestration_headers(work_dir: Path) -> None:
-    """Add ``runtime.h`` and ``<iostream>`` includes to orchestration C++ files.
-
-    Simpler's CodeRunner requires these headers in the orchestration translation
-    unit.  They are added here rather than in the code generator so that the
-    compiler back-end remains unaware of runtime-specific requirements.
-
-    Args:
-        work_dir: Root output directory produced by :func:`ir.compile`.
-    """
-    orch_dir = work_dir / "orchestration"
-    if not orch_dir.exists():
-        return
-    for cpp_file in orch_dir.glob("*.cpp"):
-        _add_headers_to_file(cpp_file)
-
-
-def _add_headers_to_file(cpp_file: Path) -> None:
-    """Insert missing ``runtime.h`` / ``<iostream>`` headers into *cpp_file*.
-
-    Args:
-        cpp_file: Path to a C++ source file that may be missing the headers.
-    """
-    content = cpp_file.read_text(encoding="utf-8")
-
-    has_runtime_h = '#include "runtime.h"' in content
-    has_iostream = "#include <iostream>" in content
-
-    if has_runtime_h and has_iostream:
-        return  # Nothing to do
-
-    headers: list[str] = []
-    if not has_runtime_h:
-        headers.append('#include "runtime.h"')
-    if not has_iostream:
-        headers.append("#include <iostream>")
-
-    # Find the first non-comment, non-blank line as the insertion point.
-    lines = content.splitlines(keepends=True)
-    insert_pos = 0
-    for i, line in enumerate(lines):
-        stripped = line.strip()
-        if stripped and not stripped.startswith(("//", "/*", "*")):
-            insert_pos = i
-            break
-
-    header_block = "\n".join(headers) + "\n"
-    if insert_pos > 0:
-        header_block += "\n"
-
-    lines.insert(insert_pos, header_block)
-    cpp_file.write_text("".join(lines), encoding="utf-8")
-
-
 # ---------------------------------------------------------------------------
 # Compiled program execution (callable API)
 # ---------------------------------------------------------------------------
@@ -1497,8 +1381,12 @@ def execute_compiled(  # noqa: PLR0913
 
     work_dir = Path(work_dir)
 
-    # Ensure orchestration headers are patched (idempotent)
-    _patch_orchestration_headers(work_dir)
+    # ``ir.compile`` stamps these when it writes the artifact. Re-apply here
+    # (idempotent) so a directory produced before that change, or one whose
+    # orchestration cpp was hand-edited for a replay, still builds.
+    from pypto.ir.compile import _ensure_orchestration_headers  # noqa: PLC0415
+
+    _ensure_orchestration_headers(str(work_dir))
 
     from .device_runner import (  # noqa: PLC0415
         compile_and_assemble,

--- a/python/pypto/runtime/worker.py
+++ b/python/pypto/runtime/worker.py
@@ -10,9 +10,9 @@
 """L2 :class:`ChipWorker` — the single-chip concrete runtime handle.
 
 Inside a ``with ChipWorker(...) as _:`` block, calls to ``CompiledProgram(...)``
-(and :func:`pypto.runtime.run`) reuse the active worker instead of creating a
-fresh one. Outside such a block, behavior is unchanged from one-shot
-construction in :func:`pypto.runtime.device_runner.execute_on_device`.
+reuse the active worker instead of creating a fresh one. Outside such a block,
+behavior is unchanged from one-shot construction in
+:func:`pypto.runtime.device_runner.execute_on_device`.
 
 For explicit dispatch (no ``ContextVar`` discovery), call
 :meth:`ChipWorker.run` directly, or pre-register with :meth:`ChipWorker.register`
@@ -123,9 +123,9 @@ class ChipWorker(Worker):
     setup. Construction without entering a ``with`` block also works — call
     :meth:`close` manually when done, or re-enter via ``with`` later.
 
-    Inside a ``with`` block, ``CompiledProgram.__call__`` and
-    :func:`pypto.runtime.run` find this worker via a ``ContextVar`` and reuse
-    its initialized device context instead of creating a fresh worker per call.
+    Inside a ``with`` block, ``CompiledProgram.__call__`` finds this worker via
+    a ``ContextVar`` and reuses its initialized device context instead of
+    creating a fresh worker per call.
     Reuse only happens when all four binding fields match and the worker has
     every capability required by the artifact — otherwise the caller either
     falls through to the one-shot path (binding mismatch) or raises (capability

--- a/tests/st/harness/core/test_runner.py
+++ b/tests/st/harness/core/test_runner.py
@@ -37,6 +37,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from pypto import ir
 from pypto.backend import (
     BackendType,
     get_backend_type,
@@ -46,7 +47,6 @@ from pypto.backend import (
 )
 from pypto.pypto_core import LogLevel, _set_thread_log_level
 from pypto.pypto_core.passes import MemoryPlanner
-from pypto.runtime import compile_program
 from pypto.runtime.golden_writer import (
     _data_dir_has_files,
     _extract_compute_golden,
@@ -137,7 +137,7 @@ _MAX_TASK_SUBMIT_INFLIGHT = 512
 
 # set_backend_type is called once per backend-type group before the thread pool
 # starts.  Only get_program() needs serialisation because the @pl.program
-# decorator is not thread-safe; compile_program() writes to isolated dirs and
+# decorator is not thread-safe; ir.compile() writes to isolated dirs and
 # runs concurrently.
 _get_program_lock = threading.Lock()
 
@@ -396,7 +396,7 @@ def _compile_for_cache(
 
     The backend type MUST already be set by the caller before entering the pool.
     Only ``get_program`` is serialised (via ``_get_program_lock``) because the
-    ``@pl.program`` decorator is not thread-safe; ``compile_program`` writes to
+    ``@pl.program`` decorator is not thread-safe; ``ir.compile`` writes to
     an isolated directory and runs concurrently.
     """
     backend_type = platform_to_backend(resolved_platform)
@@ -407,9 +407,9 @@ def _compile_for_cache(
             f"Test case {test_case.get_name()} must implement get_program() "
             "to return a @pl.program class or ir.Program"
         )
-    compile_program(
+    ir.compile(
         program,
-        work_dir,
+        output_dir=str(work_dir),
         strategy=test_case.get_strategy(),
         backend_type=backend_type,
         dump_passes=dump_passes,
@@ -1440,9 +1440,9 @@ class TestRunner:
                 )
 
             strategy = test_case.get_strategy()
-            compile_program(
+            ir.compile(
                 program,
-                work_dir,
+                output_dir=str(work_dir),
                 strategy=strategy,
                 backend_type=backend_type,
                 dump_passes=self.config.dump_passes,

--- a/tests/st/runtime/cross_core/test_cross_core_grouped_tpop_tfree.py
+++ b/tests/st/runtime/cross_core/test_cross_core_grouped_tpop_tfree.py
@@ -37,8 +37,8 @@ from typing import Any
 import pytest
 import torch
 from harness.core.harness import platform_to_backend
+from pypto import ir
 from pypto.backend.pto_backend import _preprocess_ptoas_output, _run_ptoas
-from pypto.runtime import compile_program
 from pypto.runtime.device_runner import (
     build_orch_args_from_inputs,
     compile_and_assemble,
@@ -211,9 +211,9 @@ class TestCrossCoreGroupedTpopTfree:
             cleanup_dir = work_dir
 
         try:
-            compile_program(
+            ir.compile(
                 V2CUDProgram,
-                work_dir,
+                output_dir=str(work_dir),
                 strategy=test_config.strategy,
                 backend_type=backend_type,
                 dump_passes=test_config.dump_passes,

--- a/tests/ut/runtime/test_run_config.py
+++ b/tests/ut/runtime/test_run_config.py
@@ -17,7 +17,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from pypto.backend import BackendType
 from pypto.pypto_core.passes import MemoryPlanner
-from pypto.runtime.runner import RunConfig, _DfxOpts, compile_program, execute_compiled, run
+from pypto.runtime.runner import RunConfig, _DfxOpts, execute_compiled
 
 
 class TestRunConfigPlatformResolution:
@@ -629,62 +629,61 @@ class TestMakeCallConfigDfx:
 class TestRunConfigCompileForwarding:
     """Compile-side RunConfig fields are forwarded into ``ir.compile``."""
 
-    def test_run_forwards_auto_scope_deps_switch(self, monkeypatch):
-        captured: dict = {}
+    def test_compile_kwargs_forwards_auto_scope_deps_switch(self):
+        kwargs = RunConfig(platform="a2a3sim", analyze_auto_scopes_for_deps=True).compile_kwargs()
 
-        class FakeCompiled:
-            def __call__(self, *_args, **_kwargs):
-                return None
+        assert kwargs["analyze_auto_scopes_for_deps"] is True
 
-        def fake_compile(_program, **kwargs):
-            captured.update(kwargs)
-            return FakeCompiled()
+    def test_compile_kwargs_forwards_memory_planner(self):
+        kwargs = RunConfig(platform="a2a3sim", memory_planner=MemoryPlanner.DSA_RP).compile_kwargs()
 
-        import pypto.ir as ir_mod  # noqa: PLC0415
+        assert kwargs["memory_planner"] == MemoryPlanner.DSA_RP
 
-        monkeypatch.setattr(ir_mod, "compile", fake_compile)
+    def test_compile_kwargs_forwards_ptoas_pass_dump(self):
+        kwargs = RunConfig(platform="a2a3sim", dump_ptoas_passes=True).compile_kwargs()
 
-        run(object(), config=RunConfig(platform="a2a3sim", analyze_auto_scopes_for_deps=True))
+        assert kwargs["dump_ptoas_passes"] is True
 
-        assert captured["analyze_auto_scopes_for_deps"] is True
+    def test_compile_kwargs_omits_unset_optional_fields(self):
+        """Unset optionals must be absent, not ``None``.
 
-    def test_run_forwards_memory_planner(self, monkeypatch):
-        captured: dict = {}
+        ``ir.compile`` rejects an explicit ``memory_planner`` while a
+        ``PassContext`` is active, so an unset planner has to defer to that
+        context rather than arrive as an explicit ``None``.
+        """
+        kwargs = RunConfig(platform="a2a3sim").compile_kwargs()
 
-        class FakeCompiled:
-            def __call__(self, *_args, **_kwargs):
-                return None
+        assert "memory_planner" not in kwargs
+        assert "output_dir" not in kwargs
+        assert "distributed_config" not in kwargs
 
-        def fake_compile(_program, **kwargs):
-            captured.update(kwargs)
-            return FakeCompiled()
+    def test_compile_kwargs_excludes_dispatch_only_fields(self):
+        """Dispatch-side fields are consumed by ``__call__``, not by compilation."""
+        kwargs = RunConfig(
+            platform="a2a3sim",
+            device_id=3,
+            rtol=1e-3,
+            enable_pmu=2,
+            ring_heap=1024 * 1024,
+        ).compile_kwargs()
 
-        import pypto.ir as ir_mod  # noqa: PLC0415
+        for dispatch_only in ("device_id", "rtol", "atol", "enable_pmu", "ring_heap"):
+            assert dispatch_only not in kwargs
 
-        monkeypatch.setattr(ir_mod, "compile", fake_compile)
+    def test_compile_kwargs_are_accepted_by_ir_compile(self):
+        """Every key must name a real ``ir.compile`` parameter."""
+        import inspect  # noqa: PLC0415
 
-        run(object(), config=RunConfig(platform="a2a3sim", memory_planner=MemoryPlanner.DSA_RP))
+        from pypto import ir  # noqa: PLC0415
 
-        assert captured["memory_planner"] == MemoryPlanner.DSA_RP
+        accepted = set(inspect.signature(ir.compile).parameters)
+        kwargs = RunConfig(
+            platform="a2a3sim",
+            save_kernels_dir="/tmp/pypto-compile-kwargs",
+            memory_planner=MemoryPlanner.DSA_RP,
+        ).compile_kwargs()
 
-    def test_run_forwards_ptoas_pass_dump(self, monkeypatch):
-        captured: dict = {}
-
-        class FakeCompiled:
-            def __call__(self, *_args, **_kwargs):
-                return None
-
-        def fake_compile(_program, **kwargs):
-            captured.update(kwargs)
-            return FakeCompiled()
-
-        import pypto.ir as ir_mod  # noqa: PLC0415
-
-        monkeypatch.setattr(ir_mod, "compile", fake_compile)
-
-        run(object(), config=RunConfig(platform="a2a3sim", dump_ptoas_passes=True))
-
-        assert captured["dump_ptoas_passes"] is True
+        assert set(kwargs) <= accepted
 
     def test_execute_compiled_accepts_auto_scope_deps_switch(self, tmp_path, monkeypatch):
         captured: dict = {}
@@ -795,30 +794,12 @@ class TestRunConfigCompileForwarding:
 
         assert captured["enable_sdma"] is expected_enable_sdma
 
-    def test_compile_program_forwards_auto_scope_deps_switch(self, tmp_path, monkeypatch):
-        captured: dict = {}
+    def test_compile_kwargs_carry_the_codegen_target(self):
+        """``platform`` and the ``backend_type`` it implies both reach compilation."""
+        kwargs = RunConfig(platform="a5sim").compile_kwargs()
 
-        def fake_compile(_program, **kwargs):
-            captured.update(kwargs)
-            return object()
-
-        import pypto.ir as ir_mod  # noqa: PLC0415
-        import pypto.runtime.runner as runner_mod  # noqa: PLC0415
-
-        monkeypatch.setattr(ir_mod, "compile", fake_compile)
-        monkeypatch.setattr(runner_mod, "_patch_orchestration_headers", lambda _work_dir: None)
-
-        compile_program(
-            object(),
-            tmp_path,
-            strategy=RunConfig().strategy,
-            backend_type=BackendType.Ascend910B,
-            analyze_auto_scopes_for_deps=True,
-            dump_ptoas_passes=True,
-        )
-
-        assert captured["analyze_auto_scopes_for_deps"] is True
-        assert captured["dump_ptoas_passes"] is True
+        assert kwargs["platform"] == "a5sim"
+        assert kwargs["backend_type"] == BackendType.Ascend950
 
 
 # ``execute_on_device`` lives in ``device_runner`` which eagerly imports the

--- a/tests/ut/runtime/test_task_submit_dispatch.py
+++ b/tests/ut/runtime/test_task_submit_dispatch.py
@@ -69,11 +69,12 @@ def _planner_case():
     )
 
 
-def _write_minimal_compile_output(_program, output_dir, **_kwargs):
-    (output_dir / "kernels").mkdir(parents=True)
-    (output_dir / "kernels" / "kernel.cpp").touch()
-    (output_dir / "orchestration").mkdir()
-    (output_dir / "orchestration" / "orch.cpp").touch()
+def _write_minimal_compile_output(_program, *, output_dir, **_kwargs):
+    work_dir = Path(output_dir)
+    (work_dir / "kernels").mkdir(parents=True)
+    (work_dir / "kernels" / "kernel.cpp").touch()
+    (work_dir / "orchestration").mkdir()
+    (work_dir / "orchestration" / "orch.cpp").touch()
 
 
 # ---------------------------------------------------------------------------
@@ -121,10 +122,10 @@ def test_precompile_forwards_session_memory_planner(tmp_path):
     case = _planner_case()
     with (
         patch.object(
-            test_runner,
-            "compile_program",
+            test_runner.ir,
+            "compile",
             side_effect=_write_minimal_compile_output,
-        ) as compile_program,
+        ) as ir_compile,
         patch.object(test_runner, "_write_golden_for_test_case"),
     ):
         test_runner._compile_for_cache(
@@ -135,7 +136,7 @@ def test_precompile_forwards_session_memory_planner(tmp_path):
             analyze_auto_scopes_for_deps=False,
             session_memory_planner=MemoryPlanner.DSA_RP,
         )
-    assert compile_program.call_args.kwargs["memory_planner"] == MemoryPlanner.DSA_RP
+    assert ir_compile.call_args.kwargs["memory_planner"] == MemoryPlanner.DSA_RP
 
 
 def test_inline_compile_forwards_session_memory_planner():
@@ -147,15 +148,15 @@ def test_inline_compile_forwards_session_memory_planner():
     )
     with (
         patch.object(
-            test_runner,
-            "compile_program",
+            test_runner.ir,
+            "compile",
             side_effect=_write_minimal_compile_output,
-        ) as compile_program,
+        ) as ir_compile,
         patch.object(test_runner, "_write_golden_for_test_case"),
     ):
         result = test_runner.TestRunner(config)._run_inline(case, "a2a3sim")
     assert result.passed, result.error
-    assert compile_program.call_args.kwargs["memory_planner"] == MemoryPlanner.DSA_RP
+    assert ir_compile.call_args.kwargs["memory_planner"] == MemoryPlanner.DSA_RP
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`pypto.runtime` carried four module-level compile/execute functions layered over
`ir.compile` and `CompiledProgram.__call__`, and two of them earned nothing.
`run()` compiled *and* executed, but passing no tensors made it compile-only
while it still returned a `CompiledProgram` — a function named `run` that might
not run — and it silently dropped `RunConfig.distributed_config`, compiling a
distributed `@pl.program` as a single-chip one. `compile_program()` was
`ir.compile` plus a header patch that `execute_compiled` already applied itself,
so choosing between the two came down to an invisible rule and a C++ compile
error in generated code when you got it wrong.

Both are removed. The header stamp moves into `ir.compile`, so every compile now
produces a directory the runtime can build, and callers that drove both phases
from one `RunConfig` use the new `RunConfig.compile_kwargs()`. `pypto.runtime`'s
public surface drops from 24 exports to 22, and its module-level compile/execute
functions from 5 to 3.

This is the first of four staged steps; the new dev doc records the rest.

## Changes

- `python/pypto/runtime/runner.py`: delete `run()` and `compile_program()`; add
  `RunConfig.compile_kwargs()`, which returns the compile-side fields as
  `ir.compile` keyword arguments and replaces the mapping each deleted function
  carried its own copy of. It forwards `distributed_config`, which `run()` did
  not. `execute_compiled` now re-applies the header stamp from its new home.
- `python/pypto/ir/compile.py`: stamp the `runtime.h` / `<iostream>` includes the
  runtime's CodeRunner needs as part of writing the artifact. The operation is
  idempotent, so a directory compiled before this change and a hand-edited
  replay directory both keep working through `execute_compiled`.
- `docs/en/dev/08-entry-points.md` (+ `docs/zh/` mirror, nav, index): new page
  mapping every compile and execution entry point to its layer, the defects that
  remain — four `execute_*` near-synonyms, `ir`'s nine deferred imports of
  `runtime`, `RunConfig`'s 27 mixed-concern fields — and the staged plan.
- `docs/{en,zh}/dev/{01-compile-profiling,03-runtime-dfx,03-runtime-replay,05-runtime-ring-sizing}.md`,
  `docs/{en,zh}/user/execution/01-run.md`: migrate every `run()` example and
  reference. `01-compile-profiling.md` also carried a `run()` call whose
  signature never existed.
- `examples/models/{04,06,07,09}_paged_attention*.py`: migrate to
  `ir.compile(program, **config.compile_kwargs())` then `compiled(...)`. `09`
  had been calling `run(program, config=...)` with no tensors purely to compile.
- `tests/st/harness/core/test_runner.py`,
  `tests/st/runtime/cross_core/test_cross_core_grouped_tpop_tfree.py`: call
  `ir.compile` directly.
- `tests/ut/runtime/test_run_config.py`: the four forwarding tests moved off the
  deleted functions onto `compile_kwargs()`, which is now the real seam, and no
  longer need to monkeypatch `ir.compile`. Added coverage that unset optionals
  are absent rather than `None` (`ir.compile` rejects an explicit
  `memory_planner` under an active `PassContext`), that dispatch-only fields are
  excluded, and that every returned key names a real `ir.compile` parameter.

## Migration

`pypto.runtime.run` and `pypto.runtime.compile_program` are removed. Nothing in
this repository or in `pypto-lib` imported either.

```python
# before
run(prog, *tensors, config=cfg)
compile_program(prog, work_dir, strategy=..., backend_type=...)

# after
ir.compile(prog, **cfg.compile_kwargs())(*tensors, config=cfg)
ir.compile(prog, output_dir=str(work_dir), strategy=..., backend_type=...)
```

`execute_compiled` is deliberately untouched: `pypto-lib` imports it, so it is
staged behind a deprecation shim rather than removed here.

## Verification

Run in the worktree against its own build, at the pushed commit.

- `cmake --build build --parallel 32`: exit 0
- `pytest tests/ut/ -n 16`: 10970 passed, 8 skipped, 1 xfailed
- `pytest tests/ut/runtime/ tests/ut/ir/test_compiled_program.py -n 16`: 825 passed, 1 skipped
- `tests/lint/check_*.py` (12 scripts, incl. docs nav and en/zh parity): all pass
- `ruff format --check` / `ruff check` on the changed Python files: clean
- `pyright` on the changed library files: 0 errors, 0 warnings
- End-to-end: `ir.compile` emits an orchestration `.cpp` carrying `runtime.h` and
  `<iostream>`, and re-stamping the same directory does not duplicate them

Two unit tests were deselected: `test_declared_memref.py::…::test_signature_memref_base_prints_as_a_string`
and `test_unified_ops.py::…::test_symlinked_import_path_still_names_the_caller`.
Both fail identically on unmodified `origin/main` in this environment — verified
by reverting the six changed library files and rerunning — and both are artifacts
of the local editable install and an unpinned `ruff`, not of this change.

Device tests were not run; this change touches no kernel or codegen output.