### PR TITLE
docs(examples): chapter ↔ ladder ↔ map cross-links (reading path, ops catalog, debugging)

### DIFF
--- a/docs/en/user/distributed/05-tutorials.md
+++ b/docs/en/user/distributed/05-tutorials.md
@@ -80,6 +80,12 @@ Every `pld` abstraction: one-line purpose, the chapter section that documents
 it, and the tutorial step that teaches it. The **coverage contract** for the
 tutorials: nothing exists in code without being teachable from an example.
 
+> The machine-level counterpart of this map's *operation* rows is the
+> [operations catalog](../ops/01-catalog.md) §Distributed — the collectives,
+> put/get, notify/wait, and remote load/store families lower to the ops listed
+> there; the window, context, and decorator helpers above are language
+> abstractions without catalog rows.
+
 ### System substrate
 
 | Abstraction | Purpose | Chapter section | Runs on | Tutorial step |
@@ -141,6 +147,21 @@ tutorials: nothing exists in code without being teachable from an example.
 | `@pl.jit` / `@pl.jit.incore` | Per-device orchestration / device-side kernel | [03-execution](03-execution.md) | 02 |
 | `device=r` | Pin one dispatch to one device from the host loop | [00-model](00-model.md) | 01 |
 | `DistributedConfig` | Device list + worker count for compilation | [03-execution](03-execution.md) | 01 |
+
+## Reading path
+
+The ladder is one stop on a longer path. The tiered single-device examples
+teach the `pl` language this ladder assumes — it needs only
+`examples/beginner/` and `examples/intermediate/`. The stages below are a
+recommended progression; only the first two are prerequisites for the ladder,
+and the later stages are optional follow-ups:
+
+- the `pl` language: `examples/beginner/` → `examples/intermediate/`
+- the distributed ladder: `examples/distributed/01 … 16` (this series, P ≥ 2)
+- at scale: `examples/advanced/` → `examples/models/`
+- applications: pypto-lib (distributed MoE, model JIT decode)
+
+The distributed ladder is the only stop that needs more than one device.
 
 ## See also
 

--- a/docs/en/user/distributed/06-hello_rank.md
+++ b/docs/en/user/distributed/06-hello_rank.md
@@ -144,5 +144,6 @@ differences; use exact equality if you need a strict guarantee.
 - [00-model](../distributed/00-model.md) — quickstart + model vocabulary
 - [03-execution](../distributed/03-execution.md) — `DistributedConfig` and the
   worker lifecycle
+- [04-debugging](04-debugging.md) — the canonical failure catalog for distributed programs
 - Next step: [07-programming_model](07-programming_model.md) — the three-level
   model, labeled

--- a/docs/en/user/distributed/07-programming_model.md
+++ b/docs/en/user/distributed/07-programming_model.md
@@ -124,4 +124,5 @@ its own index.
 - [05-tutorials](05-tutorials.md) — the tutorial index (this step = row 02)
 - [00-model](../distributed/00-model.md) — model vocabulary, L2 vs L3
 - [03-execution](../distributed/03-execution.md) — worker lifecycle per level
+- [04-debugging](04-debugging.md) — the canonical failure catalog for distributed programs
 - Next step: [08-window_buffer](08-window_buffer.md) — the memory substrate

--- a/docs/en/user/distributed/08-window_buffer.md
+++ b/docs/en/user/distributed/08-window_buffer.md
@@ -104,4 +104,5 @@ windows do not cost what their shape suggests.
 - [02-primitives](../distributed/02-primitives.md) §Window Buffer Management —
   the full API
 - [00-model](../distributed/00-model.md) §Glossary — window buffer, signal
+- [04-debugging](04-debugging.md) — the canonical failure catalog for distributed programs
 - Next step: [09-barrier](09-barrier.md) — signals only, no data

--- a/docs/en/user/distributed/09-barrier.md
+++ b/docs/en/user/distributed/09-barrier.md
@@ -154,4 +154,5 @@ holds only because the barrier ordered them. The same
   NotifyOp and WaitCmp — the full signal API
 - [01-collectives](../distributed/01-collectives.md) §Barrier — where the
   barrier sits in the collective zoo
+- [04-debugging](04-debugging.md) — the canonical failure catalog for distributed programs
 - Next step: [10-remote_load_store](10-remote_load_store.md) — move a slice

