### PR TITLE
refactor(runtime)!: mark the assembly layer private and give the tests one seam for it

### DIFF
--- a/docs/en/dev/03-runtime-dfx.md
+++ b/docs/en/dev/03-runtime-dfx.md
@@ -56,7 +56,7 @@ table above. Most artefacts are flat files directly under the prefix;
 subdir holding `scope_stats.jsonl`. Simpler's `CallConfig::validate()`
 rejects the call if any
 flag is enabled but `output_prefix` is empty; PyPTO mirrors that contract
-on the Python side and raises `ValueError` from `execute_on_device`
+on the Python side and raises `ValueError` from `_execute_on_device`
 *before* the C++ boundary so the failure traceback points at the
 caller.
 
@@ -331,7 +331,7 @@ this hint at the end of every scope-stats-enabled run.
 | Concern | File | Function / member |
 | ------- | ---- | ----------------- |
 | `RunConfig` field declarations | [runner.py](../../../python/pypto/runtime/runner.py) | `RunConfig` dataclass + `any_dfx_enabled()` |
-| `CallConfig` plumbing | [device_runner.py](../../../python/pypto/runtime/device_runner.py) | `execute_on_device(..., enable_*, output_prefix)` |
+| `CallConfig` plumbing | [device_runner.py](../../../python/pypto/runtime/device_runner.py) | `_execute_on_device(..., enable_*, output_prefix)` |
 | Pipeline bundle | [runner.py](../../../python/pypto/runtime/runner.py) | `_DfxOpts` dataclass + `_DfxOpts.from_run_config` |
 | Per-flag post-run dispatch | [runner.py](../../../python/pypto/runtime/runner.py) | `_collect_dfx_artifacts` |
 | Kernel-name map synthesis | [runner.py](../../../python/pypto/runtime/runner.py) | `_write_name_map` |

--- a/docs/en/dev/05-runtime-ring-sizing.md
+++ b/docs/en/dev/05-runtime-ring-sizing.md
@@ -130,7 +130,7 @@ the precedence above.
 
 A ring sizing's runtime arena costs ~800 ms to build the first time it is used.
 Workers build it eagerly at `init` — `prepare(config)` / `ChipWorker` /
-`execute_on_device` — so the cold build lands in setup instead of inside the
+`_execute_on_device` — so the cold build lands in setup instead of inside the
 first (usually timed) dispatch.
 
 The arena cache is keyed on the **full per-ring sizing vector** (all four rings'

--- a/docs/en/dev/08-entry-points.md
+++ b/docs/en/dev/08-entry-points.md
@@ -46,8 +46,8 @@ into loadable binaries. It is internal and has no supported entry point.
 | `ir.compile` | compile driver | [`ir/compile.py`](../../../python/pypto/ir/compile.py) |
 | `JITFunction.compile` | specialize + driver | [`jit/decorator.py`](../../../python/pypto/jit/decorator.py) |
 | `JITFunction.lower` | specialize only, stops at `ir.Program` | same |
-| `device_runner.compile_and_assemble` | assembly | [`runtime/device_runner.py`](../../../python/pypto/runtime/device_runner.py) |
-| `device_runner.compile_single_kernel` / `compile_single_orchestration` | assembly | same |
+| `device_runner._compile_and_assemble` | assembly | [`runtime/device_runner.py`](../../../python/pypto/runtime/device_runner.py) |
+| `device_runner._compile_single_kernel` / `_compile_single_orchestration` | assembly | same |
 | `KernelCompiler.compile_incore` | ptoas invocation | [`runtime/kernel_compiler.py`](../../../python/pypto/runtime/kernel_compiler.py) |
 
 `ir.compile` is the only supported one; the rest of the table is here so a name
@@ -77,7 +77,7 @@ and tests should take the three names from `pypto.ir`.
 | `CompiledProgram.from_dir` / `DistributedCompiledProgram.from_dir` | artifact | output directory | [`ir/compiled_program.py`](../../../python/pypto/ir/compiled_program.py) |
 | `runtime.execute_compiled` *(deprecated)* | execute | output directory | [`runtime/runner.py`](../../../python/pypto/runtime/runner.py) |
 | `execute_distributed_compiled` *(deprecated)* | execute | output directory | [`runtime/distributed_runner.py`](../../../python/pypto/runtime/distributed_runner.py) |
-| `device_runner.execute_on_device` | assembly | assembled binaries | [`runtime/device_runner.py`](../../../python/pypto/runtime/device_runner.py) |
+| `device_runner._execute_on_device` | assembly | assembled binaries | [`runtime/device_runner.py`](../../../python/pypto/runtime/device_runner.py) |
 | `execute_artifact_dir` / `execute_batch_manifest` | CLI | output directory | [`runtime/execute_artifact.py`](../../../python/pypto/runtime/execute_artifact.py) |
 
 `run` does not say which layer you are on; the receiver does. `ChipWorker.run`
@@ -160,16 +160,22 @@ These have no stability guarantee. They are not in any `__all__`, and code
 outside PyPTO should not import them:
 
 - `pypto.ir.compile` — `_ensure_orchestration_headers`
-- `pypto.runtime.runner` — `_execute_compiled`
-- `pypto.runtime.distributed_runner` — `_execute_distributed`
 - `pypto.ir.compiled_program` — `CompiledProgram._build_orch_args`,
   `CompiledProgram._build_call_config`
-- `pypto.runtime.device_runner` — `compile_and_assemble`, `compile_single_kernel`,
-  `compile_single_orchestration`, `execute_on_device`
+- `pypto.runtime.runner` — `_execute_compiled`, `_execute_golden_case`,
+  `_build_call_config`, `_coerced_to_orch_args`, `_DfxOpts`
+- `pypto.runtime.distributed_runner` — `_execute_distributed`
+- `pypto.runtime.device_runner` — the whole assembly layer:
+  `_compile_and_assemble`, `_compile_single_kernel`,
+  `_compile_single_orchestration`, `_execute_on_device`
 - `pypto.runtime.kernel_compiler` — `KernelCompiler`, `compile_incore`
-- `pypto.runtime.runner` — `_build_call_config`, `_coerced_to_orch_args`,
-  `_DfxOpts`
 - `pypto.runtime.tensor_arg`, `pypto.runtime.elf_parser`, `pypto.runtime._binary_cache`
+
+The assembly layer carries the underscore so a traceback says which side of the
+boundary it came from: an import that has to spell `_` is an import that had to
+decide to. `KernelCompiler` / `compile_incore` and the three modules on the last
+line are the exceptions — they are internal by module rather than by name, and
+carry the same absence of a stability guarantee.
 
 The two argument builders marshal user arguments into simpler's `TaskArgs` and
 `CallConfig`. `ChipWorker.run` and `ChipWorker.register` are the supported way

--- a/docs/en/user/00-getting_started.md
+++ b/docs/en/user/00-getting_started.md
@@ -102,7 +102,7 @@ finally:
     worker.close()                                   # cids + DeviceTensors released
 ```
 
-`worker.register(compiled)` triggers `compile_and_assemble` + simpler
+`worker.register(compiled)` triggers `_compile_and_assemble` + simpler
 `register` immediately, so configuration errors surface here rather than on
 first dispatch. The returned `RegistrationHandle` is callable, supports
 `with handle:` for scoped cleanup, and exposes `handle.unregister()` for

--- a/docs/zh/dev/03-runtime-dfx.md
+++ b/docs/zh/dev/03-runtime-dfx.md
@@ -49,7 +49,7 @@ PyPTO 将该 prefix 设为 `<work_dir>/dfx_outputs/`，其下的子路径按上�
 写入 `scope_stats/` 子目录，内含 `scope_stats.jsonl`。Simpler 的
 `CallConfig::validate()` 在任一 flag 开启但
 `output_prefix` 为空时拒绝调用；PyPTO 在 Python 侧镜像该契约，
-`execute_on_device` 会**先于** C++ 边界抛 `ValueError`，让 traceback
+`_execute_on_device` 会**先于** C++ 边界抛 `ValueError`，让 traceback
 直接指向调用方代码。
 
 ### L3（分布式）：每次 dispatch 一个子目录
@@ -294,7 +294,7 @@ python runtime/tools/scope_stats_plot.py \
 | 关注点 | 文件 | 函数 / 成员 |
 | ------ | ---- | ----------- |
 | `RunConfig` 字段定义 | [runner.py](../../../python/pypto/runtime/runner.py) | `RunConfig` dataclass + `any_dfx_enabled()` |
-| `CallConfig` 透传 | [device_runner.py](../../../python/pypto/runtime/device_runner.py) | `execute_on_device(..., enable_*, output_prefix)` |
+| `CallConfig` 透传 | [device_runner.py](../../../python/pypto/runtime/device_runner.py) | `_execute_on_device(..., enable_*, output_prefix)` |
 | 流水线打包 | [runner.py](../../../python/pypto/runtime/runner.py) | `_DfxOpts` dataclass + `_DfxOpts.from_run_config` |
 | 按 flag 后处理分发 | [runner.py](../../../python/pypto/runtime/runner.py) | `_collect_dfx_artifacts` |
 | kernel 名称映射合成 | [runner.py](../../../python/pypto/runtime/runner.py) | `_write_name_map` |

--- a/docs/zh/dev/05-runtime-ring-sizing.md
+++ b/docs/zh/dev/05-runtime-ring-sizing.md
@@ -120,7 +120,7 @@ L3 派发路径会消费 `RunConfig` 的 `ring_*` 字段和运行时 DFX 字段�
 ## Arena 预热与单槽缓存
 
 某个 ring 尺寸对应的运行时 arena，首次使用时需要约 800ms 构建。worker 现在会在
-`init` 时主动构建它 —— `prepare(config)` / `ChipWorker` / `execute_on_device` ——
+`init` 时主动构建它 —— `prepare(config)` / `ChipWorker` / `_execute_on_device` ——
 使这次冷构建落在 setup 阶段，而不是落在第一次（通常被计时的）派发里。
 
 arena 缓存以**完整的 per-ring 尺寸向量**为 key（4 个 ring 的 `ring_task_window` /

--- a/docs/zh/dev/08-entry-points.md
+++ b/docs/zh/dev/08-entry-points.md
@@ -43,8 +43,8 @@ PyPTO 的编译与执行入口比它拥有的概念要多，而且好几个名�
 | `ir.compile` | 编译驱动 | [`ir/compile.py`](../../../python/pypto/ir/compile.py) |
 | `JITFunction.compile` | 特化 + 驱动 | [`jit/decorator.py`](../../../python/pypto/jit/decorator.py) |
 | `JITFunction.lower` | 只做特化，止于 `ir.Program` | 同上 |
-| `device_runner.compile_and_assemble` | 装配 | [`runtime/device_runner.py`](../../../python/pypto/runtime/device_runner.py) |
-| `device_runner.compile_single_kernel` / `compile_single_orchestration` | 装配 | 同上 |
+| `device_runner._compile_and_assemble` | 装配 | [`runtime/device_runner.py`](../../../python/pypto/runtime/device_runner.py) |
+| `device_runner._compile_single_kernel` / `_compile_single_orchestration` | 装配 | 同上 |
 | `KernelCompiler.compile_incore` | 调用 ptoas | [`runtime/kernel_compiler.py`](../../../python/pypto/runtime/kernel_compiler.py) |
 
 只有 `ir.compile` 是受支持的入口；表中其余项列在这里，是为了让 traceback 里出现的
@@ -71,7 +71,7 @@ from pypto.ir import CompiledProgram, DistributedCompiledProgram, DistributedCon
 | `CompiledProgram.from_dir` / `DistributedCompiledProgram.from_dir` | 产物 | 产物目录 | [`ir/compiled_program.py`](../../../python/pypto/ir/compiled_program.py) |
 | `runtime.execute_compiled`（已弃用） | 执行 | 产物目录 | [`runtime/runner.py`](../../../python/pypto/runtime/runner.py) |
 | `execute_distributed_compiled`（已弃用） | 执行 | 产物目录 | [`runtime/distributed_runner.py`](../../../python/pypto/runtime/distributed_runner.py) |
-| `device_runner.execute_on_device` | 装配 | 已装配的二进制 | [`runtime/device_runner.py`](../../../python/pypto/runtime/device_runner.py) |
+| `device_runner._execute_on_device` | 装配 | 已装配的二进制 | [`runtime/device_runner.py`](../../../python/pypto/runtime/device_runner.py) |
 | `execute_artifact_dir` / `execute_batch_manifest` | CLI | 产物目录 | [`runtime/execute_artifact.py`](../../../python/pypto/runtime/execute_artifact.py) |
 
 `run` 本身不说明你在哪一层，接收者才说明。`ChipWorker.run` 与
@@ -147,16 +147,19 @@ compiled(*tensors, config=config)
 以下没有稳定性保证。它们不在任何 `__all__` 中，PyPTO 之外的代码不应导入：
 
 - `pypto.ir.compile` —— `_ensure_orchestration_headers`
-- `pypto.runtime.runner` —— `_execute_compiled`
-- `pypto.runtime.distributed_runner` —— `_execute_distributed`
 - `pypto.ir.compiled_program` —— `CompiledProgram._build_orch_args`、
   `CompiledProgram._build_call_config`
-- `pypto.runtime.device_runner` —— `compile_and_assemble`、`compile_single_kernel`、
-  `compile_single_orchestration`、`execute_on_device`
+- `pypto.runtime.runner` —— `_execute_compiled`、`_execute_golden_case`、
+  `_build_call_config`、`_coerced_to_orch_args`、`_DfxOpts`
+- `pypto.runtime.distributed_runner` —— `_execute_distributed`
+- `pypto.runtime.device_runner` —— 整个装配层：`_compile_and_assemble`、
+  `_compile_single_kernel`、`_compile_single_orchestration`、`_execute_on_device`
 - `pypto.runtime.kernel_compiler` —— `KernelCompiler`、`compile_incore`
-- `pypto.runtime.runner` —— `_build_call_config`、`_coerced_to_orch_args`、
-  `_DfxOpts`
 - `pypto.runtime.tensor_arg`、`pypto.runtime.elf_parser`、`pypto.runtime._binary_cache`
+
+装配层带下划线，是为了让 traceback 一眼看出它来自边界的哪一侧：一个必须拼出 `_`
+的导入，是一个做过决定的导入。`KernelCompiler` / `compile_incore` 以及最后一行的三个
+模块是例外 —— 它们靠模块而非名字划为内部，稳定性保证同样为零。
 
 这两个实参构造器把用户实参编排成 simpler 的 `TaskArgs` 与 `CallConfig`。
 `ChipWorker.run` 与 `ChipWorker.register` 是抵达这条路径的受支持方式 —— 它们会替你调用

--- a/docs/zh/user/00-getting_started.md
+++ b/docs/zh/user/00-getting_started.md
@@ -94,7 +94,7 @@ finally:
     worker.close()                                   # cids + DeviceTensors released
 ```
 
-`worker.register(compiled)` 立即触发 `compile_and_assemble` + simpler `register`，
+`worker.register(compiled)` 立即触发 `_compile_and_assemble` + simpler `register`，
 配置错误会在这里抛出而不是到第一次 dispatch 才暴露。返回的 `RegistrationHandle` 是
 可调用的、支持 `with handle:` 作用域清理，也有 `handle.unregister()` 用于显式提前
 关闭。对同一个 `compiled.chip_callable` 多次 `register` 返回的是同一个 cid 的别名；

--- a/python/pypto/ir/compiled_program.py
+++ b/python/pypto/ir/compiled_program.py
@@ -776,9 +776,9 @@ class _RuntimeFacade:
         if self._chip_callable is not None:
             return
         self._check_runtime_access()
-        from pypto.runtime.device_runner import compile_and_assemble  # noqa: PLC0415
+        from pypto.runtime.device_runner import _compile_and_assemble  # noqa: PLC0415
 
-        cc, rn, rc = compile_and_assemble(self._output_dir, self._platform)
+        cc, rn, rc = _compile_and_assemble(self._output_dir, self._platform)
         # Publish the "loaded" sentinel (_chip_callable) last so a reader can
         # never observe it set while _runtime_name / _runtime_config are None.
         self._runtime_name = rn
@@ -976,7 +976,7 @@ class CompiledProgram(_RuntimeFacade):
         orchestration param metadata (names, directions, shapes, dtypes) plus
         the return-type count -- alongside the platform / backend. Runtime
         artefacts (``chip_callable`` / ``runtime_name`` / ``runtime_config``)
-        need no persistence: ``compile_and_assemble`` already rederives them
+        need no persistence: ``_compile_and_assemble`` already rederives them
         from the generated ``kernel_config.py``.
 
         Best-effort: a program without a resolvable orchestration signature

--- a/python/pypto/ir/distributed_compiled_program.py
+++ b/python/pypto/ir/distributed_compiled_program.py
@@ -486,7 +486,7 @@ class DistributedCompiledProgram:
     ) -> "DistributedWorker":
         """Prepare a reusable L3 execution handle (setup once, dispatch many).
 
-        Runs the expensive setup (``compile_and_assemble``, generated-module
+        Runs the expensive setup (``_compile_and_assemble``, generated-module
         loading, simpler ``Worker(level=3)`` construction + registration +
         ``init()``) exactly once and returns a :class:`DistributedWorker` that
         dispatches many times on the held worker. The handle also exposes

--- a/python/pypto/runtime/_dep_gen_capture.py
+++ b/python/pypto/runtime/_dep_gen_capture.py
@@ -55,7 +55,7 @@ def _build_argspec_orch_args(args_spec: list[dict]):
     inputs route the same graph); device-resident tensors are rebuilt as zeros;
     scalars are reconstructed exactly.
 
-    The tensors/scalars stay unmaterialized until ``execute_on_device`` has
+    The tensors/scalars stay unmaterialized until ``_execute_on_device`` has
     selected their owning Worker.
     """
     coerced: list = []
