### PR TITLE
feat(distributed): support ragged (non-divisible) lengths in HOST ring allreduce

### DIFF
--- a/docs/en/dev/passes/43-lower_host_tensor_collectives.md
+++ b/docs/en/dev/passes/43-lower_host_tensor_collectives.md
@@ -139,11 +139,11 @@ Ring allreduce (`mode="ring"`) uses a rank-2 signal shaped
 signal dimensions are compile-time constants, and must be at least
 `2 * (NR - 1) + 1` when only `shape[0]` is statically known (no static check when
 both dims are dynamic). When the participating device count is statically known, the signal
-must have enough static capacity. Ring allreduce additionally requires `numel(src) % NR == 0`
-(the ring schedule partitions src into NR contiguous chunks; a non-zero remainder would leave a
-trailing partial chunk the kernel cannot handle). The host-ring `src` shape must be
-statically known — dynamic extents are rejected, since the kernel would otherwise silently
-return unreduced data when the runtime `numel` is not divisible by `NR`.
+must have enough static capacity. Ring allreduce partitions each rank's `src` into `NR` balanced,
+potentially ragged chunks at runtime — chunk `r` spans `[floor(numel*r/NR), floor(numel*(r+1)/NR))` — so
+`numel(src)` need not be divisible by `NR` and the host-ring `src` shape need not be statically
+known. Every TPUT transfer is narrowed to its chunk's exact extent via the staging tile's valid
+shape, so ragged and dynamic inputs are fully supported.
 
 Ring allreduce currently supports only `ReduceOp.Sum` with `dtype=FP32`.
 `ReduceOp.Max`, `ReduceOp.Min`, `ReduceOp.Prod`, and `FP16` are not yet available

--- a/docs/en/user/appendix/01-faq.md
+++ b/docs/en/user/appendix/01-faq.md
@@ -77,7 +77,7 @@ same rounding and overflow behaviour — the page proves it with a runnable chec
 | ---------- | ------ |
 | **Two co-live `MemRef` slots under PTOAS** | Rejected at codegen: ptoas guards only the first `multi_tile_get` of an iteration. One slot live per iteration is the shape to write |
 | **Hard `syncall` needs full occupancy** | A partial launch deadlocks on device (507018); PyPTO rejects it at compile time. Use `mode=pl.SyncAllMode.SOFT` at partial occupancy |
-| **Ring allreduce is not a one-argument change** | It needs an explicit `[2*(NR-1)+1, NR]` INT32 signal, a statically-known `src` shape, and `numel(src)` divisible by `NR`. See [Collectives](../distributed/01-collectives.md) |
+| **Ring allreduce is not a one-argument change** | It needs an explicit `[2*(NR-1)+1, NR]` INT32 signal. `src` may be ragged (any `numel`, not necessarily divisible by `NR`) with a static or dynamic shape. See [Collectives](../distributed/01-collectives.md) |
 | **`memory_planner=PTOAS` and the memory map** | Allocation passes are skipped, so pass dumps carry no offsets for the tool to draw |
 | **Doc code blocks are backend-specific** | The manual's runnable blocks execute on `a2a3sim`; A5-only behaviour is argued rather than executed |
 

--- a/docs/zh/dev/passes/43-lower_host_tensor_collectives.md
+++ b/docs/zh/dev/passes/43-lower_host_tensor_collectives.md
@@ -124,7 +124,7 @@ Ring allreduce（`mode="ring"`）
 的 signal 为 rank-2，形状为 `[2 * (NR - 1) + 1, NR]`，其
 `shape[0]` 在 signal 两个维度均为编译期常量时必须恰好等于 `2 * (NR - 1) + 1`；仅
 `shape[0]` 静态可知时则至少为 `2 * (NR - 1) + 1`（两个维度均为动态时无静态检查）。
-当参与设备数静态可知时，signal 的静态容量必须足够。ring allreduce 还要求 `numel(src) % NR == 0`（ring schedule 将 src 划分为 NR 个连续 chunk；余数非零会留下内核无法处理的尾部部分 chunk）。host-ring 的 `src` 形状必须静态已知——动态 extent 会被拒绝，否则运行时 `numel` 不被 `NR` 整除时内核会静默返回未归约的数据。
+当参与设备数静态可知时，signal 的静态容量必须足够。ring allreduce 会在运行时把每个 rank 的 `src` 划分为 `NR` 个均衡、可能不齐（ragged）的 chunk——chunk `r` 覆盖 `[floor(numel*r/NR), floor(numel*(r+1)/NR))`——因此 `numel(src)` 不必能被 `NR` 整除，host-ring 的 `src` 形状也不必静态已知。每次 TPUT 传输都通过 staging tile 的 valid shape 精确收窄到对应 chunk 的范围，因此不齐（ragged）与动态输入均得到完整支持。
 
 Ring allreduce 目前仅支持 `ReduceOp.Sum` 和 `dtype=FP32`。
 `ReduceOp.Max`、`ReduceOp.Min`、`ReduceOp.Prod` 以及 `FP16` 在