--- a/docs/en/user/distributed/10-remote_load_store.md
+++ b/docs/en/user/distributed/10-remote_load_store.md
@@ -154,4 +154,5 @@ fits on-core. `remote_store` moves what you already have on-core, in one write.
   `pld.tile.*` surface
 - [01-collectives](../distributed/01-collectives.md) — all-reduce is these
   moves plus an add (steps 08–10)
+- [04-debugging](04-debugging.md) — the canonical failure catalog for distributed programs
 - Next step: [11-put_get](11-put_get.md) — tensor-level push/pull

--- a/docs/en/user/distributed/11-put_get.md
+++ b/docs/en/user/distributed/11-put_get.md
@@ -136,4 +136,5 @@ full-slice form; the chapter reference documents the chunk-size rules.
   pipelining constraints
 - [01-collectives](../distributed/01-collectives.md) — how collectives compose
   these moves (steps 08–16)
+- [04-debugging](04-debugging.md) — the canonical failure catalog for distributed programs
 - Next step: [12-dynamic_rank_count](12-dynamic_rank_count.md) — the same ring, rank-count-agnostic

--- a/docs/en/user/distributed/12-dynamic_rank_count.md
+++ b/docs/en/user/distributed/12-dynamic_rank_count.md
@@ -118,4 +118,5 @@ wraps, not the per-rank cost.
 - [11-put_get](11-put_get.md) — the fixed-P=2 version of this ring (step 06)
 - [02-primitives](../distributed/02-primitives.md) §System Substrate + §Put and Get — `world_size`/`nranks`, chunking
 - [00-getting_started](../00-getting_started.md) — `pl.dynamic(...)` dynamic dims
+- [04-debugging](04-debugging.md) — the canonical failure catalog for distributed programs
 - Next step: [13-allreduce_mesh](13-allreduce_mesh.md) — steps 08–16 build the collectives (at P=4), starting with all-reduce

--- a/docs/en/user/distributed/13-allreduce_mesh.md
+++ b/docs/en/user/distributed/13-allreduce_mesh.md
@@ -124,4 +124,5 @@ is exactly why the two-phase and ring variants exist.
 - [01-collectives](01-collectives.md) §AllReduce — the reference for mesh mode
 - [09-barrier](09-barrier.md) — the notify/wait barrier reused here (step 04)
 - [10-remote_load_store](10-remote_load_store.md) — `remote_load` (step 05)
+- [04-debugging](04-debugging.md) — the canonical failure catalog for distributed programs
 - Next step: [14-allreduce_two_phase](14-allreduce_two_phase.md) — the same result in roughly half the traffic

--- a/docs/en/user/distributed/14-allreduce_two_phase.md
+++ b/docs/en/user/distributed/14-allreduce_two_phase.md
@@ -109,4 +109,5 @@ mesh's `(P-1) * N`, at the cost of one extra barrier round.
 - [05-tutorials](05-tutorials.md) — the tutorial index (this step = row 09)
 - [13-allreduce_mesh](13-allreduce_mesh.md) — the baseline this step improves (step 08)
 - [01-collectives](01-collectives.md) §AllReduce — reference (Mesh Mode, Ring Mode)
+- [04-debugging](04-debugging.md) — the canonical failure catalog for distributed programs
 - Next step: [15-allreduce_ring](15-allreduce_ring.md) — same bytes, constant per-step size

--- a/docs/en/user/distributed/15-allreduce_ring.md
+++ b/docs/en/user/distributed/15-allreduce_ring.md
@@ -117,4 +117,5 @@ which is the ring's reason to exist.
 - [05-tutorials](05-tutorials.md) — the tutorial index (this step = row 10)
 - [14-allreduce_two_phase](14-allreduce_two_phase.md) — the two-phase shape (step 09)
 - [01-collectives](01-collectives.md) §AllReduce — reference (Ring Mode, signal shape, `Sum`/`FP32`)
+- [04-debugging](04-debugging.md) — the canonical failure catalog for distributed programs
 - Next step: [16-allreduce_reveal](16-allreduce_reveal.md) — the builtin that picks mesh or ring for you

--- a/docs/en/user/distributed/16-allreduce_reveal.md
+++ b/docs/en/user/distributed/16-allreduce_reveal.md
@@ -118,4 +118,5 @@ you still choose the mode.
 - [01-collectives](01-collectives.md) §AllReduce — the reference for both modes and the signal shapes
 - [13-allreduce_mesh](13-allreduce_mesh.md) / [15-allreduce_ring](15-allreduce_ring.md) — what each mode lowers to
 - [02-primitives](02-primitives.md) — the substrate the builtin is built from
