### PR TITLE
refactor(runtime)!: correct which artifact-layer names are public

### DIFF
--- a/docs/en/dev/03-runtime-dfx.md
+++ b/docs/en/dev/03-runtime-dfx.md
@@ -135,7 +135,7 @@ them, matching the existing one-shot L3 replay semantics.
 The L2 subprocess rebuilds the orchestration arguments two ways: from `golden.py`
 when driven by the pytest harness (deterministic inputs → faithful graph), or
 from a recorded spec when driven by the compiled-program API
-(`execute_compiled`). The task graph can be routed by tensor *values*, not just
+(`compiled(...)`). The task graph can be routed by tensor *values*, not just
 scalars (e.g. paged-attention `block_tables` / `seq_lens`), so the spec preserves
 real data wherever it can cross the process boundary: host `torch.Tensor`s are
 saved and reloaded verbatim, scalars are preserved exactly, and only

--- a/docs/en/dev/03-runtime-replay.md
+++ b/docs/en/dev/03-runtime-replay.md
@@ -218,7 +218,7 @@ from pypto.runtime import execute_distributed_compiled
 execute_distributed_compiled("build_output/<jit_dir>/", [a, b, c])
 
 # reusable object (override the persisted platform / devices if needed):
-from pypto.ir.distributed_compiled_program import DistributedCompiledProgram, DistributedConfig
+from pypto.ir import DistributedCompiledProgram, DistributedConfig
 prog = DistributedCompiledProgram.from_dir(
     "build_output/<jit_dir>/",
     platform="a2a3",

--- a/docs/en/dev/03-runtime-replay.md
+++ b/docs/en/dev/03-runtime-replay.md
@@ -8,9 +8,10 @@ To re-run a previously compiled `build_output/<jit_dir>/` after editing
 one or more kernel cpp files — typically to verify a hand-tuned change
 under PMU / swimlane / args-dump — use the debug-only
 [`pypto.runtime.debug.replay`](../../../python/pypto/runtime/debug/replay.py)
-module. An L2 build reuses the same `execute_compiled` path as a normal
-`compiled(...)` dispatch; an L3 build is dispatched through
-`execute_distributed_compiled`. Either way DFX flags behave identically.
+module. An L2 build reuses the same dispatch path as a normal
+`compiled(...)` call; an L3 build is dispatched through a
+`DistributedCompiledProgram` rebuilt from the directory. Either way DFX
+flags behave identically.
 
 ```python
 from pypto.runtime.debug import replay
@@ -110,12 +111,12 @@ module / CLI is still usable directly against the output directory.
 
 ## Benchmarking a replayed single-chip build
 
-`execute_compiled(work_dir, ...)` is directory-driven, but `benchmark()` needs a
-live `CompiledProgram` for the orchestration param metadata — derived from the IR
-`Program`, which a directory replay does not have. So `ir.compile()` also writes a
-`compiled_meta.json` sidecar (param metadata + platform + backend) next to
-`kernel_config.py`, and `CompiledProgram.from_dir()` rebuilds a fully callable
-program from it — **no pypto recompile, no pass re-run**:
+A replay is directory-driven, but `benchmark()` needs a live `CompiledProgram`
+for the orchestration param metadata — derived from the IR `Program`, which a
+directory has none of. So `ir.compile()` also writes a `compiled_meta.json`
+sidecar (param metadata + platform + backend) next to `kernel_config.py`, and
+`CompiledProgram.from_dir()` rebuilds a fully callable program from it — **no
+pypto recompile, no pass re-run**:
 
 **`from_dir()` reloads metadata only — it does not rebuild sources.** Unlike
 `replay`, it runs neither the `.pto` → cpp splice nor the binary-cache
@@ -196,8 +197,8 @@ build_output/<jit_dir>/
 
 `replay` detects this layout automatically (no top-level `kernel_config.py`
 but `orchestration/host_orch.py` present) and dispatches via simpler
-`Worker(level=3)` instead of `execute_compiled`. The same CLI / `debug/run.py`
-flow works unchanged:
+`Worker(level=3)` instead of the single-chip path. The same CLI /
+`debug/run.py` flow works unchanged:
 
 ```bash
 python -m pypto.runtime.debug.replay build_output/<jit_dir>/
@@ -210,15 +211,15 @@ The `.pto` → cpp splice and `.so` invalidation recurse into every
 kernel cpp directly) is picked up exactly as in the single-chip case.
 
 Reconstruction works as in the single-chip case above, from
-`distributed_meta.json` alone. Two entry points expose it directly:
+`distributed_meta.json` alone, in either a one-shot or a reusable shape:
 
 ```python
-from pypto.runtime import execute_distributed_compiled
-# one-shot (distributed counterpart of execute_compiled):
-execute_distributed_compiled("build_output/<jit_dir>/", [a, b, c])
+from pypto.ir import DistributedCompiledProgram, DistributedConfig
+
+# one-shot (distributed counterpart of CompiledProgram.from_dir):
+DistributedCompiledProgram.from_dir("build_output/<jit_dir>/")(a, b, c)
 
 # reusable object (override the persisted platform / devices if needed):
-from pypto.ir import DistributedCompiledProgram, DistributedConfig
 prog = DistributedCompiledProgram.from_dir(
     "build_output/<jit_dir>/",
     platform="a2a3",

--- a/docs/en/dev/05-runtime-ring-sizing.md
+++ b/docs/en/dev/05-runtime-ring-sizing.md
@@ -4,7 +4,7 @@ PyPTO exposes Simpler's per-task ring sizing as three optional overrides on
 [`RunConfig`](../../../python/pypto/runtime/runner.py). They let you size the
 runtime's per-task ring resources for a single dispatch without touching the
 compiled artifact or any global state. This works on both the L2 single-chip
-path (`compiled(...)` / `execute_compiled()` / `ChipWorker.run()`) and the L3 distributed path
+path (`compiled(...)` / `CompiledProgram.from_dir(...)` / `ChipWorker.run()`) and the L3 distributed path
 (`DistributedWorker.run()` / the one-shot `compiled(...)`).
 
 The runtime keeps its task-launch resources in *ring buffers*. Each override
@@ -63,7 +63,7 @@ than raising an opaque `TypeError` from the power-of-two check.
 
 ## Usage
 
-### L2 single-chip (`compiled(...)` / `execute_compiled`)
+### L2 single-chip (`compiled(...)` / `ChipWorker.run`)
 
 ```python
 from pypto import ir
@@ -79,19 +79,17 @@ compiled = ir.compile(MyProgram, **config.compile_kwargs())
 compiled(a, b, c, config=config)
 ```
 
-The directory-driven entry point accepts the same per-dispatch config. Its
-existing explicit `platform`, `device_id`, DFX, and AICPU arguments keep their
-current precedence; `config` carries the ring overrides that previously had no
-route to `CallConfig.runtime_env`:
+A handle rebuilt from a build directory takes the same per-dispatch config, so
+a replay can be re-sized without recompiling:
 
 ```python
-from pypto.runtime import RunConfig, execute_compiled
+from pypto.ir import CompiledProgram
+from pypto.runtime import RunConfig
 