--- a/docs/zh/user/appendix/01-faq.md
+++ b/docs/zh/user/appendix/01-faq.md
@@ -55,7 +55,7 @@ DSL 需要知道一个循环究竟是编译期展开、设备侧循环，还是�
 | ---- | ---- |
 | **PTOAS 下两个 slot 同时存活** | codegen 拒绝：ptoas 只保护一次迭代里的第一个 `multi_tile_get`。该写的形状是一次迭代一个 slot 存活 |
 | **硬 `syncall` 需要满占用** | 部分发射会在设备上死锁（507018）；PyPTO 在编译期就拒绝。部分占用下用 `mode=pl.SyncAllMode.SOFT` |
-| **ring allreduce 不是加一个参数的事** | 它需要显式的 `[2*(NR-1)+1, NR]` INT32 signal、静态可知的 `src` 形状，以及 `numel(src)` 被 `NR` 整除。见[集合通信](../distributed/01-collectives.md) |
+| **ring allreduce 不是加一个参数的事** | 它需要显式的 `[2*(NR-1)+1, NR]` INT32 signal。`src` 可以是任意长度（不必被 `NR` 整除）的不齐（ragged）形状，静态或动态形状均可。见[集合通信](../distributed/01-collectives.md) |
 | **`memory_planner=PTOAS` 与内存图** | 分配 pass 被跳过，pass dump 里没有偏移供工具绘制 |
 | **文档代码块是 backend 相关的** | 手册里的可运行块在 `a2a3sim` 上执行；A5 独有的行为以论证给出而非执行 |
 

--- a/python/pypto/runtime/builtins/collectives/allreduce_ring/templates/kernel.cpp.in
+++ b/python/pypto/runtime/builtins/collectives/allreduce_ring/templates/kernel.cpp.in
@@ -20,9 +20,10 @@
 //   scalar(0) = nranks
 //   scalar(1) = CommContext device pointer
 //
-// Each rank's data buffer holds SIZE elements (product of tensor shapes). The
-// ring partitions data into NR contiguous chunks of chunk_elems = SIZE // NR
-// and performs RS+AG in-place on those chunk slots. The signal holds one row
+// Each rank's data buffer holds numel elements (product of tensor shapes). The
+// ring partitions data into NR balanced, potentially ragged chunks — chunk r
+// spans [floor(numel*r/NR), floor(numel*(r+1)/NR)) — and performs RS+AG in-place
+// on those chunk slots. The signal holds one row
 // per ring round (2*(NR-1) rounds) plus a final row for the return barrier.
 //
 // Data movement is PUSH (remote write) via pto::comm::TPUT, mirroring the
@@ -68,6 +69,15 @@ static constexpr int64_t kTileCount = 256;
 // NeighborBarrier is enabled by default since the push model provides the
 // ordering the pull model lacked.
 static constexpr bool kUseNeighborBarrier = true;