@@ -99,7 +99,7 @@ def main(argv: list[str]) -> int:
         "the following compile/run output is for deps.json only (timing is discarded)."
     )
 
-    from .device_runner import compile_and_assemble, execute_on_device  # noqa: PLC0415
+    from .device_runner import _compile_and_assemble, _execute_on_device  # noqa: PLC0415
 
     work_dir = Path(spec["work_dir"])
     platform = spec["platform"]
@@ -107,7 +107,7 @@ def main(argv: list[str]) -> int:
     dfx_dir = Path(spec["dfx_dir"])
     level = int(spec.get("level", 2))
 
-    chip_callable, runtime_name, runtime_config = compile_and_assemble(work_dir, platform)
+    chip_callable, runtime_name, runtime_config = _compile_and_assemble(work_dir, platform)
     enable_sdma = bool(runtime_config.get("enable_sdma", False))
 
     if spec["mode"] == "golden":
@@ -129,7 +129,7 @@ def main(argv: list[str]) -> int:
     config = RunConfig(platform=platform, **spec.get("ring_overrides", {}))
 
     dfx_dir.mkdir(parents=True, exist_ok=True)
-    execute_on_device(
+    _execute_on_device(
         chip_callable,
         orch_args,
         platform,

--- a/python/pypto/runtime/bench.py
+++ b/python/pypto/runtime/bench.py
@@ -13,7 +13,7 @@ Mirrors simpler's ``scene_test --rounds`` mode through pypto's public Worker:
 register the compiled program once, dispatch ``rounds`` cheap launches via
 :meth:`pypto.runtime.RegistrationHandle.__call__`, and aggregate per-launch
 ``device_wall_us``. This avoids the one-shot ``CompiledProgram.__call__``
-path, which re-pays ``compile_and_assemble`` +
+path, which re-pays ``_compile_and_assemble`` +
 register/load every call (hundreds of ms of host overhead that swamps the
 ~1 ms device time).
 

--- a/python/pypto/runtime/debug/replay.py
+++ b/python/pypto/runtime/debug/replay.py
@@ -22,7 +22,7 @@ The added value is:
    needed.
 2. Pre-flight invalidation of cached kernel/orchestration binaries so a
    hand-edited cpp is actually picked up on the next call. Without this,
-   ``compile_and_assemble`` would silently load a stale ``.so``/``.bin``
+   ``_compile_and_assemble`` would silently load a stale ``.so``/``.bin``
    built from the previous version of the cpp.
 
 CLI::
@@ -72,7 +72,7 @@ def invalidate_binary_cache(work_dir: Path | str) -> None:
 
     Both ``cache/*.bin`` (the pre-build cache written by ``prebuild_binaries``)
     and the sibling ``.so`` / ``.o`` files next to each cpp are deleted. CPP
-    sources are untouched, so the next ``compile_and_assemble`` rebuilds from
+    sources are untouched, so the next ``_compile_and_assemble`` rebuilds from
     source and picks up hand-edits.
 
     Handles both layouts: a single-chip / L2 build keeps ``cache/`` +

--- a/python/pypto/runtime/device_runner.py
+++ b/python/pypto/runtime/device_runner.py
@@ -12,9 +12,9 @@
 This module replaces Simpler's ``CodeRunner`` by providing PyPTO-internal
 implementations of:
 
-- :func:`compile_and_assemble`: Compile kernels + orchestration C++ → binaries,
+- :func:`_compile_and_assemble`: Compile kernels + orchestration C++ → binaries,
   assemble into ``ChipCallable``, locate runtime binaries.
-- :func:`execute_on_device`: Run a ``ChipCallable`` on device via ``ChipWorker``.
+- :func:`_execute_on_device`: Run a ``ChipCallable`` on device via ``ChipWorker``.
 - :func:`validate_golden`: Compare actual outputs against golden reference.
 
 These functions keep orchestration in PyPTO while relying on the installed
@@ -247,7 +247,7 @@ def _temporary_env(env_updates: dict[str, str]):
 # ---------------------------------------------------------------------------
 
 
-def compile_single_kernel(
+def _compile_single_kernel(
     kernel: dict,
     compiler: KernelCompiler,
     platform: str,
@@ -266,7 +266,7 @@ def compile_single_kernel(
     When *cache_dir* is provided, the final (possibly stripped) binary is
     additionally written under that directory using the function/core identity
     and, for external kernels, the content fingerprint. This is the pre-build
-    cache that :func:`compile_and_assemble` checks before calling this function.
+    cache that :func:`_compile_and_assemble` checks before calling this function.
 
     Args:
         kernel: Kernel descriptor dict with keys ``"source"``, ``"core_type"``,
@@ -313,7 +313,7 @@ def compile_single_kernel(
     return raw, kernel_bin
 
 
-def compile_single_orchestration(
+def _compile_single_orchestration(
     source: str | Path,
     compiler: KernelCompiler,
     runtime_name: str,
@@ -352,7 +352,7 @@ def compile_single_orchestration(
 
 
 # ---------------------------------------------------------------------------
-# compile_and_assemble
+# _compile_and_assemble
 # ---------------------------------------------------------------------------
 
 # ``hid`` (ELF Build-ID 64 of an orchestration ``.so``, lowercase hex) → that
@@ -490,7 +490,7 @@ def _missing_kernel_config_error(work_dir: Path) -> FileNotFoundError:
     )
 
 
-def compile_and_assemble(
+def _compile_and_assemble(
     work_dir: Path,
     platform: str,
 ) -> tuple[ChipCallable, str, dict[str, Any]]:
@@ -615,7 +615,7 @@ def _compile_and_assemble_locked(
             return (func_id, CoreCallable.build(signature=sig, binary=cached_bin))
 
         # Compile via shared function and populate the content-addressed cache.
-        _, kernel_bin = compile_single_kernel(
+        _, kernel_bin = _compile_single_kernel(
             kernel,
             compiler,
             platform,
@@ -638,7 +638,7 @@ def _compile_and_assemble_locked(
             return cached_bin
 
         # Compile via shared function; skip secondary prebuild cache write
-        return compile_single_orchestration(orchestration["source"], compiler, runtime_name)
+        return _compile_single_orchestration(orchestration["source"], compiler, runtime_name)
 
     max_workers = min(64, 1 + len(kernels))
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
@@ -672,11 +672,11 @@ def _compile_and_assemble_locked(
 
 
 # ---------------------------------------------------------------------------
-# execute_on_device
+# _execute_on_device
 # ---------------------------------------------------------------------------
 
 
-def execute_on_device(  # noqa: PLR0913
+def _execute_on_device(  # noqa: PLR0913
     chip_callable: ChipCallable,
     orch_args: list[Any],
     platform: str,
@@ -769,7 +769,7 @@ def execute_on_device(  # noqa: PLR0913
     """
     if level != 2:
         raise ValueError(
-            f"execute_on_device currently only supports level=2; got level={level}. "
+            f"_execute_on_device currently only supports level=2; got level={level}. "
             f"L3 execution is not yet exposed at the pypto user-API layer."
         )
 
@@ -788,7 +788,7 @@ def execute_on_device(  # noqa: PLR0913
     )
     if any_dfx and not output_prefix:
         raise ValueError(
-            "execute_on_device: output_prefix is required when any DFX flag "
+            "_execute_on_device: output_prefix is required when any DFX flag "
             "(enable_chip_swimlane / enable_dump_args / enable_pmu / enable_dep_gen / "
             "enable_scope_stats) is enabled — runtime CallConfig::validate() would "
             "otherwise reject the call."
@@ -917,7 +917,7 @@ def validate_golden(
 # ---------------------------------------------------------------------------
 
 # Return type for build_orch_args_from_inputs. The first element deliberately
-# remains unmaterialized until execute_on_device has selected its owning Worker.
+# remains unmaterialized until _execute_on_device has selected its owning Worker.
 _OrchArgsTuple = tuple[list[Any], dict[str, Any], dict[str, torch.Tensor], dict[str, torch.Tensor]]
 
 
@@ -935,7 +935,7 @@ def _collect_orch_args(
 
     Returns:
         ``(orch_args, all_tensors, inputs, outputs)``. ``orch_args`` is an
-        ordered Python list; :func:`execute_on_device` turns it into
+        ordered Python list; :func:`_execute_on_device` turns it into
         address-free ``TaskArgs`` after selecting the Worker.
     """
     orch_args: list[Any] = []

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -350,7 +350,7 @@ def _load_generated_module(path: Path) -> Any:
 # ---------------------------------------------------------------------------
 # Setup steps shared by the one-shot ``_execute_distributed`` path and the
 # reusable ``DistributedWorker`` handle. Keeping them as free functions lets
-# both paths run identical, expensive setup (compile_and_assemble, module load,
+# both paths run identical, expensive setup (_compile_and_assemble, module load,
 # Worker construction + registration) without duplicating it.
 # ---------------------------------------------------------------------------
 
@@ -362,7 +362,7 @@ def _assemble_chip_callables(
 
     Driven entirely by the on-disk layout — each ``next_levels/{name}/`` that
     contains a ``kernel_config.py`` is a complete single-chip sub-build that
-    :func:`compile_and_assemble` consumes directly. This requires no live IR, so
+    :func:`_compile_and_assemble` consumes directly. This requires no live IR, so
     it works identically for a freshly-compiled program and one reconstructed via
     :meth:`DistributedCompiledProgram.from_dir` (the ``runtime_dir`` replay path).
     """
@@ -377,9 +377,9 @@ def _assemble_chip_callables(
             # Imported lazily — and only once there is a real chip to build — so
             # the "no chip-level tasks" error path below stays usable without the
             # heavy device_runner → simpler toolchain import.
-            from pypto.runtime.device_runner import compile_and_assemble  # noqa: PLC0415
+            from pypto.runtime.device_runner import _compile_and_assemble  # noqa: PLC0415
 
-            chip_callable, chip_runtime, chip_runtime_config = compile_and_assemble(
+            chip_callable, chip_runtime, chip_runtime_config = _compile_and_assemble(
                 chip_dir, compiled.platform
             )
             chip_callables[chip_dir.name] = chip_callable
@@ -1486,7 +1486,7 @@ class DistributedWorker(Worker):
 
     Holds an initialized simpler ``Worker(level=3)`` plus all setup artifacts
     (chip callables, host_orch entry, sub-worker fns, comm bootstrap) so the
-    expensive setup — ``compile_and_assemble``, generated-module loading, Worker
+    expensive setup — ``_compile_and_assemble``, generated-module loading, Worker
     construction + registration + ``init()`` (fork) — happens exactly once.
 
     Mirrors the L2 ``with ChipWorker(...)`` reuse block: it exposes device-memory

--- a/python/pypto/runtime/execute_artifact.py
+++ b/python/pypto/runtime/execute_artifact.py
@@ -10,7 +10,7 @@
 """Execute a pre-compiled ``work_dir`` artifact on one device.
 
 Thin CLI that re-binds an already-compiled build directory (``.o``/``.so``
-written next to each kernel by a prior ``compile_and_assemble``) and runs its
+written next to each kernel by a prior ``_compile_and_assemble``) and runs its
 ``golden.py`` on a single device, validating against the pre-computed golden.
 
 It is the device-side half of the "compile on CPU, borrow a card per case via
@@ -21,7 +21,7 @@ CPU pool, then for each case spawns::
       'python -m pypto.runtime.execute_artifact --work-dir <wd> \\
          --platform <p> --device-id $TASK_DEVICE ...'
 
-Because the binaries are already on disk, ``compile_and_assemble`` hits the
+Because the binaries are already on disk, ``_compile_and_assemble`` hits the
 ``.o``/``.so`` cache and rebuilds the ``ChipCallable`` without recompiling or
 touching a card — the only card window is the device run + ``allclose``.
 
@@ -52,7 +52,7 @@ from pypto.runtime.runner import (
     _SWIMLANE_FULL_LEVEL,
     _SWIMLANE_MAX_LEVEL,
     _DfxOpts,
-    _execute_on_device,
+    _execute_golden_case,
 )
 
 __all__ = ["ArtifactSetupError", "execute_artifact_dir", "execute_batch_manifest", "main"]
@@ -66,7 +66,7 @@ _RESULT_PREFIX = "PYPTO_EXEC_RESULT"
 class ArtifactSetupError(Exception):
     """A pre-run artifact reconstruction / setup failure.
 
-    Raised when ``compile_and_assemble`` cannot rebuild the cached artifact
+    Raised when ``_compile_and_assemble`` cannot rebuild the cached artifact
     (missing / stale ``.o``/``.so``, bad ``work_dir``, corrupt inputs) — i.e.
     *before* any device execution. The CLI reports this as an infra problem
     (``PYPTO_EXEC_RESULT=INFRA``) rather than a device test failure
@@ -84,14 +84,14 @@ def execute_artifact_dir(
 ) -> None:
     """Rebuild the compiled artifact in *work_dir* and run it on *device_id*.
 
-    ``compile_and_assemble`` reuses the cached ``.o``/``.so`` next to each
+    ``_compile_and_assemble`` reuses the cached ``.o``/``.so`` next to each
     kernel, so this neither recompiles nor needs a card until the device run.
     The actual device outputs are always persisted under ``data/actual/`` so a
     caller can validate them separately with the test's real tolerance.
 
     Args:
         work_dir: A build directory produced by ``ir.compile`` +
-            ``compile_and_assemble`` (contains ``kernel_config.py``,
+            ``_compile_and_assemble`` (contains ``kernel_config.py``,
             ``kernels/``, ``orchestration/``, ``golden.py``, ``data/``).
         platform: Target execution platform (e.g. ``"a2a3"``).
         device_id: Hardware device index to run on.
@@ -103,7 +103,7 @@ def execute_artifact_dir(
             per-test tolerance, so this run is tolerance-independent.
 
     Raises:
-        ArtifactSetupError: ``compile_and_assemble`` could not rebuild the
+        ArtifactSetupError: ``_compile_and_assemble`` could not rebuild the
             cached artifact (infra, not a test failure). ``main`` maps it to
             ``PYPTO_EXEC_RESULT=INFRA``.
         Exception: Any device / validation error is propagated to the caller
@@ -125,15 +125,15 @@ def execute_artifact_dir(
 def _reconstruct_artifact(work_dir: Path, platform: str) -> tuple[Any, str, bool]:
     """Rebuild the cached artifact, reclassifying any failure as infra.
 
-    ``compile_and_assemble`` reuses the cached ``.o``/``.so`` next to each kernel
+    ``_compile_and_assemble`` reuses the cached ``.o``/``.so`` next to each kernel
     (a cache hit — no recompile, no card). A failure here is a reconstruction /
     setup problem, so it is wrapped as :class:`ArtifactSetupError` (the CLI reports
     ``PYPTO_EXEC_RESULT=INFRA``) rather than a device test failure.
     """
-    from pypto.runtime.device_runner import compile_and_assemble  # noqa: PLC0415
+    from pypto.runtime.device_runner import _compile_and_assemble  # noqa: PLC0415
 
     try:
-        chip_callable, runtime_name, runtime_config = compile_and_assemble(work_dir, platform)
+        chip_callable, runtime_name, runtime_config = _compile_and_assemble(work_dir, platform)
     except Exception as exc:  # noqa: BLE001 — reclassified as infra, re-raised below
         raise ArtifactSetupError(f"artifact reconstruction failed for {work_dir}: {exc}") from exc
     enable_sdma = bool(runtime_config.get("enable_sdma", False))
@@ -158,7 +158,7 @@ def _run_on_device(
     independent) so a caller can validate them separately; runs the in-process
     ``allclose`` only when *validate* is set.
     """
-    _execute_on_device(
+    _execute_golden_case(
         work_dir,
         work_dir / "golden.py",
         chip_callable,
@@ -186,7 +186,7 @@ def execute_batch_manifest(
     pypto import AND the NPU device init are paid once for the batch (not once
     per artifact) — the fix for the per-artifact cold-start cost.  Artifacts
     that share the batch's ``(platform, runtime)`` reuse the worker; a differing
-    one falls back to a fresh one-shot worker inside ``_execute_on_device``.
+    one falls back to a fresh one-shot worker inside ``_execute_golden_case``.
     Before opening the shared worker, the batch reconstructs every artifact so
     it can provision SDMA when any usable artifact on the shared worker's
     binding requires it.  Ordinary artifacts can run on that SDMA-enabled
@@ -261,7 +261,7 @@ def execute_batch_manifest(
     # Onboard swimlane runs a dep-gen subprocess that must own the card/SVM state
     # for the duration of dep capture; a batch ChipWorker held open on the same
     # device_id would collide with it. Fall back to per-artifact one-shot
-    # execution (each _execute_on_device opens + closes its own worker) so the
+    # execution (each _execute_golden_case opens + closes its own worker) so the
     # dep-gen child owns the device first, preserving the two-pass design.
     first_platform = str(entries[0]["platform"])
     if dfx.enable_chip_swimlane and not first_platform.endswith("sim"):

--- a/python/pypto/runtime/runner.py
+++ b/python/pypto/runtime/runner.py
@@ -739,7 +739,7 @@ def _execute_dfx_passes(
 def _load_golden_module(golden_path: "Path", module_name: str = "_golden") -> Any:
     """Import a generated ``golden.py`` from *golden_path* as a fresh module.
 
-    Shared by :func:`_execute_on_device` and the dep_gen subprocess so the load
+    Shared by :func:`_execute_golden_case` and the dep_gen subprocess so the load
     semantics (and the error message) stay in one place.
     """
     spec = importlib.util.spec_from_file_location(module_name, str(golden_path))
@@ -963,7 +963,7 @@ def _build_call_config(
     return cfg
 
 
-def _execute_on_device(
+def _execute_golden_case(
     work_dir: Path,
     golden_path: Path,
     chip_callable: Any,
@@ -979,15 +979,15 @@ def _execute_on_device(
 
     Shared execution logic used by both :func:`_execute_compiled` and the test harness
     (``test_runner.py``).  The caller is responsible for compiling binaries
-    via ``compile_and_assemble`` and passing the result here.
+    via ``_compile_and_assemble`` and passing the result here.
 
     Tolerances (``RTOL``, ``ATOL``) are read from the generated ``golden.py``.
 
     Args:
         work_dir: Root output directory containing ``data/``, ``golden.py``, etc.
         golden_path: Path to the generated ``golden.py`` file.
-        chip_callable: Pre-compiled ``ChipCallable`` from ``compile_and_assemble``.
-        runtime_name: Runtime name from ``compile_and_assemble``.
+        chip_callable: Pre-compiled ``ChipCallable`` from ``_compile_and_assemble``.
+        runtime_name: Runtime name from ``_compile_and_assemble``.
         platform: Target execution platform.
         device_id: Hardware device index.
         enable_sdma: Whether execution requires an SDMA-capable worker.
@@ -997,8 +997,8 @@ def _execute_on_device(
             post-run converter is invoked.
     """
     from .device_runner import (  # noqa: PLC0415
+        _execute_on_device,
         build_orch_args_from_inputs,
-        execute_on_device,
         validate_golden,
     )
 
@@ -1027,7 +1027,7 @@ def _execute_on_device(
         dfx_dir.mkdir(parents=True, exist_ok=True)
 
     def _run_pass(pass_dfx: "_DfxOpts") -> None:
-        execute_on_device(
+        _execute_on_device(
             chip_callable,
             orch_args,
             platform,
@@ -1092,7 +1092,7 @@ def _execute_on_device(
 def validate_persisted_outputs(work_dir: Path, rtol: float, atol: float) -> None:
     """Validate persisted device outputs against the golden with a given tolerance.
 
-    The counterpart to ``_execute_on_device(..., validate=False,
+    The counterpart to ``_execute_golden_case(..., validate=False,
     actual_out_dir=...)``: the device run (tolerance-independent) persisted the
     actual outputs under ``data/actual/``; this compares them against the
     pre-computed golden under ``data/out/`` using *rtol*/*atol* — letting the
@@ -1338,9 +1338,9 @@ def _execute_compiled(  # noqa: PLR0913
 ) -> None:
     """Execute a pre-compiled program with user-provided tensors and scalars.
 
-    Reuses :func:`device_runner.compile_and_assemble` for binary compilation
+    Reuses :func:`device_runner._compile_and_assemble` for binary compilation
     (with caching and parallel kernel compilation) and
-    :func:`device_runner.execute_on_device` for device dispatch.  Host
+    :func:`device_runner._execute_on_device` for device dispatch.  Host
     ``torch.Tensor`` outputs in *args* are modified in-place with device
     results; :class:`DeviceTensor` arguments retain their owning simpler
     ``Buffer`` and are packed into address-free ``TaskArgs`` (no H2D upload,
@@ -1358,7 +1358,7 @@ def _execute_compiled(  # noqa: PLR0913
         dfx: Runtime DFX toggles. When any flag is enabled the artefacts
             land under ``<work_dir>/dfx_outputs/`` and the matching
             post-run converter is invoked.
-        level: Hierarchy level. Forwarded to :func:`execute_on_device`,
+        level: Hierarchy level. Forwarded to :func:`_execute_on_device`,
             which currently only supports ``2``.
         aicpu_thread_num: Optional override of the AICPU thread count.
             When ``None`` (default), the value baked into
@@ -1391,11 +1391,11 @@ def _execute_compiled(  # noqa: PLR0913
     _ensure_orchestration_headers(str(work_dir))
 
     from .device_runner import (  # noqa: PLC0415
-        compile_and_assemble,
-        execute_on_device,
+        _compile_and_assemble,
+        _execute_on_device,
     )
 
-    chip_callable, runtime_name, runtime_config = compile_and_assemble(work_dir, platform)
+    chip_callable, runtime_name, runtime_config = _compile_and_assemble(work_dir, platform)
     enable_sdma = bool(runtime_config.get("enable_sdma", False))
 
     # Caller-supplied values take precedence over the RUNTIME_CONFIG baked
@@ -1412,7 +1412,7 @@ def _execute_compiled(  # noqa: PLR0913
         dfx_dir.mkdir(parents=True, exist_ok=True)
 
     def _run_pass(pass_dfx: "_DfxOpts") -> None:
-        execute_on_device(
+        _execute_on_device(
             chip_callable,
             args,
             platform,

--- a/python/pypto/runtime/worker.py
+++ b/python/pypto/runtime/worker.py
@@ -12,7 +12,7 @@
 Inside a ``with ChipWorker(...) as _:`` block, calls to ``CompiledProgram(...)``
 reuse the active worker instead of creating a fresh one. Outside such a block,
 behavior is unchanged from one-shot construction in
-:func:`pypto.runtime.device_runner.execute_on_device`.
+:func:`pypto.runtime.device_runner._execute_on_device`.
 
 For explicit dispatch (no ``ContextVar`` discovery), call
 :meth:`ChipWorker.run` directly, or pre-register with :meth:`ChipWorker.register`
@@ -97,7 +97,7 @@ _ACTIVE_WORKERS: contextvars.ContextVar[tuple[ChipWorker, ...]] = contextvars.Co
 # Default runtime name — matches the runtime that ``pto_backend`` bakes into
 # every generated ``kernel_config.py`` (``RUNTIME_CONFIG["runtime"]``). That is
 # the value ``CompiledProgram.runtime_name`` reports and the one the reuse
-# lookup in ``device_runner.execute_on_device`` searches for, so a
+# lookup in ``device_runner._execute_on_device`` searches for, so a
 # default-constructed ``with ChipWorker():`` bind-matches a freshly compiled
 # program instead of silently falling through to a one-shot worker. Derived from
 # the RuntimeKind enum that compilation selects, so the two cannot drift apart.
@@ -489,7 +489,7 @@ class ChipWorker(Worker):
     ) -> ChipWorker | None:
         """Return the topmost active ChipWorker matching the binding, or ``None``.
 
-        Used by :func:`pypto.runtime.device_runner.execute_on_device` to
+        Used by :func:`pypto.runtime.device_runner._execute_on_device` to
         decide whether to reuse a user-published ChipWorker or fall through
         to constructing a fresh one-shot worker. A matching worker without a
         required SDMA capability raises instead of opening a second worker on
@@ -510,7 +510,7 @@ class ChipWorker(Worker):
     def _check_binding(self, compiled: CompiledProgram) -> None:
         """Raise on a binding or worker-capability mismatch.
 
-        ``compiled.runtime_name`` triggers ``compile_and_assemble`` lazily,
+        ``compiled.runtime_name`` triggers ``_compile_and_assemble`` lazily,
         which is acceptable because any subsequent dispatch needs it anyway.
         """
         if compiled.platform != self.platform:
@@ -602,7 +602,7 @@ class ChipWorker(Worker):
     def register(self, compiled: CompiledProgram) -> RegistrationHandle:
         """Pre-register *compiled* on this ChipWorker. Returns a callable handle.
 
-        Eager registration: triggers ``compile_and_assemble`` on *compiled*
+        Eager registration: triggers ``_compile_and_assemble`` on *compiled*
         and ``simpler.Worker.register`` immediately, so configuration errors
         surface here rather than at first dispatch. The handle reuses the
         ChipWorker's existing cid cache (multiple ``register`` calls for the
@@ -615,7 +615,7 @@ class ChipWorker(Worker):
         """
         self._require_initialized("register")
         self._check_binding(compiled)
-        cc = compiled.chip_callable  # triggers compile_and_assemble lazily
+        cc = compiled.chip_callable  # triggers _compile_and_assemble lazily
         key = id(cc)
         cid = self._cid_cache.get(key)
         if cid is None:

--- a/tests/st/distributed/test_l3_manual.py
+++ b/tests/st/distributed/test_l3_manual.py
@@ -17,7 +17,7 @@ runtime API — no HOST-level DSL, no generated ``host_orch.py`` /
 The test exercises the public boundary that PyPTO's own
 ``DistributedCompiledProgram`` relies on:
 
-  * :func:`compile_and_assemble` to obtain a ``ChipCallable`` from an L2 build
+  * :func:`_compile_and_assemble` to obtain a ``ChipCallable`` from an L2 build
   * ``simpler.worker.Worker(level=3, ...)`` with manual ``register``/``init``/``run``
   * ``TaskArgs`` + ``make_tensor_arg`` + ``TensorArgType`` for argument marshalling
   * A Python SubWorker that **closes over host-side state** (``done_flag``) — a
@@ -35,7 +35,7 @@ import pypto.language as pl
 import pytest
 import torch
 from pypto import ir
-from pypto.runtime.device_runner import compile_and_assemble
+from pypto.runtime.device_runner import _compile_and_assemble
 from pypto.runtime.distributed_runner import _tensor_from_continuous
 
 
@@ -111,7 +111,7 @@ class TestL3Manual:
         # 2) Assemble the ChipCallable ourselves — the same call
         # ``_execute_distributed`` makes per next_levels/<name>/, but pointed at
         # the L2 root because no HOST-level outlining happened.
-        chip_callable, runtime_name, _ = compile_and_assemble(out_dir, platform=test_config.platform)
+        chip_callable, runtime_name, _ = _compile_and_assemble(out_dir, platform=test_config.platform)
 
         # 3) Host-side tensors. ``share_memory_()`` must happen before
         # ``Worker.init()`` so the chip/sub-worker child processes inherit the

--- a/tests/st/harness/core/test_runner.py
+++ b/tests/st/harness/core/test_runner.py
@@ -58,7 +58,7 @@ from pypto.runtime.runner import (
     RunConfig,
     RunResult,
     _DfxOpts,
-    _execute_on_device,
+    _execute_golden_case,
     validate_persisted_outputs,
 )
 from pypto.runtime.tensor_spec import TensorSpec as RuntimeTensorSpec
@@ -487,9 +487,9 @@ def _fused_compile_task(
                 resolved_platform=resolved,
                 error=None,
             )
-        from pypto.runtime.device_runner import compile_and_assemble  # noqa: PLC0415
+        from pypto.runtime.device_runner import _compile_and_assemble  # noqa: PLC0415
 
-        chip_callable, runtime_name, runtime_config = compile_and_assemble(work_dir, resolved)
+        chip_callable, runtime_name, runtime_config = _compile_and_assemble(work_dir, resolved)
         enable_sdma = bool(runtime_config.get("enable_sdma", False))
         return CompileArtifact(
             work_dir=work_dir,
@@ -901,7 +901,7 @@ def _fused_execute_task(
     device_id = _device_pool.get()
     try:
         _executed_device[cache_key] = device_id
-        _execute_on_device(
+        _execute_golden_case(
             artifact.work_dir,
             artifact.work_dir / "golden.py",
             artifact.chip_callable,
@@ -1475,9 +1475,9 @@ class TestRunner:
                     execution_time=time.time() - start_time,
                 )
 
-            from pypto.runtime.device_runner import compile_and_assemble  # noqa: PLC0415
+            from pypto.runtime.device_runner import _compile_and_assemble  # noqa: PLC0415
 
-            chip_callable, runtime_name, runtime_config = compile_and_assemble(
+            chip_callable, runtime_name, runtime_config = _compile_and_assemble(
                 work_dir,
                 resolved_platform,
             )
@@ -1516,9 +1516,9 @@ class TestRunner:
                     )
                 # Device run (--no-validate) persisted outputs; validate here.
                 return _validate_after_device_run(test_case, work_dir, time.time() - start_time)
-            # RunTiming was dropped (simpler #1177): _execute_on_device returns
+            # RunTiming was dropped (simpler #1177): _execute_golden_case returns
             # None now; timing is read from the runtime's [STRACE] log markers.
-            _execute_on_device(
+            _execute_golden_case(
                 work_dir,
                 golden_path,
                 chip_callable,

--- a/tests/st/runtime/cross_core/test_cross_core_grouped_tpop_tfree.py
+++ b/tests/st/runtime/cross_core/test_cross_core_grouped_tpop_tfree.py
@@ -40,9 +40,9 @@ from harness.core.harness import platform_to_backend
 from pypto import ir
 from pypto.backend.pto_backend import _preprocess_ptoas_output, _run_ptoas
 from pypto.runtime.device_runner import (
+    _compile_and_assemble,
+    _execute_on_device,
     build_orch_args_from_inputs,
-    compile_and_assemble,
-    execute_on_device,
     validate_golden,
 )
 
@@ -222,7 +222,7 @@ class TestCrossCoreGroupedTpopTfree:
 
             kernel_config = _load_kernel_config(work_dir)
             runtime_cfg = getattr(kernel_config, "RUNTIME_CONFIG", {})
-            chip_callable, runtime_name, _ = compile_and_assemble(work_dir, platform)
+            chip_callable, runtime_name, _ = _compile_and_assemble(work_dir, platform)
 
             for seed in (0, 1, 2):
                 torch.manual_seed(seed)
@@ -240,7 +240,7 @@ class TestCrossCoreGroupedTpopTfree:
                     output_prefix: str | None = str(dfx_dir)
                 else:
                     output_prefix = None
-                execute_on_device(
+                _execute_on_device(
                     chip_callable,
                     orch_args,
                     platform,

--- a/tests/ut/conftest.py
+++ b/tests/ut/conftest.py
@@ -12,8 +12,9 @@
 import importlib
 import os
 import sys
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
 from typing import Final
+from unittest.mock import MagicMock, patch
 
 import pytest
 from pypto import LogLevel, get_log_level, set_log_level
@@ -57,6 +58,36 @@ def device_runner(monkeypatch):
             setattr(runtime_package, "device_runner", previous_attribute)
         elif hasattr(runtime_package, "device_runner"):
             delattr(runtime_package, "device_runner")
+
+
+@pytest.fixture
+def stub_device_runner():
+    """Bind the assembly layer to mocks so a test can dispatch without a device.
+
+    Library code reaches ``pypto.runtime.device_runner`` through function-local
+    ``from ... import`` statements, because importing it eagerly would make the
+    device-only ``simpler`` package a hard dependency of ``pypto.runtime``.
+    Patching an attribute on the real module therefore requires importing it
+    first, which the unit-test runners cannot do; a stub module in
+    ``sys.modules`` lets those lazy imports bind to mocks on every platform.
+
+    This fixture is the one place in the test suite that names the assembly
+    layer's private functions, so renaming one stays a single edit here rather
+    than a sweep over every test that stubs a dispatch.
+
+    Yields the stub module. ``_compile_and_assemble`` returns a
+    ``(chip_callable, runtime_name, runtime_config)`` triple and
+    ``_execute_on_device`` returns ``None``; assign ``return_value`` /
+    ``side_effect`` on either mock to refine that.
+    """
+    stub = ModuleType("pypto.runtime.device_runner")
+    stub._compile_and_assemble = MagicMock(  # type: ignore[attr-defined]
+        name="_compile_and_assemble",
+        return_value=(MagicMock(name="chip_callable"), "tensormap_and_ringbuffer", {}),
+    )
+    stub._execute_on_device = MagicMock(name="_execute_on_device", return_value=None)  # type: ignore[attr-defined]
+    with patch.dict(sys.modules, {"pypto.runtime.device_runner": stub}):
+        yield stub
 
 
 @pytest.fixture

--- a/tests/ut/ir/test_compiled_program.py
+++ b/tests/ut/ir/test_compiled_program.py
@@ -38,16 +38,16 @@ from pypto.runtime import DeviceTensor, RunConfig
 
 @contextlib.contextmanager
 def _fake_compile_and_assemble(return_value):
-    """Stub ``pypto.runtime.device_runner.compile_and_assemble`` via a fake module.
+    """Stub ``pypto.runtime.device_runner._compile_and_assemble`` via a fake module.
 
     The real module imports ``simpler_setup`` (device-only), so it can't be loaded
     on host-only CI. Inserting a fake module into ``sys.modules`` lets the inner
-    ``from pypto.runtime.device_runner import compile_and_assemble`` resolve to the
+    ``from pypto.runtime.device_runner import _compile_and_assemble`` resolve to the
     mock on every platform. Yields the mock for call assertions.
     """
     mock = MagicMock(return_value=return_value)
     fake = types.ModuleType("pypto.runtime.device_runner")
-    setattr(fake, "compile_and_assemble", mock)
+    setattr(fake, "_compile_and_assemble", mock)
     with patch.dict(sys.modules, {"pypto.runtime.device_runner": fake}):
         yield mock
 
@@ -686,7 +686,7 @@ class TestCompiledProgramExtraction:
     """
 
     def _patch_assemble(self, chip_callable_name: str = "fake_chip"):
-        """Patch ``device_runner.compile_and_assemble`` and return the MagicMock.
+        """Patch ``device_runner._compile_and_assemble`` and return the MagicMock.
 
         The patch target is the *source* module — inner-scope ``from ... import``
         statements bind to the patched name at import time.
@@ -725,7 +725,7 @@ class TestCompiledProgramExtraction:
             assert cp.runtime_config == runtime_config
 
     def test_properties_cache_across_calls(self, tmp_path):
-        """All three properties together trigger exactly one compile_and_assemble call."""
+        """All three properties together trigger exactly one _compile_and_assemble call."""
         prog = _make_program_with_orchestration()
         cp = CompiledProgram(prog, str(tmp_path))
 

--- a/tests/ut/jit/test_jit_compile_extraction.py
+++ b/tests/ut/jit/test_jit_compile_extraction.py
@@ -255,7 +255,7 @@ class TestCompileExposesExtractionSurface:
     marshals through — enabling worker integration as required by issue #1455.
 
     These tests only verify that the attributes are *defined on the class* —
-    actually exercising compile_and_assemble (which several of these properties
+    actually exercising _compile_and_assemble (which several of these properties
     invoke lazily on first access) requires simpler + a device, which unit
     tests don't have. ``hasattr(instance, ...)`` would trigger the property
     getter and import simpler, so check the class directly.
@@ -272,7 +272,7 @@ class TestCompileExposesExtractionSurface:
         cls = type(compiled)
         # The properties + methods that ChipWorker.run / register rely on.
         # Checking ``cls`` instead of ``compiled`` avoids invoking lazy
-        # property getters (chip_callable etc.) which call compile_and_assemble.
+        # property getters (chip_callable etc.) which call _compile_and_assemble.
         for name in (
             "chip_callable",
             "runtime_name",

--- a/tests/ut/runtime/test_binary_cache_context.py
+++ b/tests/ut/runtime/test_binary_cache_context.py
@@ -303,7 +303,7 @@ def _stub_assembly(device_runner, monkeypatch, tmp_path: Path, chip_build: Mock)
     monkeypatch.setattr(device_runner, "_current_binary_context", Mock(return_value=context))
     monkeypatch.setattr(
         device_runner,
-        "compile_single_orchestration",
+        "_compile_single_orchestration",
         Mock(return_value=b"orchestration binary"),
     )
     monkeypatch.setattr(device_runner, "ChipCallable", SimpleNamespace(build=chip_build))
@@ -321,7 +321,7 @@ def test_compile_and_assemble_records_context_after_success(
     record = Mock()
     monkeypatch.setattr(device_runner, "record_binary_context", record)
 
-    assembled, _, _ = device_runner.compile_and_assemble(tmp_path, "a2a3sim")
+    assembled, _, _ = device_runner._compile_and_assemble(tmp_path, "a2a3sim")
 
     assert assembled is chip
     record.assert_called_once_with(tmp_path, context)
@@ -337,7 +337,7 @@ def test_compile_and_assemble_does_not_stamp_failed_assembly(
     monkeypatch.setattr(device_runner, "record_binary_context", record)
 
     with pytest.raises(RuntimeError, match="assemble failed"):
-        device_runner.compile_and_assemble(tmp_path, "a2a3sim")
+        device_runner._compile_and_assemble(tmp_path, "a2a3sim")
 
     record.assert_not_called()
 
@@ -353,16 +353,16 @@ def test_failed_matching_cache_is_invalidated_before_retry(
     chip = object()
     build = Mock(side_effect=[RuntimeError("assemble failed"), chip])
     _stub_assembly(device_runner, monkeypatch, tmp_path, build)
-    compile_orchestration = device_runner.compile_single_orchestration
+    compile_orchestration = device_runner._compile_single_orchestration
 
     with pytest.raises(RuntimeError, match="assemble failed"):
-        device_runner.compile_and_assemble(tmp_path, "a2a3sim")
+        device_runner._compile_and_assemble(tmp_path, "a2a3sim")
 
     assert cached_binary.exists()
     assert not binary_context_path(tmp_path).exists()
     compile_orchestration.assert_not_called()
 
-    assembled, _, _ = device_runner.compile_and_assemble(tmp_path, "a2a3sim")
+    assembled, _, _ = device_runner._compile_and_assemble(tmp_path, "a2a3sim")
 
     assert assembled is chip
     assert not cached_binary.exists()
@@ -388,7 +388,7 @@ def test_compile_and_assemble_serializes_same_work_dir(
 
     monkeypatch.setattr(device_runner, "_compile_and_assemble_locked", assemble_locked)
     process = process_context.Process(
-        target=device_runner.compile_and_assemble,
+        target=device_runner._compile_and_assemble,
         args=(tmp_path, "a2a3sim"),
     )
     process.start()

--- a/tests/ut/runtime/test_distributed_worker.py
+++ b/tests/ut/runtime/test_distributed_worker.py
@@ -2179,19 +2179,9 @@ class TestAssembleChipCallables:
             (nl / "_not_a_chip").mkdir(parents=True, exist_ok=True)
         return SimpleNamespace(output_dir=tmp_path, platform="a2a3sim")
 
-    @staticmethod
-    def _stub_device_runner(monkeypatch, ca) -> None:
-        """Inject a stub ``device_runner`` so ``_assemble_chip_callables`` can be
-        exercised without importing the real module (which pulls in the simpler
-        toolchain via ``kernel_compiler`` and is absent in the unit-test env)."""
-        monkeypatch.setitem(
-            sys.modules, "pypto.runtime.device_runner", SimpleNamespace(compile_and_assemble=ca)
-        )
-
-    def test_picks_up_chip_dirs_with_kernel_config(self, tmp_path, monkeypatch):
+    def test_picks_up_chip_dirs_with_kernel_config(self, tmp_path, stub_device_runner):
         compiled = self._build(tmp_path, ["chip_a", "chip_b"], stray=True)
-        ca = MagicMock(return_value=(MagicMock(name="ChipCallable"), "tensormap_and_ringbuffer", {}))
-        self._stub_device_runner(monkeypatch, ca)
+        ca = stub_device_runner._compile_and_assemble
         chip_callables, runtime_name, enable_sdma = _assemble_chip_callables(compiled)
 
         assert set(chip_callables) == {"chip_a", "chip_b"}  # stray dir skipped
@@ -2201,33 +2191,23 @@ class TestAssembleChipCallables:
         assert called_dirs == {tmp_path / "next_levels" / "chip_a", tmp_path / "next_levels" / "chip_b"}
         assert all(call.args[1] == "a2a3sim" for call in ca.call_args_list)
 
-    def test_aggregates_enable_sdma_across_chip_configs(self, tmp_path, monkeypatch):
+    def test_aggregates_enable_sdma_across_chip_configs(self, tmp_path, stub_device_runner):
         compiled = self._build(tmp_path, ["chip_a", "chip_b"])
-        ca = MagicMock(
-            side_effect=[
-                (MagicMock(name="ChipCallableA"), "tensormap_and_ringbuffer", {}),
-                (
-                    MagicMock(name="ChipCallableB"),
-                    "tensormap_and_ringbuffer",
-                    {"enable_sdma": True},
-                ),
-            ]
-        )
-        self._stub_device_runner(monkeypatch, ca)
+        stub_device_runner._compile_and_assemble.side_effect = [
+            (MagicMock(name="ChipCallableA"), "tensormap_and_ringbuffer", {}),
+            (MagicMock(name="ChipCallableB"), "tensormap_and_ringbuffer", {"enable_sdma": True}),
+        ]
 
         _, _, enable_sdma = _assemble_chip_callables(compiled)
 
         assert enable_sdma is True
 
-    def test_raises_on_inconsistent_runtime(self, tmp_path, monkeypatch):
+    def test_raises_on_inconsistent_runtime(self, tmp_path, stub_device_runner):
         compiled = self._build(tmp_path, ["chip_a", "chip_b"])
-        ca = MagicMock(
-            side_effect=[
-                (MagicMock(name="ChipCallable"), "rt_one", {}),
-                (MagicMock(name="ChipCallable"), "rt_two", {}),
-            ]
-        )
-        self._stub_device_runner(monkeypatch, ca)
+        stub_device_runner._compile_and_assemble.side_effect = [
+            (MagicMock(name="ChipCallable"), "rt_one", {}),
+            (MagicMock(name="ChipCallable"), "rt_two", {}),
+        ]
         with pytest.raises(RuntimeError, match="Inconsistent runtime"):
             _assemble_chip_callables(compiled)
 

--- a/tests/ut/runtime/test_execute_artifact.py
+++ b/tests/ut/runtime/test_execute_artifact.py
@@ -9,7 +9,7 @@
 
 """Unit tests for :mod:`pypto.runtime.execute_artifact`.
 
-``compile_and_assemble`` and ``_execute_on_device`` are mocked so these tests
+``_compile_and_assemble`` and ``_execute_golden_case`` are mocked so these tests
 run without a device, without ``simpler``, and without any compiled artifact.
 They pin the CLI contract the harness relies on: arg parsing, DFX passthrough,
 and the ``PYPTO_EXEC_RESULT`` marker + exit code on pass / fail.
@@ -17,8 +17,6 @@ and the ``PYPTO_EXEC_RESULT`` marker + exit code on pass / fail.
 
 import importlib
 import json
-import sys
-from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -31,18 +29,14 @@ execute_batch_manifest = execute_artifact.execute_batch_manifest
 
 
 @pytest.fixture
-def stub_compile_and_assemble():
-    """Inject a stub ``pypto.runtime.device_runner`` so these tests don't import it.
+def stub_compile_and_assemble(stub_device_runner):
+    """The assembly-layer mock these tests drive.
 
-    ``execute_artifact`` imports ``compile_and_assemble`` lazily from
-    ``pypto.runtime.device_runner``; importing that module pulls in the optional
-    ``simpler`` package, which is absent on the unit-test runners. A stub module
-    lets the lazy import resolve to a mock without it.
+    ``execute_artifact`` reaches it through a lazy import, so the stub module
+    ``stub_device_runner`` installs is what the import binds to; see that
+    fixture in ``tests/ut/conftest.py``.
     """
-    ca = MagicMock(return_value=(object(), "tensormap_and_ringbuffer", {}))
-    stub = SimpleNamespace(compile_and_assemble=ca)
-    with patch.dict(sys.modules, {"pypto.runtime.device_runner": stub}):
-        yield ca
+    return stub_device_runner._compile_and_assemble
 
 
 def _argv(work_dir, *extra):
@@ -88,7 +82,7 @@ def test_setup_error_prints_infra_marker_not_fail(tmp_path, capsys):
 
 
 def test_execute_artifact_dir_wraps_compile_failure_as_setup_error(tmp_path, stub_compile_and_assemble):
-    """A compile_and_assemble failure surfaces as ArtifactSetupError (infra)."""
+    """A _compile_and_assemble failure surfaces as ArtifactSetupError (infra)."""
     stub_compile_and_assemble.side_effect = RuntimeError("missing .so")
     with pytest.raises(execute_artifact.ArtifactSetupError):
         execute_artifact_dir(tmp_path, "a2a3", 0)
@@ -144,7 +138,7 @@ def test_execute_artifact_dir_wires_compile_then_execute(tmp_path, stub_compile_
         "tensormap_and_ringbuffer",
         {"enable_sdma": True},
     )
-    with patch.object(execute_artifact, "_execute_on_device") as exec_on_dev:
+    with patch.object(execute_artifact, "_execute_golden_case") as exec_on_dev:
         execute_artifact_dir(tmp_path, "a2a3", 1)
     stub_compile_and_assemble.assert_called_once_with(tmp_path, "a2a3")
     args, kwargs = exec_on_dev.call_args
@@ -159,7 +153,7 @@ def test_execute_artifact_dir_wires_compile_then_execute(tmp_path, stub_compile_
 
 
 def test_execute_artifact_dir_defaults_sdma_off(tmp_path, stub_compile_and_assemble):
-    with patch.object(execute_artifact, "_execute_on_device") as exec_on_dev:
+    with patch.object(execute_artifact, "_execute_golden_case") as exec_on_dev:
         execute_artifact_dir(tmp_path, "a2a3", 1)
 
     assert exec_on_dev.call_args.kwargs["enable_sdma"] is False
@@ -183,7 +177,7 @@ def test_execute_batch_runs_all_in_one_worker(tmp_path, capsys, stub_compile_and
     chipworker = MagicMock()
     with (
         patch("pypto.runtime.ChipWorker", return_value=chipworker) as cw,
-        patch.object(execute_artifact, "_execute_on_device") as on_dev,
+        patch.object(execute_artifact, "_execute_golden_case") as on_dev,
     ):
         all_ok = execute_batch_manifest(manifest, 3, validate=False)
     assert all_ok is True
@@ -211,7 +205,7 @@ def test_execute_batch_enables_sdma_worker_for_prefetch_artifact(
 
     with (
         patch("pypto.runtime.ChipWorker", return_value=MagicMock()) as worker_cls,
-        patch.object(execute_artifact, "_execute_on_device") as on_dev,
+        patch.object(execute_artifact, "_execute_golden_case") as on_dev,
     ):
         all_ok = execute_batch_manifest(manifest, 3, validate=False)
 
@@ -244,7 +238,7 @@ def test_execute_batch_mixed_sdma_capability_is_order_independent(
     stub_compile_and_assemble.side_effect = reconstruct
     with (
         patch("pypto.runtime.ChipWorker", return_value=MagicMock()) as worker_cls,
-        patch.object(execute_artifact, "_execute_on_device") as on_dev,
+        patch.object(execute_artifact, "_execute_golden_case") as on_dev,
     ):
         all_ok = execute_batch_manifest(manifest, 3, validate=False)
 
@@ -305,7 +299,7 @@ def test_execute_batch_ignores_fallback_artifact_for_shared_sdma_capability(
     stub_compile_and_assemble.side_effect = reconstruct
     with (
         patch("pypto.runtime.ChipWorker", return_value=MagicMock()) as worker_cls,
-        patch.object(execute_artifact, "_execute_on_device") as on_dev,
+        patch.object(execute_artifact, "_execute_golden_case") as on_dev,
     ):
         all_ok = execute_batch_manifest(manifest, 3, validate=False)
 
@@ -325,7 +319,7 @@ def test_execute_batch_one_failure_does_not_abort_rest(tmp_path, capsys, stub_co
     with (
         patch("pypto.runtime.ChipWorker", return_value=MagicMock()),
         # First artifact's device run fails; second still runs.
-        patch.object(execute_artifact, "_execute_on_device", side_effect=[RuntimeError("dev boom"), None]),
+        patch.object(execute_artifact, "_execute_golden_case", side_effect=[RuntimeError("dev boom"), None]),
     ):
         all_ok = execute_batch_manifest(manifest, 0, validate=False)
     assert all_ok is False
@@ -354,7 +348,7 @@ def test_execute_batch_first_rebind_failure_marks_infra_and_continues(
     stub_compile_and_assemble.side_effect = reconstruct
     with (
         patch("pypto.runtime.ChipWorker", return_value=MagicMock()),
-        patch.object(execute_artifact, "_execute_on_device"),
+        patch.object(execute_artifact, "_execute_golden_case"),
     ):
         all_ok = execute_batch_manifest(manifest, 0, validate=False)
     assert all_ok is False
@@ -379,7 +373,7 @@ def test_execute_batch_setup_failure_marks_infra_not_fail(tmp_path, capsys, stub
     stub_compile_and_assemble.side_effect = reconstruct
     with (
         patch("pypto.runtime.ChipWorker", return_value=MagicMock()),
-        patch.object(execute_artifact, "_execute_on_device"),
+        patch.object(execute_artifact, "_execute_golden_case"),
     ):
         all_ok = execute_batch_manifest(manifest, 0, validate=False)
     assert all_ok is False

--- a/tests/ut/runtime/test_external_kernel_cache.py
+++ b/tests/ut/runtime/test_external_kernel_cache.py
@@ -133,7 +133,7 @@ def test_external_compile_ignores_source_sidecar(tmp_path):
     sidecar.write_bytes(b"stale wrong-core binary")
     compiler_stub = _Compiler()
 
-    raw, kernel_binary = device_runner.compile_single_kernel(
+    raw, kernel_binary = device_runner._compile_single_kernel(
         _kernel(source, "aiv", 7),
         compiler_stub,
         "a2a3sim",
@@ -159,7 +159,7 @@ def test_external_compile_forwards_descriptor_include_dirs(tmp_path):
     kernel["extra_include_dirs"] = [str(include_dir)]
     compiler_stub = _Compiler()
 
-    device_runner.compile_single_kernel(
+    device_runner._compile_single_kernel(
         kernel,
         compiler_stub,
         "a2a3sim",

--- a/tests/ut/runtime/test_pto_isa_resolution.py
+++ b/tests/ut/runtime/test_pto_isa_resolution.py
@@ -105,7 +105,7 @@ def _write_raw_pto(work_dir):
 
 def _missing_config_message(device_runner, work_dir):
     with pytest.raises(FileNotFoundError) as exc_info:
-        device_runner.compile_and_assemble(work_dir, "a2a3")
+        device_runner._compile_and_assemble(work_dir, "a2a3")
     return str(exc_info.value)
 
 

--- a/tests/ut/runtime/test_run_config.py
+++ b/tests/ut/runtime/test_run_config.py
@@ -685,22 +685,9 @@ class TestRunConfigCompileForwarding:
 
         assert set(kwargs) <= accepted
 
-    def test_execute_compiled_accepts_auto_scope_deps_switch(self, tmp_path, monkeypatch):
-        captured: dict = {}
+    def test_execute_compiled_accepts_auto_scope_deps_switch(self, tmp_path, stub_device_runner):
         config = RunConfig(platform="a2a3sim", ring_heap=1024 * 1024)
-
-        def fake_compile_and_assemble(_work_dir, platform):
-            captured["compile"] = {"platform": platform}
-            return object(), "fake_runtime", {}
-
-        def fake_execute_on_device(*args, **kwargs):
-            captured["execute"] = {"args": args, "kwargs": kwargs}
-
-        fake_device_runner = types.SimpleNamespace(
-            compile_and_assemble=fake_compile_and_assemble,
-            execute_on_device=fake_execute_on_device,
-        )
-        monkeypatch.setitem(sys.modules, "pypto.runtime.device_runner", fake_device_runner)
+        stub_device_runner._compile_and_assemble.return_value = (object(), "fake_runtime", {})
 
         _execute_compiled(
             tmp_path,
@@ -711,25 +698,17 @@ class TestRunConfigCompileForwarding:
             config=config,
         )
 
-        assert captured["compile"]["platform"] == "a2a3sim"
-        assert captured["execute"]["args"][3] == "fake_runtime"
-        assert captured["execute"]["kwargs"]["aicpu_thread_num"] is None
-        assert captured["execute"]["kwargs"]["config"] is config
+        assert stub_device_runner._compile_and_assemble.call_args.args[1] == "a2a3sim"
+        execute_call = stub_device_runner._execute_on_device.call_args
+        assert execute_call.args[3] == "fake_runtime"
+        assert execute_call.kwargs["aicpu_thread_num"] is None
+        assert execute_call.kwargs["config"] is config
 
-    def test_execute_compiled_serializes_ring_config_for_dep_capture(self, tmp_path, monkeypatch):
+    def test_execute_compiled_serializes_ring_config_for_dep_capture(
+        self, tmp_path, monkeypatch, stub_device_runner
+    ):
         captured: dict = {}
-
-        def fake_compile_and_assemble(_work_dir, _platform):
-            return object(), "fake_runtime", {}
-
-        def fake_execute_on_device(*_args, **kwargs):
-            captured["execute_config"] = kwargs["config"]
-
-        fake_device_runner = types.SimpleNamespace(
-            compile_and_assemble=fake_compile_and_assemble,
-            execute_on_device=fake_execute_on_device,
-        )
-        monkeypatch.setitem(sys.modules, "pypto.runtime.device_runner", fake_device_runner)
+        stub_device_runner._compile_and_assemble.return_value = (object(), "fake_runtime", {})
 
         import pypto.runtime.runner as runner_mod  # noqa: PLC0415
 
@@ -755,7 +734,7 @@ class TestRunConfigCompileForwarding:
             config=config,
         )
 
-        assert captured["execute_config"] is config
+        assert stub_device_runner._execute_on_device.call_args.kwargs["config"] is config
         assert captured["spec"]["ring_overrides"] == {
             "ring_task_window": [16, 32, 64, 128],
             "ring_heap": 512 * 1024 * 1024,
@@ -775,24 +754,18 @@ class TestRunConfigCompileForwarding:
         monkeypatch,
         runtime_config,
         expected_enable_sdma,
+        stub_device_runner,
     ):
-        captured: dict = {}
-
-        def fake_compile_and_assemble(_work_dir, _platform):
-            return object(), "fake_runtime", runtime_config
-
-        def fake_execute_on_device(*_args, **kwargs):
-            captured.update(kwargs)
-
-        fake_device_runner = types.SimpleNamespace(
-            compile_and_assemble=fake_compile_and_assemble,
-            execute_on_device=fake_execute_on_device,
+        stub_device_runner._compile_and_assemble.return_value = (
+            object(),
+            "fake_runtime",
+            runtime_config,
         )
-        monkeypatch.setitem(sys.modules, "pypto.runtime.device_runner", fake_device_runner)
 
         _execute_compiled(tmp_path, [], platform="a2a3sim", device_id=0)
 
-        assert captured["enable_sdma"] is expected_enable_sdma
+        kwargs = stub_device_runner._execute_on_device.call_args.kwargs
+        assert kwargs["enable_sdma"] is expected_enable_sdma
 
     def test_compile_kwargs_carry_the_codegen_target(self):
         """``platform`` and the ``backend_type`` it implies both reach compilation."""
@@ -802,7 +775,7 @@ class TestRunConfigCompileForwarding:
         assert kwargs["backend_type"] == BackendType.Ascend950
 
 
-# ``execute_on_device`` lives in ``device_runner`` which eagerly imports the
+# ``_execute_on_device`` lives in ``device_runner`` which eagerly imports the
 # ``simpler`` package (via ``task_interface``). Unit-tests CI runs without
 # ``simpler`` installed, so the import fails at collection time. Mirror the
 # skip pattern from ``test_worker_reuse.py``.
@@ -814,15 +787,15 @@ else:
     _has_simpler = True
 
 
-@pytest.mark.skipif(not _has_simpler, reason="execute_on_device requires the simpler package")
+@pytest.mark.skipif(not _has_simpler, reason="_execute_on_device requires the simpler package")
 class TestExecuteOnDeviceDfxValidation:
-    """Verify ``execute_on_device`` rejects DFX flags without ``output_prefix``."""
+    """Verify ``_execute_on_device`` rejects DFX flags without ``output_prefix``."""
 
     def test_dfx_without_output_prefix_raises_value_error(self):
-        from pypto.runtime.device_runner import execute_on_device  # noqa: PLC0415
+        from pypto.runtime.device_runner import _execute_on_device  # noqa: PLC0415
 
         with pytest.raises(ValueError, match="output_prefix is required"):
-            execute_on_device(
+            _execute_on_device(
                 chip_callable=MagicMock(),
                 orch_args=MagicMock(),
                 platform="a5sim",
@@ -833,7 +806,7 @@ class TestExecuteOnDeviceDfxValidation:
             )
 
     def test_dfx_without_output_prefix_raises_for_each_flag(self):
-        from pypto.runtime.device_runner import execute_on_device  # noqa: PLC0415
+        from pypto.runtime.device_runner import _execute_on_device  # noqa: PLC0415
 
         for flag in [
             {"enable_chip_swimlane": True},
@@ -843,7 +816,7 @@ class TestExecuteOnDeviceDfxValidation:
             {"enable_scope_stats": True},
         ]:
             with pytest.raises(ValueError, match="output_prefix is required"):
-                execute_on_device(
+                _execute_on_device(
                     chip_callable=MagicMock(),
                     orch_args=MagicMock(),
                     platform="a5sim",
@@ -864,7 +837,7 @@ class TestExecuteOnDeviceDfxValidation:
             # _PyptoWorker.current returns None → falls to the new-Worker path.
             # ``current`` lives on ``ChipWorker``, not the ABC base ``Worker``.
             with patch("pypto.runtime.worker.ChipWorker.current", return_value=None):
-                device_runner.execute_on_device(
+                device_runner._execute_on_device(
                     chip_callable=MagicMock(),
                     orch_args=MagicMock(),
                     platform="a5sim",
@@ -883,7 +856,7 @@ class TestExecuteOnDeviceDfxValidation:
         with patch.object(device_runner, "Worker") as worker_cls:
             worker = worker_cls.return_value
             with patch("pypto.runtime.worker.ChipWorker.current", return_value=None):
-                device_runner.execute_on_device(
+                device_runner._execute_on_device(
                     chip_callable=MagicMock(),
                     orch_args=MagicMock(),
                     platform="a5sim",

--- a/tests/ut/runtime/test_swimlane_two_pass.py
+++ b/tests/ut/runtime/test_swimlane_two_pass.py
@@ -19,8 +19,6 @@ host-register mappings between DFX runs. These tests drive
 
 import ctypes
 import json
-import sys
-import types
 from pathlib import Path
 
 import pypto.runtime.runner as _runner
@@ -148,19 +146,8 @@ def test_build_args_spec_rejects_unknown_type(tmp_path):
         _build_args_spec(["not an arg"], tmp_path)  # type: ignore[list-item]  # pyright: ignore[reportArgumentType]
 
 
-def test_dep_capture_reconstructs_ring_config(tmp_path, monkeypatch):
-    captured: dict = {}
-
-    def fake_compile_and_assemble(_work_dir, _platform):
-        return object(), "fake_runtime", {}
-
-    def fake_execute_on_device(*_args, **kwargs):
-        captured.update(kwargs)
-
-    fake_device_runner = types.ModuleType("pypto.runtime.device_runner")
-    fake_device_runner.compile_and_assemble = fake_compile_and_assemble  # type: ignore[attr-defined]
-    fake_device_runner.execute_on_device = fake_execute_on_device  # type: ignore[attr-defined]
-    monkeypatch.setitem(sys.modules, "pypto.runtime.device_runner", fake_device_runner)
+def test_dep_capture_reconstructs_ring_config(tmp_path, monkeypatch, stub_device_runner):
+    stub_device_runner._compile_and_assemble.return_value = (object(), "fake_runtime", {})
 
     spec_path = tmp_path / "capture.json"
     spec_path.write_text(
@@ -183,7 +170,7 @@ def test_dep_capture_reconstructs_ring_config(tmp_path, monkeypatch):
     )
 
     assert _dep_gen_capture.main([str(spec_path)]) == 0
-    config = captured["config"]
+    config = stub_device_runner._execute_on_device.call_args.kwargs["config"]
     assert config.ring_task_window == [16, 32, 64, 128]
     assert config.ring_heap == 512 * 1024 * 1024
     assert config.ring_dep_pool == [64, 0, 0, 256]

--- a/tests/ut/runtime/test_task_submit_dispatch.py
+++ b/tests/ut/runtime/test_task_submit_dispatch.py
@@ -386,7 +386,7 @@ def test_sim_platform_never_borrows_a_card():
     tc.get_name.return_value = "case_sim"
     timing = SimpleNamespace(device_wall_us=1.0, host_wall_us=2.0)
     with (
-        patch.object(test_runner, "_execute_on_device", return_value=timing) as on_dev,
+        patch.object(test_runner, "_execute_golden_case", return_value=timing) as on_dev,
         patch.object(test_runner, "_run_artifact_via_task_submit") as via_ts,
     ):
         result = test_runner._fused_execute_task(
@@ -400,18 +400,18 @@ def test_sim_platform_never_borrows_a_card():
     via_ts.assert_not_called()
 
 
-def test_fused_compile_records_sdma_capability(tmp_path):
-    fake_compile_and_assemble = Mock(
-        return_value=(object(), "tensormap_and_ringbuffer", {"enable_sdma": True})
+def test_fused_compile_records_sdma_capability(tmp_path, stub_device_runner):
+    stub_device_runner._compile_and_assemble.return_value = (
+        object(),
+        "tensormap_and_ringbuffer",
+        {"enable_sdma": True},
     )
-    fake_device_runner = SimpleNamespace(compile_and_assemble=fake_compile_and_assemble)
     tc = Mock()
 
     with (
         patch.object(test_runner, "_resolve_platform", return_value="a2a3"),
         patch.object(test_runner, "_cache_key", return_value="prefetch@a2a3"),
         patch.object(test_runner, "_compile_for_cache"),
-        patch.dict(sys.modules, {"pypto.runtime.device_runner": fake_device_runner}),
     ):
         artifact = test_runner._fused_compile_task(tc, tmp_path, "a2a3", False, False)
 

--- a/tests/ut/runtime/test_worker_reuse.py
+++ b/tests/ut/runtime/test_worker_reuse.py
@@ -20,7 +20,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from pypto.runtime import ChipWorker, RunConfig
 
-# ``execute_on_device`` is imported lazily inside individual tests to keep
+# ``_execute_on_device`` is imported lazily inside individual tests to keep
 # this module importable in environments where the underlying ``simpler``
 # package is not installed (e.g. unit-tests CI). ``device_runner`` eagerly
 # imports ``simpler.task_interface`` at module load.
@@ -305,11 +305,11 @@ class TestActiveChipWorkerLookup:
             )
 
 
-# ``execute_on_device`` lives in ``device_runner`` which eagerly imports the
+# ``_execute_on_device`` lives in ``device_runner`` which eagerly imports the
 # ``simpler`` package. The ChipWorker-only tests above mock just the
 # ``simpler.ChipWorker`` class via ``_SimplerWorker`` and do not need
 # ``device_runner`` loaded — but the tests in this class invoke
-# ``execute_on_device`` directly, so they are skipped when ``simpler`` is not
+# ``_execute_on_device`` directly, so they are skipped when ``simpler`` is not
 # installed (e.g. unit-tests CI).
 try:
     import simpler  # noqa: F401  # pyright: ignore[reportMissingImports]
@@ -319,12 +319,12 @@ else:
     _has_simpler = True
 
 
-@pytest.mark.skipif(not _has_simpler, reason="execute_on_device requires the simpler package")
+@pytest.mark.skipif(not _has_simpler, reason="_execute_on_device requires the simpler package")
 class TestExecuteOnDeviceReuse:
-    """Verify ``execute_on_device`` reuses an active ChipWorker rather than constructing a new one."""
+    """Verify ``_execute_on_device`` reuses an active ChipWorker rather than constructing a new one."""
 
     def test_reuse_skips_init_and_close(self, fake_simpler_worker):
-        from pypto.runtime.device_runner import execute_on_device  # noqa: PLC0415
+        from pypto.runtime.device_runner import _execute_on_device  # noqa: PLC0415
 
         chip_callable = MagicMock(name="chip_callable")
         orch_args = [MagicMock(name="host_tensor")]
@@ -340,7 +340,7 @@ class TestExecuteOnDeviceReuse:
                 patch("pypto.runtime.device_runner.CallConfig", MagicMock),
                 patch("pypto.runtime.runner._coerced_to_orch_args", return_value=wire_args) as pack,
             ):
-                execute_on_device(
+                _execute_on_device(
                     chip_callable,
                     orch_args,
                     platform="a2a3sim",
@@ -356,13 +356,13 @@ class TestExecuteOnDeviceReuse:
             assert fake_simpler_worker.close.call_count == 0
 
     def test_no_active_worker_uses_one_shot_path(self, fake_simpler_worker):
-        from pypto.runtime.device_runner import execute_on_device  # noqa: PLC0415
+        from pypto.runtime.device_runner import _execute_on_device  # noqa: PLC0415
 
         chip_callable = MagicMock(name="chip_callable")
         orch_args = [MagicMock(name="host_tensor")]
         wire_args = MagicMock(name="TaskArgs")
 
-        # No `with` block — execute_on_device must construct its own ChipWorker
+        # No `with` block — _execute_on_device must construct its own ChipWorker
         # (one init + one run + one close on the underlying simpler.ChipWorker).
         # The one-shot path imports simpler.ChipWorker directly into device_runner,
         # so patch that name in addition to the wrapper's _SimplerWorker.
@@ -372,7 +372,7 @@ class TestExecuteOnDeviceReuse:
             patch("pypto.runtime.device_runner.Worker", return_value=one_shot) as worker_cls,
             patch("pypto.runtime.runner._coerced_to_orch_args", return_value=wire_args) as pack,
         ):
-            execute_on_device(
+            _execute_on_device(
                 chip_callable,
                 orch_args,
                 platform="a2a3sim",
@@ -393,13 +393,13 @@ class TestExecuteOnDeviceReuse:
         assert one_shot.close.call_count == 1
 
     def test_no_active_worker_forwards_enabled_sdma(self, fake_simpler_worker):
-        from pypto.runtime.device_runner import execute_on_device  # noqa: PLC0415
+        from pypto.runtime.device_runner import _execute_on_device  # noqa: PLC0415
 
         with (
             patch("pypto.runtime.device_runner.CallConfig", MagicMock),
             patch("pypto.runtime.device_runner.Worker") as worker_cls,
         ):
-            execute_on_device(
+            _execute_on_device(
                 MagicMock(),
                 MagicMock(),
                 platform="a2a3",
@@ -417,7 +417,7 @@ class TestExecuteOnDeviceReuse:
         )
 
     def test_sdma_required_dispatch_rejects_ordinary_active_worker(self, fake_simpler_worker):
-        from pypto.runtime.device_runner import execute_on_device  # noqa: PLC0415
+        from pypto.runtime.device_runner import _execute_on_device  # noqa: PLC0415
 
         with (
             ChipWorker(config=RunConfig(platform="a2a3sim")),
@@ -428,7 +428,7 @@ class TestExecuteOnDeviceReuse:
                 RuntimeError,
                 match="active ChipWorker was created without enable_sdma=True",
             ):
-                execute_on_device(
+                _execute_on_device(
                     MagicMock(),
                     MagicMock(),
                     platform="a2a3sim",
@@ -440,12 +440,12 @@ class TestExecuteOnDeviceReuse:
         worker_cls.assert_not_called()
 
     def test_sdma_enabled_active_worker_runs_ordinary_dispatch(self, fake_simpler_worker):
-        from pypto.runtime.device_runner import execute_on_device  # noqa: PLC0415
+        from pypto.runtime.device_runner import _execute_on_device  # noqa: PLC0415
 
         with ChipWorker(config=RunConfig(platform="a2a3sim"), enable_sdma=True):
             fake_simpler_worker.run.reset_mock()
             with patch("pypto.runtime.device_runner.CallConfig", MagicMock):
-                execute_on_device(
+                _execute_on_device(
                     MagicMock(),
                     MagicMock(),
                     platform="a2a3sim",
@@ -456,10 +456,10 @@ class TestExecuteOnDeviceReuse:
         fake_simpler_worker.run.assert_called_once()
 
     def test_level_mismatch_rejected(self, fake_simpler_worker):
-        from pypto.runtime.device_runner import execute_on_device  # noqa: PLC0415
+        from pypto.runtime.device_runner import _execute_on_device  # noqa: PLC0415
 
         with pytest.raises(ValueError, match="only supports level=2"):
-            execute_on_device(
+            _execute_on_device(
                 MagicMock(),
                 MagicMock(),
                 platform="a2a3sim",


### PR DESCRIPTION
## Summary

Between the artifact layer and the device sits an **assembly layer**: turning
`.pto` / `.cpp` into loadable binaries and launching them. It has no supported
entry point and never appeared in `pypto.runtime.__all__`, but its four
functions were spelled as public names, so nothing at a call site said which
side of the boundary it was on.

| Was | Is |
| --- | -- |
| `device_runner.compile_and_assemble` | `_compile_and_assemble` |
| `device_runner.compile_single_kernel` | `_compile_single_kernel` |
| `device_runner.compile_single_orchestration` | `_compile_single_orchestration` |
| `device_runner.execute_on_device` | `_execute_on_device` |
| `runner._execute_on_device` | `_execute_golden_case` |

Last step of Stage B in `docs/en/dev/08-entry-points.md`, after #2597 and #2609.

## Why `runner._execute_on_device` moves too

It had to move first. It is a *different* function — it loads golden inputs,
dispatches, and validates the result — and giving the device-side one its
underscore would have left two `_execute_on_device` names in sibling modules,
one calling the other, with `patch("...runner._execute_on_device")` and
`patch("...device_runner._execute_on_device")` a coin flip apart. Worse, the
function-local `from .device_runner import ...` inside it would then have
shadowed the module-level name in its own body.

`_execute_golden_case` says what it does. It is private and has two importers
outside `runner.py` (`execute_artifact.py` and the ST harness), both updated.

## The test seam

The rename is only half the change. **Six test files each reconstructed the same
`sys.modules` stub of `pypto.runtime.device_runner` by hand**, because the
library reaches the assembly layer through function-local imports — importing it
eagerly would make the device-only `simpler` package a hard dependency of
`pypto.runtime`, so patching an attribute on the real module is not available to
the unit-test runners. Six copies meant this rename had to touch all six.

`tests/ut/conftest.py` now has one `stub_device_runner` fixture, and five of the
six use it: `test_execute_artifact.py`, `test_run_config.py`,
`test_swimlane_two_pass.py`, `test_task_submit_dispatch.py`,
`test_distributed_worker.py`. Each drops its own stub construction and reads
call arguments off the fixture's mocks instead of a `captured` dict threaded
through a closure — which is also why `test_run_config.py` loses 40 lines.

`tests/ut/ir/test_compiled_program.py` deliberately keeps its local
`_fake_compile_and_assemble`: it is a context manager configured per `with`
block and used fourteen times, so converting it would restructure fourteen tests
to save one occurrence of the name, and the file already funnels every use
through that single helper.

The tests that *exercise* the assembly layer rather than stub it —
`test_binary_cache_context.py`, `test_external_kernel_cache.py`,
`test_pto_isa_resolution.py`, `test_worker_reuse.py`, and the ST suites — keep
naming it directly. That is what those tests are for.

## Docs

`docs/{en,zh}/dev/08-entry-points.md`: the compile / execute tables and the
"What is internal" list carry the new spellings. The list is regrouped by module
(the two `pypto.runtime.runner` entries had drifted apart) and gains
`_execute_golden_case`. `03-runtime-dfx.md`, `05-runtime-ring-sizing.md` and
`00-getting_started.md` follow the rename in prose. 8 pages, en/zh in step.

## Compatibility

Nothing outside this repository imports any of the five. They were already
absent from every `__all__`, so this removes no documented API — it makes the
spelling agree with the status the docs already gave them.

## Verification

Run in the worktree against its own build, at the pushed commit.

- `pytest tests/ut/ -n 16`: 11025 passed, 8 skipped, 1 xfailed
- `tests/lint/check_*.py` (12 scripts): all pass
- `ruff check` / `ruff format --check` (pinned 0.14.8): clean
- `pyright python/pypto tests examples`: only the two pre-existing
  `torch.float4_e2m1fn_x2` errors, from this machine's older torch rather than
  CI's pinned 2.8.0
- `markdownlint-cli2 v0.20.0` on the 8 changed pages: 0 errors

The usual `test_symlinked_import_path_still_names_the_caller` deselection
applies — it fails identically on unmodified `main` here.

Device tests were not run; this change touches no kernel or codegen output. The
ST call sites are renamed in lockstep and CI's device jobs cover them.