-execute_compiled(
-    work_dir,
-    [a, b, c],
-    platform="a2a3",
-    device_id=0,
+CompiledProgram.from_dir(work_dir, platform="a2a3")(
+    a,
+    b,
+    c,
     config=RunConfig(platform="a2a3", ring_heap=512 * 1024 * 1024),
 )
 ```
@@ -176,7 +174,7 @@ overwrites that slot. So:
   `runtime/src/common/task_interface/call_config.h`.
 - Worker-API examples: `runtime/examples/workers/{l2,l3}/per_task_runtime_env/`.
 - L3 dispatch entry points that accept the per-dispatch `RunConfig`:
-  `DistributedWorker.run` / `__call__` and `execute_distributed` in
-  [`distributed_runner.py`](../../../python/pypto/runtime/distributed_runner.py).
+  `DistributedWorker.run` and `DistributedCompiledProgram.__call__`, which
+  reaches [`distributed_runner.py`](../../../python/pypto/runtime/distributed_runner.py).
 - Orthogonal runtime diagnostics on the same `RunConfig`:
   [03-runtime-dfx.md](03-runtime-dfx.md).

--- a/docs/en/dev/08-entry-points.md
+++ b/docs/en/dev/08-entry-points.md
@@ -57,6 +57,17 @@ Python builtin `compile`, so prefer `from pypto import ir` and call
 
 Its parameters are documented in [Compiling](../user/execution/00-compile.md).
 
+Both artifact types it can return, and the config that selects the distributed
+one, are exported from `pypto.ir`:
+
+```python
+from pypto.ir import CompiledProgram, DistributedCompiledProgram, DistributedConfig
+```
+
+The defining module, `pypto.ir.distributed_compiled_program`, stays importable —
+`pypto.runtime` reaches for it directly to avoid an import cycle — but user code
+and tests should take the three names from `pypto.ir`.
+
 ## Execute
 
 | Entry | Layer | Takes | Location |
@@ -107,6 +118,8 @@ These have no stability guarantee. They are not in any `__all__`, and code
 outside PyPTO should not import them:
 
 - `pypto.ir.compile` — `_ensure_orchestration_headers`
+- `pypto.ir.compiled_program` — `CompiledProgram._build_orch_args`,
+  `CompiledProgram._build_call_config`
 - `pypto.runtime.device_runner` — `compile_and_assemble`, `compile_single_kernel`,
   `compile_single_orchestration`, `execute_on_device`
 - `pypto.runtime.kernel_compiler` — `KernelCompiler`, `compile_incore`
@@ -114,9 +127,11 @@ outside PyPTO should not import them:
   `_DfxOpts`
 - `pypto.runtime.tensor_arg`, `pypto.runtime.elf_parser`, `pypto.runtime._binary_cache`
 
-`DistributedCompiledProgram` and `DistributedConfig` are public, but are not
-re-exported from `pypto.ir`; import them from
-`pypto.ir.distributed_compiled_program`.
+The two argument builders marshal user arguments into simpler's `TaskArgs` and
+`CallConfig`. `ChipWorker.run` and `ChipWorker.register` are the supported way
+to reach that path — they call the builders for you, and a caller driving a
+hand-constructed `simpler.worker.Worker` still gets `chip_callable`,
+`runtime_name` and `runtime_config` from the public surface.
 
 ## Command-line entry points
 

--- a/docs/en/dev/08-entry-points.md
+++ b/docs/en/dev/08-entry-points.md
@@ -36,7 +36,7 @@ into loadable binaries. It is internal and has no supported entry point.
 | A `CompiledProgram` | One dispatch | `compiled(*args, config=...)` |
 | A `CompiledProgram` and device-resident data | Many dispatches | `ChipWorker.run(compiled, *args)` |
 | A `DistributedCompiledProgram` | Many dispatches | `compiled.prepare()` → `DistributedWorker.run(...)` |
-| A build directory on disk | One dispatch, no recompile | `execute_compiled(work_dir, args, ...)` |
+| A build directory on disk | One dispatch, no recompile | `CompiledProgram.from_dir(work_dir)(*args, config=...)` |
 | A `CompiledProgram` | Timed dispatches | `benchmark(compiled, args, ...)` |
 
 ## Compile
@@ -74,8 +74,9 @@ and tests should take the three names from `pypto.ir`.
 | ----- | ----- | ----- | -------- |
 | `CompiledProgram.__call__` | artifact | artifact handle | [`ir/compiled_program.py`](../../../python/pypto/ir/compiled_program.py) |
 | `Worker.run` / `ChipWorker.run` / `DistributedWorker.run` | execute | artifact + worker | [`runtime/worker.py`](../../../python/pypto/runtime/worker.py) |
-| `runtime.execute_compiled` | execute | output directory | [`runtime/runner.py`](../../../python/pypto/runtime/runner.py) |
-| `execute_distributed_compiled` | execute | output directory | [`runtime/distributed_runner.py`](../../../python/pypto/runtime/distributed_runner.py) |
+| `CompiledProgram.from_dir` / `DistributedCompiledProgram.from_dir` | artifact | output directory | [`ir/compiled_program.py`](../../../python/pypto/ir/compiled_program.py) |
+| `runtime.execute_compiled` *(deprecated)* | execute | output directory | [`runtime/runner.py`](../../../python/pypto/runtime/runner.py) |
+| `execute_distributed_compiled` *(deprecated)* | execute | output directory | [`runtime/distributed_runner.py`](../../../python/pypto/runtime/distributed_runner.py) |
 | `device_runner.execute_on_device` | assembly | assembled binaries | [`runtime/device_runner.py`](../../../python/pypto/runtime/device_runner.py) |
 | `execute_artifact_dir` / `execute_batch_manifest` | CLI | output directory | [`runtime/execute_artifact.py`](../../../python/pypto/runtime/execute_artifact.py) |
 
@@ -84,9 +85,50 @@ and `DistributedWorker.run` dispatch an artifact, both implementing
 `Worker.run`. `PassPipeline.run` is unrelated — it transforms a `Program` — as
 is `PassManager.run_passes`.
 
-`execute_compiled` and `execute_distributed_compiled` are the L2 and L3
-directory-driven paths. They skip the PyPTO compile entirely, which is what
-makes [replay](03-runtime-replay.md) possible.
+Dispatching a directory rather than a live handle is what makes
+[replay](03-runtime-replay.md) possible: the PyPTO compile is skipped
+entirely. `from_dir` is how you get there — it rebuilds the artifact handle
+from the persisted sidecar, and calling that handle takes the same path as a
+handle that never left memory.
+
+`execute_compiled` and `execute_distributed_compiled` were the L2 and L3
+spellings of that, and are **deprecated**. Each still forwards to the same
+implementation, and each emits a `DeprecationWarning`.
+
+The L3 one is a plain rename — it already was `from_dir` plus a call:
+
+```python
+# before
+execute_distributed_compiled(work_dir, args, config=cfg, platform="a2a3")
+
+# after
+ir.DistributedCompiledProgram.from_dir(work_dir, platform="a2a3")(*args, config=cfg)
+```
+
+**The L2 one is not**, because the two paths disagree on precedence:
+
+| Setting | `execute_compiled` | `CompiledProgram.__call__` |
+| ------- | ------------------ | -------------------------- |
+| `platform` | the explicit argument | `config.platform` when a config is passed, else the artifact's |
+| `device_id` / `dfx` / `aicpu_thread_num` | the explicit arguments | always from `config` |
+| ring overrides | from `config` | from `config` |
+
+So a `config` passed for ring sizing alone silently takes over the rest, and
+`RunConfig.platform` defaults to `a2a3sim` — dropping the explicit arguments
+would move the run to the simulator. Fold them into the config:
+
+```python
+# before -- explicit args win; cfg was read for ring sizing only
+execute_compiled(work_dir, args, platform="a2a3", device_id=0, config=cfg)
+
+# after -- cfg carries every execution setting
+cfg = dataclasses.replace(cfg, platform="a2a3", device_id=0)
+ir.CompiledProgram.from_dir(work_dir)(*args, config=cfg)
+```
+
+`dfx` and `aicpu_thread_num` need no translation: the DFX toggles and
+`aicpu_thread_num` are already `RunConfig` fields. `from_dir(platform=...)`
+still decides the platform for a call made *without* a config.
 
 ## Driving both phases from one config
 
@@ -118,6 +160,8 @@ These have no stability guarantee. They are not in any `__all__`, and code
 outside PyPTO should not import them:
 
 - `pypto.ir.compile` — `_ensure_orchestration_headers`
+- `pypto.runtime.runner` — `_execute_compiled`
+- `pypto.runtime.distributed_runner` — `_execute_distributed`
 - `pypto.ir.compiled_program` — `CompiledProgram._build_orch_args`,
   `CompiledProgram._build_call_config`
 - `pypto.runtime.device_runner` — `compile_and_assemble`, `compile_single_kernel`,

--- a/docs/en/dev/codegen/00-pto_codegen.md
+++ b/docs/en/dev/codegen/00-pto_codegen.md
@@ -826,7 +826,7 @@ The orchestration codegen generates identical orchestration C++ code using the s
 
 ### Runtime configuration (`kernel_config.py`)
 
-`kernel_config.py` exposes a `RUNTIME_CONFIG` dict that callers (e.g. `execute_compiled`) read to dispatch the program. Stable keys:
+`kernel_config.py` exposes a `RUNTIME_CONFIG` dict that the dispatch path reads to launch the program. Stable keys:
 
 | Key | When emitted | Notes |
 | --- | ------------ | ----- |

--- a/docs/en/user/distributed/00-model.md
+++ b/docs/en/user/distributed/00-model.md
@@ -100,8 +100,8 @@ Save the functions above and the driver below into the same file (`script.py`):
 
 ```python
 import torch
+from pypto.ir import DistributedConfig
 from pypto.runtime import RunConfig
-from pypto.ir.distributed_compiled_program import DistributedConfig
 
 dc = DistributedConfig(device_ids=[0, 1])
 cfg = RunConfig(platform="a2a3", distributed_config=dc)

--- a/docs/en/user/distributed/03-execution.md
+++ b/docs/en/user/distributed/03-execution.md
@@ -217,7 +217,7 @@ does not stop the child from writing it.
 
 ```python
 import torch
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 from pypto.runtime import RunConfig
 
 dc = DistributedConfig(device_ids=[0, 1, 2, 3])

--- a/docs/en/user/execution/00-compile.md
+++ b/docs/en/user/execution/00-compile.md
@@ -108,9 +108,10 @@ want when the question is "which pass changed this".
 cache holds — so a later call with the same specialization key gets the identical object.
 
 It exposes the whole extraction surface, which is what a harness driving the runtime
-directly needs: `chip_callable`, `runtime_name`, `runtime_config`, `build_orch_args`,
-`build_call_config`, `output_dir`, `platform`, `output_indices`, `param_names`,
-`orchestration_names`, `has_return`.
+directly needs: `chip_callable`, `runtime_name`, `runtime_config`, `output_dir`,
+`platform`, `output_indices`, `param_names`, `orchestration_names`, `has_return`.
+Argument marshalling is not part of that surface — dispatch through
+[`ChipWorker`](01-run.md#explicit-dispatch), which does it for you.
 
 `lower(*args)` goes one step less far: it runs the passes and returns the `Program`,
 writing no artifacts — which also means no `passes_dump/`. It is the right form for

--- a/docs/en/user/execution/01-run.md
+++ b/docs/en/user/execution/01-run.md
@@ -74,7 +74,6 @@ both H2D and D2H for that argument.
 | `param_names` / `output_indices` / `has_return` | The call shape, for a harness binding arguments itself |
 | `program` | The `Program` that was handed to `compile` — usually pre-pass, and `None` after `from_dir` |
 | `chip_callable` / `runtime_name` / `runtime_config` | The runtime-side handles |
-| `build_orch_args` / `build_call_config` | The two builders explicit dispatch needs |
 | `validate_ir` | Per-pass semantic comparison ([Precision](../precision/00-workflow.md)) |
 | `from_dir` / `load` | Rebuild a handle from a saved artifact directory |
 

--- a/docs/zh/dev/03-runtime-dfx.md
+++ b/docs/zh/dev/03-runtime-dfx.md
@@ -113,7 +113,7 @@ resident handle 和已 fork 的层级，但进入两个独立的 `Worker.run()` 
 执行程序，且不会在中间恢复可写参数，这与现有 one-shot L3 replay 语义一致。
 
 L2 子进程用两种方式重建编排实参：被 pytest harness 驱动时从 `golden.py` 重新生成
-（确定性输入 → 图忠实），被编译产物 API（`execute_compiled`）驱动时从记录下来的
+（确定性输入 → 图忠实），被编译产物 API（`compiled(...)`）驱动时从记录下来的
 规格重建。任务图可能由张量**值**（而不只是 scalar）路由，例如 paged-attention 的
 `block_tables` / `seq_lens`，所以规格会尽量保留真实数据：host `torch.Tensor`
 原样存盘再加载、scalar 原样保留，只有驻留在设备上、子进程无法访问的 `DeviceTensor`

--- a/docs/zh/dev/03-runtime-replay.md
+++ b/docs/zh/dev/03-runtime-replay.md
@@ -7,8 +7,8 @@
 需要在改完 kernel cpp 之后重新跑一遍编译产物（典型场景：手调 kernel
 后用 PMU / swimlane / args-dump 验证修改是否正确），使用 debug 专用
 的 [`pypto.runtime.debug.replay`](../../../python/pypto/runtime/debug/replay.py)
-模块。L2 构建复用与普通 `compiled(...)` 派发相同的 `execute_compiled` 路径,
-L3 构建则经由 `execute_distributed_compiled` 派发。两者的 DFX 开关行为完全一致。
+模块。L2 构建复用与普通 `compiled(...)` 派发相同的路径，L3 构建则经由从目录重建的
+`DistributedCompiledProgram` 派发。两者的 DFX 开关行为完全一致。
 
 ```python
 from pypto.runtime.debug import replay
@@ -101,9 +101,8 @@ python build_output/<jit_dir>/debug/run.py
 
 ## 对重放的单芯片构建做 benchmark
 
-`execute_compiled(work_dir, ...)` 是目录驱动的，但 `benchmark()` 需要一个活的
-`CompiledProgram` 来拿 orchestration 参数元数据——这份元数据由 IR `Program`
-派生，而目录重放没有 IR。所以 `ir.compile()` 会在 `kernel_config.py` 旁边额外
+重放是目录驱动的，但 `benchmark()` 需要一个活的 `CompiledProgram` 来拿
+orchestration 参数元数据——这份元数据由 IR `Program` 派生，而目录里没有 IR。所以 `ir.compile()` 会在 `kernel_config.py` 旁边额外
 写一个 `compiled_meta.json`（参数元数据 + platform + backend），
 `CompiledProgram.from_dir()` 只凭它就能重建出完全可调用的程序——
 **不重新编译 pypto、不重跑 pass**：
@@ -179,7 +178,7 @@ build_output/<jit_dir>/
 
 `replay` 会自动识别这种布局（无顶层 `kernel_config.py` 但存在
 `orchestration/host_orch.py`），并改用 simpler `Worker(level=3)` 派发，
-而不是 `execute_compiled`。同样的 CLI / `debug/run.py` 流程无需改动：
+而不是单芯片路径。同样的 CLI / `debug/run.py` 流程无需改动：
 
 ```bash
 python -m pypto.runtime.debug.replay build_output/<jit_dir>/
@@ -192,15 +191,15 @@ python build_output/<jit_dir>/debug/run.py
 被识别，行为与单芯片完全一致。
 
 重建方式与上面单芯片一节相同，只凭 `distributed_meta.json`。
-两个入口直接暴露这个能力：
+既可以一次性调用，也可以留作可复用对象：
 
 ```python
-from pypto.runtime import execute_distributed_compiled
-# 一次性（对标单芯片的 execute_compiled）：
-execute_distributed_compiled("build_output/<jit_dir>/", [a, b, c])
+from pypto.ir import DistributedCompiledProgram, DistributedConfig
+
+# 一次性（对标单芯片的 CompiledProgram.from_dir）：
+DistributedCompiledProgram.from_dir("build_output/<jit_dir>/")(a, b, c)
 
 # 可复用对象（需要时覆盖持久化的 platform / 设备）：
-from pypto.ir import DistributedCompiledProgram, DistributedConfig
 prog = DistributedCompiledProgram.from_dir(
     "build_output/<jit_dir>/",
     platform="a2a3",

--- a/docs/zh/dev/03-runtime-replay.md
+++ b/docs/zh/dev/03-runtime-replay.md
@@ -200,7 +200,7 @@ from pypto.runtime import execute_distributed_compiled
 execute_distributed_compiled("build_output/<jit_dir>/", [a, b, c])
 
 # 可复用对象（需要时覆盖持久化的 platform / 设备）：
-from pypto.ir.distributed_compiled_program import DistributedCompiledProgram, DistributedConfig
+from pypto.ir import DistributedCompiledProgram, DistributedConfig
 prog = DistributedCompiledProgram.from_dir(
     "build_output/<jit_dir>/",
     platform="a2a3",

--- a/docs/zh/dev/05-runtime-ring-sizing.md
+++ b/docs/zh/dev/05-runtime-ring-sizing.md
@@ -3,7 +3,7 @@
 PyPTO 通过 [`RunConfig`](../../../python/pypto/runtime/runner.py) 上的三个可选
 覆盖项暴露 Simpler 的单任务 ring 尺寸配置。它们让你在单次派发中为运行时的
 单任务 ring 资源设置尺寸，而无需改动已编译产物或任何全局状态。该能力同时适用于
-L2 单 chip 路径（`compiled(...)` / `execute_compiled()` / `ChipWorker.run()`）和 L3 分布式路径
+L2 单 chip 路径（`compiled(...)` / `CompiledProgram.from_dir(...)` / `ChipWorker.run()`）和 L3 分布式路径
 （`DistributedWorker.run()` / 一次性的 `compiled(...)`）。
 
 运行时把任务启动相关资源保存在 *ring buffer*（环形缓冲）中。每个覆盖项与
@@ -58,7 +58,7 @@ RunConfig(platform="a2a3", ring_heap=1000)
 
 ## 用法
 
-### L2 单 chip（`compiled(...)` / `execute_compiled`）
+### L2 单 chip（`compiled(...)` / `ChipWorker.run`）
 
 ```python
 from pypto import ir
@@ -74,18 +74,16 @@ compiled = ir.compile(MyProgram, **config.compile_kwargs())
 compiled(a, b, c, config=config)
 ```
 
-目录驱动的入口同样接受单次派发配置。它原有的显式 `platform`、`device_id`、DFX 和
-AICPU 参数保持现有优先级；`config` 用来携带此前无法到达
-`CallConfig.runtime_env` 的 ring 覆盖项：
+从构建目录重建出的句柄同样接受单次派发配置，因此重放时无需重新编译即可改尺寸：
 
 ```python
-from pypto.runtime import RunConfig, execute_compiled
+from pypto.ir import CompiledProgram
+from pypto.runtime import RunConfig
 
-execute_compiled(
-    work_dir,
-    [a, b, c],
-    platform="a2a3",
-    device_id=0,
+CompiledProgram.from_dir(work_dir, platform="a2a3")(
+    a,
+    b,
+    c,
     config=RunConfig(platform="a2a3", ring_heap=512 * 1024 * 1024),
 )
 ```
@@ -157,6 +155,7 @@ list 形式，如 `ring_task_window=[256, 128, 64, 0]`——是**一个** key、
 - Worker API 示例：`runtime/examples/workers/{l2,l3}/per_task_runtime_env/`。
 - 接受单次派发 `RunConfig` 的 L3 派发入口：
   [`distributed_runner.py`](../../../python/pypto/runtime/distributed_runner.py)
-  中的 `DistributedWorker.run` / `__call__` 以及 `execute_distributed`。
+  中的 `DistributedWorker.run`，以及会抵达该模块的
+  `DistributedCompiledProgram.__call__`。
 - 同一 `RunConfig` 上正交的运行时诊断特性：
   [03-runtime-dfx.md](03-runtime-dfx.md)。

--- a/docs/zh/dev/08-entry-points.md
+++ b/docs/zh/dev/08-entry-points.md
@@ -53,6 +53,15 @@ PyPTO 的编译与执行入口比它拥有的概念要多，而且好几个名�
 
 它的参数在[编译](../user/execution/00-compile.md)中有说明。
 
+它可能返回的两种产物类型，以及选定分布式那一种的配置，都从 `pypto.ir` 导出：
+
+```python
+from pypto.ir import CompiledProgram, DistributedCompiledProgram, DistributedConfig
+```
+
+定义它们的模块 `pypto.ir.distributed_compiled_program` 仍然可以导入 —— `pypto.runtime`
+直接从那里取，以避开导入环 —— 但用户代码与测试应当从 `pypto.ir` 取这三个名字。
+
 ## 执行
 
 | 入口 | 层 | 接受什么 | 位置 |
@@ -99,6 +108,8 @@ compiled(*tensors, config=config)
 以下没有稳定性保证。它们不在任何 `__all__` 中，PyPTO 之外的代码不应导入：
 
 - `pypto.ir.compile` —— `_ensure_orchestration_headers`
+- `pypto.ir.compiled_program` —— `CompiledProgram._build_orch_args`、
+  `CompiledProgram._build_call_config`
 - `pypto.runtime.device_runner` —— `compile_and_assemble`、`compile_single_kernel`、
   `compile_single_orchestration`、`execute_on_device`
 - `pypto.runtime.kernel_compiler` —— `KernelCompiler`、`compile_incore`
@@ -106,8 +117,10 @@ compiled(*tensors, config=config)
   `_DfxOpts`
 - `pypto.runtime.tensor_arg`、`pypto.runtime.elf_parser`、`pypto.runtime._binary_cache`
 
-`DistributedCompiledProgram` 与 `DistributedConfig` 是公开的，但没有从 `pypto.ir`
-重新导出；请从 `pypto.ir.distributed_compiled_program` 导入。
+这两个实参构造器把用户实参编排成 simpler 的 `TaskArgs` 与 `CallConfig`。
+`ChipWorker.run` 与 `ChipWorker.register` 是抵达这条路径的受支持方式 —— 它们会替你调用
+构造器；而自行构造 `simpler.worker.Worker` 的调用方，仍可从公开面拿到 `chip_callable`、
+`runtime_name` 与 `runtime_config`。
 
 ## 命令行入口
 

--- a/docs/zh/dev/08-entry-points.md
+++ b/docs/zh/dev/08-entry-points.md
@@ -33,7 +33,7 @@ PyPTO 的编译与执行入口比它拥有的概念要多，而且好几个名�
 | 一个 `CompiledProgram` | 派发一次 | `compiled(*args, config=...)` |
 | 一个 `CompiledProgram` 和常驻设备的数据 | 派发多次 | `ChipWorker.run(compiled, *args)` |
 | 一个 `DistributedCompiledProgram` | 派发多次 | `compiled.prepare()` → `DistributedWorker.run(...)` |
-| 磁盘上的一个构建目录 | 派发一次，不重新编译 | `execute_compiled(work_dir, args, ...)` |
+| 磁盘上的一个构建目录 | 派发一次，不重新编译 | `CompiledProgram.from_dir(work_dir)(*args, config=...)` |
 | 一个 `CompiledProgram` | 计时派发 | `benchmark(compiled, args, ...)` |
 
 ## 编译
@@ -68,8 +68,9 @@ from pypto.ir import CompiledProgram, DistributedCompiledProgram, DistributedCon
 | ---- | -- | -------- | ---- |
 | `CompiledProgram.__call__` | 产物 | 产物句柄 | [`ir/compiled_program.py`](../../../python/pypto/ir/compiled_program.py) |
 | `Worker.run` / `ChipWorker.run` / `DistributedWorker.run` | 执行 | 产物 + worker | [`runtime/worker.py`](../../../python/pypto/runtime/worker.py) |
-| `runtime.execute_compiled` | 执行 | 产物目录 | [`runtime/runner.py`](../../../python/pypto/runtime/runner.py) |
-| `execute_distributed_compiled` | 执行 | 产物目录 | [`runtime/distributed_runner.py`](../../../python/pypto/runtime/distributed_runner.py) |
+| `CompiledProgram.from_dir` / `DistributedCompiledProgram.from_dir` | 产物 | 产物目录 | [`ir/compiled_program.py`](../../../python/pypto/ir/compiled_program.py) |
+| `runtime.execute_compiled`（已弃用） | 执行 | 产物目录 | [`runtime/runner.py`](../../../python/pypto/runtime/runner.py) |
+| `execute_distributed_compiled`（已弃用） | 执行 | 产物目录 | [`runtime/distributed_runner.py`](../../../python/pypto/runtime/distributed_runner.py) |
 | `device_runner.execute_on_device` | 装配 | 已装配的二进制 | [`runtime/device_runner.py`](../../../python/pypto/runtime/device_runner.py) |
 | `execute_artifact_dir` / `execute_batch_manifest` | CLI | 产物目录 | [`runtime/execute_artifact.py`](../../../python/pypto/runtime/execute_artifact.py) |
 
@@ -77,9 +78,47 @@ from pypto.ir import CompiledProgram, DistributedCompiledProgram, DistributedCon
 `DistributedWorker.run` 派发产物，二者都实现 `Worker.run`。`PassPipeline.run`
 与此无关——它变换一个 `Program`——`PassManager.run_passes` 同理。
 
-`execute_compiled` 与 `execute_distributed_compiled` 分别是 L2 与 L3 的
-"目录驱动"路径。它们完全跳过 PyPTO 编译，[replay](03-runtime-replay.md)
-正是靠这一点成立的。
+派发一个目录而不是一个活的句柄，正是 [replay](03-runtime-replay.md) 成立的前提：
+PyPTO 编译被完全跳过。`from_dir` 就是抵达那里的方式 —— 它从持久化的 sidecar 重建
+产物句柄，而调用这个句柄走的路径，与一个从未离开内存的句柄完全相同。
+
+`execute_compiled` 与 `execute_distributed_compiled` 曾是它在 L2 与 L3 的写法，
+现已**弃用**。两者仍转发到同一份实现，并各自发出 `DeprecationWarning`。
+
+L3 那个是纯粹改名 —— 它本来就是 `from_dir` 加一次调用：
+
+```python
+# before
+execute_distributed_compiled(work_dir, args, config=cfg, platform="a2a3")
+
+# after
+ir.DistributedCompiledProgram.from_dir(work_dir, platform="a2a3")(*args, config=cfg)
+```
+
+**L2 那个不是**，因为两条路径的优先级规则不同：
+
+| 设置项 | `execute_compiled` | `CompiledProgram.__call__` |
+| ------ | ------------------ | -------------------------- |
+| `platform` | 显式传入的参数 | 传了 config 就取 `config.platform`，否则取产物自带的 |
+| `device_id` / `dfx` / `aicpu_thread_num` | 显式传入的参数 | 一律取自 `config` |
+| ring 覆写项 | 取自 `config` | 取自 `config` |
+
+也就是说，仅为 ring 尺寸而传的 `config` 会顺带接管其余各项；而
+`RunConfig.platform` 默认为 `a2a3sim`，直接丢掉那些显式参数会把这次运行悄悄挪到
+仿真器上。正确做法是把它们并入 config：
+
+```python
+# before —— 显式参数优先，cfg 只被用来读 ring 尺寸
+execute_compiled(work_dir, args, platform="a2a3", device_id=0, config=cfg)
+
+# after —— 由 cfg 承载全部执行期设置
+cfg = dataclasses.replace(cfg, platform="a2a3", device_id=0)
+ir.CompiledProgram.from_dir(work_dir)(*args, config=cfg)
+```
+
+`dfx` 与 `aicpu_thread_num` 不需要翻译：各个 DFX 开关与 `aicpu_thread_num`
+本来就是 `RunConfig` 的字段。而 `from_dir(platform=...)` 仍决定**不带 config**
+那次调用的 platform。
 
 ## 用同一个 config 驱动两个阶段
 
@@ -108,6 +147,8 @@ compiled(*tensors, config=config)
 以下没有稳定性保证。它们不在任何 `__all__` 中，PyPTO 之外的代码不应导入：
 
 - `pypto.ir.compile` —— `_ensure_orchestration_headers`
+- `pypto.runtime.runner` —— `_execute_compiled`
+- `pypto.runtime.distributed_runner` —— `_execute_distributed`
 - `pypto.ir.compiled_program` —— `CompiledProgram._build_orch_args`、
   `CompiledProgram._build_call_config`
 - `pypto.runtime.device_runner` —— `compile_and_assemble`、`compile_single_kernel`、

--- a/docs/zh/dev/codegen/00-pto_codegen.md
+++ b/docs/zh/dev/codegen/00-pto_codegen.md
@@ -785,7 +785,7 @@ output_dir/
 
 ### 运行时配置 (`kernel_config.py`)
 
-`kernel_config.py` 暴露一个 `RUNTIME_CONFIG` 字典，调用方 (如 `execute_compiled`) 据此派发程序。固定键：
+`kernel_config.py` 暴露一个 `RUNTIME_CONFIG` 字典，派发路径据此启动程序。固定键：
 
 | 键 | 何时写入 | 备注 |
 | -- | -------- | ---- |

--- a/docs/zh/user/distributed/00-model.md
+++ b/docs/zh/user/distributed/00-model.md
@@ -96,8 +96,8 @@ def orchestrator(
 
 ```python
 import torch
+from pypto.ir import DistributedConfig
 from pypto.runtime import RunConfig
-from pypto.ir.distributed_compiled_program import DistributedConfig
 
 dc = DistributedConfig(device_ids=[0, 1])
 cfg = RunConfig(platform="a2a3", distributed_config=dc)

--- a/docs/zh/user/distributed/03-execution.md
+++ b/docs/zh/user/distributed/03-execution.md
@@ -193,7 +193,7 @@ with compiled.prepare(
 
 ```python
 import torch
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 from pypto.runtime import RunConfig
 
 dc = DistributedConfig(device_ids=[0, 1, 2, 3])

--- a/docs/zh/user/execution/00-compile.md
+++ b/docs/zh/user/execution/00-compile.md
@@ -94,7 +94,7 @@ assert compiled.param_names == ["a", "b", "out"]
 
 `@pl.jit` 平时把特化 + 编译 + 派发融成一次 `kernel(*args)` 调用。`compile(*sample_args)` 在编译后停下，返回 JIT 缓存持有的那个 `CompiledProgram` —— 所以之后用同一个特化键调用会拿到同一个对象。
 
-它暴露了完整的提取面，这正是直接驱动运行时的 harness 所需要的：`chip_callable`、`runtime_name`、`runtime_config`、`build_orch_args`、`build_call_config`、`output_dir`、`platform`、`output_indices`、`param_names`、`orchestration_names`、`has_return`。
+它暴露了完整的提取面，这正是直接驱动运行时的 harness 所需要的：`chip_callable`、`runtime_name`、`runtime_config`、`output_dir`、`platform`、`output_indices`、`param_names`、`orchestration_names`、`has_return`。实参编排不属于这个面 —— 交给 [`ChipWorker`](01-run.md#显式派发) 派发，它会替你完成。
 
 `lower(*args)` 比它早停一站：只跑 pass 并返回 `Program`，不写任何产物 —— 也就意味着没有 `passes_dump/`。它适合 [torch codegen](../tools/01-torch-codegen.md)，那里要的就是 IR 本身；而[内存图](../tools/02-memory-map.md)读的是磁盘上的 dump，因此需要 `compile()`。
 

--- a/docs/zh/user/execution/01-run.md
+++ b/docs/zh/user/execution/01-run.md
@@ -66,7 +66,6 @@ with ChipWorker(config=cfg) as w:
 | `param_names` / `output_indices` / `has_return` | 调用形状，供自行绑定实参的 harness 使用 |
 | `program` | 交给 `compile` 的那份 `Program` —— 通常是未经 pass 的，且经 `from_dir` 重建后为 `None` |
 | `chip_callable` / `runtime_name` / `runtime_config` | 运行时侧的句柄 |
-| `build_orch_args` / `build_call_config` | 显式派发需要的两个构造器 |
 | `validate_ir` | 逐 pass 的语义对比（[精度](../precision/00-workflow.md)） |
 | `from_dir` / `load` | 从已保存的产物目录重建句柄 |
 

--- a/examples/distributed/01_hello_rank.py
+++ b/examples/distributed/01_hello_rank.py
@@ -35,7 +35,7 @@ import argparse
 import pypto.language as pl
 import pypto.language.distributed as pld
 import torch
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 from pypto.runtime import RunConfig
 
 N_RANKS = 2

--- a/examples/distributed/02_programming_model.py
+++ b/examples/distributed/02_programming_model.py
@@ -29,7 +29,7 @@ import argparse
 import pypto.language as pl
 import pypto.language.distributed as pld
 import torch
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 from pypto.runtime import RunConfig
 
 N_RANKS = 2

--- a/examples/distributed/03_window_buffer.py
+++ b/examples/distributed/03_window_buffer.py
@@ -29,7 +29,7 @@ import argparse
 import pypto.language as pl
 import pypto.language.distributed as pld
 import torch
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 from pypto.runtime import RunConfig
 
 N_RANKS = 2

--- a/examples/distributed/04_barrier.py
+++ b/examples/distributed/04_barrier.py
@@ -49,7 +49,7 @@ import argparse
 import pypto.language as pl
 import pypto.language.distributed as pld
 import torch
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 from pypto.runtime import RunConfig
 
 N_RANKS = 2

--- a/examples/distributed/05_remote_load_store.py
+++ b/examples/distributed/05_remote_load_store.py
@@ -32,7 +32,7 @@ import argparse
 import pypto.language as pl
 import pypto.language.distributed as pld
 import torch
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 from pypto.runtime import RunConfig
 
 N_RANKS = 2

--- a/examples/distributed/06_put_get.py
+++ b/examples/distributed/06_put_get.py
@@ -31,7 +31,7 @@ import argparse
 import pypto.language as pl
 import pypto.language.distributed as pld
 import torch
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 from pypto.runtime import RunConfig
 
 N_RANKS = 2

--- a/examples/distributed/07_dynamic_rank_count.py
+++ b/examples/distributed/07_dynamic_rank_count.py
@@ -37,7 +37,7 @@ import argparse
 import pypto.language as pl
 import pypto.language.distributed as pld
 import torch
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 from pypto.runtime import RunConfig
 
 SIZE = 64

--- a/examples/distributed/08_allreduce_mesh.py
+++ b/examples/distributed/08_allreduce_mesh.py
@@ -50,7 +50,7 @@ import pypto.language as pl
 import pypto.language.distributed as pld
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 64
 NR = pl.dynamic("NR")

--- a/examples/distributed/09_allreduce_two_phase.py
+++ b/examples/distributed/09_allreduce_two_phase.py
@@ -36,7 +36,7 @@ import pypto.language as pl
 import pypto.language.distributed as pld
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 64
 

--- a/examples/distributed/10_allreduce_ring.py
+++ b/examples/distributed/10_allreduce_ring.py
@@ -37,7 +37,7 @@ import pypto.language as pl
 import pypto.language.distributed as pld
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 64
 

--- a/examples/distributed/11_allreduce_reveal.py
+++ b/examples/distributed/11_allreduce_reveal.py
@@ -38,7 +38,7 @@ import pypto.language as pl
 import pypto.language.distributed as pld
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 64
 

--- a/examples/distributed/12_broadcast.py
+++ b/examples/distributed/12_broadcast.py
@@ -37,7 +37,7 @@ import pypto.language as pl
 import pypto.language.distributed as pld
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 64
 ROOT_RANK = 0

--- a/examples/distributed/13_allgather.py
+++ b/examples/distributed/13_allgather.py
@@ -38,7 +38,7 @@ import pypto.language as pl
 import pypto.language.distributed as pld
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 64
 

--- a/examples/distributed/14_reduce_scatter.py
+++ b/examples/distributed/14_reduce_scatter.py
@@ -43,7 +43,7 @@ import pypto.language as pl
 import pypto.language.distributed as pld
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 64
 

--- a/examples/distributed/15_all_to_all.py
+++ b/examples/distributed/15_all_to_all.py
@@ -41,7 +41,7 @@ import pypto.language as pl
 import pypto.language.distributed as pld
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 64
 

--- a/examples/distributed/16_putting_it_together.py
+++ b/examples/distributed/16_putting_it_together.py
@@ -40,7 +40,7 @@ import pypto.language as pl
 import pypto.language.distributed as pld
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 64
 ROOT_RANK = 0

--- a/examples/runtime/distributed_callback.py
+++ b/examples/runtime/distributed_callback.py
@@ -40,7 +40,7 @@ Run:  python examples/runtime/distributed_callback.py
 import pypto.language as pl
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 PLATFORM = "a2a3sim"  # swap for "a2a3" to target a real device
 

--- a/examples/runtime/multi_program_kv_cache.py
+++ b/examples/runtime/multi_program_kv_cache.py
@@ -45,7 +45,7 @@ from __future__ import annotations
 
 import pypto.language as pl
 import torch
-from pypto.ir.distributed_compiled_program import DistributedCompiledProgram, DistributedConfig
+from pypto.ir import DistributedCompiledProgram, DistributedConfig
 from pypto.runtime import DistributedWorker, RunConfig
 
 TILE = 128

--- a/python/pypto/ir/__init__.py
+++ b/python/pypto/ir/__init__.py
@@ -46,6 +46,7 @@ from .builder import IRBuilder
 from .compile import compile
 from .compiled_program import CompiledProgram
 from .directions import make_call
+from .distributed_compiled_program import DistributedCompiledProgram, DistributedConfig
 
 # Import roundtrip instrument factory
 from .instruments import make_roundtrip_instrument
@@ -104,6 +105,8 @@ __all__ = [
     "python_print",
     "compile",
     "CompiledProgram",
+    "DistributedCompiledProgram",
+    "DistributedConfig",
     "PassManager",
     "OptimizationStrategy",
     "PassDumpLevel",

--- a/python/pypto/ir/__init__.pyi
+++ b/python/pypto/ir/__init__.pyi
@@ -28,13 +28,22 @@ from pypto.pypto_core.ir import (
     TileType,
     TileView,
 )
-from pypto.pypto_core.passes import PassContext, VerificationLevel, VerificationMode
+from pypto.pypto_core.passes import (
+    DiagnosticCheck,
+    DiagnosticCheckSet,
+    DiagnosticPhase,
+    PassContext,
+    VerificationLevel,
+    VerificationMode,
+)
 
 from . import directions as directions
 from . import op as op
 from .builder import IRBuilder
 from .compile import compile
+from .compiled_program import CompiledProgram
 from .directions import make_call
+from .distributed_compiled_program import DistributedCompiledProgram, DistributedConfig
 from .instruments import make_roundtrip_instrument
 from .op_conversion import ConversionContext, op_conversion, register_op_conversion
 from .pass_manager import OptimizationStrategy, PassDumpLevel, PassManager
@@ -82,12 +91,18 @@ __all__ = [
     "TileView",
     "python_print",
     "compile",
+    "CompiledProgram",
+    "DistributedCompiledProgram",
+    "DistributedConfig",
     "PassManager",
     "OptimizationStrategy",
     "PassDumpLevel",
     "VerificationMode",
     "VerificationLevel",
     "PassContext",
+    "DiagnosticPhase",
+    "DiagnosticCheck",
+    "DiagnosticCheckSet",
     "ConversionContext",
     "op_conversion",
     "register_op_conversion",

--- a/python/pypto/ir/compiled_program.py
+++ b/python/pypto/ir/compiled_program.py
@@ -1191,9 +1191,9 @@ class CompiledProgram(_RuntimeFacade):
                 f"compiled[<name>] instead."
             )
 
-    # --- Argument builders (for users driving a simpler.Worker directly) -----
+    # --- Argument builders (internal; used by the runtime workers) ----------
 
-    def build_orch_args(
+    def _build_orch_args(
         self,
         *args: "CallArg",
         worker: Any | None = None,
@@ -1214,12 +1214,12 @@ class CompiledProgram(_RuntimeFacade):
 
         Raises:
             TypeError: Arg count / type mismatch, or called on a multi-orch
-                program (use ``compiled[<name>].build_orch_args(...)`` instead).
+                program (use ``compiled[<name>]._build_orch_args(...)`` instead).
         """
         if self._sub_chip_dirs:
             raise TypeError(
                 f"Multi-orch program has {len(self._sub_chip_dirs)} orchestrations "
-                f"{sorted(self._sub_chip_dirs)}; use compiled[<name>].build_orch_args(...)."
+                f"{sorted(self._sub_chip_dirs)}; use compiled[<name>]._build_orch_args(...)."
             )
         param_infos, output_indices, return_types = self._get_metadata()
         coerced, return_style = _coerce_args(
@@ -1227,14 +1227,14 @@ class CompiledProgram(_RuntimeFacade):
         )
         if worker is None:
             raise TypeError(
-                "build_orch_args requires the simpler Worker that will own and dispatch these TaskArgs"
+                "_build_orch_args requires the simpler Worker that will own and dispatch these TaskArgs"
             )
         from pypto.runtime.runner import _coerced_to_orch_args  # noqa: PLC0415
 
         orch_args = _coerced_to_orch_args(coerced, worker)
         return orch_args, coerced, return_style
 
-    def build_call_config(
+    def _build_call_config(
         self,
         config: Any = None,
         *,
@@ -1255,12 +1255,13 @@ class CompiledProgram(_RuntimeFacade):
         if self._sub_chip_dirs:
             raise TypeError(
                 f"Multi-orch program has {len(self._sub_chip_dirs)} orchestrations "
-                f"{sorted(self._sub_chip_dirs)}; use compiled[<name>].build_call_config(...)."
+                f"{sorted(self._sub_chip_dirs)}; use compiled[<name>]._build_call_config(...)."
             )
-        from pypto.runtime.runner import RunConfig, _build_call_config  # noqa: PLC0415
+        from pypto.runtime.runner import RunConfig  # noqa: PLC0415
+        from pypto.runtime.runner import _build_call_config as _runner_build_call_config  # noqa: PLC0415
 
         run_config = config if config is not None else RunConfig()
-        return _build_call_config(
+        return _runner_build_call_config(
             run_config,
             runtime_config=self.runtime_config,
             aicpu_thread_num_override=aicpu_thread_num,
@@ -1456,7 +1457,7 @@ class _SubChipCallable(_RuntimeFacade):
     def output_indices(self) -> list[int]:
         return list(self._output_indices)
 
-    def build_orch_args(
+    def _build_orch_args(
         self,
         *args: "CallArg",
         worker: Any | None = None,
@@ -1470,24 +1471,25 @@ class _SubChipCallable(_RuntimeFacade):
         )
         if worker is None:
             raise TypeError(
-                "build_orch_args requires the simpler Worker that will own and dispatch these TaskArgs"
+                "_build_orch_args requires the simpler Worker that will own and dispatch these TaskArgs"
             )
         from pypto.runtime.runner import _coerced_to_orch_args  # noqa: PLC0415
 
         orch_args = _coerced_to_orch_args(coerced, worker)
         return orch_args, coerced, return_style
 
-    def build_call_config(
+    def _build_call_config(
         self,
         config: Any = None,
         *,
         aicpu_thread_num: int | None = None,
         dfx_dir: "Path | None" = None,
     ) -> Any:
-        from pypto.runtime.runner import RunConfig, _build_call_config  # noqa: PLC0415
+        from pypto.runtime.runner import RunConfig  # noqa: PLC0415
+        from pypto.runtime.runner import _build_call_config as _runner_build_call_config  # noqa: PLC0415
 
         run_config = config if config is not None else RunConfig()
-        return _build_call_config(
+        return _runner_build_call_config(
             run_config,
             runtime_config=self.runtime_config,
             aicpu_thread_num_override=aicpu_thread_num,

--- a/python/pypto/ir/compiled_program.py
+++ b/python/pypto/ir/compiled_program.py
@@ -683,13 +683,13 @@ def _invoke_compiled(
         args, param_infos, output_indices, return_types, caller_name=caller_name
     )
 
-    from pypto.runtime.runner import RunConfig, _DfxOpts, execute_compiled  # noqa: PLC0415
+    from pypto.runtime.runner import RunConfig, _DfxOpts, _execute_compiled  # noqa: PLC0415
 
     execution_platform = platform if config is None else config.platform
     if config is None:
         config = RunConfig()
 
-    execute_compiled(
+    _execute_compiled(
         output_dir,
         coerced,
         platform=execution_platform,
@@ -933,7 +933,7 @@ class CompiledProgram(_RuntimeFacade):
         after codegen) rather than ``kernel_config.py`` (only present after ptoas)
         so the dispatch surface is inspectable in ``skip_ptoas=True`` builds --
         calling a sub-callable without ``kernel_config.py`` then fails cleanly
-        inside ``execute_compiled`` with a ``FileNotFoundError``. Distributed (L3+)
+        inside the dispatch path with a ``FileNotFoundError``. Distributed (L3+)
         builds are excluded: they also lay out ``next_levels/<chip_task>/`` but
         expose a single canonical entry point via ``orchestration/host_orch.py`` and
         must be invoked through :meth:`__call__` directly, not by subscript.

--- a/python/pypto/ir/distributed_compiled_program.py
+++ b/python/pypto/ir/distributed_compiled_program.py
@@ -239,7 +239,7 @@ class DistributedCompiledProgram:
     def _persist_metadata(self) -> None:
         """Write ``<output_dir>/distributed_meta.json`` for :meth:`from_dir`.
 
-        Captures exactly what :func:`execute_distributed` reads from the
+        Captures exactly what :func:`_execute_distributed` reads from the
         post-pass IR — the HOST-orchestrator param metadata (post-SSA names,
         directions, shapes, dtypes) plus the return-type count — alongside the
         platform / backend / :class:`DistributedConfig` so a later reload can
@@ -425,7 +425,7 @@ class DistributedCompiledProgram:
         live Worker; use :meth:`prepare`, allocate it through the returned
         ``DistributedWorker``, then call ``worker.run(...)``.
         """
-        from pypto.runtime.distributed_runner import execute_distributed  # noqa: PLC0415
+        from pypto.runtime.distributed_runner import _execute_distributed  # noqa: PLC0415
 
         param_infos, output_indices, return_types = self._get_metadata()
         n_params = len(param_infos)
@@ -465,7 +465,7 @@ class DistributedCompiledProgram:
                 )
             coerced.append(arg)
 
-        execute_distributed(self, coerced, config)
+        _execute_distributed(self, coerced, config)
 
         if not return_style:
             return None

--- a/python/pypto/jit/decorator.py
+++ b/python/pypto/jit/decorator.py
@@ -2293,8 +2293,6 @@ class JITFunction:
           for explicit L2 dispatch.
         - ``CompiledProgram.chip_callable`` / ``runtime_name`` / ``runtime_config``
           to drive a hand-constructed ``simpler.worker.Worker``.
-        - ``CompiledProgram.build_orch_args`` / ``build_call_config`` to
-          assemble the simpler dispatch tuple yourself.
 
         ``config=RunConfig(...)`` is still consumed (and its compile-side
         knobs forwarded to ``ir.compile()``) so the returned

--- a/python/pypto/runtime/__init__.py
+++ b/python/pypto/runtime/__init__.py
@@ -30,6 +30,16 @@ one config object can drive both phases::
     c = torch.zeros(128, 128)
     compiled(a, b, c, config=config)
 
+``execute_compiled`` and ``execute_distributed_compiled`` dispatch a build
+directory instead of an artifact handle. Both are **deprecated**: rebuild the
+handle with :meth:`pypto.ir.CompiledProgram.from_dir` or
+:meth:`pypto.ir.DistributedCompiledProgram.from_dir` and call it. They still
+work, and forward to the same implementation, but each emits a
+``DeprecationWarning`` and will be removed in a future release. Migrating
+``execute_compiled`` means moving its explicit ``platform`` / ``device_id`` /
+``dfx`` / ``aicpu_thread_num`` onto the :class:`RunConfig` first — see its
+docstring for why a plain rename changes where the run lands.
+
 ``docs/en/dev/08-entry-points.md`` maps every compile and execution entry point
 to the layer it belongs to.
 """

--- a/python/pypto/runtime/bench.py
+++ b/python/pypto/runtime/bench.py
@@ -12,8 +12,8 @@
 Mirrors simpler's ``scene_test --rounds`` mode through pypto's public Worker:
 register the compiled program once, dispatch ``rounds`` cheap launches via
 :meth:`pypto.runtime.RegistrationHandle.__call__`, and aggregate per-launch
-``device_wall_us``. This avoids the one-shot ``execute_compiled`` /
-``CompiledProgram.__call__`` path, which re-pays ``compile_and_assemble`` +
+``device_wall_us``. This avoids the one-shot ``CompiledProgram.__call__``
+path, which re-pays ``compile_and_assemble`` +
 register/load every call (hundreds of ms of host overhead that swamps the
 ~1 ms device time).
 

--- a/python/pypto/runtime/debug/replay.py
+++ b/python/pypto/runtime/debug/replay.py
@@ -12,9 +12,9 @@
 Debug-only entry point for the "I edited a kernel cpp by hand, now re-run
 with DFX (PMU / swimlane / args_dump / dep_gen / scope_stats) enabled" workflow.
 
-An L2 build reuses :func:`pypto.runtime.runner.execute_compiled`, so its
-device-side execution path is identical to a normal ``compiled(...)``
-dispatch; an L3 build goes through ``execute_distributed_compiled``.
+An L2 build reuses the implementation behind a normal ``compiled(...)``
+dispatch, so its device-side execution path is identical; an L3 build
+reconstructs a ``DistributedCompiledProgram`` and calls it.
 The added value is:
 
 1. A friendlier signature for the replay use case
@@ -61,7 +61,7 @@ from pypto.runtime.runner import (
     _SWIMLANE_MAX_LEVEL,
     RunConfig,
     _DfxOpts,
-    execute_compiled,
+    _execute_compiled,
 )
 
 __all__ = ["replay", "invalidate_binary_cache"]
@@ -117,7 +117,8 @@ def replay(
             contains ``kernel_config.py``, ``orchestration/`` and ``kernels/``.
             An L3 distributed build (``orchestration/host_orch.py`` +
             ``next_levels/{rank}/`` + ``distributed_meta.json``) is detected
-            automatically and dispatched via ``execute_distributed_compiled``.
+            automatically and dispatched via
+            :meth:`~pypto.ir.DistributedCompiledProgram.from_dir`.
         *tensors: Positional ``torch.Tensor`` (host), :class:`DeviceTensor`,
             or ctypes scalar arguments matching the orchestration entry's
             parameter order. Outputs are written in-place into the
@@ -158,7 +159,7 @@ def replay(
     work_dir = Path(work_dir)
     # L3 distributed builds have no top-level ``kernel_config.py`` (per-rank
     # configs live under ``next_levels/{rank}/``); they are identified by the
-    # generated HOST orchestrator and dispatched via ``execute_distributed_compiled``.
+    # generated HOST orchestrator and dispatched through DistributedCompiledProgram.
     is_l3 = (
         not (work_dir / "kernel_config.py").exists()
         and (work_dir / "orchestration" / "host_orch.py").exists()
@@ -204,13 +205,14 @@ def replay(
         # L3: reconstruct the distributed program from the build dir and dispatch
         # via simpler Worker(level=3); per-dispatch ring and DFX settings are
         # forwarded through its CallConfig.
-        from pypto.runtime.distributed_runner import (  # noqa: PLC0415
-            execute_distributed_compiled,
+        from pypto.ir.distributed_compiled_program import (  # noqa: PLC0415
+            DistributedCompiledProgram,
         )
 
-        execute_distributed_compiled(work_dir, list(tensors), config=config, platform=config.platform)
+        compiled = DistributedCompiledProgram.from_dir(work_dir, platform=config.platform)
+        compiled(*tensors, config=config)
     else:
-        execute_compiled(
+        _execute_compiled(
             work_dir,
             list(tensors),
             platform=config.platform,

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -348,7 +348,7 @@ def _load_generated_module(path: Path) -> Any:
 
 
 # ---------------------------------------------------------------------------
-# Setup steps shared by the one-shot ``execute_distributed`` path and the
+# Setup steps shared by the one-shot ``_execute_distributed`` path and the
 # reusable ``DistributedWorker`` handle. Keeping them as free functions lets
 # both paths run identical, expensive setup (compile_and_assemble, module load,
 # Worker construction + registration) without duplicating it.
@@ -1245,7 +1245,7 @@ def _dispatch(
     native_handle.result()
 
 
-def execute_distributed(
+def _execute_distributed(
     compiled: DistributedCompiledProgram,
     coerced_args: Sequence[torch.Tensor | DeviceTensor | StackedDeviceTensor],
     config: RunConfig | None = None,
@@ -1385,6 +1385,14 @@ def execute_distributed(
         _collect_l3_swimlane(output_dir, compiled.platform)
 
 
+_EXECUTE_DISTRIBUTED_COMPILED_DEPRECATION = (
+    "pypto.runtime.execute_distributed_compiled is deprecated; reconstruct the "
+    "artifact and call it: ir.DistributedCompiledProgram.from_dir(output_dir, "
+    "platform=...)(*args, config=...). The directory-driven function will be "
+    "removed in a future release."
+)
+
+
 def execute_distributed_compiled(
     output_dir: str | Path,
     args: Sequence[torch.Tensor | DeviceTensor | StackedDeviceTensor | ctypes._SimpleCData],
@@ -1401,13 +1409,19 @@ def execute_distributed_compiled(
 ):
     """Reconstruct a distributed program from ``output_dir`` and run it once.
 
-    The distributed counterpart of :func:`pypto.runtime.execute_compiled`: it
-    reconstructs a :class:`~pypto.ir.distributed_compiled_program.DistributedCompiledProgram`
-    from an already-compiled build directory (via
-    :meth:`DistributedCompiledProgram.from_dir`) and dispatches it once —
-    **without** re-running the pypto compile. This is the entry point the
-    ``runtime_dir`` replay workflow uses for L3 programs (point it at a
-    ``build_output/`` with hand-edited ``.pto``/``.cpp`` and re-run on device).
+    Deprecated. It reconstructs a
+    :class:`~pypto.ir.DistributedCompiledProgram` from an already-compiled
+    build directory (via :meth:`DistributedCompiledProgram.from_dir`) and
+    dispatches it once — **without** re-running the pypto compile. Both steps
+    are public, so the replacement is the two lines this function wraps::
+
+        # before
+        execute_distributed_compiled(work_dir, args, config=cfg, platform="a2a3")
+
+        # after
+        ir.DistributedCompiledProgram.from_dir(work_dir, platform="a2a3")(*args, config=cfg)
+
+    Emits a :class:`DeprecationWarning`; behaviour is unchanged.
 
     Args:
         output_dir: A build directory produced by a prior ``ir.compile`` of a
@@ -1431,6 +1445,8 @@ def execute_distributed_compiled(
         The call result: allocated output tensor(s) for a return-style program,
         otherwise ``None`` (outputs written in place into the passed arguments).
     """
+    warnings.warn(_EXECUTE_DISTRIBUTED_COMPILED_DEPRECATION, DeprecationWarning, stacklevel=2)
+
     from pypto.ir.distributed_compiled_program import DistributedCompiledProgram  # noqa: PLC0415
 
     compiled = DistributedCompiledProgram.from_dir(

--- a/python/pypto/runtime/runner.py
+++ b/python/pypto/runtime/runner.py
@@ -10,9 +10,11 @@
 """
 PyPTO runtime runner.
 
-Provides :class:`RunConfig` — the settings that drive a run — and
-:func:`execute_compiled`, which dispatches an already-compiled artifact
-directory onto an Ascend NPU (or simulator).
+Provides :class:`RunConfig` — the settings that drive a run — and the
+dispatch implementation that puts an already-compiled artifact directory
+onto an Ascend NPU (or simulator). The supported way in is
+:meth:`pypto.ir.CompiledProgram.from_dir`; the module-level
+:func:`execute_compiled` is a deprecated wrapper over the same code.
 
 Compilation is :func:`pypto.ir.compile`'s job; nothing here compiles for you.
 :meth:`RunConfig.compile_kwargs` carries the compile-side settings across::
@@ -851,7 +853,7 @@ def _coerced_to_orch_args(
     L2 boundary. Tensors and scalars are added in separate passes because
     codegen addresses them from independent pools.
 
-    Used by both :func:`execute_compiled` and the extraction path on
+    Used by both :func:`_execute_compiled` and the extraction path on
     :class:`pypto.ir.CompiledProgram` (``_build_orch_args``).
     """
     from .task_interface import (  # noqa: PLC0415
@@ -975,7 +977,7 @@ def _execute_on_device(
 ) -> None:
     """Load inputs, execute on device, and validate against golden.
 
-    Shared execution logic used by both :func:`execute_compiled` and the test harness
+    Shared execution logic used by both :func:`_execute_compiled` and the test harness
     (``test_runner.py``).  The caller is responsible for compiling binaries
     via ``compile_and_assemble`` and passing the result here.
 
@@ -1322,7 +1324,7 @@ def _generate_swimlane(
 # ---------------------------------------------------------------------------
 
 
-def execute_compiled(  # noqa: PLR0913
+def _execute_compiled(  # noqa: PLR0913
     work_dir: str | Path,
     args: list[torch.Tensor | DeviceTensor | _SimpleCData],
     *,
@@ -1463,3 +1465,66 @@ def execute_compiled(  # noqa: PLR0913
     # ``deps.json`` and the deps-render hint fires only on explicit dep_gen.
     if dfx_dir is not None:
         _collect_dfx_artifacts(dfx_dir, platform, dfx)
+
+
+_EXECUTE_COMPILED_DEPRECATION = (
+    "pypto.runtime.execute_compiled is deprecated; reconstruct the artifact and "
+    "call it: ir.CompiledProgram.from_dir(work_dir)(*args, config=cfg). Fold this "
+    "call's explicit platform / device_id / dfx / aicpu_thread_num into cfg first "
+    "-- on the artifact path a supplied config is the sole source of all four. "
+    "The directory-driven function will be removed in a future release."
+)
+
+
+def execute_compiled(  # noqa: PLR0913
+    work_dir: str | Path,
+    args: list[torch.Tensor | DeviceTensor | _SimpleCData],
+    *,
+    platform: str,
+    device_id: int,
+    dfx: _DfxOpts = _DfxOpts(),
+    level: int = 2,
+    aicpu_thread_num: int | None = None,
+    analyze_auto_scopes_for_deps: bool = False,
+    config: RunConfig | None = None,
+) -> None:
+    """Deprecated. Dispatch a build directory without recompiling.
+
+    :meth:`pypto.ir.CompiledProgram.from_dir` rebuilds the same handle from the
+    same directory and dispatches it through the same code path. **The two
+    disagree on precedence, so the migration is not a plain rename.** Here, an
+    explicit ``platform`` / ``device_id`` / ``dfx`` / ``aicpu_thread_num`` wins
+    and ``config`` supplies only the ring overrides. On the artifact path a
+    supplied ``config`` is the sole source of all four — including ``platform``,
+    which then shadows ``from_dir(platform=...)``. Since ``RunConfig.platform``
+    defaults to ``"a2a3sim"``, dropping the explicit arguments would silently
+    move the run to the simulator. Fold them into the config instead::
+
+        # before -- explicit args win; ``cfg`` was read for ring sizing only
+        execute_compiled(work_dir, args, platform="a2a3", device_id=0, config=cfg)
+
+        # after -- ``cfg`` carries every execution setting
+        cfg = dataclasses.replace(cfg, platform="a2a3", device_id=0)
+        ir.CompiledProgram.from_dir(work_dir)(*args, config=cfg)
+
+    ``dfx`` and ``aicpu_thread_num`` have no separate spelling on that path:
+    the DFX toggles and ``aicpu_thread_num`` are already ``RunConfig`` fields,
+    read fresh on every dispatch. ``from_dir(platform=...)`` still decides the
+    platform for a call made *without* a config.
+
+    Emits a :class:`DeprecationWarning` and forwards to the same implementation
+    the artifact path uses. Behaviour of this function is unchanged; only the
+    name is going away.
+    """
+    warnings.warn(_EXECUTE_COMPILED_DEPRECATION, DeprecationWarning, stacklevel=2)
+    _execute_compiled(
+        work_dir,
+        args,
+        platform=platform,
+        device_id=device_id,
+        dfx=dfx,
+        level=level,
+        aicpu_thread_num=aicpu_thread_num,
+        analyze_auto_scopes_for_deps=analyze_auto_scopes_for_deps,
+        config=config,
+    )

--- a/python/pypto/runtime/runner.py
+++ b/python/pypto/runtime/runner.py
@@ -852,7 +852,7 @@ def _coerced_to_orch_args(
     codegen addresses them from independent pools.
 
     Used by both :func:`execute_compiled` and the extraction path on
-    :class:`pypto.ir.CompiledProgram` (``build_orch_args``).
+    :class:`pypto.ir.CompiledProgram` (``_build_orch_args``).
     """
     from .task_interface import (  # noqa: PLC0415
         TaskArgs,  # pyright: ignore[reportAttributeAccessIssue]

--- a/python/pypto/runtime/tensor_arg.py
+++ b/python/pypto/runtime/tensor_arg.py
@@ -17,7 +17,7 @@ This pypto-owned wrapper widens that conversion to also accept worker-resident
 :class:`~pypto.runtime.DeviceTensor` handles (and already-built simpler
 ``Tensor`` values), so distributed programs can be invoked with
 pre-uploaded device buffers — mirroring the L2 path in
-:func:`pypto.runtime.runner.execute_compiled`.
+:func:`pypto.runtime.runner._execute_compiled`.
 
 Host ``torch.Tensor`` arguments are delegated to
 ``simpler_setup.torch_interop.make_tensor_arg(worker, tensor)``. Never route

--- a/python/pypto/runtime/worker.py
+++ b/python/pypto/runtime/worker.py
@@ -585,8 +585,8 @@ class ChipWorker(Worker):
             dfx_dir = Path(compiled.output_dir) / "dfx_outputs"
             dfx_dir.mkdir(parents=True, exist_ok=True)
 
-        orch_args, coerced, return_style = compiled.build_orch_args(*args, worker=self._impl)
-        cfg = compiled.build_call_config(rc, dfx_dir=dfx_dir)
+        orch_args, coerced, return_style = compiled._build_orch_args(*args, worker=self._impl)
+        cfg = compiled._build_call_config(rc, dfx_dir=dfx_dir)
         self._run_chip(compiled.chip_callable, orch_args, cfg)
 
         if dfx_dir is not None:

--- a/tests/st/distributed/collectives/test_l3_all_to_all.py
+++ b/tests/st/distributed/collectives/test_l3_all_to_all.py
@@ -36,7 +36,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 64
 NR = pl.dynamic("NR")

--- a/tests/st/distributed/collectives/test_l3_allgather.py
+++ b/tests/st/distributed/collectives/test_l3_allgather.py
@@ -41,7 +41,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 64  # matches COUNT_PER_RANK in simpler allgather_kernel.cpp
 NR = pl.dynamic("NR")

--- a/tests/st/distributed/collectives/test_l3_allreduce.py
+++ b/tests/st/distributed/collectives/test_l3_allreduce.py
@@ -43,7 +43,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 256  # matches ALLREDUCE_COUNT in runtime allreduce_kernel.cpp
 NR = pl.dynamic("NR")

--- a/tests/st/distributed/collectives/test_l3_allreduce_ring.py
+++ b/tests/st/distributed/collectives/test_l3_allreduce_ring.py
@@ -42,7 +42,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 256  # matches ALLREDUCE_COUNT in simpler allreduce_ring_kernel.cpp
 

--- a/tests/st/distributed/collectives/test_l3_broadcast.py
+++ b/tests/st/distributed/collectives/test_l3_broadcast.py
@@ -40,7 +40,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 64  # matches COUNT_PER_RANK in simpler broadcast_kernel.cpp
 NR = pl.dynamic("NR")

--- a/tests/st/distributed/collectives/test_l3_reduce_scatter.py
+++ b/tests/st/distributed/collectives/test_l3_reduce_scatter.py
@@ -43,7 +43,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 64  # matches COUNT_PER_RANK in simpler reduce_scatter_kernel.cpp
 NR = pl.dynamic("NR")

--- a/tests/st/distributed/collectives/test_l3_tensor_all_to_all_intrinsic.py
+++ b/tests/st/distributed/collectives/test_l3_tensor_all_to_all_intrinsic.py
@@ -29,7 +29,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 64
 

--- a/tests/st/distributed/collectives/test_l3_tensor_all_to_all_v_intrinsic.py
+++ b/tests/st/distributed/collectives/test_l3_tensor_all_to_all_v_intrinsic.py
@@ -45,7 +45,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 64
 MAX_RECV = 4

--- a/tests/st/distributed/collectives/test_l3_tensor_allgather_intrinsic.py
+++ b/tests/st/distributed/collectives/test_l3_tensor_allgather_intrinsic.py
@@ -30,7 +30,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 64
 

--- a/tests/st/distributed/collectives/test_l3_tensor_allreduce_intrinsic.py
+++ b/tests/st/distributed/collectives/test_l3_tensor_allreduce_intrinsic.py
@@ -26,7 +26,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 STAGE_CHUNK = 8192
 

--- a/tests/st/distributed/collectives/test_l3_tensor_allreduce_ring_intrinsic.py
+++ b/tests/st/distributed/collectives/test_l3_tensor_allreduce_ring_intrinsic.py
@@ -34,7 +34,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 STAGE_CHUNK = 8192
 

--- a/tests/st/distributed/collectives/test_l3_tensor_barrier_intrinsic.py
+++ b/tests/st/distributed/collectives/test_l3_tensor_barrier_intrinsic.py
@@ -27,7 +27,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 64
 

--- a/tests/st/distributed/collectives/test_l3_tensor_broadcast_intrinsic.py
+++ b/tests/st/distributed/collectives/test_l3_tensor_broadcast_intrinsic.py
@@ -26,7 +26,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 64
 ROOT_RANK = 0

--- a/tests/st/distributed/collectives/test_l3_tensor_collective_signal_reuse.py
+++ b/tests/st/distributed/collectives/test_l3_tensor_collective_signal_reuse.py
@@ -33,7 +33,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 64
 

--- a/tests/st/distributed/collectives/test_l3_tensor_reduce_scatter_intrinsic.py
+++ b/tests/st/distributed/collectives/test_l3_tensor_reduce_scatter_intrinsic.py
@@ -24,7 +24,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 64
 

--- a/tests/st/distributed/conftest.py
+++ b/tests/st/distributed/conftest.py
@@ -27,7 +27,7 @@ def disable_runtime_execution_in_codegen_only(request, monkeypatch) -> None:
         del args, kwargs
         pytest.skip("--codegen-only disables distributed runtime execution")
 
-    monkeypatch.setattr("pypto.runtime.runner.execute_compiled", skip_execution)
-    monkeypatch.setattr("pypto.runtime.distributed_runner.execute_distributed", skip_execution)
+    monkeypatch.setattr("pypto.runtime.runner._execute_compiled", skip_execution)
+    monkeypatch.setattr("pypto.runtime.distributed_runner._execute_distributed", skip_execution)
     monkeypatch.setattr(DistributedCompiledProgram, "prepare", skip_execution)
     monkeypatch.setattr(DistributedWorker, "__init__", skip_execution)

--- a/tests/st/distributed/conftest.py
+++ b/tests/st/distributed/conftest.py
@@ -20,7 +20,7 @@ def disable_runtime_execution_in_codegen_only(request, monkeypatch) -> None:
     if not request.config.getoption("--codegen-only"):
         return
 
-    from pypto.ir.distributed_compiled_program import DistributedCompiledProgram  # noqa: PLC0415
+    from pypto.ir import DistributedCompiledProgram  # noqa: PLC0415
     from pypto.runtime.distributed_runner import DistributedWorker  # noqa: PLC0415
 
     def skip_execution(*args: Any, **kwargs: Any) -> None:

--- a/tests/st/distributed/test_l2_multi_orch.py
+++ b/tests/st/distributed/test_l2_multi_orch.py
@@ -161,7 +161,7 @@ class TestL2MultiOrch:
 
         Compiles the multi-orch program with ptoas (no ``skip_ptoas``),
         then invokes one sub-orch through subscript dispatch. Verifies
-        (a) ``execute_compiled`` accepts a ``next_levels/<name>/``
+        (a) ``_execute_compiled`` accepts a ``next_levels/<name>/``
         directory and (b) the kernel produces correct output on real
         hardware.
 

--- a/tests/st/distributed/test_l3_composite_shape_dim.py
+++ b/tests/st/distributed/test_l3_composite_shape_dim.py
@@ -28,7 +28,7 @@ import pypto.language as pl
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 M = pl.dynamic("M")
 N = pl.dynamic("N")

--- a/tests/st/distributed/test_l3_deferred_completion.py
+++ b/tests/st/distributed/test_l3_deferred_completion.py
@@ -52,7 +52,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 _N_RANKS = 2
 _A2A3_SIM_AIVS = 16

--- a/tests/st/distributed/test_l3_device_tensor.py
+++ b/tests/st/distributed/test_l3_device_tensor.py
@@ -32,7 +32,7 @@ import pypto.language as pl
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 
 @pl.program

--- a/tests/st/distributed/test_l3_dfx_per_rank.py
+++ b/tests/st/distributed/test_l3_dfx_per_rank.py
@@ -41,7 +41,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 from pypto.runtime import RunConfig
 
 ROWS = 16

--- a/tests/st/distributed/test_l3_distributed.py
+++ b/tests/st/distributed/test_l3_distributed.py
@@ -27,7 +27,7 @@ import pypto.language as pl
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 128 * 128
 

--- a/tests/st/distributed/test_l3_ep_dispatch_combine.py
+++ b/tests/st/distributed/test_l3_ep_dispatch_combine.py
@@ -64,7 +64,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 # Real DeepSeek-V4 FLASH MoE shapes (pypto-lib/models/deepseek_v4_flash_mtp) — must
 # mirror the runtime example's constants. ``N_RANKS`` is supplied per-test via

--- a/tests/st/distributed/test_l3_explicit_dispatch_onboard.py
+++ b/tests/st/distributed/test_l3_explicit_dispatch_onboard.py
@@ -45,7 +45,7 @@ import pypto.language as pl
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedCompiledProgram, DistributedConfig
+from pypto.ir import DistributedCompiledProgram, DistributedConfig
 from pypto.runtime import DistributedWorker, RunConfig
 
 from examples.runtime.multi_program_kv_cache import TILE, decode, prefill

--- a/tests/st/distributed/test_l3_gemm.py
+++ b/tests/st/distributed/test_l3_gemm.py
@@ -44,7 +44,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 M0 = 64
 K = 64

--- a/tests/st/distributed/test_l3_get.py
+++ b/tests/st/distributed/test_l3_get.py
@@ -35,7 +35,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 64
 

--- a/tests/st/distributed/test_l3_host_tensor_all_to_all.py
+++ b/tests/st/distributed/test_l3_host_tensor_all_to_all.py
@@ -41,7 +41,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 64
 NR = pl.dynamic("world_size")

--- a/tests/st/distributed/test_l3_host_tensor_all_to_all_v.py
+++ b/tests/st/distributed/test_l3_host_tensor_all_to_all_v.py
@@ -63,7 +63,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 64
 MAX_RECV = 4

--- a/tests/st/distributed/test_l3_host_tensor_allgather.py
+++ b/tests/st/distributed/test_l3_host_tensor_allgather.py
@@ -41,7 +41,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 64
 NR = pl.dynamic("world_size")

--- a/tests/st/distributed/test_l3_host_tensor_allreduce.py
+++ b/tests/st/distributed/test_l3_host_tensor_allreduce.py
@@ -16,7 +16,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 256
 NR = pl.dynamic("NR")

--- a/tests/st/distributed/test_l3_host_tensor_allreduce_multicore.py
+++ b/tests/st/distributed/test_l3_host_tensor_allreduce_multicore.py
@@ -28,7 +28,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 
 def _make_rank_inputs(n_ranks: int, size: int, round_offset: float = 0.0) -> torch.Tensor:

--- a/tests/st/distributed/test_l3_host_tensor_allreduce_ring.py
+++ b/tests/st/distributed/test_l3_host_tensor_allreduce_ring.py
@@ -16,7 +16,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 256
 

--- a/tests/st/distributed/test_l3_host_tensor_barrier.py
+++ b/tests/st/distributed/test_l3_host_tensor_barrier.py
@@ -16,7 +16,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 64
 NR = pl.dynamic("NR")

--- a/tests/st/distributed/test_l3_host_tensor_broadcast.py
+++ b/tests/st/distributed/test_l3_host_tensor_broadcast.py
@@ -16,7 +16,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 64
 ROOT_RANK = 0

--- a/tests/st/distributed/test_l3_host_tensor_reduce_scatter.py
+++ b/tests/st/distributed/test_l3_host_tensor_reduce_scatter.py
@@ -16,7 +16,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 64
 NR = pl.dynamic("world_size")

--- a/tests/st/distributed/test_l3_manual.py
+++ b/tests/st/distributed/test_l3_manual.py
@@ -109,7 +109,7 @@ class TestL3Manual:
         )
 
         # 2) Assemble the ChipCallable ourselves — the same call
-        # ``execute_distributed`` makes per next_levels/<name>/, but pointed at
+        # ``_execute_distributed`` makes per next_levels/<name>/, but pointed at
         # the L2 root because no HOST-level outlining happened.
         chip_callable, runtime_name, _ = compile_and_assemble(out_dir, platform=test_config.platform)
 

--- a/tests/st/distributed/test_l3_multi_group.py
+++ b/tests/st/distributed/test_l3_multi_group.py
@@ -55,7 +55,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 64
 

--- a/tests/st/distributed/test_l3_notify_wait.py
+++ b/tests/st/distributed/test_l3_notify_wait.py
@@ -43,7 +43,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 
 def _build_signal_handshake_program():

--- a/tests/st/distributed/test_l3_parallel_reduce.py
+++ b/tests/st/distributed/test_l3_parallel_reduce.py
@@ -29,7 +29,7 @@ import pypto.language as pl
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 
 @pl.program

--- a/tests/st/distributed/test_l3_put.py
+++ b/tests/st/distributed/test_l3_put.py
@@ -39,7 +39,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 64
 

--- a/tests/st/distributed/test_l3_rank_slice_dispatch.py
+++ b/tests/st/distributed/test_l3_rank_slice_dispatch.py
@@ -40,7 +40,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 N_RANKS = 2
 ROWS = 16

--- a/tests/st/distributed/test_l3_remote_store.py
+++ b/tests/st/distributed/test_l3_remote_store.py
@@ -35,7 +35,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 SIZE = 64
 HALF = SIZE // 2

--- a/tests/st/distributed/test_l3_remote_store_window_raw.py
+++ b/tests/st/distributed/test_l3_remote_store_window_raw.py
@@ -34,7 +34,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 N_RANKS = 2
 D = 64

--- a/tests/st/distributed/test_l3_ring_sizing_prewarm.py
+++ b/tests/st/distributed/test_l3_ring_sizing_prewarm.py
@@ -29,7 +29,7 @@ import pypto.language as pl
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 from pypto.runtime import RunConfig
 
 

--- a/tests/st/distributed/test_l3_self_notify_credit_reset.py
+++ b/tests/st/distributed/test_l3_self_notify_credit_reset.py
@@ -46,7 +46,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 _REPS = 4
 

--- a/tests/st/distributed/test_l3_stacked_device_tensor.py
+++ b/tests/st/distributed/test_l3_stacked_device_tensor.py
@@ -40,7 +40,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 from pypto.runtime import DistributedWorker, StackedDeviceTensor
 
 N_RANKS = 2

--- a/tests/st/distributed/test_l3_tuple_return.py
+++ b/tests/st/distributed/test_l3_tuple_return.py
@@ -33,7 +33,7 @@ import pypto.language as pl
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 
 @pl.program

--- a/tests/st/distributed/test_l3_window_slice_incore.py
+++ b/tests/st/distributed/test_l3_window_slice_incore.py
@@ -45,7 +45,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 
 N = 16  # rows
 W = 64  # window width (cols): 64*4=256 (FP32) and 64*2=128 (FP16) → 32-byte-aligned rows

--- a/tests/st/runtime/framework_and_models/test_benchmark_st.py
+++ b/tests/st/runtime/framework_and_models/test_benchmark_st.py
@@ -29,7 +29,7 @@ import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig
 from pypto.runtime import RunConfig, benchmark
 
 _M = 128

--- a/tests/st/runtime/framework_and_models/test_compiled_program.py
+++ b/tests/st/runtime/framework_and_models/test_compiled_program.py
@@ -140,7 +140,12 @@ class TestJitCompiledProgram:
 
 
 def _manual_dispatch(compiled, *args, device_id, config=None, call_config=None):
-    """Drive a hand-built simpler.Worker via the extraction surface; return coerced list."""
+    """Drive a hand-built simpler.Worker via the extraction surface; return coerced list.
+
+    The two argument builders are internal — ``ChipWorker.run`` is the supported
+    way to reach them. This helper calls them directly so the marshalling that
+    ``ChipWorker`` delegates to stays covered on its own.
+    """
     from simpler.worker import Worker as SimplerWorker  # noqa: PLC0415 — lazy: skip on host-only CI
 
     cc = compiled.chip_callable
@@ -148,11 +153,11 @@ def _manual_dispatch(compiled, *args, device_id, config=None, call_config=None):
     if call_config is not None:
         cfg = call_config
     else:
-        cfg = compiled.build_call_config(config) if config is not None else compiled.build_call_config()
+        cfg = compiled._build_call_config(config) if config is not None else compiled._build_call_config()
     w = SimplerWorker(level=2, device_id=device_id, platform=compiled.platform, runtime=rn)
     w.init()
     try:
-        orch_args, coerced, return_style = compiled.build_orch_args(*args, worker=w)
+        orch_args, coerced, return_style = compiled._build_orch_args(*args, worker=w)
         cid = w.register(cc)
         w.run(cid, orch_args, cfg)
         w.unregister(cid)
@@ -216,7 +221,7 @@ class TestManualWorkerExtraction:
         assert isinstance(compiled.runtime_config, dict)
 
     def test_call_config_override_runs(self, test_config):
-        """build_call_config aicpu_thread_num override is accepted and runs correctly."""
+        """_build_call_config aicpu_thread_num override is accepted and runs correctly."""
         tile_add_128._cache.clear()
         a = torch.full((128, 128), 2.0, dtype=torch.float32)
         b = torch.full((128, 128), 3.0, dtype=torch.float32)
@@ -224,7 +229,7 @@ class TestManualWorkerExtraction:
         compiled = _get_cached_compiled(tile_add_128)
         # 3, not the auto value baked into RUNTIME_CONFIG — otherwise the
         # assertion cannot tell an applied override from the default.
-        cfg = compiled.build_call_config(test_config, aicpu_thread_num=3)
+        cfg = compiled._build_call_config(test_config, aicpu_thread_num=3)
         assert cfg.aicpu_thread_num == 3
         coerced, _ = _manual_dispatch(compiled, a, b, device_id=test_config.device_id, call_config=cfg)
         assert torch.allclose(coerced[compiled.output_indices[0]], torch.full((128, 128), 5.0))

--- a/tests/ut/ir/test_compiled_program.py
+++ b/tests/ut/ir/test_compiled_program.py
@@ -15,6 +15,7 @@ import json
 import os
 import sys
 import types
+import warnings
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -344,7 +345,7 @@ class TestCompiledProgramCall:
             ring_heap=512 * 1024 * 1024,
         )
 
-        with patch("pypto.runtime.runner.execute_compiled") as mock_exec:
+        with patch("pypto.runtime.runner._execute_compiled") as mock_exec:
             cp(*args, config=config)
 
         assert mock_exec.call_args.kwargs["platform"] == "a2a3"
@@ -353,12 +354,28 @@ class TestCompiledProgramCall:
         assert mock_exec.call_args.kwargs["aicpu_thread_num"] == 7
         assert mock_exec.call_args.kwargs["config"] is config
 
+    def test_dispatch_does_not_emit_the_execute_compiled_deprecation(self, tmp_path):
+        """The artifact path goes to the implementation, not the deprecated wrapper.
+
+        ``pypto.runtime.execute_compiled`` is deprecated and warns. It wraps the
+        same implementation this dispatch uses, so routing back through it would
+        make every supported call emit a deprecation the caller cannot act on.
+        """
+        prog = _make_program_with_orchestration()
+        cp = CompiledProgram(prog, str(tmp_path), platform="a2a3sim")
+        args = (torch.zeros(128, 128), torch.zeros(128, 128), torch.zeros(128, 128))
+
+        with patch("pypto.runtime.runner._execute_compiled"):
+            with warnings.catch_warnings():
+                warnings.simplefilter("error", DeprecationWarning)
+                cp(*args)
+
     def test_no_config_uses_compiled_platform(self, tmp_path):
         prog = _make_program_with_orchestration()
         cp = CompiledProgram(prog, str(tmp_path), platform="a5sim")
         args = (torch.zeros(128, 128), torch.zeros(128, 128), torch.zeros(128, 128))
 
-        with patch("pypto.runtime.runner.execute_compiled") as mock_exec:
+        with patch("pypto.runtime.runner._execute_compiled") as mock_exec:
             cp(*args)
 
         assert mock_exec.call_args.kwargs["platform"] == "a5sim"
@@ -521,7 +538,7 @@ class TestCompiledProgramScalarCall:
         a = torch.randn(128, 128)
         c = torch.zeros(128, 128)
 
-        with patch("pypto.runtime.runner.execute_compiled") as mock_exec:
+        with patch("pypto.runtime.runner._execute_compiled") as mock_exec:
             cp(a, 5, c)
 
         coerced_args = mock_exec.call_args.args[1]  # second positional arg is the args list
@@ -539,7 +556,7 @@ class TestCompiledProgramScalarCall:
         c = torch.zeros(128, 128)
         scalar = ctypes.c_int64(42)
 
-        with patch("pypto.runtime.runner.execute_compiled") as mock_exec:
+        with patch("pypto.runtime.runner._execute_compiled") as mock_exec:
             cp(a, scalar, c)
 
         coerced_args = mock_exec.call_args.args[1]
@@ -582,10 +599,10 @@ class TestCompiledProgramScalarCall:
 
         a = torch.randn(128, 128)
 
-        with patch("pypto.runtime.runner.execute_compiled") as mock_exec:
+        with patch("pypto.runtime.runner._execute_compiled") as mock_exec:
             result = cp(a, 7)
 
-        # Should have called execute_compiled with 3 args (a, scalar, allocated c)
+        # Should have called _execute_compiled with 3 args (a, scalar, allocated c)
         coerced_args = mock_exec.call_args.args[1]
         assert len(coerced_args) == 3
         assert isinstance(coerced_args[1], ctypes.c_int64)
@@ -598,7 +615,7 @@ class TestCompiledProgramDeviceTensor:
     """Verify __call__ accepts DeviceTensor in tensor parameter slots."""
 
     def test_device_tensor_in_input_slot(self, tmp_path):
-        """A DeviceTensor passed for an In param is forwarded to execute_compiled."""
+        """A DeviceTensor passed for an In param is forwarded to _execute_compiled."""
         prog = _make_program_with_orchestration()  # a (In), b (In), c (Out)
         cp = CompiledProgram(prog, str(tmp_path))
 
@@ -606,7 +623,7 @@ class TestCompiledProgramDeviceTensor:
         b = DeviceTensor(0xB0000, (128, 128), torch.float32)
         c = torch.zeros(128, 128)
 
-        with patch("pypto.runtime.runner.execute_compiled") as mock_exec:
+        with patch("pypto.runtime.runner._execute_compiled") as mock_exec:
             cp(a, b, c)
 
         coerced_args = mock_exec.call_args.args[1]
@@ -623,7 +640,7 @@ class TestCompiledProgramDeviceTensor:
         b = DeviceTensor(0x2000, (128, 128), torch.float32)
         c = DeviceTensor(0x3000, (128, 128), torch.float32)
 
-        with patch("pypto.runtime.runner.execute_compiled") as mock_exec:
+        with patch("pypto.runtime.runner._execute_compiled") as mock_exec:
             cp(a, b, c)
 
         coerced_args = mock_exec.call_args.args[1]
@@ -977,7 +994,7 @@ class TestSubChipCallableExtraction:
         sub = self._make_subchip(tmp_path)
         args = (torch.zeros(128, 128), torch.zeros(128, 128), torch.zeros(128, 128))
 
-        with patch("pypto.runtime.runner.execute_compiled") as mock_exec:
+        with patch("pypto.runtime.runner._execute_compiled") as mock_exec:
             sub(*args, config=RunConfig(platform="a2a3"))
 
         assert mock_exec.call_args.kwargs["platform"] == "a2a3"
@@ -986,7 +1003,7 @@ class TestSubChipCallableExtraction:
         sub = self._make_subchip(tmp_path)
         args = (torch.zeros(128, 128), torch.zeros(128, 128), torch.zeros(128, 128))
 
-        with patch("pypto.runtime.runner.execute_compiled") as mock_exec:
+        with patch("pypto.runtime.runner._execute_compiled") as mock_exec:
             sub(*args)
 
         assert mock_exec.call_args.kwargs["platform"] == "a2a3sim"
@@ -1062,14 +1079,14 @@ class TestCompiledMetaAndFromDir:
         assert param_infos[2].direction == ir.ParamDirection.Out
 
     def test_from_dir_dispatches_via_runner(self, tmp_path):
-        """A reconstructed program is callable and reaches execute_compiled."""
+        """A reconstructed program is callable and reaches _execute_compiled."""
         CompiledProgram(_make_program_with_orchestration(), str(tmp_path), platform="a2a3sim")
         reloaded = CompiledProgram.from_dir(tmp_path)
         a = torch.zeros(128, 128)
         b = torch.zeros(128, 128)
         c = torch.zeros(128, 128)
 
-        with patch("pypto.runtime.runner.execute_compiled") as mock_exec:
+        with patch("pypto.runtime.runner._execute_compiled") as mock_exec:
             reloaded(a, b, c)
 
         mock_exec.assert_called_once()
@@ -1290,7 +1307,7 @@ class TestCompiledMetaAndFromDir:
 
         assert reloaded.orchestration_names == []
         args = (torch.zeros(128, 128), torch.zeros(128, 128), torch.zeros(128, 128))
-        with patch("pypto.runtime.runner.execute_compiled") as mock_exec:
+        with patch("pypto.runtime.runner._execute_compiled") as mock_exec:
             reloaded(*args)
         assert mock_exec.call_args.args[0] == tmp_path.resolve()
 
@@ -1466,7 +1483,7 @@ class TestCompiledMetaOutputDirReuse:
         assert reloaded.param_names == ["x", "y", "z"]
         args = (torch.zeros(64, 64), torch.zeros(64, 64), torch.zeros(64, 64))
         for compiled in (single, reloaded):
-            with patch("pypto.runtime.runner.execute_compiled") as mock_exec:
+            with patch("pypto.runtime.runner._execute_compiled") as mock_exec:
                 compiled(*args)
             assert mock_exec.call_args.args[0] == work_dir.resolve()
 

--- a/tests/ut/ir/test_compiled_program.py
+++ b/tests/ut/ir/test_compiled_program.py
@@ -56,7 +56,7 @@ def _fake_call_config(instance):
     """Stub ``pypto.runtime.task_interface.CallConfig`` via a fake module.
 
     ``task_interface`` imports the device-only ``simpler`` package, so it can't
-    load on host CI. Fake it so ``build_call_config``'s inner import binds to a
+    load on host CI. Fake it so ``_build_call_config``'s inner import binds to a
     ``CallConfig`` that returns ``instance``."""
     fake = types.ModuleType("pypto.runtime.task_interface")
     setattr(fake, "CallConfig", MagicMock(return_value=instance))
@@ -665,7 +665,7 @@ class TestCompiledProgramDeviceTensor:
 class TestCompiledProgramExtraction:
     """Verify the extraction surface that lets users drive ``simpler.worker.Worker``
     directly: ``chip_callable`` / ``runtime_name`` / ``runtime_config`` properties,
-    ``load()``, ``build_orch_args()``, and ``build_call_config()``.
+    ``load()``, ``_build_orch_args()``, and ``_build_call_config()``.
     """
 
     def _patch_assemble(self, chip_callable_name: str = "fake_chip"):
@@ -751,7 +751,7 @@ class TestCompiledProgramExtraction:
         worker = MagicMock(name="worker")
         with patch("pypto.runtime.runner._coerced_to_orch_args") as oa_helper:
             oa_helper.return_value = "fake_orch_args"
-            orch_args, coerced, return_style = cp.build_orch_args(a, b, c, worker=worker)
+            orch_args, coerced, return_style = cp._build_orch_args(a, b, c, worker=worker)
 
         assert orch_args == "fake_orch_args"
         assert coerced == [a, b, c]
@@ -768,7 +768,7 @@ class TestCompiledProgramExtraction:
         worker = MagicMock(name="worker")
         with patch("pypto.runtime.runner._coerced_to_orch_args") as oa_helper:
             oa_helper.return_value = "fake_orch_args"
-            orch_args, coerced, return_style = cp.build_orch_args(a, b, worker=worker)
+            orch_args, coerced, return_style = cp._build_orch_args(a, b, worker=worker)
 
         assert orch_args == "fake_orch_args"
         assert return_style is True
@@ -783,7 +783,7 @@ class TestCompiledProgramExtraction:
         cp = CompiledProgram(prog, str(tmp_path))
         a = torch.zeros(128, 128)
         with pytest.raises(TypeError, match="expects 3"):
-            cp.build_orch_args(a)
+            cp._build_orch_args(a)
 
     def test_build_call_config_uses_runtime_config_default(self, tmp_path):
         """When config has no overrides, RUNTIME_CONFIG values feed CallConfig."""
@@ -798,7 +798,7 @@ class TestCompiledProgramExtraction:
         ):
             from pypto.runtime import RunConfig  # noqa: PLC0415
 
-            cfg = cp.build_call_config(RunConfig())
+            cfg = cp._build_call_config(RunConfig())
 
         assert cfg is fake_call_config
         assert fake_call_config.aicpu_thread_num == 2  # from runtime_config
@@ -815,7 +815,7 @@ class TestCompiledProgramExtraction:
         ):
             from pypto.runtime import RunConfig  # noqa: PLC0415
 
-            cp.build_call_config(RunConfig(aicpu_thread_num=8), aicpu_thread_num=4)
+            cp._build_call_config(RunConfig(aicpu_thread_num=8), aicpu_thread_num=4)
 
         assert fake_call_config.aicpu_thread_num == 4  # kwarg > RunConfig field > runtime_config
 
@@ -831,7 +831,7 @@ class TestCompiledProgramExtraction:
         ):
             from pypto.runtime import RunConfig  # noqa: PLC0415
 
-            cp.build_call_config(RunConfig(aicpu_thread_num=16))
+            cp._build_call_config(RunConfig(aicpu_thread_num=16))
 
         assert fake_call_config.aicpu_thread_num == 16  # RunConfig wins over runtime_config's 2
 
@@ -847,7 +847,7 @@ class TestCompiledProgramExtraction:
         ):
             from pypto.runtime import RunConfig  # noqa: PLC0415
 
-            cp.build_call_config(
+            cp._build_call_config(
                 RunConfig(
                     enable_chip_swimlane=True,
                     enable_dump_args=True,
@@ -884,7 +884,7 @@ class TestCompiledProgramExtraction:
         ):
             from pypto.runtime import RunConfig  # noqa: PLC0415
 
-            cp.build_call_config(RunConfig())
+            cp._build_call_config(RunConfig())
 
         # spec doesn't include "output_prefix", so any attempted set would fail.
         # Reaching here means _build_call_config correctly skipped it.
@@ -917,7 +917,7 @@ class TestCompiledProgramExtractionMultiOrch:
         b = torch.zeros(128, 128)
         c = torch.zeros(128, 128)
         with pytest.raises(TypeError, match="Multi-orch"):
-            cp.build_orch_args(a, b, c)
+            cp._build_orch_args(a, b, c)
 
 
 class TestSubChipCallableExtraction:
@@ -958,7 +958,7 @@ class TestSubChipCallableExtraction:
         worker = MagicMock(name="worker")
         with patch("pypto.runtime.runner._coerced_to_orch_args") as oa_helper:
             oa_helper.return_value = "fake_orch_args"
-            orch_args, coerced, return_style = sub.build_orch_args(a, b, c, worker=worker)
+            orch_args, coerced, return_style = sub._build_orch_args(a, b, c, worker=worker)
 
         assert orch_args == "fake_orch_args"
         assert coerced == [a, b, c]
@@ -1082,7 +1082,7 @@ class TestCompiledMetaAndFromDir:
 
         Regression test for #2344: ``benchmark`` needs ``platform`` /
         ``runtime_name`` / ``runtime_config`` / ``chip_callable`` plus the
-        metadata-derived ``build_orch_args`` / ``build_call_config`` /
+        metadata-derived ``_build_orch_args`` / ``_build_call_config`` /
         ``output_indices``, which previously required a live ``Program``.
         """
         CompiledProgram(_make_program_with_orchestration(), str(tmp_path), platform="a2a3sim")
@@ -1102,10 +1102,10 @@ class TestCompiledMetaAndFromDir:
             assert reloaded.output_indices == [2]
             with patch("pypto.runtime.runner._coerced_to_orch_args") as oa_helper:
                 oa_helper.return_value = "fake_orch_args"
-                orch_args, coerced, return_style = reloaded.build_orch_args(*args, worker=worker)
+                orch_args, coerced, return_style = reloaded._build_orch_args(*args, worker=worker)
                 oa_helper.assert_called_once_with(args, worker)
             with _fake_call_config(call_config):
-                assert reloaded.build_call_config(RunConfig()) is call_config
+                assert reloaded._build_call_config(RunConfig()) is call_config
 
         assert orch_args == "fake_orch_args"
         assert coerced == args

--- a/tests/ut/ir/test_distributed_compiled_program.py
+++ b/tests/ut/ir/test_distributed_compiled_program.py
@@ -387,5 +387,19 @@ def test_from_dir_output_indices_match_out_params(compiled, tmp_path):
     assert param_infos[2].direction == ParamDirection.Out
 
 
+def test_distributed_types_are_reexported_from_pypto_ir():
+    """``pypto.ir`` is the supported spelling; the defining module stays importable.
+
+    ``pypto.runtime`` imports the defining module directly to avoid an import
+    cycle, so the re-export must be an alias of the same objects rather than a
+    second definition — otherwise an ``isinstance`` check would depend on which
+    spelling the caller used.
+    """
+    assert ir.DistributedCompiledProgram is DistributedCompiledProgram
+    assert ir.DistributedConfig is DistributedConfig
+    assert "DistributedCompiledProgram" in ir.__all__
+    assert "DistributedConfig" in ir.__all__
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/test_distributed_compiled_program.py
+++ b/tests/ut/ir/test_distributed_compiled_program.py
@@ -10,7 +10,7 @@
 """Unit tests for ``DistributedCompiledProgram.__call__`` argument acceptance.
 
 These tests compile a small L3 program (no device needed, ``skip_ptoas=True``)
-and mock ``execute_distributed`` so the calling convention can be exercised
+and mock ``_execute_distributed`` so the calling convention can be exercised
 without a Worker. Resident tensors require a prepared Worker because their
 owner Buffer/provenance cannot belong to a temporary one-shot Worker.
 """
@@ -85,7 +85,7 @@ def test_one_shot_rejects_device_tensor_with_prepare_guidance(compiled):
     weight = DeviceTensor(0xABCD0000, (128, 128), torch.float32)  # worker-resident
     out = torch.zeros(128, 128, dtype=torch.float32)
 
-    with patch("pypto.runtime.distributed_runner.execute_distributed") as mock_exec:
+    with patch("pypto.runtime.distributed_runner._execute_distributed") as mock_exec:
         with pytest.raises(TypeError, match=r"compiled\.prepare.*worker\.alloc_tensor"):
             compiled(a, weight, out)
     mock_exec.assert_not_called()
@@ -96,7 +96,7 @@ def test_call_rejects_non_tensor(compiled):
     a = torch.zeros(128, 128, dtype=torch.float32)
     out = torch.zeros(128, 128, dtype=torch.float32)
 
-    with patch("pypto.runtime.distributed_runner.execute_distributed"):
+    with patch("pypto.runtime.distributed_runner._execute_distributed"):
         with pytest.raises(TypeError, match=r"host torch\.Tensor"):
             compiled(a, "not a tensor", out)  # type: ignore[arg-type]
 
@@ -107,7 +107,7 @@ def test_call_validates_device_tensor_shape(compiled):
     bad = DeviceTensor(0xABCD0000, (64, 64), torch.float32)  # wrong shape
     out = torch.zeros(128, 128, dtype=torch.float32)
 
-    with patch("pypto.runtime.distributed_runner.execute_distributed"):
+    with patch("pypto.runtime.distributed_runner._execute_distributed"):
         with pytest.raises(TypeError, match=r"compiled\.prepare"):
             compiled(a, bad, out)
 
@@ -125,7 +125,7 @@ def test_one_shot_rejects_stacked_device_tensor_with_prepare_guidance(compiled):
     stacked = _stacked((128, 128))  # per-card resident shards for the [128,128] param
     out = torch.zeros(128, 128, dtype=torch.float32)
 
-    with patch("pypto.runtime.distributed_runner.execute_distributed") as mock_exec:
+    with patch("pypto.runtime.distributed_runner._execute_distributed") as mock_exec:
         with pytest.raises(TypeError, match=r"worker\.alloc_stacked_tensor"):
             compiled(a, stacked, out)
     mock_exec.assert_not_called()
@@ -137,7 +137,7 @@ def test_call_validates_stacked_device_tensor_shape(compiled):
     bad = _stacked((64, 64))  # wrong full_shape for the [128,128] param
     out = torch.zeros(128, 128, dtype=torch.float32)
 
-    with patch("pypto.runtime.distributed_runner.execute_distributed"):
+    with patch("pypto.runtime.distributed_runner._execute_distributed"):
         with pytest.raises(TypeError, match=r"compiled\.prepare"):
             compiled(a, bad, out)
 
@@ -182,12 +182,12 @@ def test_from_dir_round_trips_param_metadata(compiled, tmp_path):
 
 
 def test_from_dir_dispatches_via_runner(compiled, tmp_path):
-    """A reconstructed program is callable and reaches execute_distributed."""
+    """A reconstructed program is callable and reaches _execute_distributed."""
     reloaded = DistributedCompiledProgram.from_dir(tmp_path)
     a = torch.zeros(128, 128, dtype=torch.float32)
     b = torch.zeros(128, 128, dtype=torch.float32)
     f = torch.zeros(128, 128, dtype=torch.float32)
-    with patch("pypto.runtime.distributed_runner.execute_distributed") as mock_exec:
+    with patch("pypto.runtime.distributed_runner._execute_distributed") as mock_exec:
         reloaded(a, b, f)
     mock_exec.assert_called_once()
     # arg 0 is the compiled program; arg 1 the coerced args in param order.

--- a/tests/ut/jit/test_cache.py
+++ b/tests/ut/jit/test_cache.py
@@ -10,8 +10,7 @@
 """Tests for python/pypto/jit/cache.py."""
 
 import pytest
-from pypto.ir import OptimizationStrategy
-from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.ir import DistributedConfig, OptimizationStrategy
 from pypto.jit.cache import (
     compute_source_hash,
     make_cache_key,

--- a/tests/ut/jit/test_decorator.py
+++ b/tests/ut/jit/test_decorator.py
@@ -2391,7 +2391,7 @@ class TestCompileKwargForwarding:
 
     def test_run_config_compile_kwargs_forwards_distributed_config(self):
         """A RunConfig.distributed_config is forwarded so @pl.jit.host kernels go distributed."""
-        from pypto.ir.distributed_compiled_program import DistributedConfig  # noqa: PLC0415
+        from pypto.ir import DistributedConfig  # noqa: PLC0415
 
         dc = DistributedConfig(device_ids=[0, 1])
         kwargs = _run_config_compile_kwargs(RunConfig(distributed_config=dc))
@@ -2407,7 +2407,7 @@ class TestCompileKwargForwarding:
 
     def test_make_cache_key_splits_on_distributed_config(self):
         """distributed_config participates in the cache key (distinct device_ids ≠ collide)."""
-        from pypto.ir.distributed_compiled_program import DistributedConfig  # noqa: PLC0415
+        from pypto.ir import DistributedConfig  # noqa: PLC0415
         from pypto.jit.cache import make_cache_key  # noqa: PLC0415
 
         def key_for(distributed_config):
@@ -2463,7 +2463,7 @@ class TestCompileKwargForwarding:
         different ``device_ids`` would silently target the wrong ranks.
         """
         torch = pytest.importorskip("torch")
-        from pypto.ir.distributed_compiled_program import DistributedConfig  # noqa: PLC0415
+        from pypto.ir import DistributedConfig  # noqa: PLC0415
 
         @jit
         def cfg_kernel(a: pl.Tensor[[128, 128], pl.FP32], c: pl.Out[pl.Tensor[[128, 128], pl.FP32]]):
@@ -2588,7 +2588,7 @@ class TestCompileKwargForwarding:
         # so patching the module attribute intercepts the real compilation.
         monkeypatch.setattr(ir_compile_mod, "compile", fake_compile)
 
-        from pypto.ir.distributed_compiled_program import DistributedConfig  # noqa: PLC0415
+        from pypto.ir import DistributedConfig  # noqa: PLC0415
 
         dc = DistributedConfig(device_ids=[0, 1])
         cfg = RunConfig(

--- a/tests/ut/jit/test_jit_compile_extraction.py
+++ b/tests/ut/jit/test_jit_compile_extraction.py
@@ -250,8 +250,9 @@ class TestCompileForwardsRunConfig:
 
 class TestCompileExposesExtractionSurface:
     """The returned CompiledProgram exposes the full extraction surface added
-    in PR #1496 (chip_callable / build_orch_args / build_call_config),
-    enabling worker integration as required by issue #1455.
+    in PR #1496 — the public runtime handles (chip_callable / runtime_name /
+    runtime_config) plus the internal argument builders ``ChipWorker.run``
+    marshals through — enabling worker integration as required by issue #1455.
 
     These tests only verify that the attributes are *defined on the class* —
     actually exercising compile_and_assemble (which several of these properties
@@ -276,8 +277,8 @@ class TestCompileExposesExtractionSurface:
             "chip_callable",
             "runtime_name",
             "runtime_config",
-            "build_orch_args",
-            "build_call_config",
+            "_build_orch_args",
+            "_build_call_config",
             "output_dir",
             "platform",
             "output_indices",

--- a/tests/ut/runtime/test_chip_worker_explicit_dispatch.py
+++ b/tests/ut/runtime/test_chip_worker_explicit_dispatch.py
@@ -12,7 +12,7 @@
 Exercises ``ChipWorker.run / register`` and the :class:`RegistrationHandle`
 returned by ``register`` without touching the device: ``_SimplerWorker`` is
 patched so construction does no real work, and ``CompiledProgram`` extraction
-helpers (``chip_callable / build_orch_args / build_call_config``) are stubbed
+helpers (``chip_callable / _build_orch_args / _build_call_config``) are stubbed
 to return mocks the tests can inspect.
 """
 
@@ -53,8 +53,8 @@ def _fake_compiled(
     compiled.chip_callable = cc
     compiled.output_dir = "/tmp/fake_compiled"
     compiled.output_indices = [2]
-    compiled.build_orch_args.return_value = ("orch_args", ["arg0", "arg1", "out_tensor"], False)
-    compiled.build_call_config.return_value = MagicMock(name="CallConfig")
+    compiled._build_orch_args.return_value = ("orch_args", ["arg0", "arg1", "out_tensor"], False)
+    compiled._build_call_config.return_value = MagicMock(name="CallConfig")
     return compiled
 
 
@@ -113,18 +113,18 @@ def test_run_requires_init(fake_simpler_worker):
 def test_run_inplace_returns_none(fake_simpler_worker):
     w = ChipWorker(config=RunConfig(platform="a2a3sim"))
     compiled = _fake_compiled()
-    # build_orch_args returns return_style=False — in-place call.
+    # _build_orch_args returns return_style=False — in-place call.
     result = w.run(compiled, 1, 2, 3)
     assert result is None
     w.close()
 
 
 def test_run_return_style_packs_outputs(fake_simpler_worker):
-    """When build_orch_args reports return_style, run() should pack outputs."""
+    """When _build_orch_args reports return_style, run() should pack outputs."""
     w = ChipWorker(config=RunConfig(platform="a2a3sim"))
     compiled = _fake_compiled()
     out_tensor = MagicMock(name="out_tensor")
-    compiled.build_orch_args.return_value = ("orch_args", [1, 2, out_tensor], True)
+    compiled._build_orch_args.return_value = ("orch_args", [1, 2, out_tensor], True)
     compiled.output_indices = [2]
     ret = w.run(compiled, 1, 2)
     assert ret is out_tensor

--- a/tests/ut/runtime/test_deprecated_entry_points.py
+++ b/tests/ut/runtime/test_deprecated_entry_points.py
@@ -1,0 +1,69 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""The directory-driven execute entry points warn, and still work.
+
+``execute_compiled`` and ``execute_distributed_compiled`` are deprecated in
+favour of reconstructing the artifact -- ``CompiledProgram.from_dir`` /
+``DistributedCompiledProgram.from_dir`` -- and calling it. Both remain exported
+for a deprecation cycle, so each must keep forwarding to the same
+implementation the supported path uses; a shim that warns but silently changes
+behaviour is worse than no shim.
+"""
+
+from ctypes import _SimpleCData
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+from pypto.runtime import DeviceTensor, RunConfig, execute_compiled, execute_distributed_compiled
+from pypto.runtime.runner import _DfxOpts
+
+_L3_FROM_DIR = "pypto.ir.distributed_compiled_program.DistributedCompiledProgram.from_dir"
+
+
+def test_execute_compiled_warns_and_forwards(tmp_path):
+    args: list[torch.Tensor | DeviceTensor | _SimpleCData] = [torch.zeros(4)]
+    config = RunConfig(platform="a2a3sim", device_id=2)
+
+    with patch("pypto.runtime.runner._execute_compiled") as impl:
+        with pytest.warns(DeprecationWarning, match=r"CompiledProgram\.from_dir"):
+            execute_compiled(
+                tmp_path,
+                args,
+                platform="a2a3sim",
+                device_id=2,
+                dfx=_DfxOpts.from_run_config(config),
+                config=config,
+            )
+
+    impl.assert_called_once()
+    assert impl.call_args.args[0] == tmp_path
+    assert impl.call_args.args[1] is args
+    assert impl.call_args.kwargs["platform"] == "a2a3sim"
+    assert impl.call_args.kwargs["device_id"] == 2
+    assert impl.call_args.kwargs["config"] is config
+
+
+def test_execute_distributed_compiled_warns_and_forwards(tmp_path):
+    args = [torch.zeros(4), torch.zeros(4)]
+    config = RunConfig(platform="a2a3")
+    reconstructed = MagicMock(name="DistributedCompiledProgram")
+
+    with patch(_L3_FROM_DIR, return_value=reconstructed) as from_dir:
+        with pytest.warns(DeprecationWarning, match=r"DistributedCompiledProgram\.from_dir"):
+            result = execute_distributed_compiled(tmp_path, args, config=config, platform="a2a3")
+
+    from_dir.assert_called_once_with(tmp_path, platform="a2a3", distributed_config=None)
+    reconstructed.assert_called_once_with(*args, config=config)
+    assert result is reconstructed.return_value
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/runtime/test_distributed_worker.py
+++ b/tests/ut/runtime/test_distributed_worker.py
@@ -1585,16 +1585,16 @@ class TestBindSubWorkers:
 
 
 class TestOneShotRegression:
-    """The one-shot execute_distributed path still works after helper extraction."""
+    """The one-shot _execute_distributed path still works after helper extraction."""
 
     def test_one_shot_setup_dispatch_close(self, patched_setup):
-        from pypto.runtime.distributed_runner import execute_distributed  # noqa: PLC0415
+        from pypto.runtime.distributed_runner import _execute_distributed  # noqa: PLC0415
 
         compiled = _fake_compiled([_param("a", [8, 8]), _param("b", [8, 8])], [])
         a = torch.zeros(8, 8, dtype=torch.float32)
         b = torch.zeros(8, 8, dtype=torch.float32)
 
-        execute_distributed(compiled, [a, b])
+        _execute_distributed(compiled, [a, b])
 
         patched_setup["assemble"].assert_called_once()
         patched_setup["construct"].assert_called_once()
@@ -1603,31 +1603,31 @@ class TestOneShotRegression:
         patched_setup["worker"].close.assert_called_once()
 
     def test_one_shot_rejects_resident_tensor_before_setup(self, patched_setup):
-        from pypto.runtime.distributed_runner import execute_distributed  # noqa: PLC0415
+        from pypto.runtime.distributed_runner import _execute_distributed  # noqa: PLC0415
 
         compiled = _fake_compiled([_param("a", [8, 8])], [])
         with pytest.raises(TypeError, match=r"same prepared DistributedWorker"):
-            execute_distributed(compiled, [DeviceTensor(0x1000, (8, 8), torch.float32)])
+            _execute_distributed(compiled, [DeviceTensor(0x1000, (8, 8), torch.float32)])
         patched_setup["assemble"].assert_not_called()
 
     def test_one_shot_enables_sdma_when_a_chip_requires_it(self, patched_setup):
-        from pypto.runtime.distributed_runner import execute_distributed  # noqa: PLC0415
+        from pypto.runtime.distributed_runner import _execute_distributed  # noqa: PLC0415
 
         patched_setup["assemble"].return_value = ({"chip_orch": object()}, "rt_name", True)
         compiled = _fake_compiled([_param("a", [8, 8])], [])
 
-        execute_distributed(compiled, [torch.zeros(8, 8, dtype=torch.float32)])
+        _execute_distributed(compiled, [torch.zeros(8, 8, dtype=torch.float32)])
 
         assert patched_setup["construct"].call_args.kwargs["enable_sdma"] is True
 
     def test_one_shot_retries_incomplete_worker_cleanup(self, patched_setup):
-        from pypto.runtime.distributed_runner import execute_distributed  # noqa: PLC0415
+        from pypto.runtime.distributed_runner import _execute_distributed  # noqa: PLC0415
 
         worker = patched_setup["worker"]
         worker.close.side_effect = [RuntimeError("cleanup pending"), None]
         compiled = _fake_compiled([_param("a", [8, 8])], [])
 
-        execute_distributed(compiled, [torch.zeros(8, 8, dtype=torch.float32)])
+        _execute_distributed(compiled, [torch.zeros(8, 8, dtype=torch.float32)])
 
         assert worker.close.call_count == 2
 

--- a/tests/ut/runtime/test_distributed_worker.py
+++ b/tests/ut/runtime/test_distributed_worker.py
@@ -33,8 +33,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import torch
+from pypto.ir import DistributedConfig
 from pypto.ir.compiled_program import _ParamInfo
-from pypto.ir.distributed_compiled_program import DistributedConfig
 from pypto.pypto_core import DataType
 from pypto.pypto_core.ir import ParamDirection
 from pypto.runtime import DeviceTensor, StackedDeviceTensor
@@ -2093,7 +2093,7 @@ class TestMultiProgram:
             DistributedWorker([prog_a, prog_b], callbacks={"typo": lambda args: None})
 
     def test_prepare_extra_compiled_forwards_program_list(self):
-        from pypto.ir.distributed_compiled_program import DistributedCompiledProgram  # noqa: PLC0415
+        from pypto.ir import DistributedCompiledProgram  # noqa: PLC0415
 
         primary = _fake_compiled([_param("a", [4])], [])
         extra = _fake_compiled([_param("b", [8])], [])
@@ -2103,7 +2103,7 @@ class TestMultiProgram:
         assert fake_worker.call_args.args[0] == [primary, extra]
 
     def test_prepare_forwards_persistent_flag(self):
-        from pypto.ir.distributed_compiled_program import DistributedCompiledProgram  # noqa: PLC0415
+        from pypto.ir import DistributedCompiledProgram  # noqa: PLC0415
 
         primary = _fake_compiled([_param("a", [4])], [])
         with patch("pypto.runtime.distributed_runner.DistributedWorker") as fake_worker:
@@ -2118,7 +2118,7 @@ class TestMultiProgram:
         call the user manual shows raised TypeError and the zero-copy path was reachable
         only through the lower-level API.
         """
-        from pypto.ir.distributed_compiled_program import DistributedCompiledProgram  # noqa: PLC0415
+        from pypto.ir import DistributedCompiledProgram  # noqa: PLC0415
 
         primary = _fake_compiled([_param("a", [4])], [])
         host = torch.zeros(4, dtype=torch.float32).share_memory_()
@@ -2127,7 +2127,7 @@ class TestMultiProgram:
         assert fake_worker.call_args.kwargs["inherited_host_tensors"] == [host]
 
     def test_prepare_forwards_startup_timeout(self):
-        from pypto.ir.distributed_compiled_program import DistributedCompiledProgram  # noqa: PLC0415
+        from pypto.ir import DistributedCompiledProgram  # noqa: PLC0415
 
         primary = _fake_compiled([_param("a", [4])], [])
         with patch("pypto.runtime.distributed_runner.DistributedWorker") as fake_worker:
@@ -3680,7 +3680,7 @@ class TestNamedInheritedHostRanges:
 
     def test_a_range_listed_through_prepare_is_named(self, patched_setup):
         """End to end through the documented entry point, not just the constructor."""
-        from pypto.ir.distributed_compiled_program import DistributedCompiledProgram  # noqa: PLC0415
+        from pypto.ir import DistributedCompiledProgram  # noqa: PLC0415
 
         host = torch.zeros(4, 4, dtype=torch.float32).share_memory_()
         rt = DistributedCompiledProgram.prepare(

--- a/tests/ut/runtime/test_replay.py
+++ b/tests/ut/runtime/test_replay.py
@@ -9,7 +9,7 @@
 
 """Unit tests for :mod:`pypto.runtime.debug.replay`.
 
-``execute_compiled`` is mocked so these tests run without a device and
+``_execute_compiled`` is mocked so these tests run without a device and
 without the optional ``simpler`` runtime package.
 """
 
@@ -127,7 +127,7 @@ def test_replay_routes_to_execute_compiled(tmp_path: Path) -> None:
     a = torch.zeros(2)
     b = torch.zeros(2)
     config = RunConfig(platform="a2a3sim", device_id=3, ring_heap=512 * 1024 * 1024)
-    with patch.object(replay_module, "execute_compiled") as ec:
+    with patch.object(replay_module, "_execute_compiled") as ec:
         replay(work_dir, a, b, config=config)
     ec.assert_called_once()
     call_args = ec.call_args
@@ -148,7 +148,7 @@ def test_replay_forwards_dfx_flags(tmp_path: Path) -> None:
         enable_dep_gen=True,
         enable_scope_stats=True,
     )
-    with patch.object(replay_module, "execute_compiled") as ec:
+    with patch.object(replay_module, "_execute_compiled") as ec:
         replay(work_dir, config=config)
     dfx = ec.call_args.kwargs["dfx"]
     assert dfx.enable_chip_swimlane == 4  # True normalizes to the full level
@@ -162,7 +162,7 @@ def test_replay_invalidates_by_default(tmp_path: Path) -> None:
     work_dir = _make_build_output(tmp_path)
     bin_file = _touch(work_dir / "cache" / "incore_aiv_foo.bin")
     so_file = _touch(work_dir / "kernels" / "aiv" / "foo.so")
-    with patch.object(replay_module, "execute_compiled"):
+    with patch.object(replay_module, "_execute_compiled"):
         replay(work_dir)
     assert not bin_file.exists()
     assert not so_file.exists()
@@ -172,7 +172,7 @@ def test_replay_skips_invalidation_when_recompile_false(tmp_path: Path) -> None:
     work_dir = _make_build_output(tmp_path)
     bin_file = _touch(work_dir / "cache" / "incore_aiv_foo.bin")
     so_file = _touch(work_dir / "kernels" / "aiv" / "foo.so")
-    with patch.object(replay_module, "execute_compiled"):
+    with patch.object(replay_module, "_execute_compiled"):
         replay(work_dir, recompile=False)
     assert bin_file.exists()
     assert so_file.exists()
@@ -193,7 +193,7 @@ def test_replay_calls_rebuild_before_invalidate(tmp_path: Path) -> None:
         call_order.append("invalidate")
 
     with (
-        patch.object(replay_module, "execute_compiled"),
+        patch.object(replay_module, "_execute_compiled"),
         patch.object(replay_module, "rebuild_kernel_cpp_from_pto", side_effect=_record_rebuild),
         patch.object(replay_module, "invalidate_binary_cache", side_effect=_record_invalidate),
     ):
@@ -204,7 +204,7 @@ def test_replay_calls_rebuild_before_invalidate(tmp_path: Path) -> None:
 def test_replay_skips_rebuild_from_pto_when_disabled(tmp_path: Path) -> None:
     work_dir = _make_build_output(tmp_path)
     with (
-        patch.object(replay_module, "execute_compiled"),
+        patch.object(replay_module, "_execute_compiled"),
         patch.object(replay_module, "rebuild_kernel_cpp_from_pto") as rb,
     ):
         replay(work_dir, rebuild_from_pto=False)
@@ -213,7 +213,7 @@ def test_replay_skips_rebuild_from_pto_when_disabled(tmp_path: Path) -> None:
 
 def test_replay_prints_execute_banner(tmp_path: Path, capsys) -> None:
     work_dir = _make_build_output(tmp_path)
-    with patch.object(replay_module, "execute_compiled"):
+    with patch.object(replay_module, "_execute_compiled"):
         replay(work_dir, rebuild_from_pto=False, recompile=False)
     out = capsys.readouterr().out
     assert "[execute] running on device..." in out
@@ -225,8 +225,11 @@ def test_replay_missing_kernel_config_raises(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# L3 distributed builds route to execute_distributed_compiled (#1689)
+# L3 distributed builds route through DistributedCompiledProgram (#1689)
 # ---------------------------------------------------------------------------
+
+
+_L3_FROM_DIR = "pypto.ir.distributed_compiled_program.DistributedCompiledProgram.from_dir"
 
 
 def _make_l3_build_output(tmp_path: Path) -> Path:
@@ -236,19 +239,20 @@ def _make_l3_build_output(tmp_path: Path) -> Path:
     return tmp_path
 
 
-def test_replay_routes_l3_to_execute_distributed_compiled(tmp_path: Path) -> None:
+def test_replay_routes_l3_through_distributed_compiled_program(tmp_path: Path) -> None:
     work_dir = _make_l3_build_output(tmp_path)
     a, b = torch.zeros(2), torch.zeros(2)
     with (
-        patch("pypto.runtime.distributed_runner.execute_distributed_compiled") as edc,
-        patch.object(replay_module, "execute_compiled") as ec,
+        patch(_L3_FROM_DIR) as from_dir,
+        patch.object(replay_module, "_execute_compiled") as ec,
     ):
         replay(work_dir, a, b, config=RunConfig(platform="a2a3sim"), rebuild_from_pto=False, recompile=False)
-    edc.assert_called_once()
+    from_dir.assert_called_once_with(work_dir, platform="a2a3sim")
     ec.assert_not_called()  # single-chip path must not be taken for L3
-    assert edc.call_args.args[0] == work_dir
-    assert edc.call_args.args[1] == [a, b]
-    assert edc.call_args.kwargs["platform"] == "a2a3sim"
+    compiled = from_dir.return_value
+    compiled.assert_called_once()
+    assert compiled.call_args.args == (a, b)
+    assert compiled.call_args.kwargs["config"].platform == "a2a3sim"
 
 
 def test_replay_l3_runs_l3_aware_rebuild_and_invalidate(tmp_path: Path) -> None:
@@ -264,7 +268,7 @@ def test_replay_l3_runs_l3_aware_rebuild_and_invalidate(tmp_path: Path) -> None:
         order.append("invalidate")
 
     with (
-        patch("pypto.runtime.distributed_runner.execute_distributed_compiled"),
+        patch(_L3_FROM_DIR),
         patch.object(replay_module, "rebuild_kernel_cpp_from_pto", side_effect=_rebuild),
         patch.object(replay_module, "invalidate_binary_cache", side_effect=_invalidate),
     ):
@@ -274,7 +278,7 @@ def test_replay_l3_runs_l3_aware_rebuild_and_invalidate(tmp_path: Path) -> None:
 
 def test_replay_uses_default_run_config_when_none(tmp_path: Path) -> None:
     work_dir = _make_build_output(tmp_path)
-    with patch.object(replay_module, "execute_compiled") as ec:
+    with patch.object(replay_module, "_execute_compiled") as ec:
         replay(work_dir)
     default_cfg = RunConfig()
     assert ec.call_args.kwargs["platform"] == default_cfg.platform
@@ -307,7 +311,7 @@ def test_replay_validate_passes_when_outputs_match(tmp_path: Path) -> None:
     b = torch.full((4,), 3.0)
     c = torch.full((4,), 5.0)  # already correct: a+b
 
-    with patch.object(replay_module, "execute_compiled"):
+    with patch.object(replay_module, "_execute_compiled"):
         replay(work_dir, a, b, c, validate=True)  # must not raise
 
 
@@ -318,7 +322,7 @@ def test_replay_validate_fails_when_outputs_mismatch(tmp_path: Path) -> None:
     b = torch.full((4,), 3.0)
     c = torch.zeros(4)  # wrong: should be 5.0
 
-    with patch.object(replay_module, "execute_compiled"):
+    with patch.object(replay_module, "_execute_compiled"):
         with pytest.raises(AssertionError, match="does not match golden"):
             replay(work_dir, a, b, c, validate=True)
 
@@ -339,7 +343,7 @@ def test_replay_validate_tensor_count_mismatch_raises(tmp_path: Path) -> None:
 def test_replay_validate_false_does_not_open_golden(tmp_path: Path) -> None:
     work_dir = _make_build_output(tmp_path)
     # No golden.py exists; validate=False must not care.
-    with patch.object(replay_module, "execute_compiled"):
+    with patch.object(replay_module, "_execute_compiled"):
         replay(work_dir, torch.zeros(4), validate=False)
 
 

--- a/tests/ut/runtime/test_run_config.py
+++ b/tests/ut/runtime/test_run_config.py
@@ -503,7 +503,7 @@ class TestMakeCallConfigRing:
     """
 
     def test_no_run_config_leaves_runtime_env_at_zero(self, monkeypatch):
-        from pypto.ir.distributed_compiled_program import DistributedConfig  # noqa: PLC0415
+        from pypto.ir import DistributedConfig  # noqa: PLC0415
 
         cfg = _make_dist_call_config_with_fake(DistributedConfig(), None, monkeypatch)
         assert cfg.aicpu_thread_num == 0
@@ -512,7 +512,7 @@ class TestMakeCallConfigRing:
         assert cfg.runtime_env.ring_dep_pool == 0
 
     def test_run_config_ring_overrides_transcribed(self, monkeypatch):
-        from pypto.ir.distributed_compiled_program import DistributedConfig  # noqa: PLC0415
+        from pypto.ir import DistributedConfig  # noqa: PLC0415
 
         run_config = RunConfig(
             platform="a2a3sim",
@@ -526,7 +526,7 @@ class TestMakeCallConfigRing:
         assert cfg.runtime_env.ring_dep_pool == 128
 
     def test_baseline_preserved_and_partial_ring_overlay(self, monkeypatch):
-        from pypto.ir.distributed_compiled_program import DistributedConfig  # noqa: PLC0415
+        from pypto.ir import DistributedConfig  # noqa: PLC0415
 
         dc = DistributedConfig(aicpu_thread_num=3)
         run_config = RunConfig(platform="a2a3sim", ring_heap=1024 * 1024)
@@ -541,7 +541,7 @@ class TestMakeCallConfigRing:
     def test_per_ring_list_overlaid_on_l3_dispatch(self, monkeypatch):
         # A per-program L3 dispatch can size each scope-depth ring independently
         # (e.g. a wider task window for prefill than decode).
-        from pypto.ir.distributed_compiled_program import DistributedConfig  # noqa: PLC0415
+        from pypto.ir import DistributedConfig  # noqa: PLC0415
 
         run_config = RunConfig(platform="a2a3sim", ring_task_window=[16, 32, 128, 256])
         cfg = _make_dist_call_config_with_fake(DistributedConfig(), run_config, monkeypatch)
@@ -562,7 +562,7 @@ class TestMakeCallConfigDfx:
     """
 
     def test_dfx_flags_transcribed_and_prefix_set(self, monkeypatch, tmp_path):
-        from pypto.ir.distributed_compiled_program import DistributedConfig  # noqa: PLC0415
+        from pypto.ir import DistributedConfig  # noqa: PLC0415
 
         dfx_base = tmp_path / "dfx_outputs"
         run_config = RunConfig(
@@ -584,7 +584,7 @@ class TestMakeCallConfigDfx:
         assert dfx_base.is_dir()
 
     def test_swimlane_sets_flag_and_co_enables_dep_gen(self, monkeypatch, tmp_path):
-        from pypto.ir.distributed_compiled_program import DistributedConfig  # noqa: PLC0415
+        from pypto.ir import DistributedConfig  # noqa: PLC0415
 
         dfx_base = tmp_path / "dfx_outputs"
         # User asks for swimlane only; dep_gen is auto-enabled because the
@@ -598,14 +598,14 @@ class TestMakeCallConfigDfx:
         assert cfg.output_prefix == str(dfx_base)
 
     def test_dfx_without_base_raises(self, monkeypatch):
-        from pypto.ir.distributed_compiled_program import DistributedConfig  # noqa: PLC0415
+        from pypto.ir import DistributedConfig  # noqa: PLC0415
 
         run_config = RunConfig(platform="a2a3sim", enable_pmu=1)
         with pytest.raises(ValueError, match="dfx_base is required"):
             _make_dist_call_config_with_fake(DistributedConfig(), run_config, monkeypatch, dfx_base=None)
 
     def test_no_run_config_leaves_dfx_off(self, monkeypatch):
-        from pypto.ir.distributed_compiled_program import DistributedConfig  # noqa: PLC0415
+        from pypto.ir import DistributedConfig  # noqa: PLC0415
 
         cfg = _make_dist_call_config_with_fake(DistributedConfig(), None, monkeypatch)
         assert cfg.output_prefix == ""
@@ -613,7 +613,7 @@ class TestMakeCallConfigDfx:
         assert cfg.enable_dep_gen is False
 
     def test_ring_only_run_config_creates_no_dfx_dir(self, monkeypatch, tmp_path):
-        from pypto.ir.distributed_compiled_program import DistributedConfig  # noqa: PLC0415
+        from pypto.ir import DistributedConfig  # noqa: PLC0415
 
         dfx_base = tmp_path / "dfx_outputs"
         run_config = RunConfig(platform="a2a3sim", ring_heap=1024 * 1024)

--- a/tests/ut/runtime/test_run_config.py
+++ b/tests/ut/runtime/test_run_config.py
@@ -17,7 +17,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from pypto.backend import BackendType
 from pypto.pypto_core.passes import MemoryPlanner
-from pypto.runtime.runner import RunConfig, _DfxOpts, execute_compiled
+from pypto.runtime.runner import RunConfig, _DfxOpts, _execute_compiled
 
 
 class TestRunConfigPlatformResolution:
@@ -702,7 +702,7 @@ class TestRunConfigCompileForwarding:
         )
         monkeypatch.setitem(sys.modules, "pypto.runtime.device_runner", fake_device_runner)
 
-        execute_compiled(
+        _execute_compiled(
             tmp_path,
             [],
             platform="a2a3sim",
@@ -746,7 +746,7 @@ class TestRunConfigCompileForwarding:
             ring_heap=512 * 1024 * 1024,
             ring_dep_pool=[64, 0, 0, 256],
         )
-        execute_compiled(
+        _execute_compiled(
             tmp_path,
             [],
             platform="a2a3",
@@ -790,7 +790,7 @@ class TestRunConfigCompileForwarding:
         )
         monkeypatch.setitem(sys.modules, "pypto.runtime.device_runner", fake_device_runner)
 
-        execute_compiled(tmp_path, [], platform="a2a3sim", device_id=0)
+        _execute_compiled(tmp_path, [], platform="a2a3sim", device_id=0)
 
         assert captured["enable_sdma"] is expected_enable_sdma
 


### PR DESCRIPTION
## Summary

Three moves on one question: which names on the artifact layer are meant to be
typed by hand. Two that should have been public were not; three that were public
should not have been. This is Stage B of the plan in
`docs/en/dev/08-entry-points.md`, following #2597.

| Name | Was | Is |
| ---- | --- | -- |
| `DistributedCompiledProgram`, `DistributedConfig` | public, but only reachable as `pypto.ir.distributed_compiled_program.X` | exported from `pypto.ir` |
| `CompiledProgram.build_orch_args` / `build_call_config` | public, in the user manual | `_build_orch_args` / `_build_call_config` |
| `execute_compiled`, `execute_distributed_compiled` | public | deprecated, behind a `DeprecationWarning` |

Two commits, in that order; they touch disjoint code and can be read
independently.

## 1. Re-export the distributed artifact types

`DistributedCompiledProgram` and `DistributedConfig` are public types that
`pypto.ir` did not export, so every caller reached past the package into the
defining module — 91 import statements across tests, examples and docs,
spelling out a private-looking path for two public names.

Both now come from `pypto.ir` alongside `CompiledProgram`. The defining module
stays importable and keeps its four `pypto.runtime` importers, which take it
directly to avoid an import cycle; the re-export is an alias of the same
objects, so an `isinstance` check cannot depend on the spelling — there is a
test for that.

`python/pypto/ir/__init__.pyi` needed the same two names: that stub shadows the
runtime module for type checkers. It had also drifted before this change —
`CompiledProgram`, `DiagnosticPhase`, `DiagnosticCheck` and
`DiagnosticCheckSet` were exported at runtime but absent from the stub, which is
why `ir.CompiledProgram` did not type-check. All six are now listed.

## 2. Internalize the argument builders

`CompiledProgram.build_orch_args` and `build_call_config` marshal user arguments
into simpler's `TaskArgs` and `CallConfig`. The user manual listed them as part
of the extraction surface, but the supported route to them is `ChipWorker.run` /
`register`, which calls both for you. A caller driving a hand-constructed
`simpler.worker.Worker` still gets `chip_callable`, `runtime_name` and
`runtime_config` from the public surface.

Renamed `_build_orch_args` / `_build_call_config`, on `CompiledProgram` and
`_SubChipCallable`. Nothing outside this repository imported either. The
runner-side helper the latter delegates to is now imported under an alias, so
the module-level function and the method it backs no longer share a name at the
call site.

`tests/st/runtime/framework_and_models/test_compiled_program.py` keeps calling
them directly — the marshalling `ChipWorker.run` delegates to still deserves its
own coverage — with a docstring saying why it reaches for internals.

## 3. Deprecate the directory-driven execute entry points

`execute_compiled` and `execute_distributed_compiled` dispatch a build directory
instead of an artifact handle. That was the only way to re-run a directory
before `CompiledProgram.from_dir` / `DistributedCompiledProgram.from_dir`
existed; now both reconstruct the same handle from the same sidecar, and calling
it takes the same path as a handle that never left memory. The distributed one
had already decayed into a four-line wrapper around `from_dir` plus a call.

Both are deprecated, not removed: `pypto-lib` imports `execute_compiled`
(`golden/runner.py`), so each keeps working and each now emits a
`DeprecationWarning`.

**The implementation moves out from under the deprecated name.**
`_execute_compiled` holds what `execute_compiled` used to be, and
`CompiledProgram.__call__` — every supported L2 dispatch — calls that directly.
Without the split, the warning would fire on every ordinary `compiled(...)`
call, naming a function the caller never wrote. A test pins it: dispatching a
`CompiledProgram` with `DeprecationWarning` promoted to an error must not raise.

The same move makes `execute_distributed` private. It is the one-shot L3
implementation behind `DistributedCompiledProgram.__call__`, was never in
`pypto.runtime.__all__`, and has no importer outside this repository.

`replay`'s L3 branch now reconstructs a `DistributedCompiledProgram` and calls
it, which is what `execute_distributed_compiled` was doing on its behalf.

## Migration

```python
# before
from pypto.ir.distributed_compiled_program import DistributedConfig
orch_args, coerced, style = compiled.build_orch_args(*args, worker=w)
cfg = compiled.build_call_config(run_config)

# after
from pypto.ir import DistributedConfig
worker.run(compiled, *args)          # marshals both for you
```

`execute_distributed_compiled` is a plain rename — it already was `from_dir`
plus a call:

```python
# before
execute_distributed_compiled(work_dir, args, config=cfg, platform="a2a3")

# after
ir.DistributedCompiledProgram.from_dir(work_dir, platform="a2a3")(*args, config=cfg)
```

**`execute_compiled` is not**, because the two paths disagree on precedence:

| Setting | `execute_compiled` | `CompiledProgram.__call__` |
| ------- | ------------------ | -------------------------- |
| `platform` | the explicit argument | `config.platform` when a config is passed, else the artifact's |
| `device_id` / `dfx` / `aicpu_thread_num` | the explicit arguments | always from `config` |
| ring overrides | from `config` | from `config` |

A `config` passed for ring sizing alone therefore takes over the rest, and
`RunConfig.platform` defaults to `a2a3sim` — a plain rename would move the run
to the simulator. The recipe folds the explicit arguments in:

```python
# before -- explicit args win; cfg was read for ring sizing only
execute_compiled(work_dir, args, platform="a2a3", device_id=0, config=cfg)

# after -- cfg carries every execution setting
cfg = dataclasses.replace(cfg, platform="a2a3", device_id=0)
ir.CompiledProgram.from_dir(work_dir)(*args, config=cfg)
```

Changing `CompiledProgram.__call__` to restore the old precedence instead would
alter every existing artifact dispatch, so this documents the difference rather
than papering over it. The behaviour is already pinned by
`test_explicit_config_platform_overrides_compiled_platform`.

## Docs

`docs/{en,zh}/dev/08-entry-points.md` gains the `pypto.ir` import line, marks
the two execute functions deprecated with the precedence table above, and lists
the builders and the two private implementations under "What is internal"; the
paragraph saying the distributed types are *not* re-exported is gone.
`docs/{en,zh}/user/execution/{00-compile,01-run}.md` drop the builders from the
`CompiledProgram` contract and the JIT extraction surface, pointing at
`ChipWorker`. `03-runtime-replay.md`, `05-runtime-ring-sizing.md`,
`03-runtime-dfx.md`, `codegen/00-pto_codegen.md` and the two distributed user
pages migrate their examples and prose. 18 pages, en/zh in step.

## Verification

Run in the worktree against its own build, at the pushed commit.

- `pytest tests/ut/ -n 16`: 10995 passed, 8 skipped, 1 xfailed
- `tests/lint/check_*.py` (12 scripts, incl. docs nav and en/zh parity): all pass
- `ruff check` / `ruff format --check` (pinned 0.14.8): clean
- `pyright python/pypto tests examples`: only two pre-existing
  `torch.float4_e2m1fn_x2` errors, from this machine's older torch rather than
  CI's pinned 2.8.0
- `markdownlint-cli2 v0.20.0` on the 18 changed pages: 0 errors
- Import-cycle probe: `pypto.ir`, `pypto.runtime` and seven submodules import
  cleanly as the first import in a fresh interpreter, in either order

One unit test is deselected:
`test_unified_ops.py::TestUnifiedSlicePadValue::test_symlinked_import_path_still_names_the_caller`.
It fails identically on unmodified `main` in this environment — the editable
install's meta-path finder redirects `pypto` inside the subprocess the test
spawns — and is unrelated to this change.

Device tests were not run; this change touches no kernel or codegen output.
