### PR TITLE
fix(ir): canonicalize a Graph's param-writeback returns

### DIFF
--- a/docs/en/dev/passes/00-pass_manager.md
+++ b/docs/en/dev/passes/00-pass_manager.md
@@ -62,7 +62,7 @@ Framework for organizing and executing IR transformation passes on Programs with
 | `RuntimeScopesMaterialized` | Orchestration functions carry explicit RuntimeScopeStmt nodes, so codegen emits no implicit `SIMPLER_SCOPE()` wrappers |
 | `AssignTypeSymmetry` | Every AssignStmt has `structural_equal(var->GetType(), value->GetType())` (memref excluded as an allocation detail) |
 | `ManualDepsOnSubmitOnly` | No plain cross-function Call carries `attrs["manual_dep_edges"]` — manual edges live in `Submit::deps_` |
-| `ReturnParamsExplicit` | InCore/Group/Spmd tensor returns reference function params by pointer identity (#1702) |
+| `ReturnParamsExplicit` | InCore/Group/Spmd/Graph tensor returns reference function params by pointer identity (#1702, #2601) |
 | `UnrollResolved` | No `ForKind::Unroll` survives; produced by UnrollLoops |
 | `AivSplitValid` | SplitAivScopeStmt regions are structurally valid: no cube compute or split-axis reduce inside a region, boundary ops only inside one |
 | `HardSyncallOccupancyValid` | Every hard (FFTS) `system.syncall` is launched at full occupancy — a partial or over launch deadlocks on device (507018) |

--- a/docs/en/dev/passes/26-normalize_return_order.md
+++ b/docs/en/dev/passes/26-normalize_return_order.md
@@ -31,7 +31,7 @@ This pass canonicalizes the contract so codegen can rely on
    `Out`/`InOut` parameter order, then rewrite both the return values and
    `Function::return_types_` accordingly.
 3. **Step B (call-site remap)** — for every non-InCore function
-   (Orchestration / Group / Spmd / opaque), rewrite every
+   (Orchestration / Group / Spmd / Graph / opaque), rewrite every
    `TupleGetItemExpr.index_` whose tuple operand is the result of a call
    to a function reordered in Step A. The new index is
    `permutation[old_index]`, so observers of the call result still see the

--- a/docs/en/dev/passes/26-normalize_return_order.md
+++ b/docs/en/dev/passes/26-normalize_return_order.md
@@ -22,8 +22,8 @@ This pass canonicalizes the contract so codegen can rely on
 `return[k] ↔ out_indices[k]` by position alone:
 
 1. **Step A0 (param-return canonicalization)** — for every `InCore`,
-   `Group`, and `Spmd` function, rewrite each tensor return value that is a
-   param writeback to reference the parameter directly (pointer identity),
+   `Group`, `Spmd`, and `Graph` function, rewrite each tensor return value that
+   is a param writeback to reference the parameter directly (pointer identity),
    using the shared `return_lineage` utility. Kernel-allocated outputs (not
    traceable to any param) and scalar returns are exempt and stay unchanged.
 2. **Step A (InCore rewrite)** — for every `InCore` function, compute a
@@ -72,7 +72,7 @@ result = passes.normalize_return_order()(program)
 own functions; `IncoreTileOps` guarantees the body uses tile ops, so the
 `tile.store(_, _, out_param)` signal that drives Step A is present. The
 pass produces `ReturnParamsExplicit` (verified by
-`verify_return_params_explicit.cpp`): every InCore/Group/Spmd tensor
+`verify_return_params_explicit.cpp`): every InCore/Group/Spmd/Graph tensor
 return value that is a param writeback references the param by pointer
 identity, so orchestration codegen maps returns to args with a lookup.
 It invalidates nothing — SSA form, normalized statement structure, memory
@@ -82,7 +82,7 @@ inference, and every other upstream property are preserved.
 
 ### Step A0 — Canonicalize return values to params
 
-For each `InCore` / `Group` / `Spmd` function, `CanonicalizeReturnValues`
+For each `InCore` / `Group` / `Spmd` / `Graph` function, `CanonicalizeReturnValues`
 calls `return_lineage::ReturnedParamIndices` (which traces var-to-var
 aliases, loop carries, builtin writebacks, `TupleGetItem` of tuple calls,
 and Group/Spmd wrapper calls) and replaces every tensor return value that
@@ -99,6 +99,15 @@ rather than re-running the interprocedural tracer. Reserve
 `ReturnedParamIndices` for callers that run *before* the property exists
 (`ExpandMixedKernel`, the scope outliner), for this pass itself, and for the
 property verifier, which must re-derive independently to have anything to check.
+
+`Graph` is in this set for the same reason the wrappers are: orchestration
+codegen aliases a Graph call's results to call-site tensors through this map. A
+Graph body is written `out = core(..., out, ...); return out`, which the
+outliner turns into a `TupleGetItem` rebind, so the return reaches codegen as an
+SSA rename. While Graph was excluded, that map came back all-`nullopt`, codegen
+fell back to a positional heuristic (return `j` ↦ the `j`-th `Out`/`InOut`
+param), and a Graph whose return order differed from its parameter order had
+every result bound to the wrong tensor with no diagnostic (#2601).
 
 Because it is a codegen precondition, a test that hand-builds IR and calls
 orchestration codegen directly must run this pass first (see
@@ -163,7 +172,7 @@ buffer, just under a new index.
 
 | Constraint | Reason |
 | ---------- | ------ |
-| Only `InCore` functions are rewritten in Step A | Other function kinds (`Orchestration` / `Group` / `Spmd` / opaque) follow the user's declared return shape; their callers are remapped in Step B. `Group`/`Spmd` returns are still canonicalized to params in Step A0, but never reordered |
+| Only `InCore` functions are rewritten in Step A | Other function kinds (`Orchestration` / `Group` / `Spmd` / `Graph` / opaque) follow the user's declared return shape; their callers are remapped in Step B. `Group`/`Spmd`/`Graph` returns are still canonicalized to params in Step A0, but never reordered |
 | Step A0 leaves kernel-allocated outputs and scalars untouched | Only param writebacks must be explicit; a return value with no param lineage has no param to reference |
 | Skips functions where `out_indices.size() > ret_to_param.size()` | An incomplete analysis must not produce an out-of-bounds permutation — leave the function as-is so the verifier can flag the inconsistency |
 | Permutation is identity ⇒ no rewrite | Avoids spurious `Function` clones and keeps the pass idempotent |

--- a/docs/zh/dev/passes/00-pass_manager.md
+++ b/docs/zh/dev/passes/00-pass_manager.md
@@ -62,7 +62,7 @@
 | `RuntimeScopesMaterialized` | Orchestration 函数带有显式的 RuntimeScopeStmt 节点，codegen 不再隐式生成 `SIMPLER_SCOPE()` 包裹 |
 | `AssignTypeSymmetry` | 每个 AssignStmt 满足 `structural_equal(var->GetType(), value->GetType())`（memref 作为分配细节被排除） |
 | `ManualDepsOnSubmitOnly` | 普通跨函数 Call 不携带 `attrs["manual_dep_edges"]`——手写依赖边只存在于 `Submit::deps_` |
-| `ReturnParamsExplicit` | InCore/Group/Spmd 的 tensor 返回值按指针恒等引用函数参数（#1702） |
+| `ReturnParamsExplicit` | InCore/Group/Spmd/Graph 的 tensor 返回值按指针恒等引用函数参数（#1702、#2601） |
 | `UnrollResolved` | 不再残留 `ForKind::Unroll`；由 UnrollLoops 产生 |
 | `AivSplitValid` | SplitAivScopeStmt 区域结构合法：区域内无 cube 计算与 split 轴 reduce，边界算子只出现在区域内 |
 | `HardSyncallOccupancyValid` | 每个硬 (FFTS) `system.syncall` 都在满占用下启动——部分或超额启动会导致设备侧死锁 (507018) |

--- a/docs/zh/dev/passes/26-normalize_return_order.md
+++ b/docs/zh/dev/passes/26-normalize_return_order.md
@@ -18,7 +18,7 @@ i 个 `Out`/`InOut` 参数，并相应地重映射非 InCore 调用方中的
 本 Pass 把契约规范化为「按位置 `return[k] ↔ out_indices[k]`」，分两步进行：
 
 1. **Step A0（返回值参数化规范化）** —— 对每个 `InCore`、`Group`、
-   `Spmd` 函数，把每个属于参数回写（param writeback）的 tensor 返回值改写为
+   `Spmd`、`Graph` 函数，把每个属于参数回写（param writeback）的 tensor 返回值改写为
    直接引用对应参数（指针同一性），追踪由共享的 `return_lineage` 工具完成。
    kernel 内部分配的输出（无法追踪到任何参数）和标量返回不受影响。
 2. **Step A（InCore 函数重写）** —— 对每个 `InCore` 函数，计算一个使
@@ -62,7 +62,7 @@ result = passes.normalize_return_order()(program)
 证函数体使用 tile 操作，从而 Step A 所依赖的
 `tile.store(_, _, out_param)` 信号一定存在。本 Pass 产出
 `ReturnParamsExplicit`（由 `verify_return_params_explicit.cpp` 校验）：每个
-InCore/Group/Spmd 函数中属于参数回写的 tensor 返回值都以指针同一性引用对应
+InCore/Group/Spmd/Graph 函数中属于参数回写的 tensor 返回值都以指针同一性引用对应
 参数，编排代码生成因此只需查表即可建立返回值到实参的映射。本 Pass 不使任何
 属性失效 —— SSA、规范化语句结构、内存推断等所有上游属性均被保留。
 
@@ -70,7 +70,7 @@ InCore/Group/Spmd 函数中属于参数回写的 tensor 返回值都以指针同
 
 ### Step A0 —— 把返回值规范化为参数引用
 
-对每个 `InCore` / `Group` / `Spmd` 函数，`CanonicalizeReturnValues` 调用
+对每个 `InCore` / `Group` / `Spmd` / `Graph` 函数，`CanonicalizeReturnValues` 调用
 `return_lineage::ReturnedParamIndices`（可追踪 Var 到 Var 别名、循环携带、
 builtin 回写、tuple 调用的 `TupleGetItem`，以及 Group/Spmd 包装函数调用），
 把每个可追踪到参数的 tensor 返回值替换为参数 `Var` 本身。无法追踪的值
@@ -84,6 +84,14 @@ builtin 回写、tuple 调用的 `TupleGetItem`，以及 Group/Spmd 包装函数
 取"，而不再重跑跨函数追踪器。`ReturnedParamIndices` 只保留给：在该属性建立**之
 前**运行的调用方（`ExpandMixedKernel`、scope outliner）、本 pass 自身，以及必须
 独立重新推导才能起到校验作用的属性验证器。
+
+`Graph` 被纳入该集合的理由与包装函数相同：编排代码生成正是通过这张映射把 Graph
+调用的结果别名到调用端张量。Graph 的函数体写作 `out = core(..., out, ...); return
+out`，outliner 会把它变成 `TupleGetItem` 重绑定，因此返回值到达 codegen 时是一个
+SSA 重命名。在 Graph 被排除期间，这张映射全部返回 `nullopt`，codegen 退回到位置
+启发式（返回位置 `j` ↦ 第 `j` 个 `Out`/`InOut` 参数）；一旦某个 Graph 的返回顺序
+与参数顺序不一致，它的每个结果都会被静默绑定到错误的张量，且没有任何诊断
+（#2601）。
 
 由于它是 codegen 的前置条件，手工构造 IR 并直接调用 orchestration codegen 的测试
 必须先运行本 pass（见 `tests/ut/codegen/_orchestration_codegen_common.py`），正如
@@ -141,7 +149,7 @@ builtin 回写、tuple 调用的 `TupleGetItem`，以及 Group/Spmd 包装函数
 
 | 约束 | 原因 |
 | ---- | ---- |
-| Step A 仅重写 `InCore` 函数 | 其他函数类型（`Orchestration` / `Group` / `Spmd` / opaque）遵循用户声明的返回形态；它们的调用端在 Step B 中被重映射。`Group`/`Spmd` 的返回值在 Step A0 中仍会被规范化为参数引用，但不会被重排 |
+| Step A 仅重写 `InCore` 函数 | 其他函数类型（`Orchestration` / `Group` / `Spmd` / `Graph` / opaque）遵循用户声明的返回形态；它们的调用端在 Step B 中被重映射。`Group`/`Spmd`/`Graph` 的返回值在 Step A0 中仍会被规范化为参数引用，但不会被重排 |
 | Step A0 不改动 kernel 内部分配的输出与标量 | 只有参数回写必须显式化；没有参数血缘的返回值没有可引用的参数 |
 | `out_indices.size() > ret_to_param.size()` 时跳过 | 不完整分析不能产生越界置换 —— 保留原状，让 verifier 捕获不一致 |
 | 恒等置换 ⇒ 不重写 | 避免不必要的 `Function` 克隆，使 Pass 幂等 |

--- a/docs/zh/dev/passes/26-normalize_return_order.md
+++ b/docs/zh/dev/passes/26-normalize_return_order.md
@@ -25,7 +25,7 @@ i 个 `Out`/`InOut` 参数，并相应地重映射非 InCore 调用方中的
    `ReturnStmt::value_` 与声明的 `Out`/`InOut` 参数顺序一致的置换，然后同步
    重写返回值与 `Function::return_types_`。
 3. **Step B（调用端索引重映射）** —— 对每个非 InCore 函数（Orchestration /
-   Group / Spmd / opaque），重写所有 `TupleGetItemExpr.index_`，前提是它的
+   Group / Spmd / Graph / opaque），重写所有 `TupleGetItemExpr.index_`，前提是它的
    tuple 操作数来源于 Step A 中被重排序的函数调用结果。新索引为
    `permutation[old_index]`，因此调用结果上的观察者仍然把同名 SSA 变量绑
    定到同一物理输出。

--- a/include/pypto/ir/transforms/ir_property.h
+++ b/include/pypto/ir/transforms/ir_property.h
@@ -77,8 +77,9 @@ enum class IRProperty : uint64_t {
   ManualDepsOnSubmitOnly,           ///< No plain cross-function Call (GlobalVar callee) carries
                                     ///< attrs["manual_dep_edges"] — manual dependency edges live in the
                                     ///< typed Submit::deps_ field. Op calls (system.task_dummy) are exempt
-  ReturnParamsExplicit,             ///< InCore/Group/Spmd tensor returns reference function params by
-                                    ///< pointer identity, so the return->param map is a lookup (#1702)
+  ReturnParamsExplicit,             ///< InCore/Group/Spmd/Graph tensor returns reference function params
+                                    ///< by pointer identity, so the return->param map is a lookup
+                                    ///< (#1702, #2601)
   UnrollResolved,                   ///< No ForKind::Unroll survives; produced by UnrollLoops
   AivSplitValid,                    ///< SplitAivScopeStmt regions are structurally valid: no cube compute
                                     ///< or split-axis reduce inside a region, boundary ops only inside one

--- a/src/ir/transforms/normalize_return_order_pass.cpp
+++ b/src/ir/transforms/normalize_return_order_pass.cpp
@@ -408,7 +408,17 @@ Pass NormalizeReturnOrder() {
 
     for (const auto& [gvar, func] : program->functions_) {
       const bool is_wrapper = IsWrapperType(func->func_type_);
-      if (IsInCoreType(func->func_type_) || is_wrapper) {
+      // A Graph is a *callee* whose returns orchestration codegen aliases to
+      // call-site tensors, exactly like an InCore kernel or a Group/Spmd
+      // wrapper, so it needs the same explicit-param form. Its body is written
+      // ``out = core(..., out, ...); return out``, and the outliner turns that
+      // into a TupleGetItem rebind, so the return reaches codegen as an SSA
+      // rename. Left un-canonicalized, ExplicitReturnedParamIndices comes back
+      // all-nullopt, IsReturnedParamMapPrecise rejects the map, and codegen
+      // falls back to a positional heuristic that is only right when the return
+      // order happens to match the parameter order -- silently binding every
+      // result to the wrong tensor otherwise (#2601).
+      if (IsInCoreType(func->func_type_) || is_wrapper || func->func_type_ == FunctionType::Graph) {
         // Step A0: make every tensor return an explicit param reference.
         FunctionPtr current = func;
         if (auto canonical = CanonicalizeReturnValues(current, program)) {

--- a/src/ir/transforms/utils/stmt_dependency_analysis.cpp
+++ b/src/ir/transforms/utils/stmt_dependency_analysis.cpp
@@ -167,6 +167,21 @@ class InOutUseDisciplineChecker : public IRVisitor {
     }
   }
 
+  void VisitStmt_(const ReturnStmtPtr&) override {
+    // A return value is a writeback identity, not a read. `NormalizeReturnOrder`
+    // canonicalizes a param-writeback return to reference the param itself, so a
+    // body shaped `x_1 = core(a, x); return x` returns the very var the call
+    // marked dead -- yet nothing reads its contents: codegen aliases the result
+    // to that same buffer. Counting it as a read made the two properties
+    // contradict each other, which is why `verify_inout_use.cpp` skips Group/Spmd
+    // wrappers wholesale ("they return their params explicitly"). Exempting the
+    // return here states that rule once, at its source, instead of exempting
+    // whole function kinds -- so a Graph body, which is real orchestration code
+    // rather than a 1:1 forwarder, keeps discipline checking everywhere else
+    // (#2601). Without it `CanonicalizeIOOrder` would also silently decline to
+    // reorder every Graph function.
+  }
+
   void VisitStmt_(const IfStmtPtr& op) override {
     // Then- and else-branches are mutually exclusive at runtime, so a
     // post-call mark added in one branch must not bleed into the other.

--- a/src/ir/verifier/verify_return_params_explicit.cpp
+++ b/src/ir/verifier/verify_return_params_explicit.cpp
@@ -26,7 +26,7 @@
 namespace pypto {
 namespace ir {
 
-/// Verifies IRProperty::ReturnParamsExplicit: in every InCore/Group/Spmd
+/// Verifies IRProperty::ReturnParamsExplicit: in every InCore/Group/Spmd/Graph
 /// function, each tensor return value that is a param writeback references
 /// the param by pointer identity instead of an SSA alias of it. Scalar
 /// returns and kernel-allocated tensors (untraceable to any param; they only
@@ -43,8 +43,14 @@ class ReturnParamsExplicitVerifierImpl : public PropertyVerifier {
       // implementation lives in the hand-written source named by "external_source".
       // They legitimately have no ReturnStmt, so exempt them from this property.
       if (func->HasAttr(kAttrExternalSource)) continue;
+      // Graph is in scope for the same reason InCore and the wrappers are:
+      // orchestration codegen reads its return->param map off the ReturnStmt to
+      // alias call results to call-site tensors. Exempting it made the property
+      // pass vacuously while codegen quietly guessed the map positionally
+      // (#2601), which is precisely the silent mis-binding this verifier exists
+      // to turn into an error.
       const bool applies = IsInCoreType(func->func_type_) || func->func_type_ == FunctionType::Group ||
-                           func->func_type_ == FunctionType::Spmd;
+                           func->func_type_ == FunctionType::Spmd || func->func_type_ == FunctionType::Graph;
       if (!applies) continue;
 
       bool has_tensor_return = false;

--- a/tests/ut/codegen/test_orchestration_codegen_graph.py
+++ b/tests/ut/codegen/test_orchestration_codegen_graph.py
@@ -514,5 +514,85 @@ def test_graph_allocations_are_packed_sixteen_to_a_node():
     assert body.count("rt_submit_") == 21, body
 
 
+@pl.program
+class _SwappedReturns:
+    """A Graph returning its two InOut params in the reverse of their declared order.
+
+    `InOutUseDiscipline` requires the caller to read a written param through the
+    call's return value, so a Graph that writes several InOut params returns them
+    all -- and nothing forces that return order to match the parameter order.
+    """
+
+    @pl.function(type=pl.FunctionType.Graph)
+    def layer(
+        self,
+        a: pl.Tensor[[128, 128], pl.FP32],
+        x: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+        y: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+    ) -> tuple[pl.Tensor[[128, 128], pl.FP32], pl.Tensor[[128, 128], pl.FP32]]:
+        with pl.at(level=pl.Level.CORE_GROUP):
+            t: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [0, 0], [128, 128])
+            pl.store(t, [0, 0], x)
+            u: pl.Tile[[128, 128], pl.FP32] = pl.add(t, t)
+            pl.store(u, [0, 0], y)
+        return y, x
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def consume(
+        self,
+        u: pl.Tensor[[128, 128], pl.FP32],
+        v: pl.Tensor[[128, 128], pl.FP32],
+        o: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+    ) -> pl.Tensor[[128, 128], pl.FP32]:
+        tu: pl.Tile[[128, 128], pl.FP32] = pl.load(u, [0, 0], [128, 128])
+        tv: pl.Tile[[128, 128], pl.FP32] = pl.load(v, [0, 0], [128, 128])
+        s: pl.Tile[[128, 128], pl.FP32] = pl.add(tu, tv)
+        return pl.store(s, [0, 0], o)
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def main(
+        self,
+        a: pl.Tensor[[128, 128], pl.FP32],
+        out: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+    ) -> pl.Tensor[[128, 128], pl.FP32]:
+        # Freshly created region tensors, not entry params: with entry params the
+        # compiler resolves the aliasing without emitting a binding at all, and
+        # the mis-binding stays invisible.
+        for _i in pl.range(2):
+            p: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], pl.FP32)
+            q: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], pl.FP32)
+            qq, pp = self.layer(a, p, q)
+            out = self.consume(qq, pp, out)
+        return out
+
+
+def _task_args(entry: str, params_var: str) -> list[str]:
+    """The `add_input` / `add_inout` operands of the @p params_var argument block."""
+    block = re.search(rf"{params_var};(.*?)rt_submit_", entry, re.S)
+    assert block is not None, entry
+    return re.findall(r"add_(?:input|inout)\((\w+)\)", block.group(1))
+
+
+def test_multi_param_graph_returns_bind_to_the_right_call_site_tensors():
+    """Return position j binds the arg of the param j *returns*, not the j-th Out param.
+
+    `layer` returns `(y, x)`, so `qq, pp = layer(a, p, q)` means `qq` aliases `q`
+    and `pp` aliases `p`. While Graph was excluded from `NormalizeReturnOrder`'s
+    param-return canonicalization, the return->param map came back all-nullopt and
+    codegen guessed positionally -- return 0 to the first Out/InOut param (`x`) --
+    binding every result to the wrong tensor with no diagnostic (#2601). Both
+    sides are same-shaped tensors, so nothing downstream notices; the numbers just
+    come out wrong.
+    """
+    entry = _entry_body(_compile_orch(_SwappedReturns))
+
+    # The launch itself is unremarkable: args in parameter order.
+    assert _task_args(entry, "GraphTaskArgs params_t0")[1:] == ["p", "q"], entry
+
+    # The consumer is where the mapping shows. `consume(qq, pp, out)` must read
+    # qq -> q and pp -> p; `["p", "q"]` here is exactly the swap this fixes.
+    assert _task_args(entry, "CoreTaskArgs params_t1")[:2] == ["q", "p"], entry
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_normalize_return_order.py
+++ b/tests/ut/ir/transforms/test_normalize_return_order.py
@@ -772,6 +772,54 @@ class TestReturnParamsAreStructurallyExplicit:
         assert len(values) == 1
         assert values[0] is params[1]
 
+    def test_graph_returns_reference_their_params(self):
+        """A Graph is a callee whose returns codegen aliases, so it needs the form too.
+
+        A Graph body is written ``out = core(..., out, ...); return out``, which
+        reaches this pass as a ``TupleGetItem`` rebind rather than the param.
+        While Graph was excluded from Step A0, orchestration codegen got an
+        all-``nullopt`` map, fell back to "return j is the j-th Out/InOut param",
+        and silently bound every result to the wrong call-site tensor whenever the
+        return order differed from the parameter order (#2601).
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def core(
+                self,
+                a: pl.Tensor[[64], pl.FP32],
+                x: pl.InOut[pl.Tensor[[64], pl.FP32]],
+                y: pl.InOut[pl.Tensor[[64], pl.FP32]],
+            ) -> tuple[pl.Tensor[[64], pl.FP32], pl.Tensor[[64], pl.FP32]]:
+                t: pl.Tile[[64], pl.FP32] = pl.load(a, [0], [64])
+                r0: pl.Tensor[[64], pl.FP32] = pl.store(t, [0], x)
+                r1: pl.Tensor[[64], pl.FP32] = pl.store(t, [0], y)
+                return r0, r1
+
+            @pl.function(type=pl.FunctionType.Graph)
+            def layer(
+                self,
+                a: pl.Tensor[[64], pl.FP32],
+                x: pl.InOut[pl.Tensor[[64], pl.FP32]],
+                y: pl.InOut[pl.Tensor[[64], pl.FP32]],
+            ) -> tuple[pl.Tensor[[64], pl.FP32], pl.Tensor[[64], pl.FP32]]:
+                x2, y2 = self.core(a, x, y)
+                # Reversed relative to the parameter order.
+                return y2, x2
+
+        values, _params = self._return_values(Before, "layer")
+        # Before: SSA renames produced by the tuple unpack, not the params.
+        assert all(isinstance(v, ir.Var) for v in values)
+        assert not any(v is p for v in values for p in _params)
+
+        After = _run_normalize_direct(Before)
+        values, params = self._return_values(After, "layer")
+        # After: position 0 is param `y` (index 2), position 1 is param `x` (index 1).
+        # Getting this backwards is exactly the #2601 mis-binding.
+        assert values[0] is params[2]
+        assert values[1] is params[1]
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Orchestration codegen resolves a call's return positions by reading the callee's
`ReturnStmt` — return position `j` writes back param `i` exactly when
`ReturnStmt->value_[j]` *is* `params_[i]`. `FunctionType::Graph` was never added
to the two places that establish and check that form, so for a Graph the map came
back all-`nullopt` and codegen fell back to a positional heuristic: "return `j` is
the `j`-th `Out`/`InOut` param". That is right only when the return order happens
to match the parameter order.

A Graph declaring `(a, x: InOut, y: InOut)` and returning `(y, x)` therefore had
both results bound to the wrong call-site tensors. Both sides are same-shaped
tensors, so nothing downstream noticed — the numbers just came out wrong. After
this change the map is exact for a Graph, and a future regression raises an error
naming the return position and the param it aliases instead of mis-binding
silently.

No API or DSL change: a Graph whose return order already matched its parameter
order emits exactly what it did before.

## Changes

- `src/ir/transforms/normalize_return_order_pass.cpp`: Step A0 (param-return
  canonicalization) now covers `Graph` alongside InCore and the Group/Spmd
  wrappers. A Graph body is written `out = core(..., out, ...); return out`, which
  the scope outliner turns into a `TupleGetItem` rebind, so its return reached
  codegen as an SSA rename. Step A (return *reordering*) stays InCore-only —
  reordering a Graph's returns would change its declared signature and its call
  sites' tuple indices for no benefit, since Graph returns are aliases rather than
  runtime outputs.
- `src/ir/verifier/verify_return_params_explicit.cpp`: `ReturnParamsExplicit` now
  applies to `Graph`. It did not before, so orchestration codegen's precondition on
  that property passed vacuously for a Graph — which is why the mis-binding had no
  diagnostic anywhere.
- `src/ir/transforms/utils/stmt_dependency_analysis.cpp`: the InOut-use discipline
  checker no longer counts a `ReturnStmt` value as a read. Canonicalizing makes a
  Graph return reference a param an earlier call wrote, which the discipline
  otherwise flags as reading a dead variable — the two properties contradicted each
  other. A return is a writeback identity, not a read: codegen aliases the result to
  that same buffer. Stating the rule here rather than exempting whole function kinds
  (as the verifier already does for Group/Spmd wrappers) keeps discipline checking
  inside Graph bodies, which are real orchestration code. It also matters beyond the
  verifier: `CanonicalizeIOOrder` consumes the same checker and would otherwise have
  silently declined to reorder every Graph function.
- `include/pypto/ir/transforms/ir_property.h`, `docs/{en,zh}/dev/passes/00-pass_manager.md`,
  `docs/{en,zh}/dev/passes/26-normalize_return_order.md`: record the widened scope and
  why Graph belongs in it.
- `tests/ut/ir/transforms/test_normalize_return_order.py`: a Graph returning two
  InOut params in reverse order canonicalizes to param references at the right
  positions.
- `tests/ut/codegen/test_orchestration_codegen_graph.py`: the end-to-end case. The
  reduced attempts in the issue emitted no binding at all, because entry-parameter
  tensors let the compiler resolve the aliasing without one; passing freshly created
  region tensors (`pl.create_tensor` inside a `pl.range` loop) is what makes the
  binding observable. Both new tests fail on the parent commit.

## Verification

- `cmake --build build --parallel 32`: exit 0
- `pytest tests/ut -n 16`: exit 1 — 11027 passed, 1 failed, 8 skipped, 1 xfailed.
  The failure is `test_symlinked_import_path_still_names_the_caller`, which spawns a
  subprocess with its own `PYTHONPATH` and so resolves `pypto` through this machine's
  editable install rather than the worktree; it is unrelated to this change and fails
  the same way without it.
- `pytest tests/st/runtime/framework_and_models/test_graph_execution.py`: 12 of 13
  passed. The one failure, `test_no_graph_per_layer_accumulate`, is the control case
  that uses no Graph at all; it died after a device force-reset triggered by earlier
  cases in the same session and passes when run on its own.
- Reverted the pass change and rebuilt: both new tests fail, and the widened verifier
  reports `Function 'layer' return position 1 ('x2') aliases param index 1`.
- `clang-format` 21.1.0 `--dry-run --Werror` on the changed C++: exit 0
- `clang-tidy` 21.1.0 `-p build` on the three changed `.cpp`: exit 0, no diagnostics
- `ruff` 0.14.8 `check` and `format --diff` on the changed tests: exit 0
- The 12 `tests/lint/*.py` hooks: all exit 0

Full system-test coverage is left to CI.

Fixes #2601.
