### PR TITLE
refactor(ir)!: re-export the distributed artifact types, internalize the argument builders

### DIFF
--- a/docs/en/dev/03-runtime-replay.md
+++ b/docs/en/dev/03-runtime-replay.md
@@ -218,7 +218,7 @@ from pypto.runtime import execute_distributed_compiled
 execute_distributed_compiled("build_output/<jit_dir>/", [a, b, c])
 
 # reusable object (override the persisted platform / devices if needed):
-from pypto.ir.distributed_compiled_program import DistributedCompiledProgram, DistributedConfig
+from pypto.ir import DistributedCompiledProgram, DistributedConfig
 prog = DistributedCompiledProgram.from_dir(
     "build_output/<jit_dir>/",
     platform="a2a3",

--- a/docs/en/dev/08-entry-points.md
+++ b/docs/en/dev/08-entry-points.md
@@ -57,6 +57,17 @@ Python builtin `compile`, so prefer `from pypto import ir` and call
 
 Its parameters are documented in [Compiling](../user/execution/00-compile.md).
 
+Both artifact types it can return, and the config that selects the distributed
+one, are exported from `pypto.ir`:
+
+```python
+from pypto.ir import CompiledProgram, DistributedCompiledProgram, DistributedConfig
+```
+
+The defining module, `pypto.ir.distributed_compiled_program`, stays importable —
+`pypto.runtime` reaches for it directly to avoid an import cycle — but user code
+and tests should take the three names from `pypto.ir`.
+
 ## Execute
 
 | Entry | Layer | Takes | Location |
@@ -107,6 +118,8 @@ These have no stability guarantee. They are not in any `__all__`, and code
 outside PyPTO should not import them:
 
 - `pypto.ir.compile` — `_ensure_orchestration_headers`
+- `pypto.ir.compiled_program` — `CompiledProgram._build_orch_args`,
+  `CompiledProgram._build_call_config`
 - `pypto.runtime.device_runner` — `compile_and_assemble`, `compile_single_kernel`,
   `compile_single_orchestration`, `execute_on_device`
 - `pypto.runtime.kernel_compiler` — `KernelCompiler`, `compile_incore`
@@ -114,9 +127,11 @@ outside PyPTO should not import them:
   `_DfxOpts`
 - `pypto.runtime.tensor_arg`, `pypto.runtime.elf_parser`, `pypto.runtime._binary_cache`
 
-`DistributedCompiledProgram` and `DistributedConfig` are public, but are not
-re-exported from `pypto.ir`; import them from
-`pypto.ir.distributed_compiled_program`.
+The two argument builders marshal user arguments into simpler's `TaskArgs` and
+`CallConfig`. `ChipWorker.run` and `ChipWorker.register` are the supported way
+to reach that path — they call the builders for you, and a caller driving a
+hand-constructed `simpler.worker.Worker` still gets `chip_callable`,
+`runtime_name` and `runtime_config` from the public surface.
 
 ## Command-line entry points
 

--- a/docs/en/user/distributed/00-model.md
+++ b/docs/en/user/distributed/00-model.md
@@ -100,8 +100,8 @@ Save the functions above and the driver below into the same file (`script.py`):
 
 ```python
 import torch
+from pypto.ir import DistributedConfig
 from pypto.runtime import RunConfig
-from pypto.ir.distributed_compiled_program import DistributedConfig
 
 dc = DistributedConfig(device_ids=[0, 1])
 cfg = RunConfig(platform="a2a3", distributed_config=dc)

--- a/docs/en/user/distributed/03-execution.md
+++ b/docs/en/user/distributed/03-execution.md
@@ -217,7 +217,7 @@ does not stop the child from writing it.
 
 ```python
 import torch
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 from pypto.runtime import RunConfig
 
 dc = DistributedConfig(device_ids=[0, 1, 2, 3])

--- a/docs/en/user/execution/00-compile.md
+++ b/docs/en/user/execution/00-compile.md
@@ -108,9 +108,10 @@ want when the question is "which pass changed this".
 cache holds — so a later call with the same specialization key gets the identical object.
 
 It exposes the whole extraction surface, which is what a harness driving the runtime
-directly needs: `chip_callable`, `runtime_name`, `runtime_config`, `build_orch_args`,
-`build_call_config`, `output_dir`, `platform`, `output_indices`, `param_names`,
-`orchestration_names`, `has_return`.
+directly needs: `chip_callable`, `runtime_name`, `runtime_config`, `output_dir`,
+`platform`, `output_indices`, `param_names`, `orchestration_names`, `has_return`.
+Argument marshalling is not part of that surface — dispatch through
+[`ChipWorker`](01-run.md#explicit-dispatch), which does it for you.
 
 `lower(*args)` goes one step less far: it runs the passes and returns the `Program`,
 writing no artifacts — which also means no `passes_dump/`. It is the right form for

--- a/docs/en/user/execution/01-run.md
+++ b/docs/en/user/execution/01-run.md
@@ -74,7 +74,6 @@ both H2D and D2H for that argument.
 | `param_names` / `output_indices` / `has_return` | The call shape, for a harness binding arguments itself |
 | `program` | The `Program` that was handed to `compile` — usually pre-pass, and `None` after `from_dir` |
 | `chip_callable` / `runtime_name` / `runtime_config` | The runtime-side handles |
-| `build_orch_args` / `build_call_config` | The two builders explicit dispatch needs |
 | `validate_ir` | Per-pass semantic comparison ([Precision](../precision/00-workflow.md)) |
 | `from_dir` / `load` | Rebuild a handle from a saved artifact directory |
 

--- a/docs/zh/dev/03-runtime-replay.md
+++ b/docs/zh/dev/03-runtime-replay.md
@@ -200,7 +200,7 @@ from pypto.runtime import execute_distributed_compiled
 execute_distributed_compiled("build_output/<jit_dir>/", [a, b, c])
 
 # 可复用对象（需要时覆盖持久化的 platform / 设备）：
-from pypto.ir.distributed_compiled_program import DistributedCompiledProgram, DistributedConfig
+from pypto.ir import DistributedCompiledProgram, DistributedConfig
 prog = DistributedCompiledProgram.from_dir(
     "build_output/<jit_dir>/",
     platform="a2a3",

--- a/docs/zh/dev/08-entry-points.md
+++ b/docs/zh/dev/08-entry-points.md
@@ -53,6 +53,15 @@ PyPTO 的编译与执行入口比它拥有的概念要多，而且好几个名�
 
 它的参数在[编译](../user/execution/00-compile.md)中有说明。
 
+它可能返回的两种产物类型，以及选定分布式那一种的配置，都从 `pypto.ir` 导出：
+
+```python
+from pypto.ir import CompiledProgram, DistributedCompiledProgram, DistributedConfig
+```
+
+定义它们的模块 `pypto.ir.distributed_compiled_program` 仍然可以导入 —— `pypto.runtime`
+直接从那里取，以避开导入环 —— 但用户代码与测试应当从 `pypto.ir` 取这三个名字。
+
 ## 执行
 
 | 入口 | 层 | 接受什么 | 位置 |
@@ -99,6 +108,8 @@ compiled(*tensors, config=config)
 以下没有稳定性保证。它们不在任何 `__all__` 中，PyPTO 之外的代码不应导入：
 
 - `pypto.ir.compile` —— `_ensure_orchestration_headers`
+- `pypto.ir.compiled_program` —— `CompiledProgram._build_orch_args`、
+  `CompiledProgram._build_call_config`
 - `pypto.runtime.device_runner` —— `compile_and_assemble`、`compile_single_kernel`、
   `compile_single_orchestration`、`execute_on_device`
 - `pypto.runtime.kernel_compiler` —— `KernelCompiler`、`compile_incore`
@@ -106,8 +117,10 @@ compiled(*tensors, config=config)
   `_DfxOpts`
 - `pypto.runtime.tensor_arg`、`pypto.runtime.elf_parser`、`pypto.runtime._binary_cache`
 
-`DistributedCompiledProgram` 与 `DistributedConfig` 是公开的，但没有从 `pypto.ir`
-重新导出；请从 `pypto.ir.distributed_compiled_program` 导入。
+这两个实参构造器把用户实参编排成 simpler 的 `TaskArgs` 与 `CallConfig`。
+`ChipWorker.run` 与 `ChipWorker.register` 是抵达这条路径的受支持方式 —— 它们会替你调用
+构造器；而自行构造 `simpler.worker.Worker` 的调用方，仍可从公开面拿到 `chip_callable`、
+`runtime_name` 与 `runtime_config`。
 
 ## 命令行入口
 

--- a/docs/zh/user/distributed/00-model.md
+++ b/docs/zh/user/distributed/00-model.md
@@ -96,8 +96,8 @@ def orchestrator(
 
 ```python
 import torch
+from pypto.ir import DistributedConfig
 from pypto.runtime import RunConfig
-from pypto.ir.distributed_compiled_program import DistributedConfig
 
 dc = DistributedConfig(device_ids=[0, 1])
 cfg = RunConfig(platform="a2a3", distributed_config=dc)

--- a/docs/zh/user/distributed/03-execution.md
+++ b/docs/zh/user/distributed/03-execution.md
@@ -193,7 +193,7 @@ with compiled.prepare(
 
 ```python
 import torch
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 from pypto.runtime import RunConfig
 
 dc = DistributedConfig(device_ids=[0, 1, 2, 3])

--- a/docs/zh/user/execution/00-compile.md
+++ b/docs/zh/user/execution/00-compile.md
@@ -94,7 +94,7 @@ assert compiled.param_names == ["a", "b", "out"]
 
 `@pl.jit` 平时把特化 + 编译 + 派发融成一次 `kernel(*args)` 调用。`compile(*sample_args)` 在编译后停下，返回 JIT 缓存持有的那个 `CompiledProgram` —— 所以之后用同一个特化键调用会拿到同一个对象。
 
-它暴露了完整的提取面，这正是直接驱动运行时的 harness 所需要的：`chip_callable`、`runtime_name`、`runtime_config`、`build_orch_args`、`build_call_config`、`output_dir`、`platform`、`output_indices`、`param_names`、`orchestration_names`、`has_return`。
+它暴露了完整的提取面，这正是直接驱动运行时的 harness 所需要的：`chip_callable`、`runtime_name`、`runtime_config`、`output_dir`、`platform`、`output_indices`、`param_names`、`orchestration_names`、`has_return`。实参编排不属于这个面 —— 交给 [`ChipWorker`](01-run.md#显式派发) 派发，它会替你完成。
 
 `lower(*args)` 比它早停一站：只跑 pass 并返回 `Program`，不写任何产物 —— 也就意味着没有 `passes_dump/`。它适合 [torch codegen](../tools/01-torch-codegen.md)，那里要的就是 IR 本身；而[内存图](../tools/02-memory-map.md)读的是磁盘上的 dump，因此需要 `compile()`。
 

--- a/docs/zh/user/execution/01-run.md
+++ b/docs/zh/user/execution/01-run.md
@@ -66,7 +66,6 @@ with ChipWorker(config=cfg) as w:
 | `param_names` / `output_indices` / `has_return` | 调用形状，供自行绑定实参的 harness 使用 |
 | `program` | 交给 `compile` 的那份 `Program` —— 通常是未经 pass 的，且经 `from_dir` 重建后为 `None` |
 | `chip_callable` / `runtime_name` / `runtime_config` | 运行时侧的句柄 |
-| `build_orch_args` / `build_call_config` | 显式派发需要的两个构造器 |
 | `validate_ir` | 逐 pass 的语义对比（[精度](../precision/00-workflow.md)） |
 | `from_dir` / `load` | 从已保存的产物目录重建句柄 |
 

--- a/examples/distributed/01_hello_rank.py
+++ b/examples/distributed/01_hello_rank.py
@@ -35,7 +35,7 @@ import argparse
 import pypto.language as pl
 import pypto.language.distributed as pld
 import torch
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 from pypto.runtime import RunConfig
 
 N_RANKS = 2

--- a/examples/distributed/02_programming_model.py
+++ b/examples/distributed/02_programming_model.py
@@ -29,7 +29,7 @@ import argparse
 import pypto.language as pl
 import pypto.language.distributed as pld
 import torch
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 from pypto.runtime import RunConfig
 
 N_RANKS = 2

--- a/examples/distributed/03_window_buffer.py
+++ b/examples/distributed/03_window_buffer.py
@@ -29,7 +29,7 @@ import argparse
 import pypto.language as pl
 import pypto.language.distributed as pld
 import torch
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 from pypto.runtime import RunConfig
 
 N_RANKS = 2

--- a/examples/distributed/04_barrier.py
+++ b/examples/distributed/04_barrier.py
@@ -49,7 +49,7 @@ import argparse
 import pypto.language as pl
 import pypto.language.distributed as pld
 import torch
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 from pypto.runtime import RunConfig
 
 N_RANKS = 2

--- a/examples/distributed/05_remote_load_store.py
+++ b/examples/distributed/05_remote_load_store.py
@@ -32,7 +32,7 @@ import argparse
 import pypto.language as pl
 import pypto.language.distributed as pld
 import torch
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 from pypto.runtime import RunConfig
 
 N_RANKS = 2

--- a/examples/distributed/06_put_get.py
+++ b/examples/distributed/06_put_get.py
@@ -31,7 +31,7 @@ import argparse
 import pypto.language as pl
 import pypto.language.distributed as pld
 import torch
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 from pypto.runtime import RunConfig
 
 N_RANKS = 2

--- a/examples/distributed/07_dynamic_rank_count.py
+++ b/examples/distributed/07_dynamic_rank_count.py
@@ -37,7 +37,7 @@ import argparse
 import pypto.language as pl
 import pypto.language.distributed as pld
 import torch
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 from pypto.runtime import RunConfig
 
 SIZE = 64

--- a/examples/distributed/08_allreduce_mesh.py
+++ b/examples/distributed/08_allreduce_mesh.py
@@ -50,7 +50,7 @@ import pypto.language as pl
 import pypto.language.distributed as pld
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 64
 NR = pl.dynamic("NR")

--- a/examples/distributed/09_allreduce_two_phase.py
+++ b/examples/distributed/09_allreduce_two_phase.py
@@ -36,7 +36,7 @@ import pypto.language as pl
 import pypto.language.distributed as pld
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 64
 

--- a/examples/distributed/10_allreduce_ring.py
+++ b/examples/distributed/10_allreduce_ring.py
@@ -37,7 +37,7 @@ import pypto.language as pl
 import pypto.language.distributed as pld
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 64
 

--- a/examples/distributed/11_allreduce_reveal.py
+++ b/examples/distributed/11_allreduce_reveal.py
@@ -38,7 +38,7 @@ import pypto.language as pl
 import pypto.language.distributed as pld
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 64
 

--- a/examples/distributed/12_broadcast.py
+++ b/examples/distributed/12_broadcast.py
@@ -37,7 +37,7 @@ import pypto.language as pl
 import pypto.language.distributed as pld
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 64
 ROOT_RANK = 0

--- a/examples/distributed/13_allgather.py
+++ b/examples/distributed/13_allgather.py
@@ -38,7 +38,7 @@ import pypto.language as pl
 import pypto.language.distributed as pld
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 64
 

--- a/examples/distributed/14_reduce_scatter.py
+++ b/examples/distributed/14_reduce_scatter.py
@@ -43,7 +43,7 @@ import pypto.language as pl
 import pypto.language.distributed as pld
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 64
 

--- a/examples/distributed/15_all_to_all.py
+++ b/examples/distributed/15_all_to_all.py
@@ -41,7 +41,7 @@ import pypto.language as pl
 import pypto.language.distributed as pld
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 64
 

--- a/examples/distributed/16_putting_it_together.py
+++ b/examples/distributed/16_putting_it_together.py
@@ -40,7 +40,7 @@ import pypto.language as pl
 import pypto.language.distributed as pld
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 64
 ROOT_RANK = 0

--- a/examples/runtime/distributed_callback.py
+++ b/examples/runtime/distributed_callback.py
@@ -40,7 +40,7 @@ Run:  python examples/runtime/distributed_callback.py
 import pypto.language as pl
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 PLATFORM = "a2a3sim"  # swap for "a2a3" to target a real device
 

--- a/examples/runtime/multi_program_kv_cache.py
+++ b/examples/runtime/multi_program_kv_cache.py
@@ -45,7 +45,7 @@ from __future__ import annotations
 
 import pypto.language as pl
 import torch
-from pypto.ir.distributed_compiled_program import DistributedCompiledProgram, DistributedConfig
+from pypto.ir import DistributedCompiledProgram, DistributedConfig
 from pypto.runtime import DistributedWorker, RunConfig
 
 TILE = 128

--- a/python/pypto/ir/__init__.py
+++ b/python/pypto/ir/__init__.py
@@ -46,6 +46,7 @@ from .builder import IRBuilder
 from .compile import compile
 from .compiled_program import CompiledProgram
 from .directions import make_call
+from .distributed_compiled_program import DistributedCompiledProgram, DistributedConfig
 
 # Import roundtrip instrument factory
 from .instruments import make_roundtrip_instrument
@@ -104,6 +105,8 @@ __all__ = [
     "python_print",
     "compile",
     "CompiledProgram",
+    "DistributedCompiledProgram",
+    "DistributedConfig",
     "PassManager",
     "OptimizationStrategy",
     "PassDumpLevel",

--- a/python/pypto/ir/__init__.pyi
+++ b/python/pypto/ir/__init__.pyi
@@ -28,13 +28,22 @@ from pypto.pypto_core.ir import (
     TileType,
     TileView,
 )
-from pypto.pypto_core.passes import PassContext, VerificationLevel, VerificationMode
+from pypto.pypto_core.passes import (
+    DiagnosticCheck,
+    DiagnosticCheckSet,
+    DiagnosticPhase,
+    PassContext,
+    VerificationLevel,
+    VerificationMode,
+)
 
 from . import directions as directions
 from . import op as op
 from .builder import IRBuilder
 from .compile import compile
+from .compiled_program import CompiledProgram
 from .directions import make_call
+from .distributed_compiled_program import DistributedCompiledProgram, DistributedConfig
 from .instruments import make_roundtrip_instrument
 from .op_conversion import ConversionContext, op_conversion, register_op_conversion
 from .pass_manager import OptimizationStrategy, PassDumpLevel, PassManager
@@ -82,12 +91,18 @@ __all__ = [
     "TileView",
     "python_print",
     "compile",
+    "CompiledProgram",
+    "DistributedCompiledProgram",
+    "DistributedConfig",
     "PassManager",
     "OptimizationStrategy",
     "PassDumpLevel",
     "VerificationMode",
     "VerificationLevel",
     "PassContext",
+    "DiagnosticPhase",
+    "DiagnosticCheck",
+    "DiagnosticCheckSet",
     "ConversionContext",
     "op_conversion",
     "register_op_conversion",

--- a/python/pypto/ir/compiled_program.py
+++ b/python/pypto/ir/compiled_program.py
@@ -1191,9 +1191,9 @@ class CompiledProgram(_RuntimeFacade):
                 f"compiled[<name>] instead."
             )
 
-    # --- Argument builders (for users driving a simpler.Worker directly) -----
+    # --- Argument builders (internal; used by the runtime workers) ----------
 
-    def build_orch_args(
+    def _build_orch_args(
         self,
         *args: "CallArg",
         worker: Any | None = None,
@@ -1214,12 +1214,12 @@ class CompiledProgram(_RuntimeFacade):
 
         Raises:
             TypeError: Arg count / type mismatch, or called on a multi-orch
-                program (use ``compiled[<name>].build_orch_args(...)`` instead).
+                program (use ``compiled[<name>]._build_orch_args(...)`` instead).
         """
         if self._sub_chip_dirs:
             raise TypeError(
                 f"Multi-orch program has {len(self._sub_chip_dirs)} orchestrations "
-                f"{sorted(self._sub_chip_dirs)}; use compiled[<name>].build_orch_args(...)."
+                f"{sorted(self._sub_chip_dirs)}; use compiled[<name>]._build_orch_args(...)."
             )
         param_infos, output_indices, return_types = self._get_metadata()
         coerced, return_style = _coerce_args(
@@ -1227,14 +1227,14 @@ class CompiledProgram(_RuntimeFacade):
         )
         if worker is None:
             raise TypeError(
-                "build_orch_args requires the simpler Worker that will own and dispatch these TaskArgs"
+                "_build_orch_args requires the simpler Worker that will own and dispatch these TaskArgs"
             )
         from pypto.runtime.runner import _coerced_to_orch_args  # noqa: PLC0415
 
         orch_args = _coerced_to_orch_args(coerced, worker)
         return orch_args, coerced, return_style
 
-    def build_call_config(
+    def _build_call_config(
         self,
         config: Any = None,
         *,
@@ -1255,12 +1255,13 @@ class CompiledProgram(_RuntimeFacade):
         if self._sub_chip_dirs:
             raise TypeError(
                 f"Multi-orch program has {len(self._sub_chip_dirs)} orchestrations "
-                f"{sorted(self._sub_chip_dirs)}; use compiled[<name>].build_call_config(...)."
+                f"{sorted(self._sub_chip_dirs)}; use compiled[<name>]._build_call_config(...)."
             )
-        from pypto.runtime.runner import RunConfig, _build_call_config  # noqa: PLC0415
+        from pypto.runtime.runner import RunConfig  # noqa: PLC0415
+        from pypto.runtime.runner import _build_call_config as _runner_build_call_config  # noqa: PLC0415
 
         run_config = config if config is not None else RunConfig()
-        return _build_call_config(
+        return _runner_build_call_config(
             run_config,
             runtime_config=self.runtime_config,
             aicpu_thread_num_override=aicpu_thread_num,
@@ -1456,7 +1457,7 @@ class _SubChipCallable(_RuntimeFacade):
     def output_indices(self) -> list[int]:
         return list(self._output_indices)
 
-    def build_orch_args(
+    def _build_orch_args(
         self,
         *args: "CallArg",
         worker: Any | None = None,
@@ -1470,24 +1471,25 @@ class _SubChipCallable(_RuntimeFacade):
         )
         if worker is None:
             raise TypeError(
-                "build_orch_args requires the simpler Worker that will own and dispatch these TaskArgs"
+                "_build_orch_args requires the simpler Worker that will own and dispatch these TaskArgs"
             )
         from pypto.runtime.runner import _coerced_to_orch_args  # noqa: PLC0415
 
         orch_args = _coerced_to_orch_args(coerced, worker)
         return orch_args, coerced, return_style
 
-    def build_call_config(
+    def _build_call_config(
         self,
         config: Any = None,
         *,
         aicpu_thread_num: int | None = None,
         dfx_dir: "Path | None" = None,
     ) -> Any:
-        from pypto.runtime.runner import RunConfig, _build_call_config  # noqa: PLC0415
+        from pypto.runtime.runner import RunConfig  # noqa: PLC0415
+        from pypto.runtime.runner import _build_call_config as _runner_build_call_config  # noqa: PLC0415
 
         run_config = config if config is not None else RunConfig()
-        return _build_call_config(
+        return _runner_build_call_config(
             run_config,
             runtime_config=self.runtime_config,
             aicpu_thread_num_override=aicpu_thread_num,

--- a/python/pypto/jit/decorator.py
+++ b/python/pypto/jit/decorator.py
@@ -2293,8 +2293,6 @@ class JITFunction:
           for explicit L2 dispatch.
         - ``CompiledProgram.chip_callable`` / ``runtime_name`` / ``runtime_config``
           to drive a hand-constructed ``simpler.worker.Worker``.
-        - ``CompiledProgram.build_orch_args`` / ``build_call_config`` to
-          assemble the simpler dispatch tuple yourself.
 
         ``config=RunConfig(...)`` is still consumed (and its compile-side
         knobs forwarded to ``ir.compile()``) so the returned

--- a/python/pypto/runtime/runner.py
+++ b/python/pypto/runtime/runner.py
@@ -852,7 +852,7 @@ def _coerced_to_orch_args(
     codegen addresses them from independent pools.
 
     Used by both :func:`execute_compiled` and the extraction path on
-    :class:`pypto.ir.CompiledProgram` (``build_orch_args``).
+    :class:`pypto.ir.CompiledProgram` (``_build_orch_args``).
     """
     from .task_interface import (  # noqa: PLC0415
         TaskArgs,  # pyright: ignore[reportAttributeAccessIssue]

--- a/python/pypto/runtime/worker.py
+++ b/python/pypto/runtime/worker.py
@@ -585,8 +585,8 @@ class ChipWorker(Worker):
             dfx_dir = Path(compiled.output_dir) / "dfx_outputs"
             dfx_dir.mkdir(parents=True, exist_ok=True)
 
-        orch_args, coerced, return_style = compiled.build_orch_args(*args, worker=self._impl)
-        cfg = compiled.build_call_config(rc, dfx_dir=dfx_dir)
+        orch_args, coerced, return_style = compiled._build_orch_args(*args, worker=self._impl)
+        cfg = compiled._build_call_config(rc, dfx_dir=dfx_dir)
         self._run_chip(compiled.chip_callable, orch_args, cfg)
 
         if dfx_dir is not None:

--- a/tests/st/distributed/collectives/test_l3_all_to_all.py
+++ b/tests/st/distributed/collectives/test_l3_all_to_all.py
@@ -36,7 +36,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 64
 NR = pl.dynamic("NR")

--- a/tests/st/distributed/collectives/test_l3_allgather.py
+++ b/tests/st/distributed/collectives/test_l3_allgather.py
@@ -41,7 +41,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 64  # matches COUNT_PER_RANK in simpler allgather_kernel.cpp
 NR = pl.dynamic("NR")

--- a/tests/st/distributed/collectives/test_l3_allreduce.py
+++ b/tests/st/distributed/collectives/test_l3_allreduce.py
@@ -43,7 +43,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 256  # matches ALLREDUCE_COUNT in runtime allreduce_kernel.cpp
 NR = pl.dynamic("NR")

--- a/tests/st/distributed/collectives/test_l3_allreduce_ring.py
+++ b/tests/st/distributed/collectives/test_l3_allreduce_ring.py
@@ -42,7 +42,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 256  # matches ALLREDUCE_COUNT in simpler allreduce_ring_kernel.cpp
 

--- a/tests/st/distributed/collectives/test_l3_broadcast.py
+++ b/tests/st/distributed/collectives/test_l3_broadcast.py
@@ -40,7 +40,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 64  # matches COUNT_PER_RANK in simpler broadcast_kernel.cpp
 NR = pl.dynamic("NR")

--- a/tests/st/distributed/collectives/test_l3_reduce_scatter.py
+++ b/tests/st/distributed/collectives/test_l3_reduce_scatter.py
@@ -43,7 +43,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 64  # matches COUNT_PER_RANK in simpler reduce_scatter_kernel.cpp
 NR = pl.dynamic("NR")

--- a/tests/st/distributed/collectives/test_l3_tensor_all_to_all_intrinsic.py
+++ b/tests/st/distributed/collectives/test_l3_tensor_all_to_all_intrinsic.py
@@ -29,7 +29,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 64
 

--- a/tests/st/distributed/collectives/test_l3_tensor_all_to_all_v_intrinsic.py
+++ b/tests/st/distributed/collectives/test_l3_tensor_all_to_all_v_intrinsic.py
@@ -45,7 +45,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 64
 MAX_RECV = 4

--- a/tests/st/distributed/collectives/test_l3_tensor_allgather_intrinsic.py
+++ b/tests/st/distributed/collectives/test_l3_tensor_allgather_intrinsic.py
@@ -30,7 +30,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 64
 

--- a/tests/st/distributed/collectives/test_l3_tensor_allreduce_intrinsic.py
+++ b/tests/st/distributed/collectives/test_l3_tensor_allreduce_intrinsic.py
@@ -26,7 +26,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 STAGE_CHUNK = 8192
 

--- a/tests/st/distributed/collectives/test_l3_tensor_allreduce_ring_intrinsic.py
+++ b/tests/st/distributed/collectives/test_l3_tensor_allreduce_ring_intrinsic.py
@@ -34,7 +34,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 STAGE_CHUNK = 8192
 

--- a/tests/st/distributed/collectives/test_l3_tensor_barrier_intrinsic.py
+++ b/tests/st/distributed/collectives/test_l3_tensor_barrier_intrinsic.py
@@ -27,7 +27,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 64
 

--- a/tests/st/distributed/collectives/test_l3_tensor_broadcast_intrinsic.py
+++ b/tests/st/distributed/collectives/test_l3_tensor_broadcast_intrinsic.py
@@ -26,7 +26,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 64
 ROOT_RANK = 0

--- a/tests/st/distributed/collectives/test_l3_tensor_collective_signal_reuse.py
+++ b/tests/st/distributed/collectives/test_l3_tensor_collective_signal_reuse.py
@@ -33,7 +33,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 64
 

--- a/tests/st/distributed/collectives/test_l3_tensor_reduce_scatter_intrinsic.py
+++ b/tests/st/distributed/collectives/test_l3_tensor_reduce_scatter_intrinsic.py
@@ -24,7 +24,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 64
 

--- a/tests/st/distributed/conftest.py
+++ b/tests/st/distributed/conftest.py
@@ -20,7 +20,7 @@ def disable_runtime_execution_in_codegen_only(request, monkeypatch) -> None:
     if not request.config.getoption("--codegen-only"):
         return
 
-    from pypto.ir.distributed_compiled_program import DistributedCompiledProgram  # noqa: PLC0415
+    from pypto.ir import DistributedCompiledProgram  # noqa: PLC0415
     from pypto.runtime.distributed_runner import DistributedWorker  # noqa: PLC0415
 
     def skip_execution(*args: Any, **kwargs: Any) -> None:

--- a/tests/st/distributed/test_l3_composite_shape_dim.py
+++ b/tests/st/distributed/test_l3_composite_shape_dim.py
@@ -28,7 +28,7 @@ import pypto.language as pl
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 M = pl.dynamic("M")
 N = pl.dynamic("N")

--- a/tests/st/distributed/test_l3_deferred_completion.py
+++ b/tests/st/distributed/test_l3_deferred_completion.py
@@ -52,7 +52,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 _N_RANKS = 2
 _A2A3_SIM_AIVS = 16

--- a/tests/st/distributed/test_l3_device_tensor.py
+++ b/tests/st/distributed/test_l3_device_tensor.py
@@ -32,7 +32,7 @@ import pypto.language as pl
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 
 @pl.program

--- a/tests/st/distributed/test_l3_dfx_per_rank.py
+++ b/tests/st/distributed/test_l3_dfx_per_rank.py
@@ -41,7 +41,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 from pypto.runtime import RunConfig
 
 ROWS = 16

--- a/tests/st/distributed/test_l3_distributed.py
+++ b/tests/st/distributed/test_l3_distributed.py
@@ -27,7 +27,7 @@ import pypto.language as pl
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 128 * 128
 

--- a/tests/st/distributed/test_l3_ep_dispatch_combine.py
+++ b/tests/st/distributed/test_l3_ep_dispatch_combine.py
@@ -64,7 +64,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 # Real DeepSeek-V4 FLASH MoE shapes (pypto-lib/models/deepseek_v4_flash_mtp) — must
 # mirror the runtime example's constants. ``N_RANKS`` is supplied per-test via

--- a/tests/st/distributed/test_l3_explicit_dispatch_onboard.py
+++ b/tests/st/distributed/test_l3_explicit_dispatch_onboard.py
@@ -45,7 +45,7 @@ import pypto.language as pl
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedCompiledProgram, DistributedConfig
+from pypto.ir import DistributedCompiledProgram, DistributedConfig
 from pypto.runtime import DistributedWorker, RunConfig
 
 from examples.runtime.multi_program_kv_cache import TILE, decode, prefill

--- a/tests/st/distributed/test_l3_gemm.py
+++ b/tests/st/distributed/test_l3_gemm.py
@@ -44,7 +44,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 M0 = 64
 K = 64

--- a/tests/st/distributed/test_l3_get.py
+++ b/tests/st/distributed/test_l3_get.py
@@ -35,7 +35,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 64
 

--- a/tests/st/distributed/test_l3_host_tensor_all_to_all.py
+++ b/tests/st/distributed/test_l3_host_tensor_all_to_all.py
@@ -41,7 +41,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 64
 NR = pl.dynamic("world_size")

--- a/tests/st/distributed/test_l3_host_tensor_all_to_all_v.py
+++ b/tests/st/distributed/test_l3_host_tensor_all_to_all_v.py
@@ -63,7 +63,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 64
 MAX_RECV = 4

--- a/tests/st/distributed/test_l3_host_tensor_allgather.py
+++ b/tests/st/distributed/test_l3_host_tensor_allgather.py
@@ -41,7 +41,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 64
 NR = pl.dynamic("world_size")

--- a/tests/st/distributed/test_l3_host_tensor_allreduce.py
+++ b/tests/st/distributed/test_l3_host_tensor_allreduce.py
@@ -16,7 +16,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 256
 NR = pl.dynamic("NR")

--- a/tests/st/distributed/test_l3_host_tensor_allreduce_multicore.py
+++ b/tests/st/distributed/test_l3_host_tensor_allreduce_multicore.py
@@ -28,7 +28,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 
 def _make_rank_inputs(n_ranks: int, size: int, round_offset: float = 0.0) -> torch.Tensor:

--- a/tests/st/distributed/test_l3_host_tensor_allreduce_ring.py
+++ b/tests/st/distributed/test_l3_host_tensor_allreduce_ring.py
@@ -16,7 +16,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 256
 

--- a/tests/st/distributed/test_l3_host_tensor_barrier.py
+++ b/tests/st/distributed/test_l3_host_tensor_barrier.py
@@ -16,7 +16,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 64
 NR = pl.dynamic("NR")

--- a/tests/st/distributed/test_l3_host_tensor_broadcast.py
+++ b/tests/st/distributed/test_l3_host_tensor_broadcast.py
@@ -16,7 +16,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 64
 ROOT_RANK = 0

--- a/tests/st/distributed/test_l3_host_tensor_reduce_scatter.py
+++ b/tests/st/distributed/test_l3_host_tensor_reduce_scatter.py
@@ -16,7 +16,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 64
 NR = pl.dynamic("world_size")

--- a/tests/st/distributed/test_l3_multi_group.py
+++ b/tests/st/distributed/test_l3_multi_group.py
@@ -55,7 +55,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 64
 

--- a/tests/st/distributed/test_l3_notify_wait.py
+++ b/tests/st/distributed/test_l3_notify_wait.py
@@ -43,7 +43,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 
 def _build_signal_handshake_program():

--- a/tests/st/distributed/test_l3_parallel_reduce.py
+++ b/tests/st/distributed/test_l3_parallel_reduce.py
@@ -29,7 +29,7 @@ import pypto.language as pl
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 
 @pl.program

--- a/tests/st/distributed/test_l3_put.py
+++ b/tests/st/distributed/test_l3_put.py
@@ -39,7 +39,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 64
 

--- a/tests/st/distributed/test_l3_rank_slice_dispatch.py
+++ b/tests/st/distributed/test_l3_rank_slice_dispatch.py
@@ -40,7 +40,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 N_RANKS = 2
 ROWS = 16

--- a/tests/st/distributed/test_l3_remote_store.py
+++ b/tests/st/distributed/test_l3_remote_store.py
@@ -35,7 +35,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 64
 HALF = SIZE // 2

--- a/tests/st/distributed/test_l3_remote_store_window_raw.py
+++ b/tests/st/distributed/test_l3_remote_store_window_raw.py
@@ -34,7 +34,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 N_RANKS = 2
 D = 64

--- a/tests/st/distributed/test_l3_ring_sizing_prewarm.py
+++ b/tests/st/distributed/test_l3_ring_sizing_prewarm.py
@@ -29,7 +29,7 @@ import pypto.language as pl
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 from pypto.runtime import RunConfig
 
 

--- a/tests/st/distributed/test_l3_self_notify_credit_reset.py
+++ b/tests/st/distributed/test_l3_self_notify_credit_reset.py
@@ -46,7 +46,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 _REPS = 4
 

--- a/tests/st/distributed/test_l3_stacked_device_tensor.py
+++ b/tests/st/distributed/test_l3_stacked_device_tensor.py
@@ -40,7 +40,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 from pypto.runtime import DistributedWorker, StackedDeviceTensor
 
 N_RANKS = 2

--- a/tests/st/distributed/test_l3_tuple_return.py
+++ b/tests/st/distributed/test_l3_tuple_return.py
@@ -33,7 +33,7 @@ import pypto.language as pl
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 
 @pl.program

--- a/tests/st/distributed/test_l3_window_slice_incore.py
+++ b/tests/st/distributed/test_l3_window_slice_incore.py
@@ -45,7 +45,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 N = 16  # rows
 W = 64  # window width (cols): 64*4=256 (FP32) and 64*2=128 (FP16) → 32-byte-aligned rows

--- a/tests/st/runtime/framework_and_models/test_benchmark_st.py
+++ b/tests/st/runtime/framework_and_models/test_benchmark_st.py
@@ -29,7 +29,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 from pypto.runtime import RunConfig, benchmark
 
 _M = 128

--- a/tests/st/runtime/framework_and_models/test_compiled_program.py
+++ b/tests/st/runtime/framework_and_models/test_compiled_program.py
@@ -140,7 +140,12 @@ class TestJitCompiledProgram:
 
 
 def _manual_dispatch(compiled, *args, device_id, config=None, call_config=None):
-    """Drive a hand-built simpler.Worker via the extraction surface; return coerced list."""
+    """Drive a hand-built simpler.Worker via the extraction surface; return coerced list.
+
+    The two argument builders are internal — ``ChipWorker.run`` is the supported
+    way to reach them. This helper calls them directly so the marshalling that
+    ``ChipWorker`` delegates to stays covered on its own.
+    """
     from simpler.worker import Worker as SimplerWorker  # noqa: PLC0415 — lazy: skip on host-only CI
 
     cc = compiled.chip_callable
@@ -148,11 +153,11 @@ def _manual_dispatch(compiled, *args, device_id, config=None, call_config=None):
     if call_config is not None:
         cfg = call_config
     else:
-        cfg = compiled.build_call_config(config) if config is not None else compiled.build_call_config()
+        cfg = compiled._build_call_config(config) if config is not None else compiled._build_call_config()
     w = SimplerWorker(level=2, device_id=device_id, platform=compiled.platform, runtime=rn)
     w.init()
     try:
-        orch_args, coerced, return_style = compiled.build_orch_args(*args, worker=w)
+        orch_args, coerced, return_style = compiled._build_orch_args(*args, worker=w)
         cid = w.register(cc)
         w.run(cid, orch_args, cfg)
         w.unregister(cid)
@@ -216,7 +221,7 @@ class TestManualWorkerExtraction:
         assert isinstance(compiled.runtime_config, dict)
 
     def test_call_config_override_runs(self, test_config):
-        """build_call_config aicpu_thread_num override is accepted and runs correctly."""
+        """_build_call_config aicpu_thread_num override is accepted and runs correctly."""
         tile_add_128._cache.clear()
         a = torch.full((128, 128), 2.0, dtype=torch.float32)
         b = torch.full((128, 128), 3.0, dtype=torch.float32)
@@ -224,7 +229,7 @@ class TestManualWorkerExtraction:
         compiled = _get_cached_compiled(tile_add_128)
         # 3, not the auto value baked into RUNTIME_CONFIG — otherwise the
         # assertion cannot tell an applied override from the default.
-        cfg = compiled.build_call_config(test_config, aicpu_thread_num=3)
+        cfg = compiled._build_call_config(test_config, aicpu_thread_num=3)
         assert cfg.aicpu_thread_num == 3
         coerced, _ = _manual_dispatch(compiled, a, b, device_id=test_config.device_id, call_config=cfg)
         assert torch.allclose(coerced[compiled.output_indices[0]], torch.full((128, 128), 5.0))

--- a/tests/ut/ir/test_compiled_program.py
+++ b/tests/ut/ir/test_compiled_program.py
@@ -56,7 +56,7 @@ def _fake_call_config(instance):
     """Stub ``pypto.runtime.task_interface.CallConfig`` via a fake module.
 
     ``task_interface`` imports the device-only ``simpler`` package, so it can't
-    load on host CI. Fake it so ``build_call_config``'s inner import binds to a
+    load on host CI. Fake it so ``_build_call_config``'s inner import binds to a
     ``CallConfig`` that returns ``instance``."""
     fake = types.ModuleType("pypto.runtime.task_interface")
     setattr(fake, "CallConfig", MagicMock(return_value=instance))
@@ -665,7 +665,7 @@ class TestCompiledProgramDeviceTensor:
 class TestCompiledProgramExtraction:
     """Verify the extraction surface that lets users drive ``simpler.worker.Worker``
     directly: ``chip_callable`` / ``runtime_name`` / ``runtime_config`` properties,
-    ``load()``, ``build_orch_args()``, and ``build_call_config()``.
+    ``load()``, ``_build_orch_args()``, and ``_build_call_config()``.
     """
 
     def _patch_assemble(self, chip_callable_name: str = "fake_chip"):
@@ -751,7 +751,7 @@ class TestCompiledProgramExtraction:
         worker = MagicMock(name="worker")
         with patch("pypto.runtime.runner._coerced_to_orch_args") as oa_helper:
             oa_helper.return_value = "fake_orch_args"
-            orch_args, coerced, return_style = cp.build_orch_args(a, b, c, worker=worker)
+            orch_args, coerced, return_style = cp._build_orch_args(a, b, c, worker=worker)
 
         assert orch_args == "fake_orch_args"
         assert coerced == [a, b, c]
@@ -768,7 +768,7 @@ class TestCompiledProgramExtraction:
         worker = MagicMock(name="worker")
         with patch("pypto.runtime.runner._coerced_to_orch_args") as oa_helper:
             oa_helper.return_value = "fake_orch_args"
-            orch_args, coerced, return_style = cp.build_orch_args(a, b, worker=worker)
+            orch_args, coerced, return_style = cp._build_orch_args(a, b, worker=worker)
 
         assert orch_args == "fake_orch_args"
         assert return_style is True
@@ -783,7 +783,7 @@ class TestCompiledProgramExtraction:
         cp = CompiledProgram(prog, str(tmp_path))
         a = torch.zeros(128, 128)
         with pytest.raises(TypeError, match="expects 3"):
-            cp.build_orch_args(a)
+            cp._build_orch_args(a)
 
     def test_build_call_config_uses_runtime_config_default(self, tmp_path):
         """When config has no overrides, RUNTIME_CONFIG values feed CallConfig."""
@@ -798,7 +798,7 @@ class TestCompiledProgramExtraction:
         ):
             from pypto.runtime import RunConfig  # noqa: PLC0415
 
-            cfg = cp.build_call_config(RunConfig())
+            cfg = cp._build_call_config(RunConfig())
 
         assert cfg is fake_call_config
         assert fake_call_config.aicpu_thread_num == 2  # from runtime_config
@@ -815,7 +815,7 @@ class TestCompiledProgramExtraction:
         ):
             from pypto.runtime import RunConfig  # noqa: PLC0415
 
-            cp.build_call_config(RunConfig(aicpu_thread_num=8), aicpu_thread_num=4)
+            cp._build_call_config(RunConfig(aicpu_thread_num=8), aicpu_thread_num=4)
 
         assert fake_call_config.aicpu_thread_num == 4  # kwarg > RunConfig field > runtime_config
 
@@ -831,7 +831,7 @@ class TestCompiledProgramExtraction:
         ):
             from pypto.runtime import RunConfig  # noqa: PLC0415
 
-            cp.build_call_config(RunConfig(aicpu_thread_num=16))
+            cp._build_call_config(RunConfig(aicpu_thread_num=16))
 
         assert fake_call_config.aicpu_thread_num == 16  # RunConfig wins over runtime_config's 2
 
@@ -847,7 +847,7 @@ class TestCompiledProgramExtraction:
         ):
             from pypto.runtime import RunConfig  # noqa: PLC0415
 
-            cp.build_call_config(
+            cp._build_call_config(
                 RunConfig(
                     enable_chip_swimlane=True,
                     enable_dump_args=True,
@@ -884,7 +884,7 @@ class TestCompiledProgramExtraction:
         ):
             from pypto.runtime import RunConfig  # noqa: PLC0415
 
-            cp.build_call_config(RunConfig())
+            cp._build_call_config(RunConfig())
 
         # spec doesn't include "output_prefix", so any attempted set would fail.
         # Reaching here means _build_call_config correctly skipped it.
@@ -917,7 +917,7 @@ class TestCompiledProgramExtractionMultiOrch:
         b = torch.zeros(128, 128)
         c = torch.zeros(128, 128)
         with pytest.raises(TypeError, match="Multi-orch"):
-            cp.build_orch_args(a, b, c)
+            cp._build_orch_args(a, b, c)
 
 
 class TestSubChipCallableExtraction:
@@ -958,7 +958,7 @@ class TestSubChipCallableExtraction:
         worker = MagicMock(name="worker")
         with patch("pypto.runtime.runner._coerced_to_orch_args") as oa_helper:
             oa_helper.return_value = "fake_orch_args"
-            orch_args, coerced, return_style = sub.build_orch_args(a, b, c, worker=worker)
+            orch_args, coerced, return_style = sub._build_orch_args(a, b, c, worker=worker)
 
         assert orch_args == "fake_orch_args"
         assert coerced == [a, b, c]
@@ -1082,7 +1082,7 @@ class TestCompiledMetaAndFromDir:
 
         Regression test for #2344: ``benchmark`` needs ``platform`` /
         ``runtime_name`` / ``runtime_config`` / ``chip_callable`` plus the
-        metadata-derived ``build_orch_args`` / ``build_call_config`` /
+        metadata-derived ``_build_orch_args`` / ``_build_call_config`` /
         ``output_indices``, which previously required a live ``Program``.
         """
         CompiledProgram(_make_program_with_orchestration(), str(tmp_path), platform="a2a3sim")
@@ -1102,10 +1102,10 @@ class TestCompiledMetaAndFromDir:
             assert reloaded.output_indices == [2]
             with patch("pypto.runtime.runner._coerced_to_orch_args") as oa_helper:
                 oa_helper.return_value = "fake_orch_args"
-                orch_args, coerced, return_style = reloaded.build_orch_args(*args, worker=worker)
+                orch_args, coerced, return_style = reloaded._build_orch_args(*args, worker=worker)
                 oa_helper.assert_called_once_with(args, worker)
             with _fake_call_config(call_config):
-                assert reloaded.build_call_config(RunConfig()) is call_config
+                assert reloaded._build_call_config(RunConfig()) is call_config
 
         assert orch_args == "fake_orch_args"
         assert coerced == args

--- a/tests/ut/ir/test_distributed_compiled_program.py
+++ b/tests/ut/ir/test_distributed_compiled_program.py
@@ -387,5 +387,19 @@ def test_from_dir_output_indices_match_out_params(compiled, tmp_path):
     assert param_infos[2].direction == ParamDirection.Out
 
 
+def test_distributed_types_are_reexported_from_pypto_ir():
+    """``pypto.ir`` is the supported spelling; the defining module stays importable.
+
+    ``pypto.runtime`` imports the defining module directly to avoid an import
+    cycle, so the re-export must be an alias of the same objects rather than a
+    second definition — otherwise an ``isinstance`` check would depend on which
+    spelling the caller used.
+    """
+    assert ir.DistributedCompiledProgram is DistributedCompiledProgram
+    assert ir.DistributedConfig is DistributedConfig
+    assert "DistributedCompiledProgram" in ir.__all__
+    assert "DistributedConfig" in ir.__all__
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/jit/test_cache.py
+++ b/tests/ut/jit/test_cache.py
@@ -10,8 +10,7 @@
 """Tests for python/pypto/jit/cache.py."""
 
 import pytest
-from pypto.ir import OptimizationStrategy
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig, OptimizationStrategy
 from pypto.jit.cache import (
     compute_source_hash,
     make_cache_key,

--- a/tests/ut/jit/test_decorator.py
+++ b/tests/ut/jit/test_decorator.py
@@ -2391,7 +2391,7 @@ class TestCompileKwargForwarding:
 
     def test_run_config_compile_kwargs_forwards_distributed_config(self):
         """A RunConfig.distributed_config is forwarded so @pl.jit.host kernels go distributed."""
-        from pypto.ir.distributed_compiled_program import DistributedConfig  # noqa: PLC0415
+        from pypto.ir import DistributedConfig  # noqa: PLC0415
 
         dc = DistributedConfig(device_ids=[0, 1])
         kwargs = _run_config_compile_kwargs(RunConfig(distributed_config=dc))
@@ -2407,7 +2407,7 @@ class TestCompileKwargForwarding:
 
     def test_make_cache_key_splits_on_distributed_config(self):
         """distributed_config participates in the cache key (distinct device_ids ≠ collide)."""
-        from pypto.ir.distributed_compiled_program import DistributedConfig  # noqa: PLC0415
+        from pypto.ir import DistributedConfig  # noqa: PLC0415
         from pypto.jit.cache import make_cache_key  # noqa: PLC0415
 
         def key_for(distributed_config):
@@ -2463,7 +2463,7 @@ class TestCompileKwargForwarding:
         different ``device_ids`` would silently target the wrong ranks.
         """
         torch = pytest.importorskip("torch")
-        from pypto.ir.distributed_compiled_program import DistributedConfig  # noqa: PLC0415
+        from pypto.ir import DistributedConfig  # noqa: PLC0415
 
         @jit
         def cfg_kernel(a: pl.Tensor[[128, 128], pl.FP32], c: pl.Out[pl.Tensor[[128, 128], pl.FP32]]):
@@ -2588,7 +2588,7 @@ class TestCompileKwargForwarding:
         # so patching the module attribute intercepts the real compilation.
         monkeypatch.setattr(ir_compile_mod, "compile", fake_compile)
 
-        from pypto.ir.distributed_compiled_program import DistributedConfig  # noqa: PLC0415
+        from pypto.ir import DistributedConfig  # noqa: PLC0415
 
         dc = DistributedConfig(device_ids=[0, 1])
         cfg = RunConfig(

--- a/tests/ut/jit/test_jit_compile_extraction.py
+++ b/tests/ut/jit/test_jit_compile_extraction.py
@@ -250,8 +250,9 @@ class TestCompileForwardsRunConfig:
 
 class TestCompileExposesExtractionSurface:
     """The returned CompiledProgram exposes the full extraction surface added
-    in PR #1496 (chip_callable / build_orch_args / build_call_config),
-    enabling worker integration as required by issue #1455.
+    in PR #1496 — the public runtime handles (chip_callable / runtime_name /
+    runtime_config) plus the internal argument builders ``ChipWorker.run``
+    marshals through — enabling worker integration as required by issue #1455.
 
     These tests only verify that the attributes are *defined on the class* —
     actually exercising compile_and_assemble (which several of these properties
@@ -276,8 +277,8 @@ class TestCompileExposesExtractionSurface:
             "chip_callable",
             "runtime_name",
             "runtime_config",
-            "build_orch_args",
-            "build_call_config",
+            "_build_orch_args",
+            "_build_call_config",
             "output_dir",
             "platform",
             "output_indices",

--- a/tests/ut/runtime/test_chip_worker_explicit_dispatch.py
+++ b/tests/ut/runtime/test_chip_worker_explicit_dispatch.py
@@ -12,7 +12,7 @@
 Exercises ``ChipWorker.run / register`` and the :class:`RegistrationHandle`
 returned by ``register`` without touching the device: ``_SimplerWorker`` is
 patched so construction does no real work, and ``CompiledProgram`` extraction
-helpers (``chip_callable / build_orch_args / build_call_config``) are stubbed
+helpers (``chip_callable / _build_orch_args / _build_call_config``) are stubbed
 to return mocks the tests can inspect.
 """
 
@@ -53,8 +53,8 @@ def _fake_compiled(
     compiled.chip_callable = cc
     compiled.output_dir = "/tmp/fake_compiled"
     compiled.output_indices = [2]
-    compiled.build_orch_args.return_value = ("orch_args", ["arg0", "arg1", "out_tensor"], False)
-    compiled.build_call_config.return_value = MagicMock(name="CallConfig")
+    compiled._build_orch_args.return_value = ("orch_args", ["arg0", "arg1", "out_tensor"], False)
+    compiled._build_call_config.return_value = MagicMock(name="CallConfig")
     return compiled
 
 
@@ -113,18 +113,18 @@ def test_run_requires_init(fake_simpler_worker):
 def test_run_inplace_returns_none(fake_simpler_worker):
     w = ChipWorker(config=RunConfig(platform="a2a3sim"))
     compiled = _fake_compiled()
-    # build_orch_args returns return_style=False — in-place call.
+    # _build_orch_args returns return_style=False — in-place call.
     result = w.run(compiled, 1, 2, 3)
     assert result is None
     w.close()
 
 
 def test_run_return_style_packs_outputs(fake_simpler_worker):
-    """When build_orch_args reports return_style, run() should pack outputs."""
+    """When _build_orch_args reports return_style, run() should pack outputs."""
     w = ChipWorker(config=RunConfig(platform="a2a3sim"))
     compiled = _fake_compiled()
     out_tensor = MagicMock(name="out_tensor")
-    compiled.build_orch_args.return_value = ("orch_args", [1, 2, out_tensor], True)
+    compiled._build_orch_args.return_value = ("orch_args", [1, 2, out_tensor], True)
     compiled.output_indices = [2]
     ret = w.run(compiled, 1, 2)
     assert ret is out_tensor

--- a/tests/ut/runtime/test_distributed_worker.py
+++ b/tests/ut/runtime/test_distributed_worker.py
@@ -33,8 +33,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import torch
+from pypto.ir import DistributedConfig
 from pypto.ir.compiled_program import _ParamInfo
-from pypto.ir.distributed_compiled_program import DistributedConfig
 from pypto.pypto_core import DataType
 from pypto.pypto_core.ir import ParamDirection
 from pypto.runtime import DeviceTensor, StackedDeviceTensor
@@ -2093,7 +2093,7 @@ class TestMultiProgram:
             DistributedWorker([prog_a, prog_b], callbacks={"typo": lambda args: None})
 
     def test_prepare_extra_compiled_forwards_program_list(self):
-        from pypto.ir.distributed_compiled_program import DistributedCompiledProgram  # noqa: PLC0415
+        from pypto.ir import DistributedCompiledProgram  # noqa: PLC0415
 
         primary = _fake_compiled([_param("a", [4])], [])
         extra = _fake_compiled([_param("b", [8])], [])
@@ -2103,7 +2103,7 @@ class TestMultiProgram:
         assert fake_worker.call_args.args[0] == [primary, extra]
 
     def test_prepare_forwards_persistent_flag(self):
-        from pypto.ir.distributed_compiled_program import DistributedCompiledProgram  # noqa: PLC0415
+        from pypto.ir import DistributedCompiledProgram  # noqa: PLC0415
 
         primary = _fake_compiled([_param("a", [4])], [])
         with patch("pypto.runtime.distributed_runner.DistributedWorker") as fake_worker:
@@ -2118,7 +2118,7 @@ class TestMultiProgram:
         call the user manual shows raised TypeError and the zero-copy path was reachable
         only through the lower-level API.
         """
-        from pypto.ir.distributed_compiled_program import DistributedCompiledProgram  # noqa: PLC0415
+        from pypto.ir import DistributedCompiledProgram  # noqa: PLC0415
 
         primary = _fake_compiled([_param("a", [4])], [])
         host = torch.zeros(4, dtype=torch.float32).share_memory_()
@@ -2127,7 +2127,7 @@ class TestMultiProgram:
         assert fake_worker.call_args.kwargs["inherited_host_tensors"] == [host]
 
     def test_prepare_forwards_startup_timeout(self):
-        from pypto.ir.distributed_compiled_program import DistributedCompiledProgram  # noqa: PLC0415
+        from pypto.ir import DistributedCompiledProgram  # noqa: PLC0415
 
         primary = _fake_compiled([_param("a", [4])], [])
         with patch("pypto.runtime.distributed_runner.DistributedWorker") as fake_worker:
@@ -3680,7 +3680,7 @@ class TestNamedInheritedHostRanges:
 
     def test_a_range_listed_through_prepare_is_named(self, patched_setup):
         """End to end through the documented entry point, not just the constructor."""
-        from pypto.ir.distributed_compiled_program import DistributedCompiledProgram  # noqa: PLC0415
+        from pypto.ir import DistributedCompiledProgram  # noqa: PLC0415
 
         host = torch.zeros(4, 4, dtype=torch.float32).share_memory_()
         rt = DistributedCompiledProgram.prepare(

--- a/tests/ut/runtime/test_run_config.py
+++ b/tests/ut/runtime/test_run_config.py
@@ -503,7 +503,7 @@ class TestMakeCallConfigRing:
     """
 
     def test_no_run_config_leaves_runtime_env_at_zero(self, monkeypatch):
-        from pypto.ir.distributed_compiled_program import DistributedConfig  # noqa: PLC0415
+        from pypto.ir import DistributedConfig  # noqa: PLC0415
 
         cfg = _make_dist_call_config_with_fake(DistributedConfig(), None, monkeypatch)
         assert cfg.aicpu_thread_num == 0
@@ -512,7 +512,7 @@ class TestMakeCallConfigRing:
         assert cfg.runtime_env.ring_dep_pool == 0
 
     def test_run_config_ring_overrides_transcribed(self, monkeypatch):
-        from pypto.ir.distributed_compiled_program import DistributedConfig  # noqa: PLC0415
+        from pypto.ir import DistributedConfig  # noqa: PLC0415
 
         run_config = RunConfig(
             platform="a2a3sim",
@@ -526,7 +526,7 @@ class TestMakeCallConfigRing:
         assert cfg.runtime_env.ring_dep_pool == 128
 
     def test_baseline_preserved_and_partial_ring_overlay(self, monkeypatch):
-        from pypto.ir.distributed_compiled_program import DistributedConfig  # noqa: PLC0415
+        from pypto.ir import DistributedConfig  # noqa: PLC0415
 
         dc = DistributedConfig(aicpu_thread_num=3)
         run_config = RunConfig(platform="a2a3sim", ring_heap=1024 * 1024)
@@ -541,7 +541,7 @@ class TestMakeCallConfigRing:
     def test_per_ring_list_overlaid_on_l3_dispatch(self, monkeypatch):
         # A per-program L3 dispatch can size each scope-depth ring independently
         # (e.g. a wider task window for prefill than decode).
-        from pypto.ir.distributed_compiled_program import DistributedConfig  # noqa: PLC0415
+        from pypto.ir import DistributedConfig  # noqa: PLC0415
 
         run_config = RunConfig(platform="a2a3sim", ring_task_window=[16, 32, 128, 256])
         cfg = _make_dist_call_config_with_fake(DistributedConfig(), run_config, monkeypatch)
@@ -562,7 +562,7 @@ class TestMakeCallConfigDfx:
     """
 
     def test_dfx_flags_transcribed_and_prefix_set(self, monkeypatch, tmp_path):
-        from pypto.ir.distributed_compiled_program import DistributedConfig  # noqa: PLC0415
+        from pypto.ir import DistributedConfig  # noqa: PLC0415
 
         dfx_base = tmp_path / "dfx_outputs"
         run_config = RunConfig(
@@ -584,7 +584,7 @@ class TestMakeCallConfigDfx:
         assert dfx_base.is_dir()
 
     def test_swimlane_sets_flag_and_co_enables_dep_gen(self, monkeypatch, tmp_path):
-        from pypto.ir.distributed_compiled_program import DistributedConfig  # noqa: PLC0415
+        from pypto.ir import DistributedConfig  # noqa: PLC0415
 
         dfx_base = tmp_path / "dfx_outputs"
         # User asks for swimlane only; dep_gen is auto-enabled because the
@@ -598,14 +598,14 @@ class TestMakeCallConfigDfx:
         assert cfg.output_prefix == str(dfx_base)
 
     def test_dfx_without_base_raises(self, monkeypatch):
-        from pypto.ir.distributed_compiled_program import DistributedConfig  # noqa: PLC0415
+        from pypto.ir import DistributedConfig  # noqa: PLC0415
 
         run_config = RunConfig(platform="a2a3sim", enable_pmu=1)
         with pytest.raises(ValueError, match="dfx_base is required"):
             _make_dist_call_config_with_fake(DistributedConfig(), run_config, monkeypatch, dfx_base=None)
 
     def test_no_run_config_leaves_dfx_off(self, monkeypatch):
-        from pypto.ir.distributed_compiled_program import DistributedConfig  # noqa: PLC0415
+        from pypto.ir import DistributedConfig  # noqa: PLC0415
 
         cfg = _make_dist_call_config_with_fake(DistributedConfig(), None, monkeypatch)
         assert cfg.output_prefix == ""
@@ -613,7 +613,7 @@ class TestMakeCallConfigDfx:
         assert cfg.enable_dep_gen is False
 
     def test_ring_only_run_config_creates_no_dfx_dir(self, monkeypatch, tmp_path):
-        from pypto.ir.distributed_compiled_program import DistributedConfig  # noqa: PLC0415
+        from pypto.ir import DistributedConfig  # noqa: PLC0415
 
         dfx_base = tmp_path / "dfx_outputs"
         run_config = RunConfig(platform="a2a3sim", ring_heap=1024 * 1024)


### PR DESCRIPTION
## Summary

Two entry-point cleanups from the plan of record in
`docs/en/dev/08-entry-points.md`. Both are about the same question — which names
on the artifact layer are meant to be typed by hand — and they answer it in
opposite directions, so they travel together.

`DistributedCompiledProgram` and `DistributedConfig` are public types that
`pypto.ir` did not export. Every caller therefore reached past the package into
`pypto.ir.distributed_compiled_program`: 91 import statements across tests,
examples and docs, spelling out a private-looking module path for two public
names.

`CompiledProgram.build_orch_args` and `build_call_config` are the mirror image.
They marshal user arguments into simpler's `TaskArgs` and `CallConfig`, and the
user manual listed them as part of the extraction surface — but the supported
route to them is `ChipWorker.run` / `register`, which calls both for you.

## Changes

- `python/pypto/ir/__init__.py`: export `DistributedCompiledProgram` and
  `DistributedConfig` alongside `CompiledProgram`. The defining module stays
  importable and keeps its four `pypto.runtime` importers, which take it
  directly to avoid an import cycle. The re-export is an alias of the same
  objects, so an `isinstance` check cannot depend on which spelling the caller
  used — there is a test for that.
- `python/pypto/ir/__init__.pyi`: the type stub shadows the runtime module for
  type checkers, so the two new names had to land there too. It had also drifted
  before this change — `CompiledProgram`, `DiagnosticPhase`, `DiagnosticCheck`
  and `DiagnosticCheckSet` were exported at runtime but absent from the stub,
  which is why `ir.CompiledProgram` did not type-check. All six are now listed.
- `python/pypto/ir/compiled_program.py`: rename both builders to
  `_build_orch_args` / `_build_call_config`, on `CompiledProgram` and on
  `_SubChipCallable`. The runner-side helper the latter delegates to is now
  imported under an alias, so the module-level function and the method it backs
  no longer share a name at the call site.
- `python/pypto/runtime/worker.py`, `python/pypto/jit/decorator.py`: follow the
  rename; the JIT `compile()` docstring stops advertising the builders.
- Tests and examples: 69 files migrate to `from pypto.ir import ...`.
  `tests/ut/ir/test_compiled_program.py` and `test_distributed_compiled_program.py`
  keep the module-path import — they also pull `_DISTRIBUTED_META_FILENAME` from
  it, and they are white-box tests of that module.
- `tests/st/runtime/framework_and_models/test_compiled_program.py`: the manual
  `simpler.Worker` helper keeps calling the builders directly, so the
  marshalling `ChipWorker.run` delegates to stays covered on its own; its
  docstring now says why it reaches for internals.
- Docs (`docs/{en,zh}/`, 12 files): drop the builders from the `CompiledProgram`
  contract table and from the JIT extraction surface, pointing at `ChipWorker`
  instead; list them under "What is internal" in the entry-points page, which
  also gains the `pypto.ir` import line and loses the paragraph saying the
  distributed types are *not* re-exported; migrate the remaining snippets.

## Migration

Nothing outside this repository imported either builder. `pypto-lib` imports
`DistributedConfig` / `DistributedCompiledProgram` from the module path, which
keeps working unchanged.

```python
# before
from pypto.ir.distributed_compiled_program import DistributedConfig
orch_args, coerced, style = compiled.build_orch_args(*args, worker=w)
cfg = compiled.build_call_config(run_config)

# after
from pypto.ir import DistributedConfig
worker.run(compiled, *args)          # marshals both for you
```

A caller driving a hand-constructed `simpler.worker.Worker` still gets
`chip_callable`, `runtime_name` and `runtime_config` from the public surface.

## Verification

Run in the worktree against its own build, at the pushed commit.

- `pytest tests/ut/ -n 16`: 10992 passed, 8 skipped, 1 xfailed
- `tests/lint/check_*.py` (12 scripts, incl. docs nav and en/zh parity): all pass
- `ruff check` / `ruff format --check` (pinned 0.14.8) on the changed Python
  files: clean
- `pyright python/pypto tests examples`: only two pre-existing
  `torch.float4_e2m1fn_x2` errors, from this machine's older torch rather than
  CI's pinned 2.8.0
- `markdownlint-cli2 v0.20.0` on the 12 changed pages: 0 errors
- Import-cycle probe: `pypto.ir`, `pypto.runtime`, and seven submodules import
  cleanly as the first import in a fresh interpreter, in either order

One unit test is deselected:
`test_unified_ops.py::TestUnifiedSlicePadValue::test_symlinked_import_path_still_names_the_caller`.
It fails identically on unmodified `main` in this environment — the editable
install's meta-path finder redirects `pypto` inside the subprocess the test
spawns — and is unrelated to this change.

Device tests were not run; this change touches no kernel or codegen output.
