### PR TITLE
fix(ir): stop reading past the hoist list when merging a Graph call site

### DIFF
--- a/src/ir/transforms/legalize_graph_boundary_pass.cpp
+++ b/src/ir/transforms/legalize_graph_boundary_pass.cpp
@@ -1217,10 +1217,14 @@ class CallSiteExtender : public IRMutator {
     size_t next_hoist = 0;
     size_t next_alias = 0;
     while (next_hoist < by_definition.size() || next_alias < plan.passthrough.size()) {
-      const bool alias_is_next =
-          next_alias < plan.passthrough.size() &&
-          position(plan.passthrough[next_alias].first) < position(by_definition[next_hoist]->original.get());
-      const bool take_alias = next_hoist == by_definition.size() || alias_is_next;
+      // Both lists are bounds-checked before either index is read. Definition
+      // order can end on an alias (`base = idx * 128; col = base`), leaving no
+      // hoist to compare against; asking whether the alias comes next must not
+      // be what discovers that.
+      const bool hoists_left = next_hoist < by_definition.size();
+      const bool take_alias = next_alias < plan.passthrough.size() &&
+                              (!hoists_left || position(plan.passthrough[next_alias].first) <
+                                                   position(by_definition[next_hoist]->original.get()));
       if (take_alias) {
         bind_alias(plan.passthrough[next_alias++]);
       } else {

--- a/tests/ut/ir/transforms/test_legalize_graph_boundary.py
+++ b/tests/ut/ir/transforms/test_legalize_graph_boundary.py
@@ -303,6 +303,53 @@ class TestDerivedScalarHoisting:
         assert "__FREE_VAR" not in caller, caller
         assert not re.search(r"\balias__ssa_v\d+\b", caller), caller
 
+    def test_a_pass_through_defined_after_the_last_hoist(self):
+        """Definition order can end on an alias, with no hoist left to compare it against.
+
+        The inverse of the test above: `base` is hoisted and `col` merely names
+        it, so the call site's merge runs out of hoists while a pass-through is
+        still pending. Deciding whether the alias came next read
+        `by_definition[next_hoist]` before checking a hoist was left — one past
+        the end of a non-empty vector, then dereferenced through `->original`.
+
+        The merge *result* was never wrong (the guard one line below forces the
+        alias to be taken once the hoists are gone), so this asserts the shape
+        the merge must produce and pins the path a sanitizer build watches.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Graph)
+            def layer(
+                self,
+                w: pl.Tensor[[512, 128], pl.FP32],
+                c: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+                idx: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                base = idx * 128
+                col = base
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    t: pl.Tile[[128, 128], pl.FP32] = pl.load(w, [col, 0], [128, 128])
+                    pl.store(t, [0, 0], c)
+                return c
+
+            @pl.function
+            def main(
+                self,
+                w: pl.Tensor[[512, 128], pl.FP32],
+                c: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                for i in pl.range(4):
+                    self.layer(w, c, i)
+                return c
+
+        After = _legalize_outlined(Before)
+        assert "base" in _scalar_param_names(_graph_func(After, "layer"))
+        caller = python_print(_graph_func(After, "main"))
+        # `col` names a value only the Graph has; the caller must pass `base`.
+        assert "__FREE_VAR" not in caller, caller
+        assert not re.search(r"\bcol__ssa_v\d+\b", caller), caller
+
     def test_non_graph_program_is_untouched(self):
         @pl.program
         class Before:


### PR DESCRIPTION
## Summary

`LegalizeGraphBoundary` replays a Graph region's hoisted values and its
pass-through aliases at each call site, merged in definition order. When
definition order ends on an alias, the merge ran out of hoists and then read
`by_definition[next_hoist]` anyway to decide whether the alias came next — one
past the end of a non-empty vector, dereferenced through `->original`. Reported
as a SIGSEGV compiling a Qwen3-14B decoder layer as a `@pl.jit.graph` region.

The merge *result* was never wrong: reaching that state forces
`next_hoist == by_definition.size()`, so the `take_alias` guard on the next line
is true from its first disjunct and the out-of-bounds value is always discarded.
No Graph region has been miscompiled — this removes a crash, not a wrong answer,
and that is also why a reduced case often survives the read. No behavior change,
no interface change, no migration.

## Changes

- `src/ir/transforms/legalize_graph_boundary_pass.cpp`: fold `alias_is_next` and
  `take_alias` into one bounds-checked decision, so the hoist index is never read
  without a hoist behind it. The fold is deliberate — one guard written twice,
  correct in one copy and absent in the other, is what produced the defect. All
  three paths are safe by short-circuit; the reverse direction (aliases
  exhausted, hoists remaining) was already safe and is unchanged.
- `tests/ut/ir/transforms/test_legalize_graph_boundary.py`: add
  `test_a_pass_through_defined_after_the_last_hoist`, a Graph region whose
  definition order is `base = idx * 128` (hoisted) then `col = base` (alias). The
  existing `test_an_alias_of_a_hoisted_view_resolves_at_the_call_site` is
  hoist/alias/hoist and never exhausts the hoist list, so this path had no
  coverage.

## Verification

Because the merge result was never wrong, the new test passes with and without
the fix in an ordinary build; it pins the path for a sanitizer build. To get a
failing-before signal, the unfixed pass was first built with a temporary
`INTERNAL_CHECK(next_hoist < by_definition.size())` at the loop head:

- new case raised `InternalError` at `legalize_graph_boundary_pass.cpp:1220`,
  stack `AppendHoistedArgs` ← `VisitExpr_`(:1089) ← `TransformProgram`, matching
  the reported gdb trace;
- the other 67 Graph tests passed, never reaching the state.

With the fix in place, all commands below ran in this worktree at the pushed
commit:

- `cmake --build build --parallel 32`: exit 0, no new warnings
- `pytest tests/ut/ir/transforms/test_legalize_graph_boundary.py tests/ut/ir/verifier/test_graph_boundary_legalized.py tests/ut/codegen/test_orchestration_codegen_graph.py tests/ut/ir/test_graph_function.py`: exit 0, 68 passed
- `pytest tests/ut/`: exit 0, 10969 passed, 8 skipped, 1 xfailed
- `clang-format` 21.1.0 `--dry-run --Werror`: exit 0
- `tests/lint/clang_tidy.py --strict-version --diff-base=origin/main` (clang-tidy 21.1.0): exit 0
- `ruff check` / `ruff format --check` 0.14.8: exit 0
- `tests/lint/{check_headers,check_english_only,check_no_broad_raises,check_op_name_literals,check_emitter_check_classification}.py`: exit 0

`pytest tests/ut/` deselects
`test_unified_ops.py::TestUnifiedSlicePadValue::test_symlinked_import_path_still_names_the_caller`,
which cannot pass in this checkout: the local conda environment's editable
install pins `pypto` to a different checkout, and that test's subprocess
re-execs without the meta-path override. It is unrelated to this change and is
left to CI.

Compile-only fix — no device run needed. `tests/st/runtime/framework_and_models/test_graph_execution.py`
requires hardware and was not run locally; CI covers it.