### PR TITLE
fix(parser): Keep inline parameters call-local

### DIFF
--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -8421,8 +8421,15 @@ class ASTParser:
             self.expr_evaluator.closure_vars = prev_closure_vars
             return_expr = self._inline_return_expr
             self._inline_mode, self._inline_return_expr = prev_inline_state
-            # Leak vars so inlined definitions are visible to the caller
-            self.scope_manager.exit_scope(leak_vars=True)
+            # Keep the existing statement-level inline semantics for local
+            # definitions, but never expose formal parameter bindings. A
+            # formal may share a name with an unrelated caller variable; if it
+            # escaped, a later inline call could receive the first call's
+            # actual argument instead of the caller variable it names.
+            self.scope_manager.exit_scope(
+                leak_vars=True,
+                exclude_names=set(inline_func.param_names),
+            )
 
         if return_expr is None:
             raise ParserTypeError(

--- a/python/pypto/language/parser/scope_manager.py
+++ b/python/pypto/language/parser/scope_manager.py
@@ -45,12 +45,18 @@ class ScopeManager:
         scope_id = len(self.scopes) - 1
         self.yielded_vars[scope_id] = set()
 
-    def exit_scope(self, leak_vars: bool = False) -> dict[str, Any]:
+    def exit_scope(
+        self,
+        leak_vars: bool = False,
+        exclude_names: set[str] | None = None,
+    ) -> dict[str, Any]:
         """Exit current scope and return defined variables.
 
         Args:
             leak_vars: If True, copy all variables from exiting scope to parent scope.
                        Used for plain syntax where variables should be visible after for/if.
+            exclude_names: Variable names that must remain local when ``leak_vars``
+                is True.
 
         Returns:
             Dictionary of variables defined in the exited scope
@@ -67,6 +73,8 @@ class ScopeManager:
         if leak_vars and self.scopes:
             parent_scope = self.scopes[-1]
             for name, value in scope_vars.items():
+                if exclude_names is not None and name in exclude_names:
+                    continue
                 parent_scope[name] = value
 
         # Clean up yielded vars tracking

--- a/tests/ut/language/parser/test_decorator.py
+++ b/tests/ut/language/parser/test_decorator.py
@@ -1420,6 +1420,51 @@ class TestInlineFunctionCalls:
 
         ir.assert_structural_equal(TwiceCalled, Expected)
 
+    def test_inline_formal_names_do_not_escape_call_scope(self):
+        """A formal name must not overwrite the caller binding of that name."""
+
+        @pl.inline
+        def write_value(
+            value: pl.Tensor[[4], pl.FP32],
+            output: pl.Out[pl.Tensor[[4], pl.FP32]],
+        ) -> pl.Tensor[[4], pl.FP32]:
+            output = pl.tensor.assemble(output, value, [0])
+            return output
+
+        @pl.program
+        class Actual:
+            @pl.function
+            def main(
+                self,
+                first: pl.Tensor[[4], pl.FP32],
+                second: pl.Tensor[[4], pl.FP32],
+                output: pl.Out[pl.Tensor[[4], pl.FP32]],
+            ) -> pl.Tensor[[4], pl.FP32]:
+                intermediate = pl.tensor.create([4], dtype=pl.FP32)
+                written_intermediate = write_value(first, intermediate)
+                combined = pl.add(written_intermediate, second)
+                result = write_value(combined, output)
+                return result
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(
+                self,
+                first: pl.Tensor[[4], pl.FP32],
+                second: pl.Tensor[[4], pl.FP32],
+                output: pl.Out[pl.Tensor[[4], pl.FP32]],
+            ) -> pl.Tensor[[4], pl.FP32]:
+                intermediate = pl.tensor.create([4], dtype=pl.FP32)
+                intermediate = pl.tensor.assemble(intermediate, first, [0])
+                written_intermediate = intermediate
+                combined = pl.add(written_intermediate, second)
+                output = pl.tensor.assemble(output, combined, [0])
+                result = output
+                return result
+
+        ir.assert_structural_equal(Actual, Expected)
+
     def test_inline_wrong_arg_count_raises_error(self):
         """Wrong number of arguments raises ParserTypeError."""
 


### PR DESCRIPTION
## Summary
Inline functions expand in temporary scopes, but formal parameter bindings were previously merged back into the caller together with inline-body locals. When a formal shared a name with a caller variable—especially an explicit output—the first call could overwrite the caller's binding and redirect a later inline call to an intermediate. This change keeps formal bindings call-local while preserving the established visibility of non-formal inline-body definitions; no public DSL migration is required.

## Changes
- `python/pypto/language/parser`: allow scope leakage to exclude selected names, and exclude every inline function parameter when returning to the caller scope.
- `tests/ut/language/parser/test_decorator.py`: add a structural regression with two inline calls whose `output` formal shadows the caller's output binding.

## Verification
- `cmake --build build-314 --parallel 2`: passed.
- `python -m pytest tests/ut/language/parser/test_decorator.py -n 2 -q`: 108 passed, 1 skipped.
- `ruff check python/pypto/language/parser/ast_parser.py python/pypto/language/parser/scope_manager.py tests/ut/language/parser/test_decorator.py`: passed.
- `ruff format --check python/pypto/language/parser/ast_parser.py python/pypto/language/parser/scope_manager.py tests/ut/language/parser/test_decorator.py`: passed.
- `git diff --check upstream/main..HEAD`: passed.