### PR TITLE
chore(runtime): bump the runtime submodule to simpler 15f5cbd9, renaming TaskTensor to Tensor

### DIFF
--- a/python/pypto/backend/_ptoas_preprocess.py
+++ b/python/pypto/backend/_ptoas_preprocess.py
@@ -131,7 +131,7 @@ def preprocess_ptoas_output(content: str) -> str:
     # (simpler#1681), split it in two (simpler#1974) so the 72-byte
     # ``ChipTensor`` is only the argument as it arrives at the boundary, and
     # then named the descriptor a kernel actually reads ``Tensor`` in the
-    # per-runtime ``tensor.h`` shim (simpler#2044), retiring ``TaskTensor``.
+    # per-runtime ``tensor.h`` shim (simpler#2044), retiring ``Tensor``.
     result = re.sub(
         r'(?:extern\s*"C"\s*)?(?:__global__\s+)?AICORE\s+void',
         "static __aicore__ void",

--- a/python/pypto/backend/_ptoas_preprocess.py
+++ b/python/pypto/backend/_ptoas_preprocess.py
@@ -125,16 +125,13 @@ def preprocess_ptoas_output(content: str) -> str:
         filtered.append(line)
 
     result = _restore_mgather_wrapper_operands("".join(filtered))
-    # The current PTOAS emitter spells the 128-byte, chip-resident descriptor
-    # ``Tensor``.  Simpler renamed that runtime ABI type to ``ChipTensor``
-    # (simpler#1681), then split it in two (simpler#1974): the 72-byte
-    # ``ChipTensor`` is now only the argument as it arrives at the boundary,
-    # while the 128-byte descriptor a kernel actually reads is its runtime's
-    # own type, spelled ``TaskTensor`` by the per-runtime ``tensor.h`` shim.
-    # Rewrite the exact identifier before embedding the body in PyPTO's
-    # wrapper; names such as ``GlobalTensor`` are intentionally unaffected by
-    # the word boundaries.
-    result = re.sub(r"\bTensor\b", "TaskTensor", result)
+    # The PTOAS emitter and the runtime now spell the 128-byte, chip-resident
+    # descriptor the same way -- ``Tensor`` -- so nothing has to be rewritten
+    # here.  Simpler renamed that runtime ABI type to ``ChipTensor``
+    # (simpler#1681), split it in two (simpler#1974) so the 72-byte
+    # ``ChipTensor`` is only the argument as it arrives at the boundary, and
+    # then named the descriptor a kernel actually reads ``Tensor`` in the
+    # per-runtime ``tensor.h`` shim (simpler#2044), retiring ``TaskTensor``.
     result = re.sub(
         r'(?:extern\s*"C"\s*)?(?:__global__\s+)?AICORE\s+void',
         "static __aicore__ void",

--- a/python/pypto/backend/pto_backend.py
+++ b/python/pypto/backend/pto_backend.py
@@ -576,9 +576,7 @@ def _generate_arg_unpacking(func: _ir_core.Function, *, uses_spmd: bool = False)
         assert isinstance(param.type, _ir_core.TensorType)
         c_type = param.type.dtype.to_c_type_string()
         lines.append(f"    // Unpack tensor: {param_name}")
-        lines.append(
-            f"    __gm__ TaskTensor* {param_name}_tensor = reinterpret_cast<__gm__ TaskTensor*>(args[{i}]);"
-        )
+        lines.append(f"    __gm__ Tensor* {param_name}_tensor = reinterpret_cast<__gm__ Tensor*>(args[{i}]);")
         if param_name == "__gm_pipe_buffer" and uses_spmd:
             lines.append("    // SPMD: shard GM pipe workspace by logical block_idx to avoid overlap.")
             lines.append("    int64_t __pypto_gm_block_num = static_cast<int64_t>(__pypto_spmd_block_num);")

--- a/python/pypto/ir/directions.py
+++ b/python/pypto/ir/directions.py
@@ -11,7 +11,7 @@
 
 These helpers exist for tests, examples and hand-written IR code that need to
 attach :class:`ir.ArgDirection` values to a call without importing the enum
-explicitly. They mirror the runtime ``add_input/add_output/add_output(TaskTensor)
+explicitly. They mirror the runtime ``add_input/add_output/add_output(Tensor)
 /add_inout/add_no_dep/add_scalar`` API on the call site.
 
 The user-facing DSL (``pypto.language``) keeps using :class:`pl.Out` and

--- a/python/pypto/ir/op/tensor_ops.py
+++ b/python/pypto/ir/op/tensor_ops.py
@@ -1877,7 +1877,7 @@ def view(
     PTO in-core lowering. Only orchestration lowering is restricted: it supports
     ND shape reinterprets and shaped ND/MX_A_ZZ/MX_B_NN backing/consumer views
     for FP8E8M0 MX scales; other layout-changing shape reinterprets are
-    unsupported because the runtime ``TaskTensor::reshape`` cannot express an
+    unsupported because the runtime ``Tensor::reshape`` cannot express an
     arbitrary-layout view.
 
     Args:

--- a/python/pypto/runtime/builtins/collectives/all_to_all/templates/entry.cpp.in
+++ b/python/pypto/runtime/builtins/collectives/all_to_all/templates/entry.cpp.in
@@ -19,9 +19,9 @@ namespace {
 
 template <typename DType>
 void submit_all_to_all_kernel(const ChipTaskArgs &orch_args) {
-  const TaskTensor &input = orch_args.tensor(0).ref();
-  const TaskTensor &target = orch_args.tensor(1).ref();
-  const TaskTensor &signal = orch_args.tensor(2).ref();
+  const Tensor &input = orch_args.tensor(0).ref();
+  const Tensor &target = orch_args.tensor(1).ref();
+  const Tensor &signal = orch_args.tensor(2).ref();
 
   CoreTaskArgs params;
   params.add_input(input);

--- a/python/pypto/runtime/builtins/collectives/all_to_all/templates/kernel.cpp.in
+++ b/python/pypto/runtime/builtins/collectives/all_to_all/templates/kernel.cpp.in
@@ -42,9 +42,9 @@ AICORE inline __gm__ T *CommRemotePtr(__gm__ CommContext *ctx, __gm__ T *local_p
 }  // namespace
 
 extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
-  __gm__ TaskTensor *input_tensor = reinterpret_cast<__gm__ TaskTensor *>(args[0]);
-  __gm__ TaskTensor *target_tensor = reinterpret_cast<__gm__ TaskTensor *>(args[1]);
-  __gm__ TaskTensor *signal_tensor = reinterpret_cast<__gm__ TaskTensor *>(args[2]);
+  __gm__ Tensor *input_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
+  __gm__ Tensor *target_tensor = reinterpret_cast<__gm__ Tensor *>(args[1]);
+  __gm__ Tensor *signal_tensor = reinterpret_cast<__gm__ Tensor *>(args[2]);
   int nranks = static_cast<int>(args[3]);
   __gm__ CommContext *comm_ctx = reinterpret_cast<__gm__ CommContext *>(args[4]);
 

--- a/python/pypto/runtime/builtins/collectives/all_to_all_v/templates/entry.cpp.in
+++ b/python/pypto/runtime/builtins/collectives/all_to_all_v/templates/entry.cpp.in
@@ -19,11 +19,11 @@ namespace {
 
 template <typename DType>
 void submit_all_to_all_v_kernel(const ChipTaskArgs &orch_args) {
-  const TaskTensor &input = orch_args.tensor(0).ref();
-  const TaskTensor &target = orch_args.tensor(1).ref();
-  const TaskTensor &signal = orch_args.tensor(2).ref();
-  const TaskTensor &send_counts = orch_args.tensor(3).ref();
-  const TaskTensor &recv_counts = orch_args.tensor(4).ref();
+  const Tensor &input = orch_args.tensor(0).ref();
+  const Tensor &target = orch_args.tensor(1).ref();
+  const Tensor &signal = orch_args.tensor(2).ref();
+  const Tensor &send_counts = orch_args.tensor(3).ref();
+  const Tensor &recv_counts = orch_args.tensor(4).ref();
 
   CoreTaskArgs params;
   params.add_input(input);

--- a/python/pypto/runtime/builtins/collectives/all_to_all_v/templates/kernel.cpp.in
+++ b/python/pypto/runtime/builtins/collectives/all_to_all_v/templates/kernel.cpp.in
@@ -42,11 +42,11 @@ AICORE inline __gm__ T *CommRemotePtr(__gm__ CommContext *ctx, __gm__ T *local_p
 }  // namespace
 
 extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
-  __gm__ TaskTensor *input_tensor = reinterpret_cast<__gm__ TaskTensor *>(args[0]);
-  __gm__ TaskTensor *target_tensor = reinterpret_cast<__gm__ TaskTensor *>(args[1]);
-  __gm__ TaskTensor *signal_tensor = reinterpret_cast<__gm__ TaskTensor *>(args[2]);
-  __gm__ TaskTensor *send_counts_tensor = reinterpret_cast<__gm__ TaskTensor *>(args[3]);
-  __gm__ TaskTensor *recv_counts_tensor = reinterpret_cast<__gm__ TaskTensor *>(args[4]);
+  __gm__ Tensor *input_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
+  __gm__ Tensor *target_tensor = reinterpret_cast<__gm__ Tensor *>(args[1]);
+  __gm__ Tensor *signal_tensor = reinterpret_cast<__gm__ Tensor *>(args[2]);
+  __gm__ Tensor *send_counts_tensor = reinterpret_cast<__gm__ Tensor *>(args[3]);
+  __gm__ Tensor *recv_counts_tensor = reinterpret_cast<__gm__ Tensor *>(args[4]);
   int nranks = static_cast<int>(args[5]);
   __gm__ CommContext *comm_ctx = reinterpret_cast<__gm__ CommContext *>(args[6]);
 

--- a/python/pypto/runtime/builtins/collectives/allgather/templates/entry.cpp.in
+++ b/python/pypto/runtime/builtins/collectives/allgather/templates/entry.cpp.in
@@ -19,9 +19,9 @@ namespace {
 
 template <typename DType>
 void submit_allgather_kernel(const ChipTaskArgs &orch_args) {
-  const TaskTensor &input = orch_args.tensor(0).ref();
-  const TaskTensor &target = orch_args.tensor(1).ref();
-  const TaskTensor &signal = orch_args.tensor(2).ref();
+  const Tensor &input = orch_args.tensor(0).ref();
+  const Tensor &target = orch_args.tensor(1).ref();
+  const Tensor &signal = orch_args.tensor(2).ref();
 
   CoreTaskArgs params;
   params.add_input(input);

--- a/python/pypto/runtime/builtins/collectives/allgather/templates/kernel.cpp.in
+++ b/python/pypto/runtime/builtins/collectives/allgather/templates/kernel.cpp.in
@@ -42,9 +42,9 @@ AICORE inline __gm__ T *CommRemotePtr(__gm__ CommContext *ctx, __gm__ T *local_p
 }  // namespace
 
 extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
-  __gm__ TaskTensor *input_tensor = reinterpret_cast<__gm__ TaskTensor *>(args[0]);
-  __gm__ TaskTensor *target_tensor = reinterpret_cast<__gm__ TaskTensor *>(args[1]);
-  __gm__ TaskTensor *signal_tensor = reinterpret_cast<__gm__ TaskTensor *>(args[2]);
+  __gm__ Tensor *input_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
+  __gm__ Tensor *target_tensor = reinterpret_cast<__gm__ Tensor *>(args[1]);
+  __gm__ Tensor *signal_tensor = reinterpret_cast<__gm__ Tensor *>(args[2]);
   int nranks = static_cast<int>(args[3]);
   __gm__ CommContext *comm_ctx = reinterpret_cast<__gm__ CommContext *>(args[4]);
 

--- a/python/pypto/runtime/builtins/collectives/allreduce/templates/entry.cpp.in
+++ b/python/pypto/runtime/builtins/collectives/allreduce/templates/entry.cpp.in
@@ -26,8 +26,8 @@ enum class ReduceOp : int32_t {
 
 template <ReduceOp Op>
 void submit_allreduce_kernel(const ChipTaskArgs &orch_args) {
-  const TaskTensor &data = orch_args.tensor(0).ref();
-  const TaskTensor &signal = orch_args.tensor(1).ref();
+  const Tensor &data = orch_args.tensor(0).ref();
+  const Tensor &signal = orch_args.tensor(1).ref();
 
   CoreTaskArgs params;
   params.add_inout(data);

--- a/python/pypto/runtime/builtins/collectives/allreduce/templates/kernel.cpp.in
+++ b/python/pypto/runtime/builtins/collectives/allreduce/templates/kernel.cpp.in
@@ -47,8 +47,8 @@ AICORE inline __gm__ T *CommRemotePtr(__gm__ CommContext *ctx, __gm__ T *local_p
 }  // namespace
 
 extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
-  __gm__ TaskTensor *data_tensor = reinterpret_cast<__gm__ TaskTensor *>(args[0]);
-  __gm__ TaskTensor *signal_tensor = reinterpret_cast<__gm__ TaskTensor *>(args[1]);
+  __gm__ Tensor *data_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
+  __gm__ Tensor *signal_tensor = reinterpret_cast<__gm__ Tensor *>(args[1]);
   int nranks = static_cast<int>(args[2]);
   __gm__ CommContext *comm_ctx = reinterpret_cast<__gm__ CommContext *>(args[3]);
   int32_t block_idx = get_block_idx(args);

--- a/python/pypto/runtime/builtins/collectives/allreduce_ring/templates/entry.cpp.in
+++ b/python/pypto/runtime/builtins/collectives/allreduce_ring/templates/entry.cpp.in
@@ -23,8 +23,8 @@ enum class ReduceOp : int32_t {
 
 template <ReduceOp Op, typename DType>
 void submit_allreduce_ring_kernel(const ChipTaskArgs &orch_args) {
-  const TaskTensor &data = orch_args.tensor(0).ref();
-  const TaskTensor &signal = orch_args.tensor(1).ref();
+  const Tensor &data = orch_args.tensor(0).ref();
+  const Tensor &signal = orch_args.tensor(1).ref();
 
   CoreTaskArgs params;
   params.add_inout(data);

--- a/python/pypto/runtime/builtins/collectives/allreduce_ring/templates/kernel.cpp.in
+++ b/python/pypto/runtime/builtins/collectives/allreduce_ring/templates/kernel.cpp.in
@@ -169,8 +169,8 @@ AICORE inline void StepBarrier(__gm__ CommContext *ctx, __gm__ int32_t *signal_r
 }  // namespace
 
 extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
-  __gm__ TaskTensor *data_tensor = reinterpret_cast<__gm__ TaskTensor *>(args[0]);
-  __gm__ TaskTensor *signal_tensor = reinterpret_cast<__gm__ TaskTensor *>(args[1]);
+  __gm__ Tensor *data_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
+  __gm__ Tensor *signal_tensor = reinterpret_cast<__gm__ Tensor *>(args[1]);
   int nranks = static_cast<int>(args[2]);
   __gm__ CommContext *comm_ctx = reinterpret_cast<__gm__ CommContext *>(args[3]);
 

--- a/python/pypto/runtime/builtins/collectives/barrier/templates/entry.cpp.in
+++ b/python/pypto/runtime/builtins/collectives/barrier/templates/entry.cpp.in
@@ -19,7 +19,7 @@ namespace {
 
 template <typename DType>
 void submit_barrier_kernel(const ChipTaskArgs &orch_args) {
-  const TaskTensor &signal = orch_args.tensor(0).ref();
+  const Tensor &signal = orch_args.tensor(0).ref();
 
   CoreTaskArgs params;
   params.add_inout(signal);

--- a/python/pypto/runtime/builtins/collectives/barrier/templates/kernel.cpp.in
+++ b/python/pypto/runtime/builtins/collectives/barrier/templates/kernel.cpp.in
@@ -41,7 +41,7 @@ AICORE inline __gm__ T *CommRemotePtr(__gm__ CommContext *ctx, __gm__ T *local_p
 }  // namespace
 
 extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
-  __gm__ TaskTensor *signal_tensor = reinterpret_cast<__gm__ TaskTensor *>(args[0]);
+  __gm__ Tensor *signal_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
   int nranks = static_cast<int>(args[1]);
   __gm__ CommContext *comm_ctx = reinterpret_cast<__gm__ CommContext *>(args[2]);
 

--- a/python/pypto/runtime/builtins/collectives/broadcast/templates/entry.cpp.in
+++ b/python/pypto/runtime/builtins/collectives/broadcast/templates/entry.cpp.in
@@ -19,8 +19,8 @@ namespace {
 
 template <typename DType>
 void submit_broadcast_kernel(const ChipTaskArgs &orch_args) {
-  const TaskTensor &target = orch_args.tensor(0).ref();
-  const TaskTensor &signal = orch_args.tensor(1).ref();
+  const Tensor &target = orch_args.tensor(0).ref();
+  const Tensor &signal = orch_args.tensor(1).ref();
 
   CoreTaskArgs params;
   params.add_inout(target);

--- a/python/pypto/runtime/builtins/collectives/broadcast/templates/kernel.cpp.in
+++ b/python/pypto/runtime/builtins/collectives/broadcast/templates/kernel.cpp.in
@@ -43,8 +43,8 @@ AICORE inline __gm__ T *CommRemotePtr(__gm__ CommContext *ctx, __gm__ T *local_p
 }  // namespace
 
 extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
-  __gm__ TaskTensor *target_tensor = reinterpret_cast<__gm__ TaskTensor *>(args[0]);
-  __gm__ TaskTensor *signal_tensor = reinterpret_cast<__gm__ TaskTensor *>(args[1]);
+  __gm__ Tensor *target_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
+  __gm__ Tensor *signal_tensor = reinterpret_cast<__gm__ Tensor *>(args[1]);
   int nranks = static_cast<int>(args[2]);
   __gm__ CommContext *comm_ctx = reinterpret_cast<__gm__ CommContext *>(args[3]);
 

--- a/python/pypto/runtime/builtins/collectives/reduce_scatter/templates/entry.cpp.in
+++ b/python/pypto/runtime/builtins/collectives/reduce_scatter/templates/entry.cpp.in
@@ -23,8 +23,8 @@ enum class ReduceOp : int32_t {
 
 template <ReduceOp Op, typename DType>
 void submit_reduce_scatter_kernel(const ChipTaskArgs &orch_args) {
-  const TaskTensor &target = orch_args.tensor(0).ref();
-  const TaskTensor &signal = orch_args.tensor(1).ref();
+  const Tensor &target = orch_args.tensor(0).ref();
+  const Tensor &signal = orch_args.tensor(1).ref();
 
   CoreTaskArgs params;
   params.add_inout(target);

--- a/python/pypto/runtime/builtins/collectives/reduce_scatter/templates/kernel.cpp.in
+++ b/python/pypto/runtime/builtins/collectives/reduce_scatter/templates/kernel.cpp.in
@@ -104,8 +104,8 @@ static __aicore__ inline __gm__ T *CommRemotePtr(__gm__ CommContext *ctx, __gm__
 }  // namespace
 
 extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
-  __gm__ TaskTensor *target_tensor = reinterpret_cast<__gm__ TaskTensor *>(args[0]);
-  __gm__ TaskTensor *signal_tensor = reinterpret_cast<__gm__ TaskTensor *>(args[1]);
+  __gm__ Tensor *target_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
+  __gm__ Tensor *signal_tensor = reinterpret_cast<__gm__ Tensor *>(args[1]);
   int nranks = static_cast<int>(args[2]);
   __gm__ CommContext *comm_ctx = reinterpret_cast<__gm__ CommContext *>(args[3]);
 

--- a/src/codegen/orchestration/orchestration_analysis.cpp
+++ b/src/codegen/orchestration/orchestration_analysis.cpp
@@ -225,7 +225,7 @@ void VarLineageCollector::VisitStmt_(const ForStmtPtr& for_stmt) {
       // that has no relationship to the init param.  Propagating param lineage
       // to a Scalar return_var would make the return->param map bind a Scalar
       // return element to a param index, causing EmitTensorAlias to emit
-      // ``const TaskTensor&`` for an int64_t variable (issue #1580).
+      // ``const Tensor&`` for an int64_t variable (issue #1580).
       if (i < for_stmt->return_vars_.size() && AsTensorTypeLike(for_stmt->return_vars_[i]->GetType())) {
         var_to_param[for_stmt->return_vars_[i].get()] = param;
       }

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -146,7 +146,7 @@ std::string GenerateIncludes(bool include_optional, bool include_vector = false)
   oss << "\n";
   oss << "#include \"orchestration_api.h\"\n";
   // The per-runtime `tensor.h` shim sits first on the orchestration include
-  // path and defines `TaskTensor` as whichever runtime this is built for
+  // path and defines `Tensor` as whichever runtime this is built for
   // (`simpler::tmr::Tensor` / `simpler::hbg::Tensor`). Orchestration works in
   // that type, not in the 72-byte boundary `ChipTensor` (simpler#1974), and
   // `orchestration_api.h` does not reach the shim on its own.
@@ -206,7 +206,7 @@ std::string GenerateMakeTensorExternal(const std::string& var_name, int orch_ind
                                        [[maybe_unused]] const TensorTypePtr& tensor_type,
                                        [[maybe_unused]] const CodegenBase& codegen) {
   std::ostringstream oss;
-  oss << "    const TaskTensor& ext_" << var_name << " = orch_args.tensor(" << orch_index << ").ref();\n";
+  oss << "    const Tensor& ext_" << var_name << " = orch_args.tensor(" << orch_index << ").ref();\n";
   return oss.str();
 }
 
@@ -715,7 +715,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
           carry_plans[i].dynamic_compiler_dep_collection = true;
         }
         // Override is_rebind: ClassifyIterArgCarry only sets it for TASK_ID
-        // iter_args, but TaskTensor-typed iter_args with compiler-dep edges also
+        // iter_args, but Tensor-typed iter_args with compiler-dep edges also
         // need true so the yield handler emits dynamic-collection writes.
         carry_plans[i].is_rebind = true;
       }
@@ -731,7 +731,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
     // Emit carry declarations for each iter_arg. Three lowering paths:
     //   - array_size > 0  -> TaskId array-carry (TaskId arr[N])
     //   - ArrayType carry  -> C-stack array with in-place-update semantics
-    //   - is_rebind        -> scalar/TaskTensor mutable carry variable
+    //   - is_rebind        -> scalar/Tensor mutable carry variable
     //   - else             -> trivial alias to init's emit name
     for (size_t i = 0; i < for_stmt->iter_args_.size(); ++i) {
       const auto& iter_arg = for_stmt->iter_args_[i];
@@ -862,7 +862,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
         RegisterArrayCarry(return_var.get(), carry_name, N);
       } else if (is_rebind) {
         // Scalar (single-name) carry path — only fires for non-TaskId
-        // iter_args (e.g. TaskTensor) or Sequential TaskId iter_args whose
+        // iter_args (e.g. Tensor) or Sequential TaskId iter_args whose
         // yield value isn't an inner array. Parallel TaskId iter_args are
         // guaranteed to use the array-carry path above (the const-trip-count
         // CHECK above would have fired otherwise).
@@ -876,11 +876,11 @@ class OrchestrationStmtCodegen : public CodegenBase {
         // declared names.
         std::string carry_name = ReserveSyntheticEmitName(return_var->name_hint_);
         const std::string cpp_type = GetCppType(return_var->GetType());
-        // A TaskTensor loop carry directly in a ``pl.manual_scope`` body is hoisted to
+        // A Tensor loop carry directly in a ``pl.manual_scope`` body is hoisted to
         // the enclosing scope so a task / method-receiver placed AFTER the block
-        // resolves it (issue #1713; see EmitMutableTensorCarryDecl). Non-TaskTensor
+        // resolves it (issue #1713; see EmitMutableTensorCarryDecl). Non-Tensor
         // (e.g. Sequential TaskId scalar) carries keep their in-block decl.
-        if (cpp_type == "TaskTensor") {
+        if (cpp_type == "Tensor") {
           EmitMutableTensorCarryDecl(carry_name, init_var_name);
         } else {
           EmitIndentedLine(cpp_type + " " + carry_name + " = " + init_var_name + ";");
@@ -1212,12 +1212,12 @@ class OrchestrationStmtCodegen : public CodegenBase {
   void VisitStmt_(const IfStmtPtr& if_stmt) override {
     std::string cond_expr = GenerateExprString(if_stmt->condition_);
 
-    // A default-constructed ``TaskTensor`` is deliberately uninitialised. Seed
-    // the phi declaration for a TaskTensor return_var from a valid TaskTensor
+    // A default-constructed ``Tensor`` is deliberately uninitialised. Seed
+    // the phi declaration for a Tensor return_var from a valid Tensor
     // that's already in scope instead. Try sources in order:
     //   1. The first tensor function parameter (selected by orch arg index,
     //      not lexical name — picking from ``param_name_set_`` could yield a
-    //      scalar param and emit ``TaskTensor x = <scalar>;`` which won't compile).
+    //      scalar param and emit ``Tensor x = <scalar>;`` which won't compile).
     //   2. A Var yielded by either branch that's already declared at
     //      if-entry (an outer iter_arg, or a prior in-body assignment). This
     //      handles parameterless functions whose branches yield a name
@@ -1269,11 +1269,11 @@ class OrchestrationStmtCodegen : public CodegenBase {
       if (As<ArrayType>(rv->GetType())) continue;
       const std::string emit_name = ReserveVarEmitName(rv.get());
       const std::string cpp_type = GetCppType(rv->GetType());
-      if (cpp_type == "TaskTensor") {
+      if (cpp_type == "Tensor") {
         INTERNAL_CHECK_SPAN(!tensor_phi_init.empty(), if_stmt->span_)
             << "Internal error: IfStmt return_var '" << rv->name_hint_
-            << "' is a TaskTensor but no in-scope TaskTensor was found to use as the "
-            << "valid phi placeholder (a default-constructed ``TaskTensor`` is uninitialised). "
+            << "' is a Tensor but no in-scope Tensor was found to use as the "
+            << "valid phi placeholder (a default-constructed ``Tensor`` is uninitialised). "
             << "Expected either a function parameter or a branch yield value "
             << "to resolve to a Var already declared at if-entry.";
         // Phi placeholder init — overwritten by branch yields. When the IfStmt is
@@ -1500,7 +1500,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
         }
         // Inside a ``pl.manual_scope``, collapse a pure SSA tensor copy ``X = Y``
         // by remapping ``X``'s emit name to ``Y`` instead of emitting a
-        // scope-local ``TaskTensor X = Y;`` decl (issue #1713). ``X`` is a fresh SSA
+        // scope-local ``Tensor X = Y;`` decl (issue #1713). ``X`` is a fresh SSA
         // version of the *same physical tensor* as ``Y`` (e.g. a post-loop
         // rebind ``score = score_rv`` lowering to ``score__ssa_v1 = score``, or a
         // windowed-assemble result rebind). The decl would die at the block's
@@ -1520,11 +1520,11 @@ class OrchestrationStmtCodegen : public CodegenBase {
         // ``X = <hoisted carry>`` at the manual-scope body indent — where the
         // carry is post-loop and stable (the canonical ``score = score_rv``
         // rebind). Inside the loop body (a deeper indent) a copy of the carry
-        // keeps its ``TaskTensor X = carry;`` decl, so a pre-yield snapshot can never
+        // keeps its ``Tensor X = carry;`` decl, so a pre-yield snapshot can never
         // alias the carry's later value.
         const bool carry_collapse_ok =
             hoisted_carry_names_.count(value_expr) == 0 || IsAtManualScopeBodyIndent();
-        if (cpp_type == "TaskTensor" && manual_local_names_ != nullptr && IsEnclosingScopeValid(value_expr) &&
+        if (cpp_type == "Tensor" && manual_local_names_ != nullptr && IsEnclosingScopeValid(value_expr) &&
             !IsMutableTensorNameInCurrentScope(value_expr) && !IsMutableTensorNameInCurrentScope(var_name) &&
             carry_collapse_ok) {
           emit_name_map_[assign->var_.get()] = value_expr;
@@ -1778,10 +1778,10 @@ class OrchestrationStmtCodegen : public CodegenBase {
       if (scalar_type->dtype_ == DataType::TASK_ID) return "TaskId";
       return scalar_type->dtype_.ToCTypeString();
     }
-    // TensorType: use ``TaskTensor`` so default-constructible declarations are
+    // TensorType: use ``Tensor`` so default-constructible declarations are
     // legal (C++ rejects ``auto x;`` without init). Yield/Assign downstream
     // will rebind it.
-    if (AsTensorTypeLike(type)) return "TaskTensor";
+    if (AsTensorTypeLike(type)) return "Tensor";
     if (As<CommCtxType>(type)) return "uint64_t";
     // ArrayType has split declaration syntax (``dtype name[N]``) — there's no
     // single "type expression" that names a C array. No caller should ask for
@@ -1827,9 +1827,9 @@ class OrchestrationStmtCodegen : public CodegenBase {
       case ArgDirection::OutputExisting:
         // The runtime overloads add_output on the argument type:
         //   add_output(TensorCreateInfo&)  -> OUTPUT       (runtime allocates)
-        //   add_output(TaskTensor&)            -> OUTPUT_EXISTING (write-only existing tensor)
+        //   add_output(Tensor&)            -> OUTPUT_EXISTING (write-only existing tensor)
         // The codegen pre-allocates via tensor.create + alloc_tensors, so the emitted
-        // call site always passes a TaskTensor& and the OUTPUT_EXISTING overload is selected.
+        // call site always passes a Tensor& and the OUTPUT_EXISTING overload is selected.
         // We still distinguish the two ArgDirections in the IR to let downstream phases
         // switch to the runtime-allocated form without an IR change.
         return "add_output";
@@ -3256,7 +3256,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
     EmitIndentedLine(alloc.str());
 
     for (size_t i = 0; i < emit_names.size(); i++) {
-      EmitIndentedLine("const TaskTensor& " + emit_names[i] + " = " + alloc_var + ".get_ref(" +
+      EmitIndentedLine("const Tensor& " + emit_names[i] + " = " + alloc_var + ".get_ref(" +
                        std::to_string(i) + ");");
     }
   }
@@ -3647,7 +3647,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
 
     // A caller-allocated kernel/submit output aliases an arg it writes in place
     // — it is the *same physical tensor* as that arg. Rather than mint a
-    // ``const TaskTensor& <result> = <source>;`` rename, we remap the result Var's
+    // ``const Tensor& <result> = <source>;`` rename, we remap the result Var's
     // emit name to the source, so every reference resolves directly to the
     // source name. This is the strategy ``tensor.assemble`` already uses
     // (HandleTensorAssembleAssign); applying it uniformly drops the redundant
@@ -3677,7 +3677,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
     if (mutable_alias) {
       EmitIndentedLine(alias_name + " = " + out_name + ";");
     } else {
-      EmitIndentedLine("const TaskTensor& " + alias_name + " = " + out_name + ";");
+      EmitIndentedLine("const Tensor& " + alias_name + " = " + out_name + ";");
     }
   }
 
@@ -3702,14 +3702,14 @@ class OrchestrationStmtCodegen : public CodegenBase {
   }
 
   void RegisterMutableTensorName(const std::string& cpp_type, const std::string& emit_name) {
-    if (cpp_type == "TaskTensor") {
+    if (cpp_type == "Tensor") {
       mutable_tensor_name_scopes_.back().insert(emit_name);
     }
   }
 
   /// Register a hoisted loop carry's emit name as mutable in the scope that
   /// ENCLOSES the current (manual-scope body) C++ frame — the frame the hoisted
-  /// ``TaskTensor <carry> = <init>;`` decl lands in (issue #1713). The carry's
+  /// ``Tensor <carry> = <init>;`` decl lands in (issue #1713). The carry's
   /// in-loop ``<carry> = ...;`` reassignments still resolve through that
   /// enclosing frame, and a post-loop ``X = <carry>`` rebind reads the carry as
   /// *not* mutable-in-current-scope (it is mutable one level out), so the rebind
@@ -3720,7 +3720,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
     mutable_tensor_name_scopes_[mutable_tensor_name_scopes_.size() - 2].insert(emit_name);
   }
 
-  /// Emit a mutable ``TaskTensor <name> = <init>;`` decl for a loop carry or an
+  /// Emit a mutable ``Tensor <name> = <init>;`` decl for a loop carry or an
   /// IfStmt phi placeholder, hoisting it out of a ``pl.manual_scope`` body into
   /// the enclosing scope when the construct sits directly in that body
   /// (``IsAtManualScopeBodyIndent``) and ``init`` is enclosing-scope-valid
@@ -3729,24 +3729,24 @@ class OrchestrationStmtCodegen : public CodegenBase {
   /// ``<name> = ...;`` reassignments (loop yields / branch merges) stay put and
   /// resolve through the enclosing frame. ``init`` is an enclosing-scope value
   /// that does not change between the hoist point and the block, so moving the
-  /// decl one level out is ordering-inert; a default-constructed ``TaskTensor``
+  /// decl one level out is ordering-inert; a default-constructed ``Tensor``
   /// is uninitialised, so the whole decl (init included) is hoisted, not a bare forward
   /// declaration. Registering ``<name>`` mutable in the *enclosing* frame and
   /// tracking it in ``hoisted_carry_names_`` also lets a post-block ``X = <name>``
   /// rebind collapse onto it (see the Var-RHS catch-all in VisitStmt_(AssignStmt)).
-  /// Caller guarantees the decl type is ``TaskTensor``.
+  /// Caller guarantees the decl type is ``Tensor``.
   void EmitMutableTensorCarryDecl(const std::string& name, const std::string& init_expr) {
     if (scope_hoist_sink_ != nullptr && IsAtManualScopeBodyIndent() && IsEnclosingScopeValid(init_expr)) {
-      scope_hoist_sink_->push_back(IndentAtLevel(scope_hoist_indent_level_) + "TaskTensor " + name + " = " +
+      scope_hoist_sink_->push_back(IndentAtLevel(scope_hoist_indent_level_) + "Tensor " + name + " = " +
                                    init_expr + ";\n");
       RegisterMutableTensorNameInEnclosingScope(name);
       hoisted_carry_names_.insert(name);
       if (manual_local_names_ != nullptr) manual_local_names_->erase(name);
       if (enclosing_manual_local_names_ != nullptr) enclosing_manual_local_names_->insert(name);
     } else {
-      EmitIndentedLine("TaskTensor " + name + " = " + init_expr + ";");
+      EmitIndentedLine("Tensor " + name + " = " + init_expr + ";");
 
-      RegisterMutableTensorName("TaskTensor", name);
+      RegisterMutableTensorName("Tensor", name);
     }
   }
 
@@ -4002,7 +4002,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
   ///     passed in. The runtime's ``TaskOutputTensors`` stores only
   ///     ``add_output`` entries (see runtime/.../types.h — "Only
   ///     runtime-created outputs are stored here"), so ``add_inout`` /
-  ///     in-args ``add_output(TaskTensor&)`` slots do **not** appear in
+  ///     in-args ``add_output(Tensor&)`` slots do **not** appear in
   ///     ``task_<idx>_outs`` and ``get_ref`` would skip past them or assert.
   ///   - Runtime-allocated (param_idx >= original arg count): alias to
   ///     ``task_<idx>_outs.get_ref(runtime_out_pos)`` where
@@ -4109,7 +4109,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
         if (IsMutableTensorNameInCurrentScope(elem_name)) {
           EmitIndentedLine(elem_name + " = " + source + ";");
         } else {
-          EmitIndentedLine("const TaskTensor& " + elem_name + " = " + source + ";");
+          EmitIndentedLine("const Tensor& " + elem_name + " = " + source + ";");
         }
       }
     }
@@ -4338,11 +4338,11 @@ class OrchestrationStmtCodegen : public CodegenBase {
   std::unordered_map<const Var*, ArrayPhiBinding> pending_array_phis_;
   std::unordered_map<const Var*, DynamicTaskIdCollection> dynamic_task_id_collections_;
   bool needs_vector_include_ = false;
-  /// Names of mutable TaskTensor values declared in each generated C++ block.
+  /// Names of mutable Tensor values declared in each generated C++ block.
   /// Tuple-output alias emission must avoid redeclaring names already declared
   /// in the same block, but must not treat outer-block declarations as aliases:
   /// C++ shadowing is valid and sometimes required to avoid rebinding an outer
-  /// loop-carried TaskTensor too early.
+  /// loop-carried Tensor too early.
   std::vector<std::unordered_set<std::string>> mutable_tensor_name_scopes_{{}};
   /// Manual-scope cross-scope tensor handling (issue #1697). While a
   /// ``pl.manual_scope`` block body is being buffered, EmitBatchedAllocTensors
@@ -4362,7 +4362,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
   int scope_hoist_indent_level_ = 0;
   std::set<std::string>* manual_local_names_ = nullptr;
   std::set<std::string>* enclosing_manual_local_names_ = nullptr;
-  /// Emit names of loop carries whose ``TaskTensor carry = init;`` decl was hoisted
+  /// Emit names of loop carries whose ``Tensor carry = init;`` decl was hoisted
   /// out of a manual-scope body (issue #1713). Such a carry is mutable in an
   /// *enclosing* C++ frame, so ``IsMutableTensorNameInCurrentScope`` (which only
   /// scans the back frame) does not see it. The Var-RHS collapse uses this set to
@@ -4548,7 +4548,7 @@ std::string GenerateGraphFunctions(const ProgramPtr& program, const FunctionPtr&
     for (const auto& param : graph_func->params_) {
       const std::string name = auto_name::GetCompatibleBaseName(param->name_hint_);
       if (AsTensorTypeLike(param->GetType())) {
-        oss << "    const TaskTensor& " << name << " = args.tensor(" << tensor_index << ").ref();\n";
+        oss << "    const Tensor& " << name << " = args.tensor(" << tensor_index << ").ref();\n";
         ++tensor_index;
         continue;
       }

--- a/src/codegen/tensor_op_codegen.cpp
+++ b/src/codegen/tensor_op_codegen.cpp
@@ -79,7 +79,7 @@ static std::string EmitRuntimeTensorShapeDim(const ExprPtr& expr, const DataType
 
 REGISTER_ORCHESTRATION_OP(tensor_create, ("tensor.create")) {
   // tensor.create emits TensorCreateInfo for runtime memory allocation via alloc_tensors().
-  // The batched alloc_tensors call and const TaskTensor& binding are emitted by
+  // The batched alloc_tensors call and const Tensor& binding are emitted by
   // EmitBatchedAllocTensors at scope entry (SeqStmts).
   auto result_type = As<TensorType>(op->GetType());
   CHECK(result_type) << "tensor.create must return TensorType";
@@ -302,8 +302,8 @@ REGISTER_ORCHESTRATION_OP(tensor_slice, ("tensor.slice")) {
   oss << "};\n";
 
   // Generate shape array, clamped to stay within the source tensor's extent.
-  // The #808 strided-TaskTensor runtime enforces ``offset[i] + shape[i] <= parent
-  // shapes[i]`` in ``TaskTensor::view`` and derives the dependency/extent footprint
+  // The #808 strided-Tensor runtime enforces ``offset[i] + shape[i] <= parent
+  // shapes[i]`` in ``Tensor::view`` and derives the dependency/extent footprint
   // from start_offset + strides; an over-extent view corrupts host-side
   // dependency tracking (scheduler timeout / device fault) rather than being a
   // benign no-op as it was under the old (raw_shapes, offsets) model. The clamp
@@ -334,18 +334,18 @@ REGISTER_ORCHESTRATION_OP(tensor_slice, ("tensor.slice")) {
   size_t drop_count = 0;
   for (bool drop : drop_dims) drop_count += drop ? 1 : 0;
   if (drop_count == 0) {
-    oss << "TaskTensor " << result_var << " = " << ext_input_name << ".view(" << result_var << "_shapes, "
+    oss << "Tensor " << result_var << " = " << ext_input_name << ".view(" << result_var << "_shapes, "
         << result_var << "_offsets);";
   } else {
-    oss << "TaskTensor " << result_var << "_view = " << ext_input_name << ".view(" << result_var
-        << "_shapes, " << result_var << "_offsets);\n";
+    oss << "Tensor " << result_var << "_view = " << ext_input_name << ".view(" << result_var << "_shapes, "
+        << result_var << "_offsets);\n";
     // A dynamically out-of-bounds scalar index clamps its dropped axis to
     // zero. Preserve that full-view emptiness before removing the axis: the
     // runtime intentionally leaves an empty view at the parent start offset
     // with zero extent, so reviving non-zero shapes after rank reduction would
     // make numel(), extent_elem(), and the address footprint disagree.
     oss << "bool " << result_var << "_empty = " << result_var << "_view.numel() == 0;\n";
-    oss << "TaskTensor " << result_var << " = " << result_var << "_view;\n";
+    oss << "Tensor " << result_var << " = " << result_var << "_view;\n";
     oss << result_var << ".ndims = " << (ndim - drop_count) << ";\n";
     size_t dst_dim = 0;
     for (size_t i = 0; i < ndim; ++i) {
@@ -372,7 +372,7 @@ REGISTER_ORCHESTRATION_OP(tensor_slice, ("tensor.slice")) {
 
 REGISTER_ORCHESTRATION_OP(tensor_reshape, ("tensor.reshape")) {
   // tensor.reshape(input, shape_tuple[, valid_shape_tuple]) -> Generate shape array variable and call
-  // .reshape() on the runtime TaskTensor (see runtime/.../tensor.h: TaskTensor::reshape).
+  // .reshape() on the runtime Tensor (see runtime/.../tensor.h: Tensor::reshape).
   INTERNAL_CHECK_SPAN(op->args_.size() == 2 || op->args_.size() == 3, op->span_)
       << "tensor.reshape requires 2 or 3 arguments (input, shape[, valid_shape])";
 
@@ -407,8 +407,8 @@ REGISTER_ORCHESTRATION_OP(tensor_reshape, ("tensor.reshape")) {
         << "tensor.reshape valid_shape must have same rank as shape";
   }
 
-  // Runtime TaskTensor::reshape requires the source to be contiguous; valid_shape only affects IR metadata.
-  oss << "TaskTensor " << result_var << " = " << ext_input_name << ".reshape(" << result_var << "_shapes, "
+  // Runtime Tensor::reshape requires the source to be contiguous; valid_shape only affects IR metadata.
+  oss << "Tensor " << result_var << " = " << ext_input_name << ".reshape(" << result_var << "_shapes, "
       << ndim << ");";
   return oss.str();
 }
@@ -416,16 +416,16 @@ REGISTER_ORCHESTRATION_OP(tensor_reshape, ("tensor.reshape")) {
 REGISTER_ORCHESTRATION_OP(tensor_reinterpret_view, ("tensor.reinterpret_view")) {
   CHECK_SPAN(false, op->span_)
       << "tensor.reinterpret_view is not supported in Orchestration functions because the runtime "
-         "TaskTensor API cannot change the element dtype of a view; place reinterpret_view inside an "
+         "Tensor API cannot change the element dtype of a view; place reinterpret_view inside an "
          "InCore function";
   return {};
 }
 
 REGISTER_ORCHESTRATION_OP(tensor_transpose, ("tensor.transpose")) {
-  // tensor.transpose(input, axis1, axis2) -> TaskTensor view with two axes swapped.
-  // Lowered to runtime TaskTensor::transpose(x, y), a zero-copy metadata swap of the
+  // tensor.transpose(input, axis1, axis2) -> Tensor view with two axes swapped.
+  // Lowered to runtime Tensor::transpose(x, y), a zero-copy metadata swap of the
   // two axes' shapes and strides (start_offset preserved; see runtime tensor.h:
-  // TaskTensor::transpose under the #808 strided model).
+  // Tensor::transpose under the #808 strided model).
   // The optional 4th `valid_shape` argument from the IR op is intentionally
   // ignored at the orchestration layer (it only affects IR metadata, mirroring
   // how tensor.reshape handles valid_shape here).
@@ -456,7 +456,7 @@ REGISTER_ORCHESTRATION_OP(tensor_transpose, ("tensor.transpose")) {
   CHECK(axis1 != axis2) << "tensor.transpose axis1 and axis2 must be different, got " << axis1;
   CHECK_SPAN(input_type->dtype_ != DataType::FP4 || (axis1 != ndim - 1 && axis2 != ndim - 1), op->span_)
       << "tensor.transpose cannot move the packed FP4 last axis in Orchestration functions because the "
-         "runtime TaskTensor carries physical x2 elements; keep the last axis fixed or transpose inside an "
+         "runtime Tensor carries physical x2 elements; keep the last axis fixed or transpose inside an "
          "InCore function";
 
   // If the optional valid_shape operand is present, validate its structure even though it is
@@ -472,14 +472,14 @@ REGISTER_ORCHESTRATION_OP(tensor_transpose, ("tensor.transpose")) {
   std::string result_var = codegen.GetCurrentResultTarget();
 
   std::ostringstream oss;
-  oss << "TaskTensor " << result_var << " = " << ext_input_name << ".transpose(" << axis1 << ", " << axis2
+  oss << "Tensor " << result_var << " = " << ext_input_name << ".transpose(" << axis1 << ", " << axis2
       << ");";
   return oss.str();
 }
 
 REGISTER_ORCHESTRATION_OP(tensor_view, ("tensor.view")) {
   // tensor.view(input[, shape[, valid_shape]], layout=...) is a metadata reinterpret over the
-  // same physical buffer. Runtime TaskTensor has no layout tag or arbitrary-stride
+  // same physical buffer. Runtime Tensor has no layout tag or arbitrary-stride
   // constructor, so shape-changing orchestration views lower to reshape only
   // for ND layouts. Layout-only keeps the legacy ND/DN alias/transpose
   // behavior.
@@ -514,16 +514,16 @@ REGISTER_ORCHESTRATION_OP(tensor_view, ("tensor.view")) {
          (src_layout == TensorLayout::ND && IsMxTensorLayout(target_layout)));
     CHECK_SPAN(target_layout == src_layout || is_mx_scale_backing_nd_view, op->span_)
         << "tensor.view orchestration lowering cannot combine shape reinterpret with layout change: "
-        << "runtime TaskTensor::reshape has no arbitrary-stride layout view; pass only a shape argument "
+        << "runtime Tensor::reshape has no arbitrary-stride layout view; pass only a shape argument "
         << "(no layout change) in orchestration code or lower the view through PTO in-core codegen";
     CHECK_SPAN(
         (src_layout == TensorLayout::ND && target_layout == TensorLayout::ND) || is_mx_scale_backing_nd_view,
         op->span_)
         << "tensor.view orchestration lowering only supports shape reinterpret for ND layout tensors: "
-        << "runtime TaskTensor::reshape assumes row-major contiguous storage; lower non-ND views through "
+        << "runtime Tensor::reshape assumes row-major contiguous storage; lower non-ND views through "
         << "PTO in-core codegen";
     if (is_mx_scale_backing_nd_view) {
-      return "TaskTensor " + result_var + " = " + ext_input_name + ";";
+      return "Tensor " + result_var + " = " + ext_input_name + ";";
     }
     auto shape_tuple = As<MakeTuple>(op->args_[1]);
     auto tuple_type = As<TupleType>(op->args_[1]->GetType());
@@ -538,13 +538,13 @@ REGISTER_ORCHESTRATION_OP(tensor_view, ("tensor.view")) {
       oss << EmitRuntimeTensorShapeDim(shape_dim, input_type->dtype_, i, ndim, codegen);
     }
     oss << "};\n";
-    oss << "TaskTensor " << result_var << " = " << ext_input_name << ".reshape(" << result_var << "_shapes, "
+    oss << "Tensor " << result_var << " = " << ext_input_name << ".reshape(" << result_var << "_shapes, "
         << ndim << ");";
     return oss.str();
   }
 
   if (target_layout == src_layout) {
-    oss << "TaskTensor " << result_var << " = " << ext_input_name << ";";
+    oss << "Tensor " << result_var << " = " << ext_input_name << ";";
   } else {
     int64_t ndim = static_cast<int64_t>(input_type->shape_.size());
     INTERNAL_CHECK_SPAN(ndim >= 2, op->span_)
@@ -552,8 +552,8 @@ REGISTER_ORCHESTRATION_OP(tensor_view, ("tensor.view")) {
         << "; DeduceTensorViewType is supposed to reject cross-layout flips below rank 2";
     CHECK_SPAN(input_type->dtype_ != DataType::FP4, op->span_)
         << "tensor.view cannot move the packed FP4 last axis during an Orchestration layout change because "
-           "the runtime TaskTensor carries physical x2 elements; lower the view through PTO in-core codegen";
-    oss << "TaskTensor " << result_var << " = " << ext_input_name << ".transpose(" << (ndim - 2) << ", "
+           "the runtime Tensor carries physical x2 elements; lower the view through PTO in-core codegen";
+    oss << "Tensor " << result_var << " = " << ext_input_name << ".transpose(" << (ndim - 2) << ", "
         << (ndim - 1) << ");";
   }
 

--- a/src/ir/op/tensor_ops/transform.cpp
+++ b/src/ir/op/tensor_ops/transform.cpp
@@ -362,7 +362,7 @@ TypePtr DeduceTensorTransposeType(const std::vector<ExprPtr>& args,
   //     drive the implicit "swap last two dims" path used by DN-source loads.
   //
   //  2. Explicit strides. tensor.transpose at orchestration level lowers to
-  //     runtime TaskTensor::transpose, a metadata-only swap of shapes / offsets;
+  //     runtime Tensor::transpose, a metadata-only swap of shapes / offsets;
   //     the underlying GM data stays in the source's row-major layout. So the
   //     physical strides for the post-transpose view are the source's strides
   //     reordered at (axis1, axis2). Recording those strides on the result

--- a/src/ir/transforms/classify_iter_arg_carry_pass.cpp
+++ b/src/ir/transforms/classify_iter_arg_carry_pass.cpp
@@ -279,7 +279,7 @@ class AliasForest {
 
     // A single-result call to a kernel that writes one of its args (e.g. an
     // InCore kernel): the result aliases the arg the callee actually returns,
-    // mirroring the codegen alias ``const TaskTensor& result = args[out_idx];``.
+    // mirroring the codegen alias ``const Tensor& result = args[out_idx];``.
     // For kernels with multiple Out params (e.g. real result + GM scratch passed
     // through pl.spmd mixed dispatch), tracing the ReturnStmt back to its Param
     // avoids aliasing the result to an arbitrary scratch tensor.

--- a/tests/st/runtime/control_flow/test_dyn_orch_shape.py
+++ b/tests/st/runtime/control_flow/test_dyn_orch_shape.py
@@ -147,7 +147,7 @@ class DynOrchReshapeAddTestCase(PTOTestCase):
     """Test add kernel where the orchestration uses ``pl.reshape`` on dynamic 1D inputs.
 
     Validates that ``tensor.reshape`` is supported in Orchestration functions and lowers
-    to the runtime ``TaskTensor::reshape`` interface (issue #1068).  The orchestration takes
+    to the runtime ``Tensor::reshape`` interface (issue #1068).  The orchestration takes
     flat 1D tensors of length ``rows*cols`` and reshapes them to ``[rows, cols]`` before
     forwarding them to a 2D InCore add kernel.
     Expected result: c = a + b over the full rows×cols tile.
@@ -219,12 +219,12 @@ class DynOrchTransposeAddTestCase(PTOTestCase):
     """Test add kernel where the orchestration uses ``pl.transpose`` on dynamic 2D inputs.
 
     Validates that ``tensor.transpose`` is supported in Orchestration functions and lowers
-    to the runtime ``TaskTensor::transpose`` interface (issue #1071).  The orchestration takes
+    to the runtime ``Tensor::transpose`` interface (issue #1071).  The orchestration takes
     ``[rows, cols]`` tensors, swaps axes 0/1 via ``pl.transpose`` (zero-copy metadata
     swap of shape/raw_shape/offset), and forwards the resulting ``[cols, rows]`` views to
     a 2D InCore add kernel.
 
-    Because ``TaskTensor::transpose`` only swaps metadata and the kernel performs an
+    Because ``Tensor::transpose`` only swaps metadata and the kernel performs an
     element-wise add (which is layout-agnostic at the byte level), the bit pattern of
     ``c`` equals the bit pattern of ``a + b`` re-laid out to ``[cols, rows]``.
     """
@@ -772,7 +772,7 @@ class TestDynOrchShapeOperations:
         """Test add where the orchestration transposes dynamic 2D inputs before dispatch.
 
         Validates ``pl.transpose`` (issue #1071) inside an Orchestration function lowers
-        to the runtime ``TaskTensor::transpose`` zero-copy metadata swap.  Uses an asymmetric
+        to the runtime ``Tensor::transpose`` zero-copy metadata swap.  Uses an asymmetric
         shape (rows != cols) so the ``[rows, cols] -> [cols, rows]`` view transformation
         is actually exercised end-to-end (a buggy no-op transpose would not pass this).
         """

--- a/tests/st/runtime/external_kernel/kernels/aiv/spmd_write.cpp
+++ b/tests/st/runtime/external_kernel/kernels/aiv/spmd_write.cpp
@@ -24,7 +24,7 @@
  * header reachable.
  *
  * Args:
- *   args[0] = output TaskTensor* (INOUT)
+ *   args[0] = output Tensor* (INOUT)
  *   args[1] = scalar: base_cl (starting cache line index for this task)
  */
 
@@ -57,7 +57,7 @@
 #endif
 
 extern "C" __aicore__ void kernel_entry(__gm__ int64_t* args) {
-  __gm__ TaskTensor* out_tensor = reinterpret_cast<__gm__ TaskTensor*>(args[0]);
+  __gm__ Tensor* out_tensor = reinterpret_cast<__gm__ Tensor*>(args[0]);
   __gm__ float* out = reinterpret_cast<__gm__ float*>(out_tensor->buffer.addr) + out_tensor->start_offset;
 
   int32_t base_cl = static_cast<int32_t>(args[1]);

--- a/tests/st/runtime/ops/test_trans.py
+++ b/tests/st/runtime/ops/test_trans.py
@@ -12,7 +12,7 @@ Two scenarios live in this file:
 
 1. Issue #1209 follow-up — ``pl.transpose(x, 0, 1)`` + ``pl.slice(xt, ...)``
    must access column ``h`` of ``x`` (not the first contiguous chunk in
-   memory). The runtime ``TaskTensor::transpose`` is a metadata-only swap, so the
+   memory). The runtime ``Tensor::transpose`` is a metadata-only swap, so the
    IR result must record swapped physical strides for codegen to emit a
    correctly addressed ``make_tensor_view``. Restricted to a5/a5sim — the
    path produces a ``GlobalTensor<DN>`` source that a2a3 rejects at the

--- a/tests/ut/codegen/_orchestration_codegen_common.py
+++ b/tests/ut/codegen/_orchestration_codegen_common.py
@@ -138,7 +138,7 @@ def _out_of_scope_tensor_refs(code: str) -> list[str]:
     Numeric literals (``= 0;``), casts, and scalar locals carry neither marker,
     so they never yield false positives.
     """
-    decl_re = re.compile(r"\b(?:const\s+TaskTensor\s*&|TaskTensor|TaskOutputTensors|Arg)\s+(\w+)")
+    decl_re = re.compile(r"\b(?:const\s+Tensor\s*&|Tensor|TaskOutputTensors|Arg)\s+(\w+)")
     declared_anywhere = set(decl_re.findall(code))
     # An SSA-versioned tensor temp is unambiguously a tensor regardless of whether
     # its declaration still exists, so an out-of-scope reference to one is always
@@ -153,7 +153,7 @@ def _out_of_scope_tensor_refs(code: str) -> list[str]:
         line = raw.strip()
         # Declarations and uses are each emitted on their own line (never sharing
         # a line with a scope brace), so resolve them against the current scope
-        # set first. Declarations are recorded before uses so a ``const TaskTensor& Y
+        # set first. Declarations are recorded before uses so a ``const Tensor& Y
         # = X`` line registers Y while still checking the RHS read of X.
         for m in decl_re.finditer(line):
             scopes[-1].add(m.group(1))

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -84,15 +84,15 @@ class TestOrchestration:
             __attribute__((visibility("default")))
             void aicpu_orchestration_entry(const ChipTaskArgs& orch_args) {
                 // External tensors
-                const TaskTensor& ext_a = orch_args.tensor(0).ref();
-                const TaskTensor& ext_b = orch_args.tensor(1).ref();
-                const TaskTensor& ext_d = orch_args.tensor(2).ref();
+                const Tensor& ext_a = orch_args.tensor(0).ref();
+                const Tensor& ext_b = orch_args.tensor(1).ref();
+                const Tensor& ext_d = orch_args.tensor(2).ref();
 
                 SIMPLER_SCOPE() {
                     uint32_t c_ci_shapes[2] = {16, 16};
                     TensorCreateInfo c_ci(c_ci_shapes, 2, DataType::FLOAT32);
                     TaskOutputTensors alloc_0 = alloc_tensors(c_ci);
-                    const TaskTensor& c = alloc_0.get_ref(0);
+                    const Tensor& c = alloc_0.get_ref(0);
 
                     // Task 0: kernel_add
                     CoreTaskArgs params_t0;
@@ -479,9 +479,9 @@ class TestOrchestration:
             __attribute__((visibility("default")))
             void aicpu_orchestration_entry(const ChipTaskArgs& orch_args) {
                 // External tensors
-                const TaskTensor& ext_a = orch_args.tensor(0).ref();
-                const TaskTensor& ext_b = orch_args.tensor(1).ref();
-                const TaskTensor& ext_f = orch_args.tensor(2).ref();
+                const Tensor& ext_a = orch_args.tensor(0).ref();
+                const Tensor& ext_b = orch_args.tensor(1).ref();
+                const Tensor& ext_f = orch_args.tensor(2).ref();
 
                 SIMPLER_SCOPE() {
                     uint32_t c_ci_shapes[2] = {16, 16};
@@ -493,10 +493,10 @@ class TestOrchestration:
                     uint32_t g_ci_shapes[2] = {16, 16};
                     TensorCreateInfo g_ci(g_ci_shapes, 2, DataType::FLOAT32);
                     TaskOutputTensors alloc_0 = alloc_tensors(c_ci, d_ci, e_ci, g_ci);
-                    const TaskTensor& c = alloc_0.get_ref(0);
-                    const TaskTensor& d = alloc_0.get_ref(1);
-                    const TaskTensor& e = alloc_0.get_ref(2);
-                    const TaskTensor& g = alloc_0.get_ref(3);
+                    const Tensor& c = alloc_0.get_ref(0);
+                    const Tensor& d = alloc_0.get_ref(1);
+                    const Tensor& e = alloc_0.get_ref(2);
+                    const Tensor& g = alloc_0.get_ref(3);
 
                     // Task 0: kernel_add
                     CoreTaskArgs params_t0;
@@ -720,13 +720,13 @@ class TestOrchestration:
 
         # All orch params are external tensors:
         # mij=0, lij=1, oi_new=2, mi_in=3, li_in=4, oi_in=5, dst_in=6, final=7
-        assert "const TaskTensor& ext_mi_in = orch_args.tensor(3).ref()" in code
-        assert "const TaskTensor& ext_li_in = orch_args.tensor(4).ref()" in code
-        assert "const TaskTensor& ext_oi_in = orch_args.tensor(5).ref()" in code
-        assert "const TaskTensor& ext_dst_in = orch_args.tensor(6).ref()" in code
+        assert "const Tensor& ext_mi_in = orch_args.tensor(3).ref()" in code
+        assert "const Tensor& ext_li_in = orch_args.tensor(4).ref()" in code
+        assert "const Tensor& ext_oi_in = orch_args.tensor(5).ref()" in code
+        assert "const Tensor& ext_dst_in = orch_args.tensor(6).ref()" in code
 
         # Final return tensor is external
-        assert "const TaskTensor& ext_final = orch_args.tensor(7).ref()" in code
+        assert "const Tensor& ext_final = orch_args.tensor(7).ref()" in code
 
         # Two tasks: online_update + kernel_add
         assert code.count("rt_submit_aiv_task") == 2
@@ -811,7 +811,7 @@ class TestOrchestration:
         assert "params_t0.add_inout(ext_inout_t)" in code
 
         # Each tuple result is the in-place arg it writes, so it remaps to that
-        # arg (no per-output ``const TaskTensor&`` alias is minted). The consumer
+        # arg (no per-output ``const Tensor&`` alias is minted). The consumer
         # ``combine`` reads ta/tb/tc — each result mapped to its OWN arg, NOT
         # shifted onto inout_t (issue #1573).
         ia = code.index("params_t1.add_input(ext_ta)")
@@ -821,7 +821,7 @@ class TestOrchestration:
         # The scrambled (shifted-by-one) mapping must NOT appear: combine must
         # not read inout_t, and no const-ref output alias is emitted.
         assert "add_input(ext_inout_t)" not in code
-        assert all(f"const TaskTensor& o{i}" not in code for i in (1, 2, 3)), code
+        assert all(f"const Tensor& o{i}" not in code for i in (1, 2, 3)), code
 
     @staticmethod
     def _manual_cross_scope_code(create_inside: bool) -> str:
@@ -898,22 +898,22 @@ class TestOrchestration:
         manual_open = code.index("SIMPLER_SCOPE(ScopeMode::MANUAL)")
         manual_close = code.index("}", manual_open)
         # The buffer AND the alloc handle backing it are declared in the
-        # enclosing scope, ahead of the block — if only ``const TaskTensor& buf`` were
+        # enclosing scope, ahead of the block — if only ``const Tensor& buf`` were
         # hoisted while ``TaskOutputTensors alloc_0 = ...`` stayed inside, ``buf``
         # would reference an out-of-scope handle and the .cpp would not compile.
         assert code.index("TaskOutputTensors alloc_") < manual_open, code
         assert code.index("alloc_tensors(") < manual_open, code
-        decl = code.index("const TaskTensor& buf = ")
+        decl = code.index("const Tensor& buf = ")
         assert decl < manual_open, code
         # The after-scope consumer reads ``buf`` directly — no const-ref alias
         # is minted for the producer's SSA output.
         assert "add_input(buf)" in code[manual_close:], code
-        assert "const TaskTensor& buf__" not in code, code
+        assert "const Tensor& buf__" not in code, code
 
     def test_manual_scope_tensor_created_before_read_after(self):
         """Regression for #1697: a tensor created BEFORE a ``pl.manual_scope``,
         written by a submit inside it, and read by a task after it. The output
-        previously minted ``const TaskTensor& buf__ssa_v1 = buf;`` at the deep block
+        previously minted ``const Tensor& buf__ssa_v1 = buf;`` at the deep block
         indent; the after-scope ``add_input(buf__ssa_v1)`` then named an
         out-of-scope identifier and the orchestration ``.cpp`` failed to compile.
         The output is now remapped to read ``buf`` directly."""
@@ -938,11 +938,11 @@ class TestOrchestration:
         ``fresh_carry`` selects which lowering shape the loop carry takes:
           * False — the carry threads the before-scope tensor in place, so the
             post-loop ``score = score_rv`` rebind lowers to a catch-all
-            ``TaskTensor score__ssa_v1 = score;`` copy emitted at the deep block
+            ``Tensor score__ssa_v1 = score;`` copy emitted at the deep block
             indent; the after-scope ``pl.reshape`` reader then named the
             out-of-scope ``score__ssa_v1``.
           * True — the loop yields a freshly created tensor each iteration
-            (``is_rebind``), so codegen mints a mutable carry ``TaskTensor acc_rv =
+            (``is_rebind``), so codegen mints a mutable carry ``Tensor acc_rv =
             acc;`` *inside* the block AND a chained ``acc__ssa_v1 = acc_rv;``
             post-loop copy. The after-scope kernel read named the out-of-scope
             chain. The carry decl is now hoisted out and the copy collapses.
@@ -1029,7 +1029,7 @@ class TestOrchestration:
         (a method-receiver use the old ``add_*``-only scope checker missed).
 
         The post-loop ``score = score_rv`` rebind lowered to a catch-all
-        ``TaskTensor score__ssa_v1 = score;`` copy at the deep block indent; the
+        ``Tensor score__ssa_v1 = score;`` copy at the deep block indent; the
         after-scope ``score_flat = score__ssa_v1.reshape(...)`` then named an
         out-of-scope identifier and the ``.cpp`` failed to C++-compile. The copy
         is now collapsed onto the enclosing ``score``."""
@@ -1047,8 +1047,8 @@ class TestOrchestration:
         ``pl.manual_scope`` (the loop yields a freshly created tensor each
         iteration, so OptimizeOrchTensors Pattern-5 externalizes the windowed
         write) read by a kernel after the scope. Codegen minted a mutable carry
-        ``TaskTensor acc_rv = acc;`` inside the block plus a chained
-        ``TaskTensor acc__ssa_v1 = acc_rv;`` post-loop copy; the after-scope
+        ``Tensor acc_rv = acc;`` inside the block plus a chained
+        ``Tensor acc__ssa_v1 = acc_rv;`` post-loop copy; the after-scope
         ``add_input`` named the out-of-scope chain.
 
         The carry decl is now hoisted to the enclosing scope and the chained copy
@@ -1058,12 +1058,12 @@ class TestOrchestration:
         # The windowed externalization actually fired (exercises Pattern-5).
         assert "produce__windowed" in code, code
         manual_open = code.index("SIMPLER_SCOPE(ScopeMode::MANUAL)")
-        # The mutable carry for ``acc`` (``TaskTensor acc_rv = acc;``) is hoisted AHEAD
+        # The mutable carry for ``acc`` (``Tensor acc_rv = acc;``) is hoisted AHEAD
         # of the manual block header (declared in the enclosing scope). Anchor the
         # match to the ``acc`` carry initialised from ``acc`` so an unrelated
         # ``_rv`` temp emitted earlier can't be picked by mistake.
         carry_decls = list(
-            re.finditer(r"^\s*TaskTensor\s+(acc\w*_rv\w*)\s*=\s*acc;", code[:manual_open], flags=re.MULTILINE)
+            re.finditer(r"^\s*Tensor\s+(acc\w*_rv\w*)\s*=\s*acc;", code[:manual_open], flags=re.MULTILINE)
         )
         assert len(carry_decls) == 1, code[:manual_open]
         carry_name = carry_decls[0].group(1)
@@ -1074,7 +1074,7 @@ class TestOrchestration:
 
     def test_manual_scope_loop_carry_not_hoisted_outside_manual(self):
         """Negative control for #1713: an identical loop carry NOT inside a
-        ``pl.manual_scope`` keeps its in-place ``TaskTensor <carry> = <init>;`` decl
+        ``pl.manual_scope`` keeps its in-place ``Tensor <carry> = <init>;`` decl
         (the hoist is gated on a manual-scope body). Guards against the hoist
         firing in ordinary AUTO-scope codegen."""
         backend.reset_for_testing()
@@ -1124,10 +1124,10 @@ class TestOrchestration:
         code = _generate_orch_code(NoManualScopeProgram)
         assert _out_of_scope_tensor_refs(code) == [], code
         # No manual scope present -> no hoist machinery engaged; the mutable carry
-        # decl stays in place (a `TaskTensor <carry> = <init>;` exists) and is
+        # decl stays in place (a `Tensor <carry> = <init>;` exists) and is
         # reassigned in the loop.
         assert "SIMPLER_SCOPE(ScopeMode::MANUAL)" not in code, code
-        assert re.search(r"^\s*TaskTensor\s+\w*_rv\w*\s*=\s*\w+;", code, flags=re.MULTILINE), code
+        assert re.search(r"^\s*Tensor\s+\w*_rv\w*\s*=\s*\w+;", code, flags=re.MULTILINE), code
 
     def test_manual_scope_windowed_submit_read_after_reshape(self):
         """Regression for #1713 (the issue's headline shape): a tensor created
@@ -1136,7 +1136,7 @@ class TestOrchestration:
         Pattern-5 externalizes it into ``produce__windowed`` + ``score.view(...)``
         + ``tensor.assemble``), and read AFTER the scope via ``pl.reshape``.
 
-        The assemble result's SSA rebind lowered to ``TaskTensor score__ssa_v1 =
+        The assemble result's SSA rebind lowered to ``Tensor score__ssa_v1 =
         score;`` at the deep block indent; the after-scope ``score__ssa_v1.reshape
         (...)`` named an out-of-scope identifier (``'<name>__ssa_v<N>' was not
         declared in this scope``). The copy now collapses onto the enclosing
@@ -1209,7 +1209,7 @@ class TestOrchestration:
         carry taken INSIDE the loop body (a deeper indent than the manual-scope
         body) must NOT collapse onto the hoisted carry — otherwise a reader of
         the copy placed before the loop's yield rebind would alias the carry's
-        later value. The copy keeps a distinct ``TaskTensor snap = <carry>;`` decl.
+        later value. The copy keeps a distinct ``Tensor snap = <carry>;`` decl.
 
         (The post-loop ``acc = acc_rv`` rebind, at the manual-scope body indent,
         still collapses — exercised by the other #1713 tests; this guards the
@@ -1281,17 +1281,17 @@ class TestOrchestration:
             if f.func_type == ir.FunctionType.Orchestration and f.name == "main"
         )
         assert _out_of_scope_tensor_refs(code) == [], code
-        # The in-loop snapshot is materialised as its own ``TaskTensor snap = ...;``
+        # The in-loop snapshot is materialised as its own ``Tensor snap = ...;``
         # value and read as ``add_input(snap)`` — NOT collapsed onto the carry,
         # so the later ``<carry> = ...;`` yield rebind cannot change what the
         # snapshot reader sees.
-        assert re.search(r"^\s*TaskTensor\s+snap\s*=\s*\w+;", code, flags=re.MULTILINE), code
+        assert re.search(r"^\s*Tensor\s+snap\s*=\s*\w+;", code, flags=re.MULTILINE), code
         assert "add_input(snap)" in code, code
 
     def test_manual_scope_ifstmt_phi_read_after(self):
         """Regression for #1713 (IfStmt phi sibling of the loop-carry hoist): an
         ``if`` inside a ``pl.manual_scope`` that conditionally rewrites a tensor
-        produces a phi placeholder ``TaskTensor <buf>__phi_v<N> = <init>;`` at the
+        produces a phi placeholder ``Tensor <buf>__phi_v<N> = <init>;`` at the
         block indent (reassigned in each branch); a task after the scope reading
         the phi then named an out-of-scope identifier.
 
@@ -1346,15 +1346,15 @@ class TestOrchestration:
             for f in program.functions.values()
             if f.func_type == ir.FunctionType.Orchestration and f.name == "main"
         )
-        # The IfStmt actually produced a TaskTensor phi placeholder (exercises the path).
-        assert re.search(r"TaskTensor\s+\w+__phi_v\d+\s*=", code), code
+        # The IfStmt actually produced a Tensor phi placeholder (exercises the path).
+        assert re.search(r"Tensor\s+\w+__phi_v\d+\s*=", code), code
         # No identifier names an out-of-scope name (including the after-scope read).
         assert _out_of_scope_tensor_refs(code) == [], code
         # The phi decl is hoisted AHEAD of the manual block header; the branch
         # ``<phi> = ...;`` merges stay inside the block (resolving through the
         # enclosing frame).
         manual_open = code.index("SIMPLER_SCOPE(ScopeMode::MANUAL)")
-        phi_decl = re.search(r"^\s*TaskTensor\s+(\w+__phi_v\d+)\s*=", code[:manual_open], flags=re.MULTILINE)
+        phi_decl = re.search(r"^\s*Tensor\s+(\w+__phi_v\d+)\s*=", code[:manual_open], flags=re.MULTILINE)
         assert phi_decl, code[:manual_open]
         phi_name = phi_decl.group(1)
         # The after-scope consumer reads the hoisted phi directly (in scope).
@@ -1389,11 +1389,11 @@ class TestOrchestration:
 
         code = _generate_orch_code(TensorCreateProgram)
 
-        # tensor.create generates TensorCreateInfo; const TaskTensor& binding emitted at submit site
+        # tensor.create generates TensorCreateInfo; const Tensor& binding emitted at submit site
         # FP16 = DataType::FLOAT16
         assert "uint32_t buf_ci_shapes[2] = {32, 32};" in code
         assert "TensorCreateInfo buf_ci(buf_ci_shapes, 2, DataType::FLOAT16)" in code
-        assert "const TaskTensor& buf = " in code
+        assert "const Tensor& buf = " in code
         assert "make_tensor_external(nullptr, buf_ci_shapes, 2, DataType::FLOAT16)" not in code
 
     def test_tensor_create_with_manual_dep(self):
@@ -1518,13 +1518,13 @@ class TestOrchestration:
             __attribute__((visibility("default")))
             void aicpu_orchestration_entry(const ChipTaskArgs& orch_args) {
                 // External tensors
-                const TaskTensor& ext_mij = orch_args.tensor(0).ref();
-                const TaskTensor& ext_lij = orch_args.tensor(1).ref();
-                const TaskTensor& ext_oi_new = orch_args.tensor(2).ref();
-                const TaskTensor& ext_mi = orch_args.tensor(3).ref();
-                const TaskTensor& ext_li = orch_args.tensor(4).ref();
-                const TaskTensor& ext_oi = orch_args.tensor(5).ref();
-                const TaskTensor& ext_dst = orch_args.tensor(6).ref();
+                const Tensor& ext_mij = orch_args.tensor(0).ref();
+                const Tensor& ext_lij = orch_args.tensor(1).ref();
+                const Tensor& ext_oi_new = orch_args.tensor(2).ref();
+                const Tensor& ext_mi = orch_args.tensor(3).ref();
+                const Tensor& ext_li = orch_args.tensor(4).ref();
+                const Tensor& ext_oi = orch_args.tensor(5).ref();
+                const Tensor& ext_dst = orch_args.tensor(6).ref();
 
                 SIMPLER_SCOPE() {
 

--- a/tests/ut/codegen/test_orchestration_codegen_graph.py
+++ b/tests/ut/codegen/test_orchestration_codegen_graph.py
@@ -220,28 +220,33 @@ def test_artifact_targets_the_graph_runtime(artifacts):
 def _runtime_include_args(repo_root: Path) -> list[str]:
     """``-I`` flags for the a2a3 host_build_graph orchestration headers.
 
-    Every directory holding a header, minus ``tensormap_and_ringbuffer``: the two
-    runtimes ship same-named headers (``types.h``, ``runtime_status.h``), so
-    leaving the other one on the path lets it shadow the one under test. The
-    tree roots come last, for the includes spelled with a directory prefix
-    (``common/host_phase_kind.h``, ``host_build_graph/graph_cache.h``).
+    The same directories, in the same order, that simpler's own kernel compiler
+    puts on an orchestration TU: ``get_orchestration_include_dirs`` followed by
+    the runtime's ``build_config`` ``orchestration.include_dirs``. Handing the
+    compiler every directory that holds a header instead lets a runtime that is
+    not under test shadow the one that is -- ``common/hierarchical/types.h``
+    wins over ``host_build_graph/types.h`` and drags in
+    ``task_interface/buffer.h``, whose global ``Tensor`` then collides with the
+    runtime's own ``Tensor`` alias. The tree root comes last, for the includes
+    spelled with a directory prefix (``common/host_phase_kind.h``).
     """
     src = repo_root / "runtime" / "src"
-    dirs = sorted(
-        {
-            header.parent
-            for tree in ("common", "a2a3")
-            for header in (src / tree).rglob("*.h")
-            if "tensormap_and_ringbuffer" not in header.parts
-        }
-    )
-    roots = [
-        src / "common" / "platform" / "include",
-        src / "a2a3" / "platform" / "include",
-        src / "common",
-        src,
+    runtime_dir = src / "a2a3" / "runtime" / "host_build_graph"
+    return [
+        f"-I{path}"
+        for path in (
+            runtime_dir / "runtime",
+            runtime_dir / "orchestration",
+            runtime_dir / "common",
+            src / "a2a3" / "runtime",
+            src / "common" / "host_build_graph",
+            src / "common" / "task_interface",
+            src / "common",
+            src / "a2a3" / "platform" / "include",
+            src / "common" / "platform" / "include",
+            src,
+        )
     ]
-    return [f"-I{path}" for path in [*dirs, *roots]]
 
 
 def test_generated_orchestration_compiles_against_the_pinned_runtime(artifact_root):

--- a/tests/ut/codegen/test_orchestration_codegen_graph.py
+++ b/tests/ut/codegen/test_orchestration_codegen_graph.py
@@ -130,8 +130,8 @@ def test_graph_is_a_named_file_scope_function(orch):
 
 def test_boundary_tensors_are_bound_from_the_task_args(orch):
     body = _graph_body(orch)
-    assert "const TaskTensor& a = args.tensor(0).ref();" in body
-    assert "const TaskTensor& c = args.tensor(1).ref();" in body
+    assert "const Tensor& a = args.tensor(0).ref();" in body
+    assert "const Tensor& c = args.tensor(1).ref();" in body
 
 
 def test_boundary_scalars_are_bound_by_reference(orch):
@@ -252,7 +252,7 @@ def test_generated_orchestration_compiles_against_the_pinned_runtime(artifact_ro
     actual types: `rt_submit_graph` takes `void (*)(const GraphTaskArgs&)` and
     `GraphTaskArgs` is a different `Arg` instantiation from `CoreTaskArgs`, while
     `args.tensor(i).ref()` yields `const simpler::hbg::Tensor&` (aliased
-    `TaskTensor`). Emitting `CoreTaskArgs` or a boundary tensor type there is a
+    `Tensor`). Emitting `CoreTaskArgs` or a boundary tensor type there is a
     hard compile error in the generated file that a string assertion happily
     confirms instead of catching.
     """

--- a/tests/ut/codegen/test_orchestration_codegen_more.py
+++ b/tests/ut/codegen/test_orchestration_codegen_more.py
@@ -63,7 +63,7 @@ class TestOrchestrationMore:
         assert "DataType::FP4E2M1" in code
 
     def test_fp4_slice_uses_x2_carrier_shape_and_offset(self):
-        """FP4 slice metadata passed to runtime TaskTensor::view is in carrier units."""
+        """FP4 slice metadata passed to runtime Tensor::view is in carrier units."""
         backend.reset_for_testing()
         backend.set_backend_type(BackendType.Ascend950)
 
@@ -80,7 +80,7 @@ class TestOrchestrationMore:
         code = _generate_orch_code(Fp4SliceProgram)
         assert "uint32_t chunk_offsets[2] = {0, 4};" in code
         assert "std::min<uint32_t>(4, ext_data.shapes[1] - chunk_offsets[1])" in code
-        assert "TaskTensor chunk = ext_data.view(chunk_shapes, chunk_offsets);" in code
+        assert "Tensor chunk = ext_data.view(chunk_shapes, chunk_offsets);" in code
 
     def test_fp4_slice_dynamic_offset_checks_alignment_before_conversion(self):
         """Dynamic packed-axis offsets are checked before conversion to carrier units."""
@@ -139,9 +139,9 @@ class TestOrchestrationMore:
 
         code = _generate_orch_code(Fp4ShapeViewProgram)
         assert "uint32_t reshaped_shapes[2] = {4, 16};" in code
-        assert "TaskTensor reshaped = ext_data.reshape(reshaped_shapes, 2);" in code
+        assert "Tensor reshaped = ext_data.reshape(reshaped_shapes, 2);" in code
         assert "uint32_t viewed_shapes[2] = {2, 32};" in code
-        assert "TaskTensor viewed = reshaped.reshape(viewed_shapes, 2);" in code
+        assert "Tensor viewed = reshaped.reshape(viewed_shapes, 2);" in code
 
     def test_fp4_transpose_keeps_packed_axis_fixed(self):
         """Swapping non-packed axes is representable; moving the packed axis is not."""
@@ -159,7 +159,7 @@ class TestOrchestrationMore:
                 return transposed
 
         code = _generate_orch_code(Fp4NonPackedTransposeProgram)
-        assert "TaskTensor transposed = ext_data.transpose(0, 1);" in code
+        assert "Tensor transposed = ext_data.transpose(0, 1);" in code
 
         @pl.program
         class Fp4PackedTransposeProgram:
@@ -312,7 +312,7 @@ class TestOrchestrationMore:
             in code
         )
         assert "uint32_t chunk_offsets[2] = {static_cast<uint32_t>((i * 16)), 0};" in code
-        assert "TaskTensor chunk = ext_data.view(chunk_shapes, chunk_offsets);" in code
+        assert "Tensor chunk = ext_data.view(chunk_shapes, chunk_offsets);" in code
 
         # tensor.read now goes through get_tensor_data<T>() so the runtime owns
         # access validation/synchronization, instead of bypassing it with a raw
@@ -350,7 +350,7 @@ class TestOrchestrationMore:
             in code
         )
         assert "uint32_t chunk_offsets[2] = {0, 0};" in code
-        assert "TaskTensor chunk = ext_data.view(chunk_shapes, chunk_offsets);" in code
+        assert "Tensor chunk = ext_data.view(chunk_shapes, chunk_offsets);" in code
 
     def test_tensor_slice_with_drop_dims(self):
         """A scalar-indexed tensor slice emits a view followed by rank reduction."""
@@ -369,7 +369,7 @@ class TestOrchestrationMore:
 
         code = _generate_orch_code(DropDimSliceProgram)
 
-        assert "TaskTensor chunk_view = ext_data.view(chunk_shapes, chunk_offsets);" in code
+        assert "Tensor chunk_view = ext_data.view(chunk_shapes, chunk_offsets);" in code
         assert "chunk.ndims = 2;" in code
         assert "chunk.shapes[0] = chunk_view.shapes[0];" in code
         assert "chunk.strides[0] = chunk_view.strides[0];" in code
@@ -409,7 +409,7 @@ class TestOrchestrationMore:
         assert "chunk.is_contiguous = chunk_empty || chunk_contiguous;" in code
 
     def test_tensor_reshape_external_input(self):
-        """tensor.reshape on an external orchestration input emits TaskTensor::reshape on ext_<name>."""
+        """tensor.reshape on an external orchestration input emits Tensor::reshape on ext_<name>."""
         backend.reset_for_testing()
         backend.set_backend_type(BackendType.Ascend910B)
 
@@ -427,11 +427,11 @@ class TestOrchestrationMore:
 
         # Shape array emitted with the result variable name as prefix.
         assert "uint32_t r_shapes[2] = {16, 16};" in code
-        # Reshape lowers to runtime TaskTensor::reshape on the external tensor handle.
-        assert "TaskTensor r = ext_data.reshape(r_shapes, 2);" in code
+        # Reshape lowers to runtime Tensor::reshape on the external tensor handle.
+        assert "Tensor r = ext_data.reshape(r_shapes, 2);" in code
 
     def test_tensor_reshape_after_slice(self):
-        """slice -> reshape chain: reshape input is a local TaskTensor (no ext_ prefix)."""
+        """slice -> reshape chain: reshape input is a local Tensor (no ext_ prefix)."""
         backend.reset_for_testing()
         backend.set_backend_type(BackendType.Ascend910B)
 
@@ -456,13 +456,13 @@ class TestOrchestrationMore:
             "(chunk_offsets[2] >= ext_data.shapes[2] ? 0u : std::min<uint32_t>(16, ext_data.shapes[2] - chunk_offsets[2]))};"  # noqa: E501
             in code
         )
-        assert "TaskTensor chunk = ext_data.view(chunk_shapes, chunk_offsets);" in code
-        # reshape emits its shape array and calls .reshape on the local TaskTensor (no ext_ prefix).
+        assert "Tensor chunk = ext_data.view(chunk_shapes, chunk_offsets);" in code
+        # reshape emits its shape array and calls .reshape on the local Tensor (no ext_ prefix).
         assert "uint32_t r_shapes[2] = {16, 16};" in code
-        assert "TaskTensor r = chunk.reshape(r_shapes, 2);" in code
+        assert "Tensor r = chunk.reshape(r_shapes, 2);" in code
 
     def test_tensor_transpose_external_input(self):
-        """tensor.transpose on an external orchestration input emits TaskTensor::transpose on ext_<name>."""
+        """tensor.transpose on an external orchestration input emits Tensor::transpose on ext_<name>."""
         backend.reset_for_testing()
         backend.set_backend_type(BackendType.Ascend910B)
 
@@ -478,8 +478,8 @@ class TestOrchestrationMore:
 
         code = _generate_orch_code(TransposeExternalProgram)
 
-        # transpose lowers to runtime TaskTensor::transpose on the external tensor handle.
-        assert "TaskTensor t = ext_data.transpose(0, 1);" in code
+        # transpose lowers to runtime Tensor::transpose on the external tensor handle.
+        assert "Tensor t = ext_data.transpose(0, 1);" in code
 
     def test_tensor_transpose_negative_axis(self):
         """tensor.transpose with negative axis indices is normalized at codegen time."""
@@ -499,10 +499,10 @@ class TestOrchestrationMore:
         code = _generate_orch_code(TransposeNegativeProgram)
 
         # -1 / -2 on a 3D tensor should normalize to axes 2 and 1 respectively.
-        assert "TaskTensor t = ext_data.transpose(2, 1);" in code
+        assert "Tensor t = ext_data.transpose(2, 1);" in code
 
     def test_tensor_transpose_after_slice(self):
-        """slice -> transpose chain: transpose input is a local TaskTensor (no ext_ prefix)."""
+        """slice -> transpose chain: transpose input is a local Tensor (no ext_ prefix)."""
         backend.reset_for_testing()
         backend.set_backend_type(BackendType.Ascend910B)
 
@@ -520,12 +520,12 @@ class TestOrchestrationMore:
         code = _generate_orch_code(TransposeAfterSliceProgram)
 
         # slice still emits view on the external tensor.
-        assert "TaskTensor chunk = ext_data.view(chunk_shapes, chunk_offsets);" in code
-        # transpose calls .transpose on the local TaskTensor (no ext_ prefix).
-        assert "TaskTensor t = chunk.transpose(1, 2);" in code
+        assert "Tensor chunk = ext_data.view(chunk_shapes, chunk_offsets);" in code
+        # transpose calls .transpose on the local Tensor (no ext_ prefix).
+        assert "Tensor t = chunk.transpose(1, 2);" in code
 
     def test_tensor_view_cross_flip_lowers_to_transpose(self):
-        """Cross-layout flip (ND→DN) lowers to runtime TaskTensor::transpose on the
+        """Cross-layout flip (ND→DN) lowers to runtime Tensor::transpose on the
         trailing pair (shapes + strides swapped, start_offset preserved)."""
         backend.reset_for_testing()
         backend.set_backend_type(BackendType.Ascend910B)
@@ -541,9 +541,9 @@ class TestOrchestrationMore:
 
         code = _generate_orch_code(program)
 
-        # Cross-layout flip swaps the trailing pair via runtime TaskTensor::transpose
+        # Cross-layout flip swaps the trailing pair via runtime Tensor::transpose
         # on the external tensor handle (start_offset preserved).
-        assert "TaskTensor b_dn = ext_b.transpose(0, 1);" in code
+        assert "Tensor b_dn = ext_b.transpose(0, 1);" in code
         # The deleted pre-#808 fields must never be emitted.
         assert "raw_shapes" not in code
         assert "is_raw_eq_shapes" not in code
@@ -564,7 +564,7 @@ class TestOrchestrationMore:
 
         code = _generate_orch_code(program)
 
-        assert "TaskTensor b_same = ext_b;" in code
+        assert "Tensor b_same = ext_b;" in code
         assert ".transpose(" not in code
 
     def test_tensor_view_shape_reinterpret_runs_through_default_pipeline(self):
@@ -591,12 +591,12 @@ class TestOrchestrationMore:
         shape_decl = re.search(r"uint32_t (\w+)_shapes\[2\] = \{4, 8\};", code)
         assert shape_decl is not None, code
         viewed_name = shape_decl.group(1)
-        reshape_line = next(line for line in code.splitlines() if f"TaskTensor {viewed_name} =" in line)
+        reshape_line = next(line for line in code.splitlines() if f"Tensor {viewed_name} =" in line)
         assert f".reshape({viewed_name}_shapes, 2);" in reshape_line
 
     def test_tensor_view_shape_layout_combination_rejected(self):
         """Combining shape reinterpret with a layout change is rejected at
-        orchestration codegen time -- the runtime ``TaskTensor::reshape`` does not
+        orchestration codegen time -- the runtime ``Tensor::reshape`` does not
         support arbitrary-stride layout views. The error uses ``CHECK_SPAN``
         and raises ``ValueError`` (not ``InternalError``).
 
@@ -653,7 +653,7 @@ class TestOrchestrationMore:
 
         code = _generate_orch_code(program)
 
-        assert "TaskTensor viewed = ext_scale;" in code
+        assert "Tensor viewed = ext_scale;" in code
         assert all(line.strip() != "Tensor viewed = ext_scale;" for line in code.splitlines())
         assert ".reshape(" not in code
 
@@ -661,7 +661,7 @@ class TestOrchestrationMore:
         """Shape-only tensor.view on a DN source cannot lower to runtime reshape.
 
         Even when the requested target layout equals the source layout, runtime
-        ``TaskTensor::reshape`` assumes ND/row-major contiguous storage and cannot
+        ``Tensor::reshape`` assumes ND/row-major contiguous storage and cannot
         preserve a DN physical stride.
         """
         backend.reset_for_testing()
@@ -898,7 +898,7 @@ class TestOrchestrationMore:
 
         # TensorCreateInfo declarations exist (exactly once each)
         # a_acc is a return value → external (orch_args.tensor(i).ref())
-        assert code.count("const TaskTensor& ext_a_acc = orch_args.tensor(1).ref()") == 1
+        assert code.count("const Tensor& ext_a_acc = orch_args.tensor(1).ref()") == 1
         assert code.count("TensorCreateInfo b_acc_ci(") == 1
 
         # For loop exists with correct structure
@@ -955,7 +955,7 @@ class TestOrchestrationMore:
         code = _generate_orch_code(transformed)
 
         assert "alloc_tensors(acc_ci)" in code
-        assert "const TaskTensor& acc = alloc_0.get_ref(0);" in code
+        assert "const Tensor& acc = alloc_0.get_ref(0);" in code
         assert "make_tensor_external(nullptr" not in code
         assert "acc__loop_state" not in code
         assert "params_t1.add_input(acc);" in code
@@ -1045,9 +1045,9 @@ class TestOrchestrationMore:
 
         code = _generate_orch_code(transformed)
 
-        assert "TaskTensor row = ext_out.view(row_shapes, row_offsets);" in code
+        assert "Tensor row = ext_out.view(row_shapes, row_offsets);" in code
         assert "params_t0.add_inout(row)" in code
-        assert "TaskTensor row = make_tensor(" not in code
+        assert "Tensor row = make_tensor(" not in code
         assert "memcpy(" not in code
         assert "ext_out = out;" not in code
 
@@ -1089,9 +1089,9 @@ class TestOrchestrationMore:
         code = _generate_orch_code(transformed)
 
         assert "TensorCreateInfo row_ci(row_ci_shapes, 2, DataType::FLOAT32);" in code
-        assert "const TaskTensor& row = " in code
+        assert "const Tensor& row = " in code
         assert "make_tensor_external(nullptr, row_ci_shapes, 2, DataType::FLOAT32)" not in code
-        assert "TaskTensor row = ext_out.view(row_shapes, row_offsets);" not in code
+        assert "Tensor row = ext_out.view(row_shapes, row_offsets);" not in code
 
     def test_tensor_assemble_slice_source_does_not_require_view_fast_path(self):
         """tensor.assemble should stay codegenable when the source is not a rewritten tensor.create."""
@@ -1116,8 +1116,8 @@ class TestOrchestrationMore:
 
         code = _generate_orch_code(transformed)
 
-        assert "TaskTensor chunk = ext_x.view(chunk_shapes, chunk_offsets);" in code
-        assert "TaskTensor chunk = ext_out.view(chunk_shapes, chunk_offsets);" not in code
+        assert "Tensor chunk = ext_x.view(chunk_shapes, chunk_offsets);" in code
+        assert "Tensor chunk = ext_out.view(chunk_shapes, chunk_offsets);" not in code
 
     def test_param_with_numeric_suffix(self):
         """Regression test for issue #573: params with numeric suffixes must not be collapsed.
@@ -1176,7 +1176,7 @@ class TestOrchestrationMore:
         assert "expected_arg_count = 3" in code
 
         # Tuple-return elements must not be collapsed into a single alias
-        assert "TaskTensor& out =" not in code
+        assert "Tensor& out =" not in code
 
     def test_repeated_auto_output_buffers_get_unique_names(self):
         """Repeated auto-generated output buffers should keep distinct emitted names."""
@@ -1219,11 +1219,11 @@ class TestOrchestrationMore:
         assert "params_t0.add_output(ret0__out)" in code
         assert "params_t1.add_output(ret0__out_1)" in code
         # ``first`` is kernel_add's in-place output buffer ret0__out, so it
-        # remaps to ret0__out (no ``const TaskTensor& first = ...`` alias is minted);
+        # remaps to ret0__out (no ``const Tensor& first = ...`` alias is minted);
         # the second call reads that buffer directly.
         assert "params_t1.add_input(ret0__out)" in code
-        assert "const TaskTensor& first" not in code
-        assert "const TaskTensor& second" not in code
+        assert "const Tensor& first" not in code
+        assert "const Tensor& second" not in code
 
     def test_unused_alias_not_emitted(self):
         """Alias for a kernel result that is never consumed downstream should be omitted."""
@@ -1257,7 +1257,7 @@ class TestOrchestrationMore:
         code = _generate_orch_code(transformed)
 
         assert "rt_submit_" in code
-        assert "const TaskTensor& result" not in code
+        assert "const Tensor& result" not in code
 
     def test_multi_scope_alloc_tensors_batching(self):
         """Each scope (function body, for body) batches its own alloc_tensors independently."""
@@ -1312,9 +1312,9 @@ class TestOrchestrationMore:
         assert "alloc_0 = alloc_tensors(" in code
         assert "alloc_1 = alloc_tensors(" in code
         # Verify bindings from each alloc
-        assert "const TaskTensor& t1 = alloc_0.get_ref(0);" in code
-        assert "const TaskTensor& t2 = alloc_0.get_ref(1);" in code
-        assert "const TaskTensor& tmp = alloc_1.get_ref(0);" in code
+        assert "const Tensor& t1 = alloc_0.get_ref(0);" in code
+        assert "const Tensor& t2 = alloc_0.get_ref(1);" in code
+        assert "const Tensor& tmp = alloc_1.get_ref(0);" in code
 
     def test_alloc_tensors_splits_at_16(self):
         """More than 16 create_tensor in one scope are split into multiple alloc_tensors calls."""

--- a/tests/ut/codegen/test_orchestration_codegen_more.py
+++ b/tests/ut/codegen/test_orchestration_codegen_more.py
@@ -654,7 +654,6 @@ class TestOrchestrationMore:
         code = _generate_orch_code(program)
 
         assert "Tensor viewed = ext_scale;" in code
-        assert all(line.strip() != "Tensor viewed = ext_scale;" for line in code.splitlines())
         assert ".reshape(" not in code
 
     def test_tensor_view_shape_reinterpret_rejects_dn_source(self):

--- a/tests/ut/codegen/test_orchestration_manual_scope.py
+++ b/tests/ut/codegen/test_orchestration_manual_scope.py
@@ -108,7 +108,7 @@ class TestManualScopeCodegen:
         code = _generate_orch_code(transformed)
 
         assert code.count("params_t0.add_scalar(signal_ctx);") == 1, code
-        assert "const TaskTensor& y = task_0_outs.get_ref(0);" in code, code
+        assert "const Tensor& y = task_0_outs.get_ref(0);" in code, code
         assert "params_t1.add_input(y);" in code, code
         assert "signal_ctx.get_ref" not in code, code
 

--- a/tests/ut/codegen/test_orchestration_misc.py
+++ b/tests/ut/codegen/test_orchestration_misc.py
@@ -68,8 +68,8 @@ class TestTupleLineagePointerKeying:
     propagated onto the other tuple's consumers. In the DeepSeek-V4 KV compressor
     this made the ``kv_state`` / ``score_state`` return aliases reuse the
     externalized ``kv_cache`` / ``kv`` window reshape names, so the generated
-    orchestration C++ declared those names twice (``TaskTensor X = ...`` then
-    ``const TaskTensor& X = ...``) and failed to compile with ``conflicting
+    orchestration C++ declared those names twice (``Tensor X = ...`` then
+    ``const Tensor& X = ...``) and failed to compile with ``conflicting
     declaration``.
     """
 
@@ -112,7 +112,7 @@ class TestTupleLineagePointerKeying:
 
         # No declared name may appear twice (the conflicting-declaration bug).
         declared = re.findall(
-            r"^\s*(?:const\s+TaskTensor&|TaskTensor|TaskId|auto)\s+([A-Za-z_]\w*)\s*=",
+            r"^\s*(?:const\s+Tensor&|Tensor|TaskId|auto)\s+([A-Za-z_]\w*)\s*=",
             code,
             flags=re.MULTILINE,
         )
@@ -121,8 +121,8 @@ class TestTupleLineagePointerKeying:
 
         # Each consumer must reshape from its OWN tuple's element, not a stale /
         # undeclared getitem name. Before the fix, ``fa`` read undeclared ``a0``.
-        assert "TaskTensor fa = rsh0.reshape" in code, code
-        assert "TaskTensor fb = rsh1.reshape" in code, code
+        assert "Tensor fa = rsh0.reshape" in code, code
+        assert "Tensor fb = rsh1.reshape" in code, code
         assert "a0.reshape" not in code and "b0.reshape" not in code, code
 
 
@@ -149,7 +149,7 @@ class TestUnregisteredOpError:
             codegen.generate_orchestration(program, orch_func)
 
     def test_reinterpret_view_has_explicit_orchestration_error(self):
-        """Runtime TaskTensor views cannot change dtype; direct users get an actionable error."""
+        """Runtime Tensor views cannot change dtype; direct users get an actionable error."""
         backend.reset_for_testing()
         backend.set_backend_type(BackendType.Ascend910B)
 
@@ -867,7 +867,7 @@ class TestTupleReturnNameHintCollision:
         # tmp_first and tmp_second share the name_hint "ret__tmp_v0"; the tuple
         # metadata must still attach each call's elements to that call. Each
         # element is the in-place Out arg of its call, so it remaps to that arg
-        # (no ``const TaskTensor& first_a = ...`` alias is minted). The consumer
+        # (no ``const Tensor& first_a = ...`` alias is minted). The consumer
         # reading first_a/second_a/first_b/second_b therefore reads call_a's
         # outs then call_b's outs, in order — not cross-contaminated.
         i_a1 = code.index("// Task 2: kernel_consume")
@@ -879,10 +879,10 @@ class TestTupleReturnNameHintCollision:
         assert a1 < a2 < b1 < b2, code
         # No per-element const-ref alias survives the remap.
         for name in ("first_a", "second_a", "first_b", "second_b"):
-            assert f"const TaskTensor& {name} " not in code, code
+            assert f"const Tensor& {name} " not in code, code
 
         declared_names = re.findall(
-            r"^\s*(?:const\s+TaskTensor&|TaskTensor)\s+([A-Za-z_]\w*)\s*=",
+            r"^\s*(?:const\s+Tensor&|Tensor)\s+([A-Za-z_]\w*)\s*=",
             code,
             flags=re.MULTILINE,
         )
@@ -896,13 +896,13 @@ class TestScalarCarryPhiCodegen:
     """Regression tests for scalar loop carries in orchestration codegen."""
 
     def test_scalar_carry_phi_not_emitted_as_tensor(self):
-        """Regression for #1580: Scalar loop carry must not be aliased as const TaskTensor&.
+        """Regression for #1580: Scalar loop carry must not be aliased as const Tensor&.
 
         When a Scalar variable is defined before a pl.parallel loop and then
         reused (reassigned) inside it, alongside Tensor carries, ConvertToSSA
         promotes the scalar into the parallel-loop carry tuple.  The orchestration
         codegen must emit the Scalar carry phi as ``int64_t = 0`` (untraced scalar
-        default), NOT as ``const TaskTensor& = <carry_var>`` (type mismatch that causes
+        default), NOT as ``const Tensor& = <carry_var>`` (type mismatch that causes
         a C++ compile error).
         """
         backend.reset_for_testing()
@@ -939,7 +939,7 @@ class TestScalarCarryPhiCodegen:
 
                 # The parallel loop carries global_c_idx (Scalar) mixed with
                 # Tensor carries out_b, out_c.  Before the fix, the Scalar carry
-                # phi was emitted as ``const TaskTensor&`` causing a C++ compile error.
+                # phi was emitted as ``const Tensor&`` causing a C++ compile error.
                 for batch_idx in pl.parallel(0, N // TILE):
                     with pl.at(level=pl.Level.CORE_GROUP, name_hint="scope_b"):
                         for inner in pl.range(TILE):
@@ -953,12 +953,12 @@ class TestScalarCarryPhiCodegen:
         code = _generate_orch_code(transformed)
 
         # The Scalar carry phi must be emitted as int64_t = 0 (untraced scalar
-        # default), never as const TaskTensor& = <carry> (type mismatch / #1580).
+        # default), never as const Tensor& = <carry> (type mismatch / #1580).
         assert "int64_t global_c_idx__rv" in code, (
-            "global_c_idx carry phi should be emitted as int64_t, not const TaskTensor&\n" + code
+            "global_c_idx carry phi should be emitted as int64_t, not const Tensor&\n" + code
         )
-        assert "const TaskTensor& global_c_idx" not in code, (
-            "global_c_idx must not be aliased as const TaskTensor& (scalar/tensor type mismatch)\n" + code
+        assert "const Tensor& global_c_idx" not in code, (
+            "global_c_idx must not be aliased as const Tensor& (scalar/tensor type mismatch)\n" + code
         )
 
         # out_b and out_c Tensor carries must each alias to their own carry.

--- a/tests/ut/codegen/test_orchestration_returned_param_map.py
+++ b/tests/ut/codegen/test_orchestration_returned_param_map.py
@@ -262,7 +262,7 @@ _TASK_RE = re.compile(
 _OP_RE = re.compile(r"\.add_(input|inout|output)\((\w+)\)")
 
 # A loop-tail carry rebind, e.g. "cur__rv_v3 = cur__ssa_v4;". Matches the bare assignment
-# only -- the "TaskTensor cur__rv_v3 = cur;" declaration above the loop is not a rebind.
+# only -- the "Tensor cur__rv_v3 = cur;" declaration above the loop is not a rebind.
 _CARRY_RE = re.compile(r"^\s*(\w+)__rv_v\d+\s*=\s*(\w+);\s*$", re.MULTILINE)
 
 

--- a/tests/ut/codegen/test_orchestration_tensor_rw.py
+++ b/tests/ut/codegen/test_orchestration_tensor_rw.py
@@ -278,9 +278,9 @@ class TestTensorReadWriteOffsetCodegen:
         )
 
         # Check every direct identity edge, including carry initialization,
-        # carry updates, and the fully simplified ``TaskTensor b = ext_b`` form.
+        # carry updates, and the fully simplified ``Tensor b = ext_b`` form.
         identity_edge_re = re.compile(
-            r"^\s*(?:(?:const\s+)?(?:Tensor|ChipTensor|TaskTensor)&?\s+)?"
+            r"^\s*(?:(?:const\s+)?(?:Tensor|ChipTensor|Tensor)&?\s+)?"
             r"(?P<lhs>(?:ext_)?(?P<lhs_base>[ab])(?:__rv[A-Za-z0-9_]*)?)\s*=\s*"
             r"(?P<rhs>(?:ext_)?(?P<rhs_base>[ab])(?:__rv[A-Za-z0-9_]*)?)\s*;\s*$",
             re.MULTILINE,
@@ -421,7 +421,7 @@ class TestTensorReadWriteOffsetCodegen:
         assert "kv_proj__windowed" in code, code
 
         declared_names = re.findall(
-            r"^\s*(?:const\s+TaskTensor&|TaskTensor|TaskId|auto)\s+([A-Za-z_]\w*)\s*=",
+            r"^\s*(?:const\s+Tensor&|Tensor|TaskId|auto)\s+([A-Za-z_]\w*)\s*=",
             code,
             flags=re.MULTILINE,
         )
@@ -430,11 +430,9 @@ class TestTensorReadWriteOffsetCodegen:
             f"generated C++ redeclared names {sorted(duplicate_declarations)}:\n{code}"
         )
 
-        mutable_tensor_names = set(
-            re.findall(r"^\s*TaskTensor\s+([A-Za-z_]\w*)\s*=", code, flags=re.MULTILINE)
-        )
+        mutable_tensor_names = set(re.findall(r"^\s*Tensor\s+([A-Za-z_]\w*)\s*=", code, flags=re.MULTILINE))
         const_alias_names = set(
-            re.findall(r"^\s*const\s+TaskTensor&\s+([A-Za-z_]\w*)\s*=", code, flags=re.MULTILINE)
+            re.findall(r"^\s*const\s+Tensor&\s+([A-Za-z_]\w*)\s*=", code, flags=re.MULTILINE)
         )
         assert not (mutable_tensor_names & const_alias_names), code
 
@@ -829,7 +827,7 @@ class TestTensorReadWriteOffsetCodegen:
         # If the codegen emits an explicit SSA alias for the SPMD result,
         # it must bind to ext_out and never to ext_scratch.
         out_alias_lines = [
-            line for line in code.splitlines() if line.lstrip().startswith("const TaskTensor& out__")
+            line for line in code.splitlines() if line.lstrip().startswith("const Tensor& out__")
         ]
         for line in out_alias_lines:
             assert "ext_out" in line and "ext_scratch" not in line, (
@@ -918,9 +916,7 @@ class TestTensorReadWriteOffsetCodegen:
             )
 
         # Any explicit SSA alias for the result must bind to ext_out as well.
-        alias_lines = [
-            line for line in code.splitlines() if line.lstrip().startswith("const TaskTensor& out")
-        ]
+        alias_lines = [line for line in code.splitlines() if line.lstrip().startswith("const Tensor& out")]
         for line in alias_lines:
             assert "ext_pre" not in line and "ext_post" not in line, (
                 f"SPMD return alias bound to the wrong output:\n{line}\n\nFull code:\n{code}"

--- a/tests/ut/codegen/test_pto_codegen.py
+++ b/tests/ut/codegen/test_pto_codegen.py
@@ -1240,12 +1240,10 @@ class TestPreprocessPtoasOutput:
         result = _preprocess_ptoas_output(SAMPLE_PTOAS_OUTPUT)
         assert "ptoas_bitcast" in result
 
-    def test_renames_only_standalone_ptoas_tensor_type(self):
-        source = "Tensor value; GlobalTensor<float> global; TensorView view; TaskTensor ready;\n"
+    def test_leaves_ptoas_tensor_type_names_untouched(self):
+        source = "Tensor value; GlobalTensor<float> global; TensorView view; ChipTensor arg;\n"
 
-        assert _preprocess_ptoas_output(source) == (
-            "TaskTensor value; GlobalTensor<float> global; TensorView view; TaskTensor ready;\n"
-        )
+        assert _preprocess_ptoas_output(source) == source
 
     def test_mgather_preprocess_fast_path_preserves_unrelated_content(self):
         source = "AICORE void kernel() {\n  TSTORE(v3);\n}\n"
@@ -1363,17 +1361,17 @@ class TestGenerateArgUnpacking:
     def test_tensor_only(self):
         func = _make_func("test_fn", [("a", "tensor"), ("b", "tensor"), ("out", "tensor")])
         code, names = _generate_arg_unpacking(func)
-        assert "reinterpret_cast<__gm__ TaskTensor*>(args[0])" in code
-        assert "reinterpret_cast<__gm__ TaskTensor*>(args[1])" in code
-        assert "reinterpret_cast<__gm__ TaskTensor*>(args[2])" in code
+        assert "reinterpret_cast<__gm__ Tensor*>(args[0])" in code
+        assert "reinterpret_cast<__gm__ Tensor*>(args[1])" in code
+        assert "reinterpret_cast<__gm__ Tensor*>(args[2])" in code
         assert names == ["a", "b", "out"]
 
     def test_mixed_tensor_scalar(self):
         func = _make_func("test_fn", [("input", "tensor"), ("scale", "scalar"), ("output", "tensor")])
         code, names = _generate_arg_unpacking(func)
         # Tensors-first: input=args[0], output=args[1], scale=args[2]
-        assert "reinterpret_cast<__gm__ TaskTensor*>(args[0])" in code
-        assert "reinterpret_cast<__gm__ TaskTensor*>(args[1])" in code
+        assert "reinterpret_cast<__gm__ Tensor*>(args[0])" in code
+        assert "reinterpret_cast<__gm__ Tensor*>(args[1])" in code
         assert "scale_conv.u64 = args[2];" in code
         assert "float scale = scale_conv.val;" in code
         assert names == ["input", "output", "scale"]

--- a/tests/ut/ir/transforms/test_classify_iter_arg_carry.py
+++ b/tests/ut/ir/transforms/test_classify_iter_arg_carry.py
@@ -381,7 +381,7 @@ def test_no_dep_arg_carry_is_not_a_rebind():
     ``pl.at(no_dep_args=[out])`` stamps the *call-site* direction ``NoDep``; the
     callee's ``ParamDirection`` stays ``Out``/``InOut``, which is what codegen's
     own result alias (``CollectOutIndices``) reads. Classifying such a carry as a
-    rebind would have codegen materialise a fresh ``TaskTensor`` for a slot it is
+    rebind would have codegen materialise a fresh ``Tensor`` for a slot it is
     simultaneously aliasing to the arg.
 
     Written in the scope form because ``no_dep_args`` is a ``pl.at`` / ``pl.submit``


### PR DESCRIPTION
## Summary

Two changes, one forced by the other.

### 1. Update the `runtime` submodule (simpler)

`dbdd041e` → `15f5cbd9`, 40 commits of `hw-native-sys/simpler` main.

- **pto-isa follows automatically**, `be5ccb76` → `96ba706c`: it is derived from the submodule's own `runtime/pto_isa.pin` (simpler #2085), which `toolchain/versions.env` names as the source of truth, so there is no pypto-side pin to edit.
- **ptoas is untouched.** It is pypto-owned and stays at `v0.57` per #2563 (the level-3 TMP / 3-arg `tci` rollback); this PR does not re-open that coupling.

Notable runtime-side changes in the range:

| simpler PR | Change |
|---|---|
| #2044 | the tensor rename that section 2 is about |
| #2092, #2089 | `simpler_init` provisions the async-DMA workspace itself; provisioning asks for one flag instead of an engine set |
| #2087 | each runtime gets its own `TaskId` type |
| #2072, #2063, #2056 | A5 HBG single-lane scheduling completed; Ready routing and scheduler contracts |
| #2073, #2068, #2051 | HBG task table merged into one `ChipTaskStorage`; host-orchestration cleanups |
| #2031, #2040 | HBG resolution-thread swimlane phases; bind-phase wall time split into running/waiting |
| #2030, #1982 | heap-overflow fix in the HBG Graph recording hazard map; ready queues sized from reachable tasks |
| #2091, #2061 | `ProfilerBase::quiesce()`; simulated device logs folded into `HostLogger` |

### 2. Rename `TaskTensor` → `Tensor`

simpler #2044 renamed each runtime's working tensor from `TaskTensor` to `Tensor` in the kernel and orchestration umbrellas (`using Tensor = simpler::{hbg,tmr}::Tensor;`) and deliberately kept no alias — the prefix only ever existed because `Tensor` was taken inside those TUs by `task_interface/buffer.h`, and #2032 / #2038 cut that include edge.

Everything pypto *generates* still said `TaskTensor`, so every generated kernel and orchestration TU failed to compile against the bumped runtime — `'TaskTensor' does not name a type; did you mean 'Tensor'?`, followed by the `ext_*` / `*_tensor` undeclared-identifier cascade. On the first CI run that took out `examples-tests`, `system-tests`, `system-tests-direct`, `dist-system-tests`, `onboard-tests-a5`, `system-tests-a5sim` and `pypto-lib-model`.

Word-boundary rename across everything pypto emits, and everything that asserts on what it emits:

- the C++ emitters — `src/codegen/orchestration/`, `src/codegen/tensor_op_codegen.cpp` — and `python/pypto/backend/pto_backend.py`
- the collective builtin templates, `python/pypto/runtime/builtins/collectives/*/templates/{entry,kernel}.cpp.in` (allgather, allreduce, allreduce_ring, all_to_all, all_to_all_v, barrier, broadcast, reduce_scatter)
- the hand-written external AIV kernel under `tests/st/runtime/external_kernel/`
- the codegen UT expectations, and the prose describing the type

`ChipTensor` and `GlobalTensor` are untouched, matching the runtime-side sweep. The small reformatting is a consequence of the four-character-shorter name letting clang-format / ruff rejoin wrapped lines.

Three follow-ons the rename forced:

- **`_ptoas_preprocess` no longer rewrites the identifier.** It existed to map the PTOAS emitter's `Tensor` onto the runtime's `TaskTensor`; both spell it `Tensor` now, so the substitution had become an identity. Its test asserts the names pass through instead.
- **`test_generated_orchestration_compiles_against_the_pinned_runtime` gets a faithful include path.** It handed the compiler every directory holding a header, so `common/hierarchical/types.h` shadowed `host_build_graph/types.h` and pulled in `task_interface/buffer.h`, whose global `struct Tensor` collides with the runtime's `Tensor` alias — precisely the collision #2044 describes. It now uses the directories simpler's own kernel compiler puts on an orchestration TU, in its order.
- **The ND/MX alias test drops one assertion.** It asserted both that `Tensor viewed = ext_scale;` is emitted and that no line is exactly that; the second guarded the bare spelling back when the emitted one was `TaskTensor`, and can no longer mean anything. The reshape-free assertion carries the test.

## Test plan

- [x] Full CI green on `f3c1e097`: `unit-tests`, `codegen-tests`, `system-tests`, `system-tests-direct`, `system-tests-a5sim`, `dist-system-tests`, `onboard-tests-a5`, `examples-tests`, `pypto-lib-model`, `clang-tidy`, `pre-commit`, wheels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CGgKEqRJtXGSABeAZeueAp
