### PR TITLE
docs(distributed): pypto-lib application boundary — cross-links by name

### DIFF
--- a/docs/en/user/distributed/05-tutorials.md
+++ b/docs/en/user/distributed/05-tutorials.md
@@ -142,6 +142,25 @@ tutorials: nothing exists in code without being teachable from an example.
 | `device=r` | Pin one dispatch to one device from the host loop | [00-model](00-model.md) | 01 |
 | `DistributedConfig` | Device list + worker count for compilation | [03-execution](03-execution.md) | 01 |
 
+## Beyond the ladder: pypto-lib applications
+
+The ladder teaches the `pld` language; real programs built on it are
+applications and live in pypto-lib (or in pypto's model examples). The ladder
+cross-links them as "more advanced" next steps — by name and PR, never
+restating or duplicating their content:
+
+| Application | Pattern it uses | Home |
+| ----------- | --------------- | ---- |
+| L3 AllGather–GEMM comm/compute overlap ([#869](https://github.com/hw-native-sys/pypto-lib/pull/869)) | an allgather — step 13 | pypto-lib |
+| DeepSeek-V4 distributed MoE (EP dispatch/combine), LM-head TP | an all-to-all — step 15 | pypto-lib `models/deepseek_v4_*` |
+| Qwen3-32B JIT decode | the `@pl.jit` host + device model — step 02 | pypto `examples/models/qwen3_jit/` |
+| `examples/advanced/allreduce.py` | the "everything at once" version of steps 08–11 | pypto-lib `examples/advanced/` |
+
+The step-15 walkthrough ([20-all_to_all](20-all_to_all.md)) and the compose
+step ([21-putting_it_together](21-putting_it_together.md)) name the first two
+by PR already. The boundary is explicit: nothing from these applications is
+ported or restated here.
+
 ## See also
 
 - [00-model](00-model.md) — Quickstart and model vocabulary

--- a/docs/zh/user/distributed/05-tutorials.md
+++ b/docs/zh/user/distributed/05-tutorials.md
@@ -134,6 +134,23 @@
 | `device=r` | 从主机循环将一次分发固定到某个设备 | [00-model](00-model.md) | 01 |
 | `DistributedConfig` | 编译的设备列表与 worker 数量 | [03-execution](03-execution.md) | 01 |
 
+## 阶梯之外：pypto-lib 应用
+
+本阶梯教授 `pld` 语言；构建于其上的真实程序是应用，位于 pypto-lib（或 pypto
+的模型示例）中。本阶梯按名称与 PR 将它们作为"更高级"的下一步交叉链接——
+绝不重述或复制其内容：
+
+| 应用 | 使用的模式 | 位置 |
+| ---- | ---------- | ---- |
+| L3 AllGather–GEMM 通信/计算重叠（[#869](https://github.com/hw-native-sys/pypto-lib/pull/869)） | allgather——步骤 13 | pypto-lib |
+| DeepSeek-V4 分布式 MoE（EP dispatch/combine）、LM-head TP | all-to-all——步骤 15 | pypto-lib `models/deepseek_v4_*` |
+| Qwen3-32B JIT decode | `@pl.jit` 宿主 + 设备模型——步骤 02 | pypto `examples/models/qwen3_jit/` |
+| `examples/advanced/allreduce.py` | 步骤 08–11 的"一步到位"版本 | pypto-lib `examples/advanced/` |
+
+步骤 15 的走读（[20-all_to_all](20-all_to_all.md)）与组合步骤
+（[21-putting_it_together](21-putting_it_together.md)）已按 PR 点名前两者。
+边界是明确的：这里不移植、不重述这些应用的任何内容。
+
 ## 参见（See also）
 
 - [00-model](00-model.md) — 快速入门与模型词汇


### PR DESCRIPTION
## Summary

Doc-plan 05: makes the pypto-lib boundary explicit in the distributed teaching ladder. The ladder teaches the `pld` language; real programs built on it live in pypto-lib (or pypto's model examples). `05-tutorials.md` (en + zh) gains a **"Beyond the ladder: pypto-lib applications"** section that cross-links them by name and PR with a one-line description — never restating or duplicating their content.

Referenced applications (verified live): DeepSeek-V4 distributed MoE / LM-head TP (`models/deepseek_v4_*`), Qwen3 JIT decode (`examples/models/qwen3_jit/` — the move to pypto-lib was cancelled in plan 01), and `examples/advanced/allreduce.py`.

> **Note:** owner confirmation with the pypto-lib maintainers (Shenggan, zhangqi-chen) is still pending, flagged per the plan. The section only cross-links; it ports/restates no application content.

## Verification

- `check_docs_nav.py` / `check_docs_en_zh_parity.py`: 181/181
- pre-commit (markdownlint, docs lints): all passed
- `mkdocs build --strict`: exit 0