+
+// Balanced ragged segment start for chunk r: floor(numel * r / nranks).
+// The ring partitions the per-rank buffer into NR contiguous chunks with these
+// boundaries, so chunk lengths differ by at most one element and the trailing
+// chunk may be shorter (mirrors the InCore composite ring's floor(i * SIZE / NR)
+// segment boundaries — #2161).
+AICORE inline int64_t RingChunkStart(int64_t numel, int nranks, int r) {
+  return (numel * static_cast<int64_t>(r)) / static_cast<int64_t>(nranks);
+}
 
 template <typename T>
 AICORE inline __gm__ T *CommRemotePtr(__gm__ CommContext *ctx, __gm__ T *local_ptr, int pe) {
@@ -195,15 +205,18 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
 
   // Soft guards: on any unsupported shape the kernel drains its pipes and
   // returns without touching data. The host lowering pass and the builtin
-  // type deducer validate divisibility at compile time, so a well-formed
-  // program never hits these early returns; they exist only to keep the
-  // device kernel memory-safe if invoked directly.
-  if (nranks <= 1 || nranks > kMaxSupportedRanks || numel <= 0 || (numel % nranks) != 0) {
+  // type deducer no longer enforce divisibility — ragged numel is handled by
+  // the balanced RingChunkStart geometry below — so these early returns exist
+  // only to keep the device kernel memory-safe if invoked directly.
+  if (nranks <= 1 || nranks > kMaxSupportedRanks || numel <= 0) {
     pipe_barrier(PIPE_ALL);
     return;
   }
 
-  const int64_t chunk_elems = numel / nranks;
+  // Ragged chunk geometry: chunk r spans [RingChunkStart(numel, nranks, r),
+  // RingChunkStart(numel, nranks, r+1)).  The staging tile must cover the
+  // largest chunk (ceil(numel / nranks)) but no more.
+  const int64_t max_chunk_elems = (numel + nranks - 1) / nranks;
 
   const int expected_rounds = 2 * (nranks - 1) + 1;
   if (signal_rows < expected_rounds || signal_cols < nranks) {
@@ -228,7 +241,7 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
   // (ColMaskInternal), NOT the GlobalTensor shape, so the tile's column mask
   // is narrowed to each chunk's exact extent below; a 256-col tile with a
   // shorter transfer would over-read/overwrite adjacent chunk slots.
-  const int tile_cols = static_cast<int>(chunk_elems < kTileCount ? chunk_elems : kTileCount);
+  const int tile_cols = static_cast<int>(max_chunk_elems < kTileCount ? max_chunk_elems : kTileCount);
   TileData send_tile(1, tile_cols);
   TASSIGN(send_tile, 0x10000);
 
@@ -249,17 +262,19 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
 
     const int right = (my_rank + 1) % nranks;
     const int send_idx = (my_rank - step + nranks) % nranks;
+    const int64_t send_base = RingChunkStart(numel, nranks, send_idx);
+    const int64_t send_end = RingChunkStart(numel, nranks, send_idx + 1);
+    const int64_t send_len = send_end - send_base;
 
-    for (int64_t tile_off = 0; tile_off < chunk_elems; tile_off += tile_cols) {
-      int64_t remain64 = chunk_elems - tile_off;
+    for (int64_t tile_off = 0; tile_off < send_len; tile_off += tile_cols) {
+      int64_t remain64 = send_len - tile_off;
       int tile_elems = static_cast<int>(remain64 < tile_cols ? remain64 : tile_cols);
       send_tile.ColMaskInternal = tile_elems;
 
       ShapeDyn tile_shape(1, 1, 1, 1, tile_elems);
       StrideDyn tile_stride(tile_elems, tile_elems, tile_elems, tile_elems, 1);
 
-      __gm__ {{dtype_cpp}} *src_ptr =
-          chunks + static_cast<size_t>(send_idx * chunk_elems + tile_off);
+      __gm__ {{dtype_cpp}} *src_ptr = chunks + static_cast<size_t>(send_base + tile_off);
       __gm__ {{dtype_cpp}} *dst_ptr = CommRemotePtr(comm_ctx, src_ptr, right);
       Global src_g(src_ptr, tile_shape, tile_stride);
       Global dst_g(dst_ptr, tile_shape, tile_stride);
@@ -282,17 +297,19 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
 
     const int right = (my_rank + 1) % nranks;
     const int send_idx = (my_rank - step + 1 + nranks) % nranks;
+    const int64_t send_base = RingChunkStart(numel, nranks, send_idx);
+    const int64_t send_end = RingChunkStart(numel, nranks, send_idx + 1);
+    const int64_t send_len = send_end - send_base;
 
-    for (int64_t tile_off = 0; tile_off < chunk_elems; tile_off += tile_cols) {
-      int64_t remain64 = chunk_elems - tile_off;
+    for (int64_t tile_off = 0; tile_off < send_len; tile_off += tile_cols) {
+      int64_t remain64 = send_len - tile_off;
       int tile_elems = static_cast<int>(remain64 < tile_cols ? remain64 : tile_cols);
       send_tile.ColMaskInternal = tile_elems;
 
       ShapeDyn tile_shape(1, 1, 1, 1, tile_elems);
       StrideDyn tile_stride(tile_elems, tile_elems, tile_elems, tile_elems, 1);
 
-      __gm__ {{dtype_cpp}} *src_ptr =
-          chunks + static_cast<size_t>(send_idx * chunk_elems + tile_off);
+      __gm__ {{dtype_cpp}} *src_ptr = chunks + static_cast<size_t>(send_base + tile_off);
       __gm__ {{dtype_cpp}} *dst_ptr = CommRemotePtr(comm_ctx, src_ptr, right);
       Global src_g(src_ptr, tile_shape, tile_stride);
       Global dst_g(dst_ptr, tile_shape, tile_stride);

--- a/src/ir/op/distributed/collective.cpp
+++ b/src/ir/op/distributed/collective.cpp
@@ -167,25 +167,11 @@ TypePtr DeduceBuiltinTensorAllReduceRingType(const std::vector<ExprPtr>& args,
         << " for NR = " << sig_shape1_const->value_;
   }
 
-  // Compile-time validation: the host builtin ring kernel partitions src into
-  // NR contiguous compile-time chunks, so the src shape must be statically
-  // known — a dynamic extent could reach the kernel with a runtime numel that
-  // is not divisible by NR and silently return unreduced data.  A non-divisible
-  // numel would produce a trailing partial chunk the schedule cannot handle.
-  if (sig_shape1_const && sig_shape1_const->value_ > 0) {
-    int64_t src_numel = 1;
-    for (const auto& dim : src_type->shape_) {
-      auto extent = As<ConstInt>(dim);
-      CHECK(extent) << kOpName
-                    << " requires a statically-known src shape (dynamic host-ring extents are not "
-                       "supported; the ring schedule partitions src into NR compile-time chunks)";
-      src_numel *= extent->value_;
-    }
-    const int64_t nr = sig_shape1_const->value_;
-    CHECK(src_numel % nr == 0) << kOpName << " requires the src data size (product of shape = " << src_numel
-                               << ") to be an exact multiple of the rank count (" << nr
-                               << "); got a remainder of " << (src_numel % nr);
-  }
+  // The host builtin ring kernel partitions src into NR balanced, potentially
+  // ragged chunks at runtime (chunk r spans [floor(numel*r/NR), floor(numel*(r+1)/NR)))
+  // and narrows every TPUT transfer to the chunk's exact extent via the staging
+  // tile's valid_shape — no compile-time static-shape or divisibility
+  // requirement remains (issue #2242).
 
   auto op_value = GetRequiredKwarg<int>(kwargs, "op", kOpName);
   auto dtype = GetRequiredKwarg<DataType>(kwargs, "dtype", kOpName);

--- a/src/ir/transforms/lower_host_tensor_collectives_pass.cpp
+++ b/src/ir/transforms/lower_host_tensor_collectives_pass.cpp
@@ -178,38 +178,6 @@ void CheckStaticSignalCapacity(const CallPtr& call, const ExprPtr& signal_expr, 
       << ") must be at least the participating device count (" << required_slots << ")";
 }
 
-void CheckRingChunkConstraints(const CallPtr& call, const ExprPtr& src_expr, size_t world_size) {
-  auto src_type = As<DistributedTensorType>(src_expr->GetType());
-  INTERNAL_CHECK_SPAN(src_type, call->span_)
-      << "LowerHostTensorCollectives: ring allreduce src must be DistributedTensorType";
-  if (src_type->shape_.empty()) return;
-
-  // The ring kernel partitions src into NR contiguous compile-time chunks
-  // (chunk_elems = numel / NR), so the host-ring path requires a
-  // statically-known src shape.  A dynamic extent would let a runtime numel
-  // that is not divisible by NR reach the kernel, which silently returns
-  // unreduced data instead of failing — reject dynamic host-ring extents here.
-  int64_t src_numel = 1;
-  for (const auto& dim : src_type->shape_) {
-    auto extent = As<ConstInt>(dim);
-    CHECK_SPAN(extent, call->span_)
-        << "LowerHostTensorCollectives: ring allreduce requires a statically-known "
-           "src shape (dynamic host-ring extents are not supported; the ring "
-           "schedule partitions src into NR compile-time chunks)";
-    src_numel *= extent->value_;
-  }
-
-  int64_t nr = static_cast<int64_t>(world_size);
-
-  // Divisibility: the host builtin ring schedule partitions data into NR
-  // contiguous chunks of chunk_elems = numel // NR.  A non-divisible numel
-  // would produce a trailing partial chunk that the kernel cannot handle.
-  CHECK_SPAN(src_numel % nr == 0, call->span_)
-      << "LowerHostTensorCollectives: ring allreduce requires the per-rank data size (product of src shape = "
-      << src_numel << ") to be an exact multiple of the rank count (" << nr << "); got a remainder of "
-      << (src_numel % nr);
-}
-
 void CheckRingSignalCapacity(const CallPtr& call, const ExprPtr& signal_expr, size_t world_size) {
   auto signal_type = As<DistributedTensorType>(signal_expr->GetType());
   INTERNAL_CHECK_SPAN(signal_type, call->span_)
@@ -287,9 +255,6 @@ void CheckAllReduceSignalCapacity(const CallPtr& call, const ExprPtr& signal_exp
     CHECK_SPAN(world_size <= kMaxSupportedRanks, call->span_)
         << "LowerHostTensorCollectives: ring allreduce requires " << static_cast<int>(kMaxSupportedRanks)
         << " or fewer participating devices, got " << world_size;
-    INTERNAL_CHECK_SPAN(call->args_.size() >= 1, call->span_)
-        << "LowerHostTensorCollectives: ring allreduce requires a src arg";
-    CheckRingChunkConstraints(call, call->args_[0], world_size);
     return;
   }
   CheckAllReduceCoreCapacity(call, core_num);
@@ -316,6 +281,12 @@ void CheckAllReduceSignalCapacity(const CallPtr& call, const ExprPtr& signal_exp
   INTERNAL_CHECK_SPAN(src_type, call->span_)
       << "LowerHostTensorCollectives: pld.tensor.allreduce src must be DistributedTensorType";
   auto op_value = call->GetKwarg<int>("op");
+  // The host builtin ring kernel partitions src into NR balanced, potentially
+  // ragged chunks at runtime — chunk r spans [floor(numel*r/NR), floor(numel*(r+1)/NR))
+  // — and narrows every TPUT transfer to the chunk's exact extent via the staging
+  // tile's valid_shape (ColMaskInternal). No compile-time static-shape or
+  // divisibility requirement remains: dynamic extents and a non-divisible numel
+  // are handled by the kernel (issue #2242).
   const bool as_ring = ShouldLowerAllReduceAsRing(call);
   std::vector<std::pair<std::string, std::any>> kwargs = {
       {"op", op_value},

--- a/tests/st/distributed/test_l3_host_tensor_allreduce_ring.py
+++ b/tests/st/distributed/test_l3_host_tensor_allreduce_ring.py
@@ -19,6 +19,8 @@ from pypto import ir
 from pypto.ir import DistributedConfig
 
 SIZE = 256
+STAGE_CHUNK = 8192
+DTYPE_BYTES = 4  # fp32
 
 
 def _expected_allreduce(inputs: torch.Tensor) -> torch.Tensor:
@@ -26,70 +28,101 @@ def _expected_allreduce(inputs: torch.Tensor) -> torch.Tensor:
     return torch.stack([reduced] * inputs.shape[0])
 
 
-def _make_rank_inputs(n_ranks: int, round_offset: float = 0.0) -> torch.Tensor:
+def _stage_shape(size: int) -> tuple:
+    """Stage-in/out tile shape, mirroring the InCore composite ring ST.
+
+    ``size == 1`` uses a 32-byte ``[8, 1]`` tile (one UB row) so the window
+    buffer store/load stays within alignment; larger sizes chunk the buffer
+    into ``STAGE_CHUNK``-wide sub-tiles to keep the VEC tile under the
+    platform memory limit for large ragged lengths (e.g. 65537). The tile
+    width is rounded up to a 32-byte row alignment (cols * dtype_bytes
+    multiple of 32) so PTOAS ``pto.alloc_tile`` accepts it even when the
+    ragged length itself is unaligned (e.g. 17 or 4097).
+    """
+    if size == 1:
+        return 32 // DTYPE_BYTES, 1
+    alignment = 32 // DTYPE_BYTES
+    stage_cols = min(STAGE_CHUNK, ((size + alignment - 1) // alignment) * alignment)
+    return 1, stage_cols
+
+
+def _make_rank_inputs(n_ranks: int, size: int = SIZE, round_offset: float = 0.0) -> torch.Tensor:
     """Build distinct per-rank rows; ``round_offset`` distinguishes reuse rounds."""
     rows = [
-        torch.arange(r * 100.0 + round_offset, r * 100.0 + round_offset + SIZE, dtype=torch.float32).reshape(
-            1, SIZE
+        torch.arange(r * 100.0 + round_offset, r * 100.0 + round_offset + size, dtype=torch.float32).reshape(
+            1, size
         )
         for r in range(n_ranks)
     ]
     return torch.stack(rows)
 
 
-def _build_host_ring_allreduce_program(n_ranks: int):
+def _build_host_ring_allreduce_program(n_ranks: int, size: int = SIZE):
     total_rounds = 2 * (n_ranks - 1) + 1
+    stage_rows, stage_cols = _stage_shape(size)
 
     @pl.program
     class HostTensorAllReduceRing:
         @pl.function(type=pl.FunctionType.InCore)
         def publish_step(
             self,
-            inp: pl.Tensor[[1, SIZE], pl.FP32],
-            data: pl.InOut[pld.DistributedTensor[[1, SIZE], pl.FP32]],
-        ) -> pld.DistributedTensor[[1, SIZE], pl.FP32]:
-            local = pl.load(inp, [0, 0], [1, SIZE])
-            return pl.store(local, [0, 0], data)
+            inp: pl.Tensor[[1, size], pl.FP32],
+            data: pl.InOut[pld.DistributedTensor[[1, size], pl.FP32]],
+        ) -> pld.DistributedTensor[[1, size], pl.FP32]:
+            # Stage-in: copy local input into this rank's window slot in
+            # UB-bounded chunks (valid-shape tail for ragged lengths).
+            for col, (data_iter,) in pl.range(0, size, stage_cols, init_values=(data,)):
+                valid = pl.min(stage_cols, size - col)
+                local = pl.load(inp, [0, col], [stage_rows, stage_cols], valid_shape=[1, valid])
+                data_iter = pl.store(local, [0, col], data_iter)
+                staged_data = pl.yield_(data_iter)
+            return staged_data
 
         @pl.function(type=pl.FunctionType.Orchestration)
         def publish_orch(
             self,
-            inp: pl.Tensor[[1, SIZE], pl.FP32],
-            data: pl.InOut[pld.DistributedTensor[[1, SIZE], pl.FP32]],
-        ) -> pld.DistributedTensor[[1, SIZE], pl.FP32]:
+            inp: pl.Tensor[[1, size], pl.FP32],
+            data: pl.InOut[pld.DistributedTensor[[1, size], pl.FP32]],
+        ) -> pld.DistributedTensor[[1, size], pl.FP32]:
             return self.publish_step(inp, data)
 
         @pl.function(type=pl.FunctionType.InCore)
         def consume_step(
             self,
-            data: pld.DistributedTensor[[1, SIZE], pl.FP32],
-            out: pl.Out[pl.Tensor[[1, SIZE], pl.FP32]],
-        ) -> pl.Tensor[[1, SIZE], pl.FP32]:
-            reduced = pl.load(data, [0, 0], [1, SIZE])
-            return pl.store(reduced, [0, 0], out)
+            data: pld.DistributedTensor[[1, size], pl.FP32],
+            out: pl.Out[pl.Tensor[[1, size], pl.FP32]],
+        ) -> pl.Tensor[[1, size], pl.FP32]:
+            # Stage-out: copy the reduced result from the window slot to the
+            # local output in UB-bounded chunks.
+            for col, (out_iter,) in pl.range(0, size, stage_cols, init_values=(out,)):
+                valid = pl.min(stage_cols, size - col)
+                acc = pl.load(data, [0, col], [stage_rows, stage_cols], valid_shape=[1, valid])
+                out_iter = pl.store(acc, [0, col], out_iter)
+                staged_out = pl.yield_(out_iter)
+            return staged_out
 
         @pl.function(type=pl.FunctionType.Orchestration)
         def consume_orch(
             self,
-            data: pld.DistributedTensor[[1, SIZE], pl.FP32],
-            out: pl.Out[pl.Tensor[[1, SIZE], pl.FP32]],
-        ) -> pl.Tensor[[1, SIZE], pl.FP32]:
+            data: pld.DistributedTensor[[1, size], pl.FP32],
+            out: pl.Out[pl.Tensor[[1, size], pl.FP32]],
+        ) -> pl.Tensor[[1, size], pl.FP32]:
             return self.consume_step(data, out)
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(
             self,
-            inputs: pl.Tensor[[n_ranks, 1, SIZE], pl.FP32],
-            outputs: pl.Out[pl.Tensor[[n_ranks, 1, SIZE], pl.FP32]],
-        ) -> pl.Tensor[[n_ranks, 1, SIZE], pl.FP32]:
-            data_buf = pld.alloc_window_buffer(SIZE * pl.FP32.get_byte())
+            inputs: pl.Tensor[[n_ranks, 1, size], pl.FP32],
+            outputs: pl.Out[pl.Tensor[[n_ranks, 1, size], pl.FP32]],
+        ) -> pl.Tensor[[n_ranks, 1, size], pl.FP32]:
+            data_buf = pld.alloc_window_buffer(size * pl.FP32.get_byte())
             signal_buf = pld.alloc_window_buffer(total_rounds * n_ranks * pl.INT32.get_byte())
 
             for r in pl.range(pld.world_size()):
-                data = pld.window(data_buf, [1, SIZE], dtype=pl.FP32)
+                data = pld.window(data_buf, [1, size], dtype=pl.FP32)
                 self.publish_orch(inputs[r], data, device=r)
 
-            data = pld.window(data_buf, [1, SIZE], dtype=pl.FP32)
+            data = pld.window(data_buf, [1, size], dtype=pl.FP32)
             signal = pld.window(signal_buf, [total_rounds, n_ranks], dtype=pl.INT32)
             data = pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum, mode="ring")
 
@@ -217,6 +250,45 @@ class TestL3HostTensorAllReduceRing:
         expected = _expected_allreduce(inputs)
         assert torch.allclose(outputs, expected), (
             f"host ring allreduce P={n_ranks} mismatch: max diff = {(outputs - expected).abs().max().item()}"
+        )
+
+    @pytest.mark.parametrize("size", [1, 17, 4097, 65537])
+    @pytest.mark.parametrize("n_ranks", [2, 4])
+    def test_host_tensor_allreduce_ring_ragged(self, test_config, device_ids, n_ranks, size):
+        """Non-divisible (ragged) HOST ring allreduce — the #2242 leftover.
+
+        Sizes {1, 17, 4097, 65537} are all non-divisible by both P=2 and P=4
+        (and 65537 exceeds UB), mirroring the InCore composite ring ragged ST
+        (`test_l3_tensor_allreduce_ring_intrinsic.py`). The host builtin ring
+        kernel partitions src into NR balanced, potentially ragged chunks and
+        narrows each TPUT transfer via the staging tile's valid_shape.
+        """
+        if len(device_ids) < n_ranks:
+            pytest.skip(f"host ring allreduce P={n_ranks} needs {n_ranks} devices, got {device_ids}")
+
+        program = _build_host_ring_allreduce_program(n_ranks, size)
+        compiled = ir.compile(
+            program,
+            platform=test_config.platform,
+            distributed_config=DistributedConfig(
+                device_ids=device_ids[:n_ranks],
+                num_sub_workers=0,
+            ),
+        )
+
+        variant_dir = compiled.output_dir / "next_levels" / "builtin.tensor.allreduce_ring__sum__fp32"
+        assert variant_dir.is_dir()
+        assert (variant_dir / "kernel_config.py").is_file()
+
+        inputs = _make_rank_inputs(n_ranks, size)
+        outputs = torch.zeros((n_ranks, 1, size), dtype=torch.float32)
+
+        compiled(inputs, outputs)
+
+        expected = _expected_allreduce(inputs)
+        assert torch.allclose(outputs, expected), (
+            f"host ring allreduce ragged P={n_ranks} size={size} mismatch: "
+            f"max diff = {(outputs - expected).abs().max().item()}"
         )
 
     @pytest.mark.parametrize("n_ranks", [2, 4])

--- a/tests/ut/ir/test_distributed_ops.py
+++ b/tests/ut/ir/test_distributed_ops.py
@@ -328,6 +328,21 @@ def test_tensor_allreduce_accepts_dynamic_shape():
     assert call.type is src.type
 
 
+def test_tensor_allreduce_ring_accepts_dynamic_shape():
+    """HOST ring allreduce type-deduces a dynamic-extent src (issue #2242).
+
+    The ring builtin partitions src into NR balanced, potentially ragged chunks
+    at runtime, so a dynamic extent needs no compile-time guard — mirror the
+    mesh analogue above, with the ring's rank-2 ``[2*(NR-1) + 1, NR]`` signal
+    (NR=4 -> ``[7, 4]``)."""
+    span = ir.Span.unknown()
+    n = ir.Var("n", ir.ScalarType(DataType.INT64), span)
+    src = ir.Var("src", ir.DistributedTensorType([n], DataType.FP32), span)
+    signal = _make_distributed_tensor_var("signal", [7, 4], DataType.INT32, span)
+    call = dist_tensor_ops.allreduce(src, signal, op=ir.ReduceOp.Sum, mode="ring", span=span)
+    assert call.type is src.type
+
+
 def test_tensor_allreduce_rejects_plain_tensor_src():
     span = ir.Span.unknown()
     src = ir.Var("src", ir.TensorType([ir.ConstInt(16, DataType.INT64, span)], DataType.FP32), span)

--- a/tests/ut/ir/transforms/test_lower_host_tensor_collectives.py
+++ b/tests/ut/ir/transforms/test_lower_host_tensor_collectives.py
@@ -1982,6 +1982,53 @@ def test_host_allreduce_ring_accepts_nondivisible_numel():
     )
 
 
+def test_host_allreduce_ring_accepts_dynamic_src_extent():
+    """Dynamic-extent HOST ring allreduce src is accepted (#2242).
+
+    The ring kernel accumulates ``numel`` at runtime from the tensor descriptor
+    shapes and partitions it into NR balanced, potentially ragged chunks, so a
+    ``src`` whose leading extent is only known at runtime needs no compile-time
+    guard. ``pld.world_size()`` as a window dim is a ``pld.system.world_size``
+    Call rather than a ``ConstInt``, which is exactly the shape the removed
+    static-shape check used to reject.
+
+    This is the lowering-side companion to
+    ``test_tensor_allreduce_ring_accepts_dynamic_shape``: only the lowering
+    reaches ``builtin.tensor.allreduce_ring``'s type deducer, since the builtin
+    is internal-only and is constructed solely by this pass.
+    """
+    SIZE = 64
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(self, data: pld.DistributedTensor[[4, SIZE], pl.FP32]):
+            return data
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(self):
+            data_buf = pld.alloc_window_buffer(pld.world_size() * SIZE * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(7 * 4 * pl.INT32.get_byte())
+            data = pld.window(data_buf, [pld.world_size(), SIZE], dtype=pl.FP32)
+            signal = pld.window(signal_buf, [7, 4], dtype=pl.INT32)
+            for r in pl.range(pld.world_size()):
+                self.chip_orch(data, device=r)
+            pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum, mode="ring")
+            return 0
+
+    program = cast(ir.Program, passes.materialize_comm_domain_scopes()(P))
+    result = cast(ir.Program, passes.lower_host_tensor_collectives()(program))
+
+    _assert_builtin_dispatch(
+        result,
+        "builtin.tensor.allreduce_ring",
+        arg_names=["data", "signal"],
+        arg_directions=[ir.ArgDirection.InOut, ir.ArgDirection.InOut],
+        kwargs={"op": int(pld.ReduceOp.Sum), "dtype": pl.FP32},
+        attrs={"op": int(pld.ReduceOp.Sum), "dtype": pl.FP32},
+    )
+
+
 def test_host_allreduce_ring_rejects_too_many_ranks():
     """Ring allreduce rejects more than 16 participating devices (P=17)."""
     SIZE = 64

--- a/tests/ut/ir/transforms/test_lower_host_tensor_collectives.py
+++ b/tests/ut/ir/transforms/test_lower_host_tensor_collectives.py
@@ -1945,8 +1945,11 @@ def test_host_allreduce_ring_rejects_mismatched_signal_shape():
         passes.lower_host_tensor_collectives()(program)
 
 
-def test_host_allreduce_ring_rejects_nondivisible_numel():
-    """Ring allreduce rejects numel that is not an exact multiple of NR at P=4."""
+def test_host_allreduce_ring_accepts_nondivisible_numel():
+    """Ragged HOST ring allreduce: numel that is not an exact multiple of NR is
+    accepted (#2242). The kernel partitions src into
+    NR balanced, potentially ragged chunks at runtime instead of rejecting it —
+    the lowering emits the ring builtin for SIZE=27 at P=4 (27 % 4 != 0)."""
     SIZE = 27  # 27 % 4 != 0
 
     @pl.program
@@ -1961,16 +1964,22 @@ def test_host_allreduce_ring_rejects_nondivisible_numel():
             signal_buf = pld.alloc_window_buffer(7 * 4 * pl.INT32.get_byte())
             data = pld.window(data_buf, [SIZE], dtype=pl.FP32)
             signal = pld.window(signal_buf, [7, 4], dtype=pl.INT32)
-            self.chip_orch(data, device=0)
-            self.chip_orch(data, device=1)
-            self.chip_orch(data, device=2)
-            self.chip_orch(data, device=3)
+            for r in pl.range(pld.world_size()):
+                self.chip_orch(data, device=r)
             pld.tensor.allreduce(data, signal, op=pld.ReduceOp.Sum, mode="ring")
             return 0
 
-    program = passes.materialize_comm_domain_scopes()(P)
-    with pytest.raises(ValueError, match=r"exact multiple of the rank count"):
-        passes.lower_host_tensor_collectives()(program)
+    program = cast(ir.Program, passes.materialize_comm_domain_scopes()(P))
+    result = cast(ir.Program, passes.lower_host_tensor_collectives()(program))
+
+    _assert_builtin_dispatch(
+        result,
+        "builtin.tensor.allreduce_ring",
+        arg_names=["data", "signal"],
+        arg_directions=[ir.ArgDirection.InOut, ir.ArgDirection.InOut],
+        kwargs={"op": int(pld.ReduceOp.Sum), "dtype": pl.FP32},
+        attrs={"op": int(pld.ReduceOp.Sum), "dtype": pl.FP32},
+    )
 
 
 def test_host_allreduce_ring_rejects_too_many_ranks():


### PR DESCRIPTION
## Summary

Closes the HOST-ring ragged / arbitrary-length leftover of issue #2242.

The host builtin ring allreduce previously required a statically-known src shape with `numel % NR == 0`. This PR relaxes both enforcement points and makes the kernel partition each rank's buffer into **NR balanced, potentially ragged chunks at runtime** — chunk `r` spans `[floor(numel·r/NR), floor(numel·(r+1)/NR))` — mirroring the InCore composite ring (#2161).

## Changes

- **`CheckRingChunkConstraints`** (`src/ir/transforms/lower_host_tensor_collectives_pass.cpp`): dropped the static-shape + `src_numel % NR == 0` CHECK_SPAN. Only the distributed-type internal check remains, plus a comment documenting the runtime ragged partition.
- **Ring builtin deducer** (`src/ir/op/distributed/collective.cpp`): dropped the compile-time static-shape + `numel % nr` validation block (the `kMaxSupportedRanks` check stays).
- **`allreduce_ring` kernel template** (`python/pypto/runtime/builtins/collectives/allreduce_ring/templates/kernel.cpp.in`): added `RingChunkStart()`; the soft guard no longer rejects non-divisible `numel`; `max_chunk_elems = ceil(numel/nranks)`; `tile_cols = min(max_chunk_elems, kTileCount)`; both RS/AG loops iterate ragged send spans, with each TPUT transfer narrowed to the chunk's exact extent via the staging tile's valid shape (`ColMaskInternal`).
- **ST** (`tests/st/distributed/test_l3_host_tensor_allreduce_ring.py`): new ragged test `{1, 17, 4097, 65537}` × P=2/P=4 (all non-divisible by both P=2 and P=4; 65537 > UB); stage-in/out chunked (`STAGE_CHUNK=8192`, 32-byte `[8,1]` tile for `SIZE=1`, stage cols rounded to 32-byte row alignment).
- **UT** (`tests/ut/ir/transforms/test_lower_host_tensor_collectives.py`): `test_host_allreduce_ring_rejects_nondivisible_numel` → `test_host_allreduce_ring_accepts_nondivisible_numel` (SIZE=27, P=4).

## Verification

| Gate | Result |
|---|---|
| UT `test_lower_host_tensor_collectives.py` | **51/51** |
| a2a3sim `test_l3_host_tensor_allreduce_ring.py` (uniform + ragged + signal-reuse) | **12/12** |
| NPU P=2 (devices 4-5) | **6/6** |
| NPU P=4 (devices 4-7) | **12/12** |
| pre-commit (all hooks on the changed files) | green |

The NPU runs are the ordering gate: TPUT push + `NeighborBarrier` + `pipe_barrier(PIPE_ALL)`/`dsb` ordering is not modelled in sim, and is proven on silicon for every ragged size × rank count.

## Scope notes

- **Sum-only (deliberate):** the HOST ring kernel is Sum-only by construction (`entry.cpp.in` `enum ReduceOp { kSum = 0 }`; `TPUT<AtomicType::AtomicAdd>` cannot Prod). Prod on the HOST ring requires the atomic-add → non-atomic-push algorithm change, tracked separately. The ragged ST mirrors the InCore ring ragged ST, which is also Sum-only.
- **No perf regression on the previously-supported path by construction:** for `numel % NR == 0` the floor boundaries coincide exactly with the old `chunk_elems` multiples, so `send_base`/`send_end`/`send_len`/`max_chunk_elems`/`tile_cols` are identical and the generated kernel is unchanged (the only removed code is the `numel % nranks != 0` guard branch, which never fired on the supported path).
- **Pre-existing pyright failure (unrelated):** `pre-commit run --all-files` reports 4 pyright errors in `python/pypto/runtime/distributed_runner.py` (`DataType`/`AccessMode`/`BackendKind` unknown import symbol) that reproduce identically on a pristine `origin/main` worktree @ `f1a2f35f` — an environment artifact of the isolated hook env (missing `_task_interface` C-extension the installed `simpler` re-exports from), not caused by this PR. pyright passes on all files changed here.