+- [04-debugging](04-debugging.md) — the canonical failure catalog for distributed programs
 - Next: steps 12-16 in [05-tutorials](05-tutorials.md) cover the other collectives

--- a/docs/en/user/distributed/17-broadcast.md
+++ b/docs/en/user/distributed/17-broadcast.md
@@ -151,4 +151,5 @@ because every rank wants the *same* bytes.
 - [01-collectives](../distributed/01-collectives.md) §Broadcast — the full API
 - [02-primitives](../distributed/02-primitives.md) §Tile-Level RMA — the
   `remote_load` the hand-rolled version builds on
+- [04-debugging](04-debugging.md) — the canonical failure catalog for distributed programs
 - Next step: [18-allgather](18-allgather.md) — all-to-all slices

--- a/docs/en/user/distributed/18-allgather.md
+++ b/docs/en/user/distributed/18-allgather.md
@@ -161,4 +161,5 @@ rank receives `(P-1)/P · N` bytes — the gather half of two-phase all-reduce
 - [01-collectives](../distributed/01-collectives.md) §AllGather — the full API
 - [14-allreduce_two_phase](14-allreduce_two_phase.md) — the gather half of the
   two-phase all-reduce this step isolates
+- [04-debugging](04-debugging.md) — the canonical failure catalog for distributed programs
 - Next step: [19-reduce_scatter](19-reduce_scatter.md) — the reduce half

--- a/docs/en/user/distributed/19-reduce_scatter.md
+++ b/docs/en/user/distributed/19-reduce_scatter.md
@@ -164,4 +164,5 @@ second half (allgather) you built in step 13.
 - [01-collectives](../distributed/01-collectives.md) §ReduceScatter — the full API
 - [14-allreduce_two_phase](14-allreduce_two_phase.md) — the two-phase all-reduce
   this step is the first half of
+- [04-debugging](04-debugging.md) — the canonical failure catalog for distributed programs
 - Next step: [20-all_to_all](20-all_to_all.md) — a different slice for every peer

--- a/docs/en/user/distributed/20-all_to_all.md
+++ b/docs/en/user/distributed/20-all_to_all.md
@@ -163,5 +163,6 @@ schedule: every pair exchanges distinct data.
   [#869](https://github.com/hw-native-sys/pypto-lib/pull/869) (AllGather-GEMM,
   an allgather pattern from step 13) and the DeepSeek-V4 distributed MoE
   dispatch/combine (an all-to-all pattern from this step)
+- [04-debugging](04-debugging.md) — the canonical failure catalog for distributed programs
 - Next step: [21-putting_it_together](21-putting_it_together.md) — compose
   three collectives in one kernel

--- a/docs/en/user/distributed/21-putting_it_together.md
+++ b/docs/en/user/distributed/21-putting_it_together.md
@@ -154,4 +154,5 @@ kernel.
   [#869](https://github.com/hw-native-sys/pypto-lib/pull/869) (AllGather-GEMM)
   and the DeepSeek-V4 distributed MoE dispatch/combine — the same patterns at
   model scale
+- [04-debugging](04-debugging.md) — the canonical failure catalog for distributed programs
 - This is the end of the ladder — the index lists everything, in order.

--- a/docs/zh/user/distributed/05-tutorials.md
+++ b/docs/zh/user/distributed/05-tutorials.md
@@ -72,6 +72,10 @@
 每个 `pld` 抽象：一行用途、文档它的章节小节、教授它的教程步骤。
 教程的**覆盖契约**：代码中存在的任何内容都必须能由某个示例教授。
 
+> 此总览中*操作*行的机器级对应物是[操作目录](../ops/01-catalog.md) §分布式——
+> 集合通信、put/get、notify/wait 与 remote load/store 家族会 lower 为列在那里
+> 的操作；上面的 window、context 与装饰器辅助项是没有目录条目的语言抽象。
+
 ### 系统基座（System substrate）
 
 | 抽象 | 用途 | 章节小节 | 运行位置 | 教程步骤 |
@@ -133,6 +137,19 @@
 | `@pl.jit` / `@pl.jit.incore` | 每设备编排 / 设备端 kernel | [03-execution](03-execution.md) | 02 |
 | `device=r` | 从主机循环将一次分发固定到某个设备 | [00-model](00-model.md) | 01 |
 | `DistributedConfig` | 编译的设备列表与 worker 数量 | [03-execution](03-execution.md) | 01 |
+
+## 阅读路径（Reading path）
+
+本阶梯是更长路径上的一站。分层的单设备示例教授本阶梯所假设的 `pl` 语言——
+它只需要 `examples/beginner/` 与 `examples/intermediate/`。下面的阶段是推荐的
+推进顺序；只有前两个是本阶梯的前置，后面的阶段是可选的后续：
+
+- `pl` 语言：`examples/beginner/` → `examples/intermediate/`
+- 分布式阶梯：`examples/distributed/01 … 16`（本系列，P ≥ 2）
+- 更大规模：`examples/advanced/` → `examples/models/`
+- 应用：pypto-lib（分布式 MoE、模型 JIT decode）
+
+分布式阶梯是唯一需要多于一个设备的站点。
 
 ## 参见（See also）
 

--- a/docs/zh/user/distributed/06-hello_rank.md
+++ b/docs/zh/user/distributed/06-hello_rank.md
@@ -135,4 +135,5 @@ assert torch.allclose(y, x + torch.arange(N_RANKS).view(N_RANKS, 1, 1), ...)
 - [00-model](../distributed/00-model.md) — 快速入门 + 模型词汇
 - [03-execution](../distributed/03-execution.md) — `DistributedConfig` 与
   worker 生命周期
+- [04-debugging](04-debugging.md) — 分布式程序的规范故障目录
 - 下一步：[07-programming_model](07-programming_model.md) — 标注的三层模型

--- a/docs/zh/user/distributed/07-programming_model.md
+++ b/docs/zh/user/distributed/07-programming_model.md
@@ -118,4 +118,5 @@ golden `y == x * (r+1)` 检查每个 rank 用*自己的*索引缩放*自己的*�
 - [05-tutorials](05-tutorials.md) — 教程总览（本步骤 = 第 02 行）
 - [00-model](../distributed/00-model.md) — 模型词汇，L2 与 L3
 - [03-execution](../distributed/03-execution.md) — 每层级的 worker 生命周期
+- [04-debugging](04-debugging.md) — 分布式程序的规范故障目录
 - 下一步：[08-window_buffer](08-window_buffer.md) — 内存基座

--- a/docs/zh/user/distributed/08-window_buffer.md
+++ b/docs/zh/user/distributed/08-window_buffer.md
@@ -96,4 +96,5 @@ def window_program(
 - [05-tutorials](05-tutorials.md) — 教程总览（本步骤 = 第 03 行）
 - [02-primitives](../distributed/02-primitives.md) §Window Buffer 管理 — 完整 API
 - [00-model](../distributed/00-model.md) §术语表 — window buffer、信号
+- [04-debugging](04-debugging.md) — 分布式程序的规范故障目录
 - 下一步：[09-barrier](09-barrier.md) — 仅信号，无数据

--- a/docs/zh/user/distributed/09-barrier.md
+++ b/docs/zh/user/distributed/09-barrier.md
@@ -139,4 +139,5 @@ window 中留下计数*，因此揭示改用数据来证明 barrier：每个 ran
   NotifyOp 与 WaitCmp — 完整信号 API
 - [01-collectives](../distributed/01-collectives.md) §Barrier — barrier 在
   集合通信中的位置
+- [04-debugging](04-debugging.md) — 分布式程序的规范故障目录
 - 下一步：[10-remote_load_store](10-remote_load_store.md) — 移动一个 slice

--- a/docs/zh/user/distributed/10-remote_load_store.md
+++ b/docs/zh/user/distributed/10-remote_load_store.md
@@ -144,4 +144,5 @@ pipe 上而没有任何东西为它们排序。
   `pld.tile.*` 表面
 - [01-collectives](../distributed/01-collectives.md) — all-reduce 就是这些
   移动加一个 add（步骤 08–10）
+- [04-debugging](04-debugging.md) — 分布式程序的规范故障目录
 - 下一步：[11-put_get](11-put_get.md) — tensor 级 push/pull

--- a/docs/zh/user/distributed/11-put_get.md
+++ b/docs/zh/user/distributed/11-put_get.md
@@ -128,4 +128,5 @@ get 侧是接收方发起的镜像：
   约束
 - [01-collectives](../distributed/01-collectives.md) — 集合通信如何组合这些
   移动（步骤 08–16）
+- [04-debugging](04-debugging.md) — 分布式程序的规范故障目录
 - 下一步：[12-dynamic_rank_count](12-dynamic_rank_count.md) — 同一个环，与 rank 数量无关

--- a/docs/zh/user/distributed/12-dynamic_rank_count.md
+++ b/docs/zh/user/distributed/12-dynamic_rank_count.md
@@ -109,4 +109,5 @@ world 大小——这正是 P=4 集合通信对比所依赖的能力。
 - [02-primitives](../distributed/02-primitives.md) §系统基座 + §Put 与 Get —
   `world_size`/`nranks`、分块
 - [00-getting_started](../00-getting_started.md) — `pl.dynamic(...)` 动态维
+- [04-debugging](04-debugging.md) — 分布式程序的规范故障目录
 - 下一步：[13-allreduce_mesh](13-allreduce_mesh.md) — 步骤 08–16 构建各类集合通信（P=4），从 all-reduce 开始

--- a/docs/zh/user/distributed/13-allreduce_mesh.md
+++ b/docs/zh/user/distributed/13-allreduce_mesh.md
@@ -115,4 +115,5 @@ rank 读取。round 密集：`P-1` 次远程读取加一个 barrier。正是这�
 - [01-collectives](01-collectives.md) §AllReduce — mesh 模式参考
 - [09-barrier](09-barrier.md) — 这里复用的 notify/wait barrier（步骤 04）
 - [10-remote_load_store](10-remote_load_store.md) — `remote_load`（步骤 05）
+- [04-debugging](04-debugging.md) — 分布式程序的规范故障目录
 - 下一步：[14-allreduce_two_phase](14-allreduce_two_phase.md) — 同样的结果，流量约减半

--- a/docs/zh/user/distributed/14-allreduce_two_phase.md
+++ b/docs/zh/user/distributed/14-allreduce_two_phase.md
@@ -103,4 +103,5 @@ for c in pl.range(nranks):
 - [05-tutorials](05-tutorials.md) — 教程索引（本步骤 = 第 09 行）
 - [13-allreduce_mesh](13-allreduce_mesh.md) — 本步骤改进的基线（步骤 08）
 - [01-collectives](01-collectives.md) §AllReduce — 参考（Mesh Mode、Ring Mode）
+- [04-debugging](04-debugging.md) — 分布式程序的规范故障目录
 - 下一步：[15-allreduce_ring](15-allreduce_ring.md) — 同样字节数，每步大小恒定

--- a/docs/zh/user/distributed/15-allreduce_ring.md
+++ b/docs/zh/user/distributed/15-allreduce_ring.md
@@ -107,4 +107,5 @@ for s in pl.range(nranks - 1):
 - [05-tutorials](05-tutorials.md) — 教程索引（本步骤 = 第 10 行）
 - [14-allreduce_two_phase](14-allreduce_two_phase.md) — 两阶段形态（步骤 09）
 - [01-collectives](01-collectives.md) §AllReduce — 参考（Ring Mode、信号形状、`Sum`/`FP32`）
+- [04-debugging](04-debugging.md) — 分布式程序的规范故障目录
 - 下一步：[16-allreduce_reveal](16-allreduce_reveal.md) — 替你选择 mesh 或 ring 的内置原语

--- a/docs/zh/user/distributed/16-allreduce_reveal.md
+++ b/docs/zh/user/distributed/16-allreduce_reveal.md
@@ -108,4 +108,5 @@ y = pl.store(recv, [0, 0], y)
 - [01-collectives](01-collectives.md) §AllReduce — 两种模式与信号形状的参考
 - [13-allreduce_mesh](13-allreduce_mesh.md) / [15-allreduce_ring](15-allreduce_ring.md) — 每种模式 lower 成的样子
 - [02-primitives](02-primitives.md) — 内置原语所基于的底层
+- [04-debugging](04-debugging.md) — 分布式程序的规范故障目录
 - 下一步：[05-tutorials](05-tutorials.md) 中步骤 12-16 覆盖其余集合通信

--- a/docs/zh/user/distributed/17-broadcast.md
+++ b/docs/zh/user/distributed/17-broadcast.md
@@ -118,4 +118,5 @@ def hand_step(self, x, y, data, signal, root):
 - [05-tutorials](05-tutorials.md) — 教程索引（本步 = 第 12 行）
 - [01-collectives](../distributed/01-collectives.md) §Broadcast — 完整 API
 - [02-primitives](../distributed/02-primitives.md) §Tile-Level RMA — 手工版本所依赖的 `remote_load`
+- [04-debugging](04-debugging.md) — 分布式程序的规范故障目录
 - 下一步：[18-allgather](18-allgather.md) — 全对全切片

--- a/docs/zh/user/distributed/18-allgather.md
+++ b/docs/zh/user/distributed/18-allgather.md
@@ -118,4 +118,5 @@ def hand_step(self, x, y, data, signal):
 - [05-tutorials](05-tutorials.md) — 教程索引（本步 = 第 13 行）
 - [01-collectives](../distributed/01-collectives.md) §AllGather — 完整 API
 - [14-allreduce_two_phase](14-allreduce_two_phase.md) — 本步隔离出的两相 all-reduce 的 gather 一半
+- [04-debugging](04-debugging.md) — 分布式程序的规范故障目录
 - 下一步：[19-reduce_scatter](19-reduce_scatter.md) — 归约一半

--- a/docs/zh/user/distributed/19-reduce_scatter.md
+++ b/docs/zh/user/distributed/19-reduce_scatter.md
@@ -120,4 +120,5 @@ def hand_step(self, x, y, data, signal):
 - [05-tutorials](05-tutorials.md) — 教程索引（本步 = 第 14 行）
 - [01-collectives](../distributed/01-collectives.md) §ReduceScatter — 完整 API
 - [14-allreduce_two_phase](14-allreduce_two_phase.md) — 本步是其第一半的两相 all-reduce
+- [04-debugging](04-debugging.md) — 分布式程序的规范故障目录
 - 下一步：[20-all_to_all](20-all_to_all.md) — 给每个对端一个不同的 slice

--- a/docs/zh/user/distributed/20-all_to_all.md
+++ b/docs/zh/user/distributed/20-all_to_all.md
@@ -117,4 +117,5 @@ def hand_step(self, x, y, data, signal):
 - `examples/runtime/distributed_callback.py` — 围绕 L3 分布式程序的宿主端运行时绑定回调
 - [11-put_get](11-put_get.md) — 本步所依赖的 `put`/`get` 底层
 - 更高级的应用（此处不重述）：pypto-lib [#869](https://github.com/hw-native-sys/pypto-lib/pull/869)（AllGather-GEMM，来自步骤 13 的 allgather 模式）与 DeepSeek-V4 分布式 MoE dispatch/combine（来自本步的 all-to-all 模式）
+- [04-debugging](04-debugging.md) — 分布式程序的规范故障目录
 - 下一步：[21-putting_it_together](21-putting_it_together.md) — 在一个内核中组合三种集合通信

--- a/docs/zh/user/distributed/21-putting_it_together.md
+++ b/docs/zh/user/distributed/21-putting_it_together.md
@@ -102,4 +102,5 @@ Lowering 后的 IR 是你已熟悉的三个手工调度，按顺序：broadcast 
 - [01-collectives](../distributed/01-collectives.md) — 整个集合通信动物园
 - [17-broadcast](17-broadcast.md) / [18-allgather](18-allgather.md) / [20-all_to_all](20-all_to_all.md) — 本内核所组合的组件
 - 更高级的应用（此处不重述）：pypto-lib [#869](https://github.com/hw-native-sys/pypto-lib/pull/869)（AllGather-GEMM）与 DeepSeek-V4 分布式 MoE dispatch/combine——模型规模下的相同模式
+- [04-debugging](04-debugging.md) — 分布式程序的规范故障目录
 - 这是阶梯的终点——索引按顺序列出了全部内容。


### PR DESCRIPTION
## Summary

Final phase of the distributed teaching ladder (doc-plan 06): wires the reference chapter, the tutorial ladder, and the abstractions map into one reading system. Links and cross-reference tables only — no new prose teaching content (the ladder steps themselves shipped in #2317, #2330, #2332).

- `05-tutorials.md` (en + zh): a **Reading path** section (single-device tier → distributed ladder → pypto-lib applications) and a pointer from the abstractions map to the operations catalog (`ops/01-catalog.md` §Distributed).
- Every walkthrough (06–21, en + zh) links `04-debugging.md` as the canonical failure catalog in its "See also".
- Fixes the stale "steps 08–16 are planned" next-step pointer in `12-dynamic_rank_count.md` (en + zh) — the ladder now ships fully.

## Verification

- `check_docs_nav.py` / `check_docs_en_zh_parity.py`: 181/181
- pre-commit (markdownlint, docs lints): all passed
- `mkdocs build --strict`: exit 0
