### PR TITLE
feat(ir): hoist a Graph region's own allocations out to its call sites

### DIFF
--- a/docs/en/dev/passes/26-normalize_return_order.md
+++ b/docs/en/dev/passes/26-normalize_return_order.md
@@ -37,9 +37,11 @@ This pass canonicalizes the contract so codegen can rely on
    `permutation[old_index]`, so observers of the call result still see the
    same SSA values bound to the same names.
 
-The pass is a **no-op** for any function whose return order already matches
-its `Out`/`InOut` parameter order, and a no-op for any program with no
-InCore functions.
+The pass is a **no-op** for any function whose tensor returns already name
+their parameters and whose return order already matches its `Out`/`InOut`
+parameter order, and a no-op for any program with no `InCore`, `Group`,
+`Spmd`, or `Graph` function — Step A0 covers all four, so "no InCore
+functions" alone no longer implies the pass does nothing.
 
 **Pipeline position**: slot #20 in the `Default` strategy — after
 `SplitVectorKernel` (#19) and before `LowerPipelineLoops` (#21). It runs

--- a/docs/en/dev/passes/45-legalize_graph_boundary.md
+++ b/docs/en/dev/passes/45-legalize_graph_boundary.md
@@ -1,9 +1,9 @@
 # LegalizeGraphBoundary Pass
 
 Makes every `FunctionType::Graph` function legal for the `host_build_graph`
-runtime to record and replay: hoists the boundary scalars a Graph body derives
-out to its call sites, and rejects the boundaries the runtime would decline to
-cache.
+runtime to record and replay: hoists the boundary scalars a Graph body derives,
+the boundary views it takes and the intermediates it allocates out to its call
+sites, and rejects the boundaries the runtime would decline to cache.
 
 ## Overview
 
@@ -13,16 +13,21 @@ things: the addresses of the boundary tensors, and the values of the boundary
 scalars. Everything else — node count, shapes, dependency edges, block counts —
 is frozen into the recorded Definition.
 
-That makes two classes of problem possible, and both are silent at runtime:
+That makes four classes of problem possible, and every one of them is silent at
+runtime:
 
 | Problem | What the runtime does | What this pass does |
 | ------- | --------------------- | ------------------- |
 | A boundary scalar is *derived* inside the region | Classifies it as static data and freezes the first call's value into the recording. No warning, ever. | **Step A** — hoists the computation to the call site, or leaves it alone when the frozen value is provably the right one |
+| A view of a boundary tensor is taken *inside* the region | Freezes the first call's offset and patches only the address, so a later call reads call one's window | **Step B** — hoists the view to the call site, or accepts it when its window is replay-invariant |
+| The region allocates its own intermediates | Records them correctly, on a heap it never reclaims mid-run, so the live set grows with the number of submissions | **Step C** — hoists the allocation to the call site as an `InOut` boundary tensor |
 | The boundary itself is not cacheable | Declines to cache and silently runs the region as ordinary tasks | **Step D** — rejects it at compile time |
 
-The first produces wrong answers. The second produces correct answers with none
-of the intended speedup — invisible to any numerical test, which is why the
-checks live here rather than being left to a runtime log line.
+The first two produce wrong answers. The third produces correct answers that run
+out of memory, or merely slower, as the layer count grows. The last produces
+correct answers with none of the intended speedup — invisible to any numerical
+test, which is why the checks live here rather than being left to a runtime log
+line.
 
 ## Step A — derived boundary scalars
 
@@ -151,6 +156,25 @@ can only name a source defined before it. Leaving `wr` behind is silent:
 `graph_rebind_tensor` patches the buffer address from `wl` but keeps the offset
 recorded on the first call.
 
+**Provenance crosses an in-place call.** `tmp = kernel(a, tmp)` rebinds the
+buffer to a fresh SSA name, and a view of *that* name is still a view of a
+boundary tensor. Tracking only bare `alias = var` assignments loses the root
+there, and Step B then skips the view outright — no hoist and no check — so a
+call-varying offset stays in the region with the first call's window frozen. The
+rebind is followed through
+[`ExplicitReturnedParamIndices`](26-normalize_return_order.md), the same
+return-position -> parameter map orchestration codegen aliases a call result on,
+so provenance and codegen cannot disagree about which buffer a result names.
+This applies to a boundary *parameter* just as much as to a Step C allocation.
+
+The argument that map points at is resolved with `CallerSuppliedArg`, which
+splits the three regions of the `Submit::args_` contract in `ir/expr.h`. A
+`Submit` legally omits a runtime-allocated `Out` tail, and its caller-supplied
+prefix still maps positionally, so requiring full arity would silently drop
+provenance for every such launch. A parameter in the runtime-allocated gap
+correctly yields nothing: the runtime creates that buffer, so there is no
+caller-side root to inherit.
+
 **A hoisted view must have a compile-time-constant shape.** Replay copies a
 view's `shapes` and `strides` straight from the recorded template and patches
 only `buffer_addr` and `start_offset`, so an extent read from a boundary scalar
@@ -190,27 +214,90 @@ motivating case, a per-layer `layer_idx * 5120`.
 
 ## Step C — allocations inside the region
 
-`pl.create_tensor` **is allowed** in the region, subject to one rule: its shape
-must be a compile-time constant.
+`pl.create_tensor` at the top level of the region is **hoisted to the call
+site**, where it becomes an `InOut` boundary tensor:
 
-Codegen lowers it into a batched `alloc_tensors`, and the runtime records that as
-a kernel-less node — the same shape `submit_dummy_task` records — so it does not
-poison the recording. It does count toward the node limit, and one under a
-runtime loop or branch is a topology that varies between calls; both are Step D's
-concern.
+```python
+# Before
+@pl.jit.graph
+def layer(a: pl.Tensor, acc: pl.InOut[pl.Tensor]):
+    tmp = pl.create_tensor([ROWS, COLS], pl.FP32)   # allocated per submission
+    ...
+    return acc
 
-What recording cannot reproduce is a *shape* read from a boundary scalar. The
-extent is copied into the node and the buffer's address derived from it, and
-replay never re-runs the body, so a later call with a larger extent is handed the
-first call's buffer — a wrong address layout rather than a fallback. Step D
-rejects that, and `tensor.full` outright, which orchestration codegen has no
-lowering for.
+# After — the call site owns the buffer
+def layer(a, acc, tmp: pl.InOut[pl.Tensor]): ...
+tmp__graph_arg0 = pl.tensor.create([ROWS, COLS], pl.FP32)
+acc = layer(a, acc, tmp__graph_arg0)
+```
 
-Hoisting a region-local allocation to a boundary parameter is *not* done: it
-would add a second `InOut` parameter, and the return-alias mapping requires the
-callee's `ReturnStmt` to name a parameter directly in order to disambiguate which
-one a tensor return aliases — an invariant a synthesised parameter does not
-satisfy. Automating it needs that mapping reworked first.
+Recording it in place is *correct* — codegen lowers a create into a batched
+`alloc_tensors` and the runtime records that as a kernel-less node, the same
+shape `submit_dummy_task` records — but the buffer comes off the **graph heap**,
+which `task_allocator.h` never reclaims mid-run ("The whole graph must fit at
+once; nothing is reclaimed mid-run"). The live set then grows with the number of
+submissions rather than staying flat: a decoder layer holding 14 intermediates
+costs 14 × N over N recorded layers. Hoisting puts the buffer back on the
+ordinary reclaimable heap and empties the region of allocation nodes.
+
+simpler's hand-written `examples/a2a3/host_build_graph/qwen3_14b_decode` scene
+does the same thing by hand, for the same stated reason — "This keeps the
+temporary live set flat in layer count and fits the default ring configuration."
+
+The parameter is `InOut`, never `In`: the region *writes* the buffer, and
+declared `In` codegen would emit `add_input`, the launch would never register as
+a writer, and a caller that hoisted the allocation out of its own loop would get
+no ordering between successive launches over it. `Out` is not available — on a
+Graph boundary it means the runtime allocates, which `rt_graph_args_cacheable`
+refuses.
+
+A hoisted allocation **is a boundary tensor**, so a view of it is held to the
+Step B rule above rather than left alone. That is not optional bookkeeping: the
+`GraphBoundaryLegalized` verifier treats every tensor parameter as a boundary
+root, so a view left in place with a window that can move would make this pass
+produce IR its own verifier rejects.
+
+Two allocations are deliberately left where they are:
+
+| Left in place | Why |
+| ------------- | --- |
+| `tensor.full` | Orchestration codegen has no lowering for it at the call site either, so hoisting would only move the failure. Step D rejects it outright |
+| A create under a loop | It is a *fresh* buffer per iteration. Collapsing N buffers into one parameter would make iterations alias, and the cross-task edges that would have to re-serialise them were derived by [`AutoDeriveTaskDependencies`](39-auto_derive_task_dependencies.md), well upstream of here |
+
+What recording cannot reproduce either way is a *shape* read from a boundary
+scalar. The extent is copied into the node and the buffer's address derived from
+it, and replay never re-runs the body, so a later call with a larger extent is
+handed the first call's buffer — a wrong address layout rather than a fallback.
+Step D rejects that, before Step C runs, so every allocation Step C hoists has a
+compile-time-constant shape.
+
+### Prerequisite: a Graph's returns name their parameters
+
+Step B and Step C both *append* an `InOut` parameter, and that is what made
+automating this hoist a rework rather than a wiring job. Orchestration codegen
+maps a call result onto one of the callee's `Out`/`InOut` params through
+`return_lineage::ExplicitReturnedParamIndices` — a pointer-identity read of the
+callee's `ReturnStmt` — and falls back to "the single `Out`/`InOut` param" only
+when that map yields nothing:
+
+```cpp
+// GenerateSingleReturnAlias, orchestration_codegen.cpp
+INTERNAL_CHECK_SPAN(returned_idx.has_value() || out_indices.size() == 1, call->span_)
+```
+
+A Graph body is `c_1 = layer_incore_0(a, c); return c_1` once
+`OutlineIncoreScopes` has run — a rebind, not the parameter — so a Graph has
+always relied on that fallback, and the fallback stops existing at the second
+`InOut` parameter.
+
+[`NormalizeReturnOrder`](26-normalize_return_order.md) supplies what the hoists
+need: it canonicalizes a Graph's tensor returns the way it already did for
+kernels and wrappers (canonicalization only — no Graph return is *reordered*),
+and `IRProperty::ReturnParamsExplicit` covers `Graph`, so the nineteen passes
+between there and here cannot quietly undo it. That landed separately in
+PR #2618, so this step depends on it rather than providing it — which is why
+`_legalize_outlined` in the unit tests runs `NormalizeReturnOrder`: without it
+the map is all-nullopt and the hoists silently do nothing.
 
 ## Step D — boundary legality
 
@@ -223,7 +310,7 @@ satisfy. Automating it needs that mapping reworked first.
 | No `Out` tensor parameter | `Out` means the runtime allocates the buffer; a recorded graph's boundary tensors must already exist so replay can patch their addresses |
 | Scalar parameters are `In` | A boundary scalar is passed by value and replayed from the call site |
 | Returns only its own parameters | `rt_submit_graph` yields a valid task id only on a cache *hit*, so nothing can depend on a graph call's result. `return c` for an `InOut` parameter is the in-place spelling and is fine; a computed value is not |
-| Between 1 and 1024 launched tasks | `graph_execution_storage_layout` refuses a node count of zero as well as one over `GRAPH_MAX_NODES`. A launch in a loop counts once per iteration, not once per call site, and `system.task_dummy` counts too — it lowers to `rt_submit_dummy_task`, and `ExpandManualPhaseFence` inserts them automatically. Allocations record nodes too, counted as an *upper* bound so that passing this check means the runtime will accept the Graph. Codegen collects every eligible create in a statement list — an intervening launch does not close the batch — and packs them at most `kAllocTensorsArgs` (16) to an `alloc_tensors`. Two of its three ineligibility rules cannot fire here (a shape reading a local is already rejected as non-constant; an already-declared var cannot recur under SSA), so those creates are counted exactly. The third can — an injected GM pipe buffer leaves the shared batch when its `core_num` reads a body-local, which only the emitter's use-resolution knows — so each of those is charged its worst case of one node. The batch size and the GM-pipe predicate are shared with the emitter in `utils/alloc_batching.h` rather than restated here |
+| Between 1 and 1024 launched tasks | `graph_execution_storage_layout` refuses a node count of zero as well as one over `GRAPH_MAX_NODES`. A launch in a loop counts once per iteration, not once per call site, and `system.task_dummy` counts too — it lowers to `rt_submit_dummy_task`, and `ExpandManualPhaseFence` inserts them automatically. Allocations record nodes too, counted as an *upper* bound so that passing this check means the runtime will accept the Graph. Codegen collects every eligible create in a statement list — an intervening launch does not close the batch — and packs them at most `kAllocTensorsArgs` (16) to an `alloc_tensors`. Two of its three ineligibility rules cannot fire here (a shape reading a local is already rejected as non-constant; an already-declared var cannot recur under SSA), so those creates are counted exactly. The third can — an injected GM pipe buffer leaves the shared batch when its `core_num` reads a body-local, which only the emitter's use-resolution knows — so each of those is charged its worst case of one node. The batch size and the GM-pipe predicate are shared with the emitter in `utils/alloc_batching.h` rather than restated here. Counted **after** the hoisting steps, unlike every other check in this table: Step C *removes* allocation nodes, so the pre-hoist body would reject a Graph that fits and disagree with the verifier, which re-derives the same count from the rewritten IR |
 | No allocation under a runtime loop or branch | Each records a node, so a count that varies between calls is a topology that varies |
 | Allocation shapes are compile-time constants | Recording copies the shape into the node and derives the buffer address from it; a shape reading a boundary scalar is frozen at the first call's value |
 | No `tensor.full` in the region | Orchestration codegen has no lowering for it and rejects it as a misplaced tensor op |
@@ -263,9 +350,16 @@ pass had just produced.
 
 ## Not yet handled
 
-Automatically hoisting a region-local allocation to a boundary parameter — one
-is allowed in place, subject to the constant-shape rule above — and packing a
-boundary of more than 128 tensors into a scratch arena.
+Hoisting an allocation made **under a loop** — it is a fresh buffer per
+iteration, so the call site would have to allocate an array of them rather than
+one (see Step C). Hoisting one whose shape reads a boundary scalar, which Step D
+rejects rather than rebuilding at the call site. And packing a boundary of more
+than 128 tensors into a scratch arena.
+
+Neither does anything hoist a call-site allocation out of the caller's own loop:
+a create lands immediately before the launch, so each call still gets its own
+buffer. The win is that the buffer now comes off the ordinary reclaimable heap
+instead of the graph heap, which is independent of where the caller puts it.
 
 ## See also
 

--- a/docs/zh/dev/passes/26-normalize_return_order.md
+++ b/docs/zh/dev/passes/26-normalize_return_order.md
@@ -30,8 +30,10 @@ i 个 `Out`/`InOut` 参数，并相应地重映射非 InCore 调用方中的
    `permutation[old_index]`，因此调用结果上的观察者仍然把同名 SSA 变量绑
    定到同一物理输出。
 
-对于返回顺序已经与 `Out`/`InOut` 参数声明顺序匹配的函数，本 Pass 是
-**no-op**；对于不含 InCore 函数的程序也是 no-op。
+对于 tensor 返回值已经直接指名形参、且返回顺序已经与 `Out`/`InOut` 参数声
+明顺序匹配的函数，本 Pass 是 **no-op**；对于不含 `InCore`、`Group`、`Spmd`、
+`Graph` 函数的程序也是 no-op —— Step A0 覆盖这四类，所以「不含 InCore 函数」
+本身已不足以说明本 Pass 什么都不做。
 
 **流水线位置**: `Default` 策略中 #20 —— 位于 `SplitVectorKernel`（#19）之
 后、`LowerPipelineLoops`（#21）之前。这样既保证所有 kernel 拆分 / tile 结构

--- a/docs/zh/dev/passes/45-legalize_graph_boundary.md
+++ b/docs/zh/dev/passes/45-legalize_graph_boundary.md
@@ -1,8 +1,8 @@
 # LegalizeGraphBoundary Pass
 
 让每个 `FunctionType::Graph` 函数都能被 `host_build_graph` runtime 合法地录制与
-回放：把 Graph 函数体内派生出来的边界标量外提到调用点，并拒绝那些 runtime 不会
-缓存的边界形态。
+回放：把 Graph 函数体内派生出来的边界标量、取出的边界视图、以及自己分配的中间
+张量都外提到调用点，并拒绝那些 runtime 不会缓存的边界形态。
 
 ## 概述
 
@@ -10,15 +10,18 @@
 录制。回放只 patch 两样东西：边界张量的地址，以及边界标量的值。其余一切 —— 节点
 数、形状、依赖边、block 数 —— 都被烙进录制下来的 Definition。
 
-由此产生两类问题，而且在 runtime 侧都是静默的：
+由此产生四类问题，而且在 runtime 侧都是静默的：
 
 | 问题 | runtime 的行为 | 本 pass 的处理 |
 | ---- | -------------- | -------------- |
 | 边界标量在区域内被**派生**出来 | 归类为静态数据，把第一次调用的值冻进录制。永远不告警。 | **Step A** —— 把计算外提到调用点；当冻结下来的值可证明就是正确值时，原地保留 |
+| 边界张量的视图在区域**内部**取出 | 冻结第一次调用的偏移，只 patch 地址，于是后续调用读到的是第一次调用的窗口 | **Step B** —— 把视图外提到调用点；当其窗口对回放不变时，原地保留 |
+| 区域自己分配中间张量 | 能正确录制，但分配在一块运行期间从不回收的堆上，于是活跃集随提交次数增长 | **Step C** —— 把分配外提到调用点，成为 `InOut` 边界张量 |
 | 边界本身不可缓存 | 拒绝缓存，静默地按普通任务执行该区域 | **Step D** —— 编译期拒绝 |
 
-前者产生错误结果。后者结果正确但完全没有预期的加速 —— 任何数值测试都看不见，这
-正是这些检查放在这里、而不是交给一条 runtime 日志的原因。
+前两类产生错误结果。第三类结果正确，但随着层数增长会耗尽内存、或者只是变慢。最
+后一类结果正确但完全没有预期的加速 —— 任何数值测试都看不见，这正是这些检查放在
+这里、而不是交给一条 runtime 日志的原因。
 
 ## Step A —— 派生的边界标量
 
@@ -130,6 +133,21 @@ Step B 把这个切片搬出去，把结果作为一个新的边界张量传进�
 一次前向遍历就能走完整条链 —— 一个 view 只能引用在它之前定义的源。把 `wr` 留在原地是
 静默的：`graph_rebind_tensor` 会用 `wl` patch buffer 地址，但保留第一次调用时录下的偏移。
 
+**provenance 要穿过原地写回的调用。** `tmp = kernel(a, tmp)` 把同一块 buffer 重新
+绑定到一个新的 SSA 名字上，而对*那个*名字取的 view 仍然是对边界张量取的 view。若只
+跟踪 `alias = var` 这种裸别名，root 就在这里断了，Step B 会直接跳过该 view —— 既不外
+提也不检查 —— 于是一个逐次变化的偏移留在区域内，冻结的是第一次调用的窗口。这里通过
+[`ExplicitReturnedParamIndices`](26-normalize_return_order.md) 跟过去，也就是
+orchestration codegen 给调用结果做别名时用的同一张「返回位 -> 形参」表，因此
+provenance 与 codegen 不会对「这个结果指向哪块 buffer」产生分歧。这一点对边界*形参*
+和 Step C 的分配同样适用。
+
+该映射指向的实参由 `CallerSuppliedArg` 解析，它按 `ir/expr.h` 里 `Submit::args_` 契约
+划分的三个区域来取。`Submit` 合法地可以省略由 runtime 分配的 `Out` 尾巴，而它调用方
+提供的前缀仍然按位置一一对应，所以要求实参与形参数量完全相等，会让每一个这样的 launch
+都静默丢掉 provenance。落在 runtime 分配区间的形参则正确地取不到实参：那块 buffer 由
+runtime 创建，没有可继承的调用方 root。
+
 **被外提的 view 形状必须是编译期常量。** 回放直接从录制模板里抄 view 的 `shapes` 和
 `strides`，只 patch `buffer_addr` 和 `start_offset`，所以从边界标量读出来的 extent 会把
 第一次调用的形状套到后续调用的 buffer 上。回放不变的 extent 会被接受，理由和别处一样：
@@ -162,20 +180,78 @@ Step B 把这个切片搬出去，把结果作为一个新的边界张量传进�
 
 ## Step C —— 区域内的分配
 
-区域内**允许** `pl.create_tensor`，但有一条约束：它的 shape 必须是编译期常量。
+区域顶层的 `pl.create_tensor` 会被**外提到调用点**，成为 `InOut` 边界张量：
 
-codegen 会把它降级成批量 `alloc_tensors`，runtime 把这个记成一个无 kernel 的节点
-（和 `submit_dummy_task` 记录的形状相同），所以并不会毒化录制。但它会计入节点上限；
-放在运行时循环或分支里则意味着拓扑随调用变化——这两点都归 Step D 管。
+```python
+# 外提前
+@pl.jit.graph
+def layer(a: pl.Tensor, acc: pl.InOut[pl.Tensor]):
+    tmp = pl.create_tensor([ROWS, COLS], pl.FP32)   # 每次提交都分配一次
+    ...
+    return acc
 
-录制无法复现的是从边界标量读出来的 **shape**：extent 会被抄进节点、缓冲区地址由它
-推出，而回放不会重新执行函数体，所以后续调用即使 extent 更大，拿到的仍是第一次调用
-的 buffer —— 这是错误的地址布局，不是 fallback。Step D 会拒绝这种写法，也会直接拒绝
-`tensor.full`（orchestration codegen 根本没有它的降级路径）。
+# 外提后 —— buffer 归调用点所有
+def layer(a, acc, tmp: pl.InOut[pl.Tensor]): ...
+tmp__graph_arg0 = pl.tensor.create([ROWS, COLS], pl.FP32)
+acc = layer(a, acc, tmp__graph_arg0)
+```
 
-区域局部分配**不会**被自动外提成边界形参：那会新增第二个 `InOut` 形参，而返回值别名
-映射要求被调方的 `ReturnStmt` 直接指名某个形参，才能确定张量返回值别名到哪一个 ——
-合成出来的形参不满足这个不变量。要自动化，得先把那套映射改造掉。
+原地录制本身是**正确**的 —— codegen 把 create 降级成批量 `alloc_tensors`，runtime
+把它记成一个无 kernel 的节点（和 `submit_dummy_task` 记录的形状相同）—— 但 buffer
+来自 **graph 堆**，而 `task_allocator.h` 在整轮运行结束前从不回收它（"The whole
+graph must fit at once; nothing is reclaimed mid-run"）。于是活跃集随提交次数增长
+而不是保持恒定：一个持有 14 个中间张量的 decoder layer，录制 N 层就要占 14 × N 份。
+外提之后 buffer 回到普通的可回收堆上，区域内也不再有任何分配节点。
+
+simpler 手写的 `examples/a2a3/host_build_graph/qwen3_14b_decode` 场景就是手工这么
+做的，理由也写在它的 README 里 —— "This keeps the temporary live set flat in layer
+count and fits the default ring configuration."
+
+形参是 `InOut`，绝不能是 `In`：区域会**写**这块 buffer；声明成 `In` 时 codegen 发射
+`add_input`，这次 launch 永远不会被登记为该 buffer 的写者，调用方若把分配提出自己的
+循环，前后两次 launch 之间就没有任何定序。`Out` 也不可用 —— 在 Graph 边界上它表示
+"由 runtime 分配"，而 `rt_graph_args_cacheable` 会直接拒绝。
+
+被外提的分配**就是**边界张量，所以对它取的视图同样要走上面 Step B 的规则，而不是原
+地放过。这不是可选的整理：`GraphBoundaryLegalized` verifier 把每个张量形参都当作
+boundary root，因此一个窗口可变、却被留在原地的视图，会让本 pass 产出连自己的
+verifier 都拒绝的 IR。
+
+有两类分配是刻意留在原地的：
+
+| 留在原地 | 原因 |
+| -------- | ---- |
+| `tensor.full` | orchestration codegen 在调用点同样没有它的降级路径，外提只是把失败挪个地方。Step D 直接拒绝它 |
+| 循环内的 create | 它是**每次迭代一份**的新 buffer。把 N 份塌缩成一个形参会让各迭代互相别名，而本该重新串行化它们的跨任务依赖边，是更早的 [`AutoDeriveTaskDependencies`](39-auto_derive_task_dependencies.md) 推导出来的 |
+
+无论外提与否，录制都无法复现从边界标量读出来的 **shape**：extent 会被抄进节点、缓冲
+区地址由它推出，而回放不会重新执行函数体，所以后续调用即使 extent 更大，拿到的仍是
+第一次调用的 buffer —— 这是错误的地址布局，不是 fallback。Step D 在 Step C 之前就拒
+绝这种写法，因此 Step C 外提的每个分配的 shape 都是编译期常量。
+
+### 前置条件：Graph 的返回值必须直接指名形参
+
+Step B 和 Step C 都会**追加** `InOut` 形参，而这正是自动化这次外提为什么是一次改造、
+而不是接根线的原因。orchestration codegen 通过
+`return_lineage::ExplicitReturnedParamIndices`（对被调方 `ReturnStmt` 的指针同一性读
+取）把调用结果映射到被调方的某个 `Out`/`InOut` 形参上，只有当该映射给不出结果时，才
+退回到"被调方唯一的那个 `Out`/`InOut` 形参"：
+
+```cpp
+// GenerateSingleReturnAlias, orchestration_codegen.cpp
+INTERNAL_CHECK_SPAN(returned_idx.has_value() || out_indices.size() == 1, call->span_)
+```
+
+`OutlineIncoreScopes` 跑完之后，Graph 函数体是 `c_1 = layer_incore_0(a, c); return
+c_1` —— 返回的是重绑定而不是形参本身，所以 Graph 一直依赖那条退路；而第二个 `InOut`
+形参一出现，这条退路就不存在了。
+
+外提所需要的东西由 [`NormalizeReturnOrder`](26-normalize_return_order.md) 提供：它会
+像处理 kernel 与 wrapper 那样规范化 Graph 的张量返回值（**只**规范化，不重排 Graph 的
+返回顺序），并且 `IRProperty::ReturnParamsExplicit` 覆盖了 `Graph`，使得从那里到这里的
+十九个 pass 无法悄悄破坏它。这部分是在 #2618 中单独落地的。本步骤是**依赖**它而不是
+提供它 —— 这也是单元测试里 `_legalize_outlined` 要跑 `NormalizeReturnOrder` 的原因：
+不跑的话那张表全是 nullopt，外提会静默地什么都不做。
 
 ## Step D —— 边界合法性
 
@@ -188,7 +264,7 @@ codegen 会把它降级成批量 `alloc_tensors`，runtime 把这个记成一个
 | 不允许 `Out` 张量形参 | `Out` 意味着 runtime 分配该 buffer；被录制的 graph 其边界张量必须已存在，回放才能 patch 地址 |
 | 标量形参必须是 `In` | 边界标量按值传入、由调用点回放 |
 | 只能返回自己的形参 | `rt_submit_graph` 只在缓存**命中**时才返回有效 task id，所以任何东西都不能依赖 graph 调用的结果。`return c`（`c` 为 `InOut` 形参）是原地写的写法，可以；返回计算出的新值不行 |
-| 被拉起的任务数在 1..1024 之间 | `graph_execution_storage_layout` 既拒绝 0 个节点，也拒绝超过 `GRAPH_MAX_NODES` 的。循环内的 launch 按迭代次数计入而非按词法调用点计 1；`system.task_dummy` 也计入——它 lower 成 `rt_submit_dummy_task`，且 `ExpandManualPhaseFence` 会自动插入。分配同样会记节点，按**上界**计——通过这项检查即意味着 runtime 会接受该 Graph。codegen 会收集一个语句列表里所有符合条件的 create（中间夹着 launch 不会打断批次），再按每次 `alloc_tensors` 最多 `kAllocTensorsArgs`（16）个打包。它的三条不合格规则里有两条在这里不可能触发（shape 读局部变量已被按非常量拒绝；SSA 下不可能出现已声明的 var），这些 create 是**精确**计数的。第三条可能触发——被注入的 GM pipe buffer 在其 `core_num` 读到 body-local 时会离开共享批次，而这只有 emitter 的 use-resolution 才知道——所以这类按最坏情况各计 1 个节点。批量大小和 GM-pipe 判定与 emitter 共用 `utils/alloc_batching.h`，而非各自重述 |
+| 被拉起的任务数在 1..1024 之间 | `graph_execution_storage_layout` 既拒绝 0 个节点，也拒绝超过 `GRAPH_MAX_NODES` 的。循环内的 launch 按迭代次数计入而非按词法调用点计 1；`system.task_dummy` 也计入——它 lower 成 `rt_submit_dummy_task`，且 `ExpandManualPhaseFence` 会自动插入。分配同样会记节点，按**上界**计——通过这项检查即意味着 runtime 会接受该 Graph。codegen 会收集一个语句列表里所有符合条件的 create（中间夹着 launch 不会打断批次），再按每次 `alloc_tensors` 最多 `kAllocTensorsArgs`（16）个打包。它的三条不合格规则里有两条在这里不可能触发（shape 读局部变量已被按非常量拒绝；SSA 下不可能出现已声明的 var），这些 create 是**精确**计数的。第三条可能触发——被注入的 GM pipe buffer 在其 `core_num` 读到 body-local 时会离开共享批次，而这只有 emitter 的 use-resolution 才知道——所以这类按最坏情况各计 1 个节点。批量大小和 GM-pipe 判定与 emitter 共用 `utils/alloc_batching.h`，而非各自重述。与本表其他检查不同，这一项在外提步骤**之后**才计数：Step C 会*移除*分配节点，按外提前的函数体计会拒掉本来放得下的 Graph，也会与 verifier 不一致——后者是从改写后的 IR 重新推导同一个计数的 |
 | 运行时循环 / 分支内不得有分配 | 每次分配都记一个节点，所以数量随调用变化就是拓扑随调用变化 |
 | 分配的 shape 必须是编译期常量 | 录制会把 shape 抄进节点并据此推出缓冲区地址；读取边界标量的 shape 会被冻结在首次调用的值上 |
 | 区域内不得有 `tensor.full` | orchestration codegen 没有它的 lowering，会按 misplaced tensor op 拒绝 |
@@ -224,8 +300,13 @@ verifier 拒绝本 pass 刚刚产出的 IR。
 
 ## 尚未处理
 
-把区域内的局部分配自动外提为边界形参——分配本身是允许的，受上面的常量 shape
-规则约束——以及把超过 128 个张量的边界自动打包进 scratch arena。
+外提**循环内**的分配 —— 它是每次迭代一份的新 buffer，调用点得分配一组而不是一个
+（见 Step C）。外提 shape 读自边界标量的分配 —— Step D 直接拒绝，而不是在调用点重
+建它。以及把超过 128 个张量的边界自动打包进 scratch arena。
+
+也没有任何东西会把调用点的分配提出调用方自己的循环：create 落在 launch 的紧前面，
+所以每次调用仍然拿到自己的 buffer。收益在于这块 buffer 现在来自普通的可回收堆而不
+是 graph 堆，这与调用方把它放在哪里无关。
 
 ## 另见
 

--- a/include/pypto/ir/transforms/utils/transform_utils.h
+++ b/include/pypto/ir/transforms/utils/transform_utils.h
@@ -24,11 +24,13 @@
 #include <vector>
 
 #include "pypto/ir/expr.h"
+#include "pypto/ir/function.h"
 #include "pypto/ir/kind_traits.h"
 #include "pypto/ir/op_registry.h"
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/stmt.h"
 #include "pypto/ir/transforms/utils/attrs.h"
+#include "pypto/ir/type.h"
 
 namespace pypto::ir::transform_utils {
 
@@ -170,6 +172,43 @@ inline CallPtr AsCallOrSubmitView(const ExprPtr& expr) {
   if (auto call = As<Call>(expr)) return call;
   if (auto submit = As<Submit>(expr)) return SubmitToCallView(submit);
   return nullptr;
+}
+
+/// Number of trailing ``CommCtxType`` parameters on @p callee.
+///
+/// ``MaterializeDistTensorCtx`` appends these, and they are what makes a
+/// ``Submit``'s argument mapping stop being positional identity. See the
+/// ``Submit::args_`` comment in ``ir/expr.h`` for the full contract.
+[[nodiscard]] inline size_t TrailingCommCtxParamCount(const FunctionPtr& callee) {
+  size_t count = 0;
+  while (count < callee->params_.size() &&
+         IsA<CommCtxType>(callee->params_[callee->params_.size() - 1 - count]->GetType())) {
+    ++count;
+  }
+  return count;
+}
+
+/// The argument @p call passes for callee parameter @p param_index, or null.
+///
+/// Resolves region 1 of the ``Submit::args_`` mapping documented on
+/// ``ir/expr.h`` — the caller-supplied prefix, where ``args_[i]`` binds
+/// ``params_[i]`` by identity. Null means the parameter has no caller argument:
+/// either it sits in the runtime-allocated gap a ``Submit`` may leave (so the
+/// value is created by the runtime and has no caller-side provenance), or it is
+/// part of the ``CommCtx`` suffix.
+///
+/// Requiring full arity instead would be wrong, not merely conservative: a
+/// ``Submit`` that omits a runtime-allocated ``Out`` tail is ordinary DSL, and
+/// its caller-supplied prefix still maps positionally. Orchestration codegen
+/// splits the same three regions in ``GenerateSubmitReturnAliases``.
+[[nodiscard]] inline ExprPtr CallerSuppliedArg(const CallPtr& call, const FunctionPtr& callee,
+                                               size_t param_index) {
+  if (!call || !callee) return nullptr;
+  const size_t ctx = TrailingCommCtxParamCount(callee);
+  if (call->args_.size() < ctx || call->args_.size() > callee->params_.size()) return nullptr;
+  const size_t caller_supplied = call->args_.size() - ctx;
+  if (param_index >= caller_supplied) return nullptr;
+  return call->args_[param_index];
 }
 
 /// Constant-evaluate @p expr if it is a ``ConstInt``, or a ``Neg`` of one;

--- a/src/ir/transforms/legalize_graph_boundary_pass.cpp
+++ b/src/ir/transforms/legalize_graph_boundary_pass.cpp
@@ -15,8 +15,8 @@
  *
  * The host_build_graph runtime records a Graph function's task topology on the
  * first call and replays it afterwards, patching only buffer addresses and
- * boundary scalars. Two classes of problem follow from that, and this pass
- * exists to catch both at compile time:
+ * boundary scalars. Three classes of problem follow from that, and this pass
+ * exists to catch all three at compile time:
  *
  * **Step A — derived boundary scalars (silent wrong answers).** A boundary
  * scalar is tracked by *pointer identity*: the runtime anchors the address of
@@ -32,6 +32,15 @@
  * tensor's own extent — is left where it is and accepted, because the frozen
  * copy is the correct one. `graph_replay::ReplayInvariantSet` draws that line;
  * the class comment there explains why it is strictly weaker than hoistability.
+ *
+ * **Step C — region allocations (unbounded memory).** A `tensor.create` inside
+ * the region records a kernel-less `alloc_tensors` node, so it replays
+ * correctly — but the buffer comes off the graph heap, which `task_allocator.h`
+ * never reclaims mid-run. The live set then grows with the number of
+ * submissions rather than staying flat: a decoder layer holding 14 intermediates
+ * costs 14 x N over N recorded layers. Step C moves each one to the call site as
+ * an `InOut` boundary tensor, which is what simpler's hand-written
+ * `qwen3_14b_decode` scene does by hand and for the same stated reason.
  *
  * **Step D — boundary legality (silent fallback).** Almost every other runtime
  * constraint degrades to a silent non-graph fallback in a release build: the
@@ -73,6 +82,7 @@
 #include "pypto/ir/transforms/utils/alloc_batching.h"
 #include "pypto/ir/transforms/utils/graph_replay_invariant.h"
 #include "pypto/ir/transforms/utils/return_lineage_utils.h"
+#include "pypto/ir/transforms/utils/transform_utils.h"
 #include "pypto/ir/type.h"
 
 namespace pypto {
@@ -149,7 +159,8 @@ struct GraphPlan {
 /// or a tensor read is not, and is reported rather than silently frozen.
 class DerivedScalarCollector : public IRVisitor {
  public:
-  explicit DerivedScalarCollector(const FunctionPtr& func) : func_(func), invariant_(func) {
+  DerivedScalarCollector(const FunctionPtr& func, ProgramPtr program)
+      : func_(func), program_(std::move(program)), invariant_(func) {
     for (const auto& param : func->params_) {
       if (IsScalarType(param->GetType())) {
         scalar_params_.insert(param.get());
@@ -188,7 +199,18 @@ class DerivedScalarCollector : public IRVisitor {
   [[nodiscard]] const std::unordered_map<const Var*, const Var*>& tensor_root() const { return tensor_root_; }
 
   /// Step C: tensors the region allocates for itself, in definition order.
+  ///
+  /// Only the ones the call site can take over: a `tensor.create` at the top
+  /// level of the body. See `VisitStmt_(AssignStmtPtr)` for what is left behind
+  /// and why.
   [[nodiscard]] const std::vector<std::pair<VarPtr, ExprPtr>>& creates() const { return creates_; }
+
+  /// The vars in `creates()`, for direction lookup.
+  ///
+  /// A hoisted allocation is `InOut`, and so is any view of it — but it is not a
+  /// parameter of the *original* signature, so `BuildPlan`'s parameter-direction
+  /// map cannot answer for it.
+  [[nodiscard]] const std::unordered_set<const Var*>& created_vars() const { return created_vars_; }
 
   /// Scalar `alias = <name>` bindings, alias -> the name it copies.
   ///
@@ -253,14 +275,74 @@ class DerivedScalarCollector : public IRVisitor {
       return;
     }
 
+    // A tuple result, remembered so the `TupleGetItemExpr` that unpacks it can
+    // resolve element `i` back to the argument the callee writes through.
+    // `pl.submit` / `pl.spmd_submit` bind their results this way.
+    if (auto call_like = transform_utils::AsCallOrSubmitView(op->value_)) {
+      if (As<TupleType>(op->value_->GetType()) != nullptr) {
+        tuple_result_[var.get()] = call_like;
+        return;
+      }
+    }
+
+    if (auto element = As<TupleGetItemExpr>(op->value_)) {
+      auto tuple_var = AsVarLike(element->tuple_);
+      auto it = tuple_var ? tuple_result_.find(tuple_var.get()) : tuple_result_.end();
+      if (it != tuple_result_.end() && element->index_ >= 0) {
+        PropagateRootThroughCallResult(var, it->second, static_cast<size_t>(element->index_));
+      }
+      return;
+    }
+
     auto call = As<Call>(op->value_);
     if (!call) return;
 
-    // Step C: an allocation inside the region. Codegen lowers `tensor.create`
-    // into a batched `alloc_tensors`, and a bare `alloc_tensors` anywhere in a
-    // recorded region poisons the recording outright.
+    // Step C: an allocation inside the region, hoisted to the call site.
+    //
+    // Codegen lowers `tensor.create` into a batched `alloc_tensors`, which the
+    // runtime records as a kernel-less node — so it does not poison the
+    // recording, but the buffer comes off the *graph* heap, and
+    // `task_allocator.h` reclaims nothing there until the run ends. A region
+    // that allocates for itself therefore holds one buffer per submission
+    // instead of one per program: a decoder layer with 14 intermediates recorded
+    // over N layers holds 14 x N. Hoisting the create to the call site moves it
+    // back onto the ordinary reclaimable heap and empties the region of
+    // allocation nodes.
+    //
+    // Two allocations are deliberately left where they are:
+    //
+    // * `tensor.full` — orchestration codegen has no lowering for it at the call
+    //   site either, so hoisting would only move the failure.
+    //   `RegionAllocationChecker` has already rejected it before `BuildPlan`
+    //   runs, which is why this branch never reaches a live one.
+    // * one under a loop — it is a *fresh* buffer per iteration. Collapsing N
+    //   buffers into one parameter would make iterations alias, and the
+    //   cross-task edges that would have to re-serialise them were derived by
+    //   `AutoDeriveTaskDependencies`, well upstream of here.
     if (IsOp(call, "tensor.create") || IsOp(call, "tensor.full")) {
-      creates_.emplace_back(var, op->value_);
+      if (loop_depth_ == 0 && IsOp(call, "tensor.create")) {
+        // Its own boundary root: once hoisted it *is* a boundary tensor, so a
+        // view of it has to face the same Step B rule as a view of any other —
+        // the verifier holds every tensor parameter to it, and one left in place
+        // with a moving window would make this pass produce IR its own property
+        // verifier rejects.
+        tensor_root_[var.get()] = var.get();
+        created_vars_.insert(var.get());
+        definition_index_[var.get()] = next_definition_++;
+        creates_.emplace_back(var, op->value_);
+      }
+      return;
+    }
+
+    // An in-place call rebinds the buffer to a fresh SSA name — `tmp =
+    // kernel(a, tmp)` — and the result still *is* the boundary tensor the
+    // callee wrote through. Provenance has to follow, or `RootBoundaryTensor`
+    // answers null for the new name, Step B skips a view of it outright, and a
+    // call-varying offset stays in the region with its first call's window
+    // frozen. That is the exact failure Step B exists to prevent, reached by a
+    // name it could not see through.
+    if (As<GlobalVar>(call->op_) != nullptr) {
+      PropagateRootThroughCallResult(var, call, /*return_position=*/0);
       return;
     }
 
@@ -345,10 +427,86 @@ class DerivedScalarCollector : public IRVisitor {
     slices_.emplace_back(var, op->value_);
   }
 
+  // Step C hoists only what the call site can bind once per launch, so it needs
+  // to know whether the statement it is looking at runs once. Tracked over both
+  // loop kinds rather than `ForStmt` alone: a `while` around an allocation is
+  // rejected further on, and depending on that rejection to keep this collector
+  // correct would couple two checks that read independently today.
+  void VisitStmt_(const ForStmtPtr& op) override {
+    ++loop_depth_;
+    IRVisitor::VisitStmt_(op);
+    --loop_depth_;
+  }
+
+  void VisitStmt_(const WhileStmtPtr& op) override {
+    ++loop_depth_;
+    IRVisitor::VisitStmt_(op);
+    --loop_depth_;
+  }
+
  private:
+  /// Carry boundary provenance across a call that writes through an argument.
+  ///
+  /// @p return_position selects which returned value @p var binds — 0 for a
+  /// single result, the `TupleGetItemExpr` index for an unpacked one.
+  ///
+  /// The return-position -> parameter map is the one orchestration codegen
+  /// aliases on (`ExplicitReturnedParamIndices`, a pointer-identity read of the
+  /// callee's `ReturnStmt` that `NormalizeReturnOrder` establishes), so
+  /// provenance follows exactly the edge the emitted C++ follows. Deriving it
+  /// some other way here would let the two disagree about which buffer a result
+  /// names.
+  void PropagateRootThroughCallResult(const VarPtr& var, const CallPtr& call, size_t return_position) {
+    auto gvar = As<GlobalVar>(call->op_);
+    if (!gvar || !program_) return;
+    auto callee = program_->GetFunction(gvar->name_);
+    if (!callee) return;
+
+    const auto& ret_map = ReturnedParamsFor(gvar->name_, callee);
+    if (return_position >= ret_map.size()) return;
+    // Bound to a name before the guard: the optional-access analysis does not
+    // track a value through a subscript, so testing `ret_map[i].has_value()`
+    // and then dereferencing `ret_map[i]` reads to it as an unchecked access.
+    const auto& returned_param = ret_map[return_position];
+    if (!returned_param.has_value()) return;
+
+    // Not an arity check. A `Submit` legally omits a runtime-allocated `Out`
+    // tail, and its caller-supplied prefix still maps positionally; demanding
+    // full arity would drop provenance for every one of those and leave the
+    // silent-window bug this guard exists to close. Null here means the
+    // parameter genuinely has no caller argument — the runtime creates it, so
+    // there is no boundary root to inherit.
+    auto source = AsVarLike(transform_utils::CallerSuppliedArg(call, callee, *returned_param));
+    const Var* root = source ? RootBoundaryTensor(source) : nullptr;
+    if (root == nullptr) return;
+
+    tensor_root_[var.get()] = root;
+    // Whatever the argument could not offer, the rebind cannot either.
+    if (in_place_views_.count(source.get()) != 0) in_place_views_.insert(var.get());
+    // Bound like a bare alias: the rebound name denotes the same buffer as the
+    // argument, so a hoisted view written in terms of it resolves at the call
+    // site to whatever the caller passed. Without this the call site would keep
+    // a name only the region has, and the printer would mark it `__FREE_VAR`.
+    definition_index_[var.get()] = next_definition_++;
+    passthrough_order_.emplace_back(var.get(), source);
+  }
+
+  /// `ExplicitReturnedParamIndices(callee)`, memoized by callee name.
+  ///
+  /// The collector visits each statement once, so an un-memoized lookup would
+  /// re-read a callee's `ReturnStmt` per call site and make the walk quadratic
+  /// in a body that launches the same kernel repeatedly.
+  [[nodiscard]] const std::vector<std::optional<size_t>>& ReturnedParamsFor(const std::string& name,
+                                                                            const FunctionPtr& callee) {
+    auto it = returned_params_.find(name);
+    if (it != returned_params_.end()) return it->second;
+    return returned_params_.emplace(name, return_lineage::ExplicitReturnedParamIndices(callee)).first->second;
+  }
+
   /// The boundary tensor parameter @p var derives from, or null.
   ///
-  /// A parameter is its own root; an alias or a collected view inherits one.
+  /// A parameter is its own root; an alias, a rebind or a collected view
+  /// inherits one.
   [[nodiscard]] const Var* RootBoundaryTensor(const VarPtr& var) const {
     if (!var) return nullptr;
     if (tensor_params_.count(var.get()) != 0) return var.get();
@@ -399,7 +557,13 @@ class DerivedScalarCollector : public IRVisitor {
   }
 
   FunctionPtr func_;
+  ProgramPtr program_;
   graph_replay::ReplayInvariantSet invariant_;
+  /// Tuple-valued call/submit results, so `TupleGetItemExpr` can resolve back
+  /// to the callee argument each element writes through.
+  std::unordered_map<const Var*, CallPtr> tuple_result_;
+  /// `ExplicitReturnedParamIndices` per callee name; see `ReturnedParamsFor`.
+  std::unordered_map<std::string, std::vector<std::optional<size_t>>> returned_params_;
   std::unordered_set<const Var*> scalar_params_;
   std::unordered_set<const Var*> tensor_params_;
   std::unordered_set<const Var*> derived_vars_;
@@ -416,9 +580,16 @@ class DerivedScalarCollector : public IRVisitor {
   /// these can be hoisted: the call site has no name for any of them.
   std::unordered_set<const Var*> in_place_views_;
   /// Body tensor var -> the boundary parameter it derives from (alias or view).
+  ///
+  /// A hoisted region allocation is its own root: it becomes a boundary tensor.
   std::unordered_map<const Var*, const Var*> tensor_root_;
   std::vector<std::pair<VarPtr, ExprPtr>> slices_;
   std::vector<std::pair<VarPtr, ExprPtr>> creates_;
+  /// The vars in `creates_`, for the direction lookup `BuildPlan` cannot make
+  /// from the original signature.
+  std::unordered_set<const Var*> created_vars_;
+  /// How many loops enclose the statement being visited.
+  size_t loop_depth_ = 0;
 };
 
 /// True when @p expr is built only from literals.
@@ -1138,12 +1309,12 @@ class GraphCallSiteChecker : public IRVisitor {
 ///
 /// Tensors are appended before scalars so the resulting signature keeps
 /// `CoreTaskArgs`' tensor-before-scalar ordering, which the runtime enforces.
-[[nodiscard]] GraphPlan BuildPlan(const FunctionPtr& func) {
+[[nodiscard]] GraphPlan BuildPlan(const FunctionPtr& func, const ProgramPtr& program) {
   GraphPlan plan;
   plan.name = func->name_;
   if (!func->body_) return plan;
 
-  DerivedScalarCollector collector(func);
+  DerivedScalarCollector collector(func, program);
   collector.VisitStmt(func->body_);
 
   auto add = [&plan](const VarPtr& var, const ExprPtr& value, ParamDirection dir, bool is_tensor) {
@@ -1160,17 +1331,42 @@ class GraphCallSiteChecker : public IRVisitor {
   // carry wider access than the tensor it views, so the root's own direction is
   // both sufficient and never an under-declaration.
   const auto& roots = collector.tensor_root();
+  const auto& created = collector.created_vars();
   std::unordered_map<const Var*, ParamDirection> param_direction;
   for (size_t i = 0; i < func->params_.size(); ++i) {
     param_direction[func->params_[i].get()] =
         i < func->param_directions_.size() ? func->param_directions_[i] : ParamDirection::In;
   }
+  // Step C: a region allocation becomes an `InOut` boundary tensor.
+  //
+  // `Out` is what it would be by dataflow — nothing reads it before the region
+  // writes it — but `Out` on a Graph boundary means "the runtime allocates
+  // this", which `rt_graph_args_cacheable` refuses outright. `InOut` is the
+  // spelling for a buffer the caller owns and the region writes, and it is what
+  // `CheckGraphSignature` accepts. `In` would under-declare: codegen would emit
+  // `add_input`, the launch would never register as a writer, and a caller that
+  // hoisted the create out of its own loop would get no ordering between
+  // successive launches over the same buffer.
+  //
+  // Ahead of Step B so that a view of a hoisted allocation is appended after the
+  // allocation it views. Parameter order is otherwise free — the call site binds
+  // in definition order, not parameter order — but keeping the two consistent
+  // makes a printed signature readable.
+  for (const auto& [var, value] : collector.creates()) {
+    add(var, value, ParamDirection::InOut, /*is_tensor=*/true);
+  }
   for (const auto& [var, value] : collector.slices()) {
     ParamDirection dir = ParamDirection::In;
     auto root = roots.find(var.get());
     if (root != roots.end()) {
-      auto it = param_direction.find(root->second);
-      if (it != param_direction.end()) dir = it->second;
+      // A view rooted at a hoisted allocation, whose direction is not in the
+      // original signature to look up. It is `InOut` for the same reason the
+      // allocation is: the region writes through it.
+      if (created.count(root->second) != 0) {
+        dir = ParamDirection::InOut;
+      } else if (auto it = param_direction.find(root->second); it != param_direction.end()) {
+        dir = it->second;
+      }
     }
     add(var, value, dir, /*is_tensor=*/true);
   }
@@ -1424,24 +1620,13 @@ class CallSiteExtender : public IRMutator {
     nested.VisitStmt(func->body_);
 
     CheckGraphReturns(func, program);
-
-    GraphNodeCounter counter(func, program);
-    counter.VisitStmt(func->body_);
-    CHECK_SPAN(counter.count() >= 1, func->span_)
-        << "Graph function '" << func->name_
-        << "' launches no tasks. `graph_execution_storage_layout` refuses a node count of zero, so "
-           "the region would never be cached; call it directly instead of marking it a Graph.";
-    CHECK_SPAN(counter.count() <= kMaxGraphNodes, func->span_)
-        << "Graph function '" << func->name_ << "' launches " << counter.count()
-        << " tasks, over the runtime's per-graph limit of " << kMaxGraphNodes
-        << ". Split the region into several graphs.";
   }
 
   // Step A: plan, then rewrite bodies and call sites together.
   std::unordered_map<std::string, GraphPlan> plans;
   for (const auto& [gvar, func] : program->functions_) {
     if (!func || func->func_type_ != FunctionType::Graph) continue;
-    auto plan = BuildPlan(func);
+    auto plan = BuildPlan(func, program);
     // An alias-only plan still has work to do: the body rewrite deletes the
     // scalar copies even when nothing is hoisted. Its call sites are rebuilt
     // with an unchanged argument list, which is a no-op by construction.
@@ -1484,6 +1669,24 @@ class CallSiteExtender : public IRMutator {
       // argument.
       LaunchSpecChecker launch_spec(func, result);
       launch_spec.VisitStmt(func->body_);
+
+      // Counted here rather than in part 1 because Step C *removes* nodes: every
+      // region allocation it hoists is an `alloc_tensors` operand the emitted
+      // region no longer carries. Counting the pre-hoist body would reject a
+      // Graph that fits — and disagree with `GraphBoundaryLegalized`, which
+      // re-derives the same count from this rewritten IR. The message still
+      // names the user's own function: `ExtendGraphSignature` carries `name_`
+      // and `span_` through unchanged.
+      GraphNodeCounter counter(func, result);
+      counter.VisitStmt(func->body_);
+      CHECK_SPAN(counter.count() >= 1, func->span_)
+          << "Graph function '" << func->name_
+          << "' launches no tasks. `graph_execution_storage_layout` refuses a node count of zero, so "
+             "the region would never be cached; call it directly instead of marking it a Graph.";
+      CHECK_SPAN(counter.count() <= kMaxGraphNodes, func->span_)
+          << "Graph function '" << func->name_ << "' launches " << counter.count()
+          << " tasks, over the runtime's per-graph limit of " << kMaxGraphNodes
+          << ". Split the region into several graphs.";
       continue;
     }
     GraphCallSiteChecker call_checker(func, result);

--- a/src/ir/verifier/verify_graph_functions.cpp
+++ b/src/ir/verifier/verify_graph_functions.cpp
@@ -32,6 +32,7 @@
 #include <optional>
 #include <sstream>
 #include <string>
+#include <unordered_map>
 #include <unordered_set>
 #include <utility>
 #include <vector>
@@ -49,6 +50,7 @@
 #include "pypto/ir/transforms/utils/alloc_batching.h"
 #include "pypto/ir/transforms/utils/graph_replay_invariant.h"
 #include "pypto/ir/transforms/utils/return_lineage_utils.h"
+#include "pypto/ir/transforms/utils/transform_utils.h"
 #include "pypto/ir/type.h"
 #include "pypto/ir/verifier/verifier.h"
 
@@ -386,12 +388,59 @@ class GraphBodyChecker : public IRVisitor {
 
   /// An allocation outside any statement list — a loop body that is a single
   /// assign, say — is a batch of one.
-  /// Boundary provenance: a parameter is its own root, an alias inherits one.
+  /// Boundary provenance: a parameter is its own root, an alias inherits one,
+  /// and so does the result of a call that writes through a boundary argument.
+  ///
+  /// The call case is not decoration. `tmp = kernel(a, tmp)` rebinds the buffer
+  /// to a fresh SSA name, and a view of *that* name is still a view of a
+  /// boundary tensor. Tracking only bare aliases would let it slip past
+  /// `CheckBoundaryView` with a window that can move between calls — the very
+  /// thing this verifier exists to catch, reached by a name it could not see
+  /// through.
   void TrackTensorAlias(const AssignStmtPtr& op) {
     auto var = AsVarLike(op->var_);
     if (!var || As<ScalarType>(var->GetType()) != nullptr) return;
     auto aliased = AsVarLike(op->value_);
-    if (aliased && tensor_root_.count(aliased.get()) != 0) tensor_root_.insert(var.get());
+    if (aliased && tensor_root_.count(aliased.get()) != 0) {
+      tensor_root_.insert(var.get());
+      return;
+    }
+    if (auto element = As<TupleGetItemExpr>(op->value_)) {
+      auto tuple_var = AsVarLike(element->tuple_);
+      auto it = tuple_var ? tuple_result_.find(tuple_var.get()) : tuple_result_.end();
+      if (it != tuple_result_.end() && element->index_ >= 0) {
+        TrackWriteback(var, it->second, static_cast<size_t>(element->index_));
+      }
+      return;
+    }
+    auto call = transform_utils::AsCallOrSubmitView(op->value_);
+    if (!call) return;
+    if (As<TupleType>(op->value_->GetType()) != nullptr) {
+      tuple_result_[var.get()] = call;
+      return;
+    }
+    TrackWriteback(var, call, /*return_position=*/0);
+  }
+
+  /// Insert @p var as a boundary root when @p call writes it through one.
+  ///
+  /// Re-derived from `ExplicitReturnedParamIndices` rather than shared with the
+  /// pass, like every other rule here: the point is to disagree if a later
+  /// rewrite reintroduces a state the pass ruled out.
+  void TrackWriteback(const VarPtr& var, const CallPtr& call, size_t return_position) {
+    auto gvar = As<GlobalVar>(call->op_);
+    if (!gvar || !program_) return;
+    auto callee = program_->GetFunction(gvar->name_);
+    if (!callee) return;
+    const auto ret_map = return_lineage::ExplicitReturnedParamIndices(callee);
+    if (return_position >= ret_map.size()) return;
+    // Named before the guard; see the matching comment in `LegalizeGraphBoundary`.
+    const auto& returned_param = ret_map[return_position];
+    if (!returned_param.has_value()) return;
+    // The caller-supplied prefix of a `Submit` maps positionally even when it
+    // omits a runtime-allocated `Out` tail; see `Submit::args_` in ir/expr.h.
+    auto source = AsVarLike(transform_utils::CallerSuppliedArg(call, callee, *returned_param));
+    if (source && tensor_root_.count(source.get()) != 0) tensor_root_.insert(var.get());
   }
 
   void VisitStmt_(const AssignStmtPtr& op) override {
@@ -598,6 +647,9 @@ class GraphBodyChecker : public IRVisitor {
   std::unordered_set<const Var*> tensor_params_;
   /// Tensor vars that derive from a boundary parameter, directly or by alias.
   std::unordered_set<const Var*> tensor_root_;
+  /// Tuple-valued call/submit results, so `TupleGetItemExpr` can resolve back
+  /// to the callee argument each element writes through.
+  std::unordered_map<const Var*, CallPtr> tuple_result_;
   size_t count_ = 0;
   std::unordered_set<const Stmt*> batched_;
 };

--- a/tests/ut/codegen/test_orchestration_codegen_graph.py
+++ b/tests/ut/codegen/test_orchestration_codegen_graph.py
@@ -377,6 +377,11 @@ class _BatchedAllocs:
     The interleaving is the point: a launch between two creates does not close
     the batch, so codegen packs all 20 into ``ceil(20 / 16) = 2``
     ``alloc_tensors`` calls -- two recorded nodes, not twenty.
+
+    Under a constant-trip loop so the allocations stay in the region: Step C of
+    ``LegalizeGraphBoundary`` hoists a *top-level* region allocation out to the
+    call site, which is what ``_RegionAllocs`` below covers. The loop body is
+    still one statement list, which is what the batching rule is about.
     """
 
     @pl.function(type=pl.FunctionType.AIV)
@@ -395,47 +400,87 @@ class _BatchedAllocs:
     ) -> pl.Tensor[[128, 128], pl.FP32]:
         # Chained so every buffer stays live: an unused create would be folded
         # away and the batch would never reach the packing boundary.
+        for _ in pl.range(2):
+            s0: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], pl.FP32)
+            s0 = self.kernel(a, s0)
+            s1: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], pl.FP32)
+            s1 = self.kernel(s0, s1)
+            s2: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], pl.FP32)
+            s2 = self.kernel(s1, s2)
+            s3: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], pl.FP32)
+            s3 = self.kernel(s2, s3)
+            s4: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], pl.FP32)
+            s4 = self.kernel(s3, s4)
+            s5: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], pl.FP32)
+            s5 = self.kernel(s4, s5)
+            s6: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], pl.FP32)
+            s6 = self.kernel(s5, s6)
+            s7: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], pl.FP32)
+            s7 = self.kernel(s6, s7)
+            s8: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], pl.FP32)
+            s8 = self.kernel(s7, s8)
+            s9: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], pl.FP32)
+            s9 = self.kernel(s8, s9)
+            s10: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], pl.FP32)
+            s10 = self.kernel(s9, s10)
+            s11: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], pl.FP32)
+            s11 = self.kernel(s10, s11)
+            s12: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], pl.FP32)
+            s12 = self.kernel(s11, s12)
+            s13: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], pl.FP32)
+            s13 = self.kernel(s12, s13)
+            s14: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], pl.FP32)
+            s14 = self.kernel(s13, s14)
+            s15: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], pl.FP32)
+            s15 = self.kernel(s14, s15)
+            s16: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], pl.FP32)
+            s16 = self.kernel(s15, s16)
+            s17: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], pl.FP32)
+            s17 = self.kernel(s16, s17)
+            s18: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], pl.FP32)
+            s18 = self.kernel(s17, s18)
+            s19: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], pl.FP32)
+            s19 = self.kernel(s18, s19)
+            c = self.kernel(s19, c)
+        return c
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def main(
+        self,
+        a: pl.Tensor[[128, 128], pl.FP32],
+        c: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+    ) -> pl.Tensor[[128, 128], pl.FP32]:
+        c = self.layer(a, c)
+        return c
+
+
+@pl.program
+class _RegionAllocs:
+    """A Graph whose body allocates two scratch tensors at the top level.
+
+    Step C hoists both to the call site, so the recorded region carries no
+    allocation node at all and the entry allocates the buffers instead.
+    """
+
+    @pl.function(type=pl.FunctionType.AIV)
+    def kernel(
+        self, x: pl.Tensor[[128, 128], pl.FP32], o: pl.InOut[pl.Tensor[[128, 128], pl.FP32]]
+    ) -> pl.Tensor[[128, 128], pl.FP32]:
+        t: pl.Tile[[128, 128], pl.FP32] = pl.load(x, [0, 0], [128, 128])
+        o = pl.store(t, [0, 0], o)
+        return o
+
+    @pl.function(type=pl.FunctionType.Graph)
+    def layer(
+        self,
+        a: pl.Tensor[[128, 128], pl.FP32],
+        c: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+    ) -> pl.Tensor[[128, 128], pl.FP32]:
         s0: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], pl.FP32)
         s0 = self.kernel(a, s0)
         s1: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], pl.FP32)
         s1 = self.kernel(s0, s1)
-        s2: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], pl.FP32)
-        s2 = self.kernel(s1, s2)
-        s3: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], pl.FP32)
-        s3 = self.kernel(s2, s3)
-        s4: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], pl.FP32)
-        s4 = self.kernel(s3, s4)
-        s5: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], pl.FP32)
-        s5 = self.kernel(s4, s5)
-        s6: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], pl.FP32)
-        s6 = self.kernel(s5, s6)
-        s7: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], pl.FP32)
-        s7 = self.kernel(s6, s7)
-        s8: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], pl.FP32)
-        s8 = self.kernel(s7, s8)
-        s9: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], pl.FP32)
-        s9 = self.kernel(s8, s9)
-        s10: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], pl.FP32)
-        s10 = self.kernel(s9, s10)
-        s11: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], pl.FP32)
-        s11 = self.kernel(s10, s11)
-        s12: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], pl.FP32)
-        s12 = self.kernel(s11, s12)
-        s13: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], pl.FP32)
-        s13 = self.kernel(s12, s13)
-        s14: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], pl.FP32)
-        s14 = self.kernel(s13, s14)
-        s15: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], pl.FP32)
-        s15 = self.kernel(s14, s15)
-        s16: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], pl.FP32)
-        s16 = self.kernel(s15, s16)
-        s17: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], pl.FP32)
-        s17 = self.kernel(s16, s17)
-        s18: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], pl.FP32)
-        s18 = self.kernel(s17, s18)
-        s19: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], pl.FP32)
-        s19 = self.kernel(s18, s19)
-        c = self.kernel(s19, c)
+        c = self.kernel(s1, c)
         return c
 
     @pl.function(type=pl.FunctionType.Orchestration)
@@ -592,6 +637,37 @@ def test_multi_param_graph_returns_bind_to_the_right_call_site_tensors():
     # The consumer is where the mapping shows. `consume(qq, pp, out)` must read
     # qq -> q and pp -> p; `["p", "q"]` here is exactly the swap this fixes.
     assert _task_args(entry, "CoreTaskArgs params_t1")[:2] == ["q", "p"], entry
+
+
+def test_a_region_allocation_is_hoisted_to_the_call_site():
+    """Step C: the recorded region allocates nothing; the entry does it instead.
+
+    The graph heap is never reclaimed mid-run, so an allocation the region makes
+    for itself is held for the whole run and the live set grows with the number
+    of submissions. Moving it to the call site puts it back on the ordinary
+    reclaimable heap.
+
+    Asserted on the emitted C++ rather than on the pass's parameter list because
+    the two halves have to agree: the buffer has to leave the region *and*
+    arrive as a boundary tensor the launch declares as an output. Declared
+    ``add_input``, the launch would not register as a writer of it.
+    """
+    orch = _compile_orch(_RegionAllocs)
+    body = _graph_body(orch)
+    assert "alloc_tensors(" not in body, body
+    # Both scratch buffers arrive as boundary tensors, after the two the user
+    # wrote. They are appended, so the original indices do not move.
+    assert "const Tensor& a = args.tensor(0).ref();" in body, body
+    assert "const Tensor& c = args.tensor(1).ref();" in body, body
+    assert "const Tensor& s0 = args.tensor(2).ref();" in body, body
+    assert "const Tensor& s1 = args.tensor(3).ref();" in body, body
+
+    entry = _entry_body(orch)
+    assert "alloc_tensors(" in entry, entry
+    # `InOut`, not `Input`: the region writes them, and a caller that hoisted the
+    # allocation out of its own loop needs successive launches ordered.
+    assert entry.count(".add_inout(s0") == 1, entry
+    assert entry.count(".add_inout(s1") == 1, entry
 
 
 if __name__ == "__main__":

--- a/tests/ut/ir/transforms/test_legalize_graph_boundary.py
+++ b/tests/ut/ir/transforms/test_legalize_graph_boundary.py
@@ -46,10 +46,19 @@ def _legalize_outlined(program: ir.Program) -> ir.Program:
     That is the shape every Graph body actually has by the time this pass runs,
     so a check written against the pre-outlining shape can reject the entire
     feature while ``_legalize`` still passes.
+
+    ``NormalizeReturnOrder`` is in the chain for the same reason. It runs at
+    pass 26 and this pass at 45, and it is what establishes
+    ``IRProperty::ReturnParamsExplicit`` — the pointer-identity return -> param
+    map the pass reads to carry boundary provenance across an in-place call
+    (``tmp = kernel(a, tmp)``). Without it that map answers nullopt for every
+    callee, the propagation cannot fire, and a test asserting on it passes for
+    the wrong reason.
     """
     with passes.PassContext([], runtime=passes.RuntimeKind.HOST_BUILD_GRAPH):
         ssa = passes.convert_to_ssa()(program)
-        return passes.legalize_graph_boundary()(passes.outline_incore_scopes()(ssa))
+        outlined = passes.outline_incore_scopes()(ssa)
+        return passes.legalize_graph_boundary()(passes.normalize_return_order()(outlined))
 
 
 def _graph_func(program: ir.Program, name: str) -> ir.Function:
@@ -550,6 +559,11 @@ def _tensor_param_names(func: ir.Function) -> list[str]:
     ]
 
 
+def _param_directions(func: ir.Function) -> dict[str, ir.ParamDirection]:
+    """Parameter name (SSA suffix stripped) -> declared direction."""
+    return {re.sub(r"__ssa_v\d+$", "", p.name_hint): d for p, d in zip(func.params, func.param_directions)}
+
+
 class TestDerivedSliceHoisting:
     def test_slice_of_a_boundary_tensor_becomes_a_parameter(self):
         """Replay patches a boundary tensor's address, not a view derived inside.
@@ -676,11 +690,15 @@ class TestDerivedSliceHoisting:
         assert "again" not in printed, printed
         assert "layer_idx" in printed, printed
 
-    def test_a_region_local_slice_is_left_alone(self):
-        """Only a view *of a boundary tensor* has to move out.
+    def test_a_view_of_a_hoisted_allocation_moves_out_with_it(self):
+        """A region allocation is a boundary tensor, so its views are too.
 
-        A view of a tensor the region allocated is re-derived from that tensor,
-        which the recording owns, so it is replay-stable where it stands.
+        Once Step C hoists ``local``, it is a boundary parameter — and a view of
+        a boundary tensor taken *inside* the region is exactly what Step B
+        exists to move out. Leaving ``lv`` behind would also make this pass
+        produce IR its own ``GraphBoundaryLegalized`` verifier rejects: that
+        verifier treats every tensor parameter as a boundary root and holds any
+        in-region view of one to the replay-invariant-window rule.
         """
 
         @pl.program
@@ -708,8 +726,10 @@ class TestDerivedSliceHoisting:
                 return c
 
         layer = _graph_func(_legalize_outlined(Before), "layer")
-        # `lv` is derived from a region-local tensor, so it stays put.
-        assert _tensor_param_names(layer) == ["w", "c"]
+        # The allocation first, then the view of it — both appended as InOut.
+        assert _tensor_param_names(layer) == ["w", "c", "local", "lv"]
+        assert _param_directions(layer)["local"] == ir.ParamDirection.InOut
+        assert _param_directions(layer)["lv"] == ir.ParamDirection.InOut
 
     def test_slice_of_a_local_tensor_is_left_alone(self):
         """Only views *of a boundary tensor* need hoisting."""
@@ -940,6 +960,475 @@ class TestDerivedSliceHoisting:
 
         with pytest.raises(ValueError, match="shape is not a compile-time constant"):
             _legalize_outlined(Before)
+
+
+# ---------------------------------------------------------------------------
+# Step C — allocations the region makes for itself
+# ---------------------------------------------------------------------------
+
+
+class TestRegionAllocationHoisting:
+    """A `pl.create_tensor` in the region comes off the graph heap.
+
+    `task_allocator.h` reclaims nothing there until the run ends, so a region
+    that allocates for itself holds one buffer per *submission* rather than one
+    per program: a decoder layer with 14 intermediates recorded over N layers
+    holds 14 x N. Step C moves each one to the call site, where it is an
+    ordinary reclaimable allocation.
+    """
+
+    def test_region_allocation_becomes_an_inout_parameter(self):
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Graph)
+            def layer(
+                self,
+                a: pl.Tensor[[128, 128], pl.FP32],
+                c: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                tmp: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], pl.FP32)
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    t: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [0, 0], [128, 128])
+                    pl.store(t, [0, 0], tmp)
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    u: pl.Tile[[128, 128], pl.FP32] = pl.load(tmp, [0, 0], [128, 128])
+                    pl.store(u, [0, 0], c)
+                return c
+
+            @pl.function
+            def main(
+                self,
+                a: pl.Tensor[[128, 128], pl.FP32],
+                c: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                c = self.layer(a, c)
+                return c
+
+        layer = _graph_func(_legalize_outlined(Before), "layer")
+        assert _tensor_param_names(layer) == ["a", "c", "tmp"]
+        # `InOut`, not `In`: the region writes it. Declared `In`, codegen emits
+        # `add_input`, the launch never registers as a writer of the buffer, and
+        # a caller that hoisted the allocation out of its own loop would get no
+        # ordering between successive launches over it. `Out` is illegal on a
+        # Graph boundary — it means the *runtime* allocates.
+        assert _param_directions(layer)["tmp"] == ir.ParamDirection.InOut
+        # The region no longer allocates at all.
+        assert "pl.tensor.create" not in python_print(layer), python_print(layer)
+
+    def test_the_call_site_takes_over_the_allocation(self):
+        """The buffer has to be created somewhere; the caller is that somewhere.
+
+        Bound to a local ahead of the launch rather than written inline into the
+        argument list: orchestration codegen accepts only a Var or a literal as
+        an argument.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Graph)
+            def layer(
+                self,
+                a: pl.Tensor[[128, 128], pl.FP32],
+                c: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                tmp: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], pl.FP32)
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    t: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [0, 0], [128, 128])
+                    pl.store(t, [0, 0], tmp)
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    u: pl.Tile[[128, 128], pl.FP32] = pl.load(tmp, [0, 0], [128, 128])
+                    pl.store(u, [0, 0], c)
+                return c
+
+            @pl.function
+            def main(
+                self,
+                a: pl.Tensor[[128, 128], pl.FP32],
+                c: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                c = self.layer(a, c)
+                return c
+
+        After = _legalize_outlined(Before)
+        main = _graph_func(After, "main")
+        printed = python_print(main)
+        assert "pl.tensor.create" in printed, printed
+        assert "__graph_arg" in printed, printed
+        # Every parameter supplied: a Graph has no runtime-allocated tail.
+        assert len(_graph_func(After, "layer").params) == 3
+
+    def test_a_view_of_a_hoisted_allocation_with_a_moving_window_is_rejected(self):
+        """Hoisting the allocation subjects its views to the Step B rule.
+
+        Recording stores a `BOUNDARY_VIEW`'s offset as the delta seen on the
+        first call and patches only the buffer address, so an offset that can
+        differ between calls replays call one's window. That is now reachable
+        for a view of a region allocation, because the allocation is a boundary
+        tensor — and it is rejected here rather than left for the runtime to get
+        silently wrong.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Graph)
+            def layer(
+                self,
+                a: pl.Tensor[[128, 128], pl.FP32],
+                c: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+                n: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                tmp: pl.Tensor[[512, 128], pl.FP32] = pl.create_tensor([512, 128], pl.FP32)
+                for i in pl.range(4):
+                    off = n + i * 128
+                    tv: pl.Tensor[[128, 128], pl.FP32] = pl.tensor.slice(tmp, [128, 128], [off, 0])
+                    with pl.at(level=pl.Level.CORE_GROUP):
+                        t: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [0, 0], [128, 128])
+                        pl.store(t, [0, 0], tv)
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    u: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [0, 0], [128, 128])
+                    pl.store(u, [0, 0], c)
+                return c
+
+            @pl.function
+            def main(
+                self,
+                a: pl.Tensor[[128, 128], pl.FP32],
+                c: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+                n: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                c = self.layer(a, c, n)
+                return c
+
+        with pytest.raises(ValueError, match="neither reconstructible at the call site nor the same"):
+            _legalize_outlined(Before)
+
+    def test_an_allocation_under_a_loop_stays_in_the_region(self):
+        """A loop-nested create is a *fresh* buffer per iteration.
+
+        Hoisting it would collapse N buffers into one parameter, so iterations
+        that used to write disjoint memory would alias — and the cross-task
+        edges that would have to re-serialise them were derived by
+        `AutoDeriveTaskDependencies`, well upstream of this pass.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                a: pl.Tensor[[128, 128], pl.FP32],
+                out: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                t: pl.Tile[[128, 128], pl.FP32] = pl.load(
+                    a, [0, 0], [128, 128], target_memory=pl.MemorySpace.Vec
+                )
+                return pl.store(t, [0, 0], out)
+
+            @pl.function(type=pl.FunctionType.Graph)
+            def layer(
+                self,
+                a: pl.Tensor[[128, 128], pl.FP32],
+                c: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                for _ in pl.range(4):
+                    tmp: pl.Tensor[[128, 128], pl.FP32] = pl.create_tensor([128, 128], pl.FP32)
+                    tmp = self.kernel(a, tmp)
+                    c = self.kernel(tmp, c)
+                return c
+
+            @pl.function
+            def main(
+                self,
+                a: pl.Tensor[[128, 128], pl.FP32],
+                c: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                c = self.layer(a, c)
+                return c
+
+        layer = _graph_func(_legalize_outlined(Before), "layer")
+        assert _tensor_param_names(layer) == ["a", "c"]
+        assert "pl.tensor.create" in python_print(layer), python_print(layer)
+
+    def test_a_view_of_an_inout_rebound_allocation_moves_out_with_it(self):
+        """Provenance has to survive the SSA rebind an in-place call creates.
+
+        ``tmp = self.kernel(a, tmp)`` binds a *fresh* name to the same buffer.
+        Tracking only bare `alias = var` assignments loses the boundary root
+        there, so Step B skips the view of the rebound name outright — no hoist
+        and no check — and a call-varying offset stays in the region with the
+        first call's window frozen into the recording.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.InOut[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                t: pl.Tile[[128, 128], pl.FP32] = pl.load(
+                    a, [0, 0], [128, 128], target_memory=pl.MemorySpace.Vec
+                )
+                out = pl.store(t, [0, 0], out)
+                return out
+
+            @pl.function(type=pl.FunctionType.Graph)
+            def layer(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                c: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+                n: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                tmp: pl.Tensor[[512, 128], pl.FP32] = pl.create_tensor([512, 128], pl.FP32)
+                tmp = self.kernel(a, tmp)
+                tv: pl.Tensor[[128, 128], pl.FP32] = pl.tensor.slice(tmp, [128, 128], [n, 0])
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    t: pl.Tile[[128, 128], pl.FP32] = pl.load(tv, [0, 0], [128, 128])
+                    pl.store(t, [0, 0], c)
+                return c
+
+            @pl.function
+            def main(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                c: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+                n: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                c = self.layer(a, c, n)
+                return c
+
+        layer = _graph_func(_legalize_outlined(Before), "layer")
+        # Both the allocation and the view of its rebound name are boundary
+        # tensors now; neither is left for the recording to freeze.
+        assert _tensor_param_names(layer) == ["a", "c", "tmp", "tv"]
+        assert "pl.tensor.slice" not in python_print(layer), python_print(layer)
+
+    def test_a_view_of_an_inout_rebound_parameter_moves_out_with_it(self):
+        """The same rebind on a plain boundary parameter — no allocation involved.
+
+        Step B has always had this hole: it is the `tensor_root_` lookup that
+        fails, not anything specific to Step C. Pinned separately so a future
+        change to the allocation path cannot quietly take the parameter path
+        back down with it.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.InOut[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                t: pl.Tile[[128, 128], pl.FP32] = pl.load(
+                    a, [0, 0], [128, 128], target_memory=pl.MemorySpace.Vec
+                )
+                out = pl.store(t, [0, 0], out)
+                return out
+
+            @pl.function(type=pl.FunctionType.Graph)
+            def layer(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                w: pl.InOut[pl.Tensor[[512, 128], pl.FP32]],
+                c: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+                n: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                w = self.kernel(a, w)
+                wl: pl.Tensor[[128, 128], pl.FP32] = pl.tensor.slice(w, [128, 128], [n, 0])
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    t: pl.Tile[[128, 128], pl.FP32] = pl.load(wl, [0, 0], [128, 128])
+                    pl.store(t, [0, 0], c)
+                return c
+
+            @pl.function
+            def main(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                w: pl.InOut[pl.Tensor[[512, 128], pl.FP32]],
+                c: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+                n: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                c = self.layer(a, w, c, n)
+                return c
+
+        layer = _graph_func(_legalize_outlined(Before), "layer")
+        assert _tensor_param_names(layer) == ["a", "w", "c", "wl"]
+        assert "pl.tensor.slice" not in python_print(layer), python_print(layer)
+
+    def test_a_view_of_a_prefix_submit_result_moves_out_with_it(self):
+        """A `Submit` may omit a runtime-allocated `Out` tail, and still writes back.
+
+        `pl.submit(self.kernel, a, w)` against a callee declaring a trailing
+        `pl.Out` is ordinary DSL: the runtime allocates the omitted parameter.
+        The caller-supplied prefix still maps positionally, so the returned `w`
+        is the boundary tensor the callee wrote through.
+
+        Demanding full arity before reading that mapping would drop provenance
+        for every such submit — the exact shape `Submit::args_` in `ir/expr.h`
+        documents as legal — and the dynamic view below would stay in the
+        region with the first invocation's window frozen.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                w: pl.InOut[pl.Tensor[[512, 128], pl.FP32]],
+                scratch: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                t: pl.Tile[[128, 128], pl.FP32] = pl.load(
+                    a, [0, 0], [128, 128], target_memory=pl.MemorySpace.Vec
+                )
+                scratch = pl.store(t, [0, 0], scratch)
+                w = pl.store(t, [0, 0], w)
+                return w
+
+            @pl.function(type=pl.FunctionType.Graph)
+            def layer(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                w: pl.InOut[pl.Tensor[[512, 128], pl.FP32]],
+                c: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+                n: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                with pl.manual_scope():
+                    # `scratch` omitted — the runtime allocates it.
+                    w, _tid = pl.submit(self.kernel, a, w)
+                wl: pl.Tensor[[128, 128], pl.FP32] = pl.tensor.slice(w, [128, 128], [n, 0])
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    t: pl.Tile[[128, 128], pl.FP32] = pl.load(wl, [0, 0], [128, 128])
+                    pl.store(t, [0, 0], c)
+                return c
+
+            @pl.function
+            def main(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                w: pl.InOut[pl.Tensor[[512, 128], pl.FP32]],
+                c: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+                n: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                c = self.layer(a, w, c, n)
+                return c
+
+        layer = _graph_func(_legalize_outlined(Before), "layer")
+        assert _tensor_param_names(layer) == ["a", "w", "c", "wl"]
+        assert "pl.tensor.slice" not in python_print(layer), python_print(layer)
+
+    def test_a_rebound_view_with_a_moving_window_is_rejected(self):
+        """Seeing through the rebind also restores the *check*, not just the hoist.
+
+        ``n + i * 128`` can neither be rebuilt at the call site (``i`` does not
+        exist there) nor frozen (``n`` is patched every call). Before provenance
+        crossed the rebind this was skipped in silence; now it reaches the same
+        three-way decision every other boundary view faces, and is rejected.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.InOut[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                t: pl.Tile[[128, 128], pl.FP32] = pl.load(
+                    a, [0, 0], [128, 128], target_memory=pl.MemorySpace.Vec
+                )
+                out = pl.store(t, [0, 0], out)
+                return out
+
+            @pl.function(type=pl.FunctionType.Graph)
+            def layer(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                w: pl.InOut[pl.Tensor[[512, 128], pl.FP32]],
+                c: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+                n: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                w = self.kernel(a, w)
+                for i in pl.range(2):
+                    off = n + i * 128
+                    wl: pl.Tensor[[128, 128], pl.FP32] = pl.tensor.slice(w, [128, 128], [off, 0])
+                    with pl.at(level=pl.Level.CORE_GROUP):
+                        t: pl.Tile[[128, 128], pl.FP32] = pl.load(wl, [0, 0], [128, 128])
+                        pl.store(t, [0, 0], c)
+                return c
+
+            @pl.function
+            def main(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                w: pl.InOut[pl.Tensor[[512, 128], pl.FP32]],
+                c: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+                n: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                c = self.layer(a, w, c, n)
+                return c
+
+        with pytest.raises(ValueError, match="neither reconstructible at the call site nor the same"):
+            _legalize_outlined(Before)
+
+    def test_a_graph_return_names_its_parameter_directly(self):
+        """Guards the dependency that makes a second `InOut` parameter legal.
+
+        `NormalizeReturnOrder` canonicalizing a Graph's returns is not this
+        pass's work — it landed in #2618 — but Steps B and C are unusable
+        without it. Orchestration codegen maps a call result onto one of the
+        callee's Out/InOut params through `ExplicitReturnedParamIndices`, a
+        pointer-identity read, and falls back to "the single Out/InOut param"
+        only when that map yields nothing; a Graph body is
+        `c_1 = layer_incore_0(a, c); return c_1` after the scope outliner, so
+        the fallback is all it ever had, and it stops existing at the second
+        `InOut`.
+
+        Pinned here, in the consumer, rather than left to #2618's own tests:
+        narrowing that gate would break the hoists silently, and this is where
+        that shows up.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Graph)
+            def layer(
+                self,
+                a: pl.Tensor[[128, 128], pl.FP32],
+                c: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    t: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [0, 0], [128, 128])
+                    pl.store(t, [0, 0], c)
+                return c
+
+            @pl.function
+            def main(
+                self,
+                a: pl.Tensor[[128, 128], pl.FP32],
+                c: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                c = self.layer(a, c)
+                return c
+
+        with passes.PassContext([], runtime=passes.RuntimeKind.HOST_BUILD_GRAPH):
+            ssa = passes.convert_to_ssa()(Before)
+            outlined = passes.outline_incore_scopes()(ssa)
+            before = _graph_func(outlined, "layer")
+            normalized = passes.normalize_return_order()(outlined)
+
+        # The outliner leaves the return on the rebind, which resolves to
+        # nothing under a pointer-identity read.
+        assert "return c__ssa_v1" in python_print(before), python_print(before)
+
+        layer = _graph_func(normalized, "layer")
+        printed = python_print(layer)
+        # Now the parameter itself, by name and so by pointer identity.
+        assert f"return {layer.params[1].name_hint}" in printed, printed
+        # The rebind is still computed — it is a task launch with side effects.
+        assert "= layer_incore_0(" in printed, printed
 
 
 # ---------------------------------------------------------------------------
@@ -1362,9 +1851,15 @@ class TestBoundaryLegality:
     def test_allocations_count_toward_the_node_limit(self):
         """A Graph at the launch limit is over it once it also allocates.
 
-        1024 launches plus one create is at least 1025 recorded nodes. Leaving
-        allocations out of the total entirely would pass this and leave the
-        runtime to decline the cache silently.
+        1024 launches plus a two-trip loop holding one create is 1026 recorded
+        nodes. Leaving allocations out of the total entirely would pass this and
+        leave the runtime to decline the cache silently.
+
+        The create sits under a loop so that it stays in the region: Step C
+        hoists a *top-level* allocation to the call site, and one it hoists is a
+        node the emitted region no longer has. Two trips rather than one because
+        `Simplify` collapses a single-trip loop into its body, which would put
+        the create back at the top level in the real pipeline.
         """
 
         @pl.program
@@ -1386,7 +1881,8 @@ class TestBoundaryLegality:
                 a: pl.Tensor[[128, 128], pl.FP32],
                 c: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
             ) -> pl.Tensor[[128, 128], pl.FP32]:
-                _s: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)
+                for _ in pl.range(2):
+                    _s: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)
                 for _ in pl.range(1024):
                     c = self.kernel(a, c)
                 return c
@@ -1400,7 +1896,7 @@ class TestBoundaryLegality:
                 c = self.layer(a, c)
                 return c
 
-        with pytest.raises(ValueError, match="launches 1025 tasks, over the runtime's per-graph limit"):
+        with pytest.raises(ValueError, match="launches 1026 tasks, over the runtime's per-graph limit"):
             _legalize_outlined(Before)
 
     def test_interleaved_allocations_batch_across_the_statement_list(self):
@@ -1414,9 +1910,16 @@ class TestBoundaryLegality:
         passing, because both this and the adjacent-run counting it replaced
         accept a small Graph — the two only diverge in the number. Here:
 
-            launches  = 20 interleaved + 1024 in the loop + 1 for the scope
-            batched   = ceil(20 / 16) = 2      -> 1047
-            per-create= 20                     -> 1065
+        The interleaved run sits under a two-trip loop so that Step C leaves it
+        in the region — it hoists a *top-level* allocation to the call site, and
+        one it hoists is a node the emitted region no longer has. The loop body
+        is still one statement list, which is what the batching rule is about.
+        Two trips rather than one because `Simplify` collapses a single-trip
+        loop into its body.
+
+            per iteration = 20 interleaved launches + ceil(20 / 16) = 2 batched
+            total         = 2 * 22 + 1024 in the loop + 1 for the scope -> 1069
+            per-create    = 2 * 40 + 1025                               -> 1105
 
         so the reported total is what distinguishes them.
         """
@@ -1441,46 +1944,47 @@ class TestBoundaryLegality:
                 c: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
                 d: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
             ) -> pl.Tensor[[128, 128], pl.FP32]:
-                _s0: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)
-                d = self.kernel(a, d)
-                _s1: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)
-                d = self.kernel(a, d)
-                _s2: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)
-                d = self.kernel(a, d)
-                _s3: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)
-                d = self.kernel(a, d)
-                _s4: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)
-                d = self.kernel(a, d)
-                _s5: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)
-                d = self.kernel(a, d)
-                _s6: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)
-                d = self.kernel(a, d)
-                _s7: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)
-                d = self.kernel(a, d)
-                _s8: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)
-                d = self.kernel(a, d)
-                _s9: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)
-                d = self.kernel(a, d)
-                _s10: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)
-                d = self.kernel(a, d)
-                _s11: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)
-                d = self.kernel(a, d)
-                _s12: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)
-                d = self.kernel(a, d)
-                _s13: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)
-                d = self.kernel(a, d)
-                _s14: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)
-                d = self.kernel(a, d)
-                _s15: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)
-                d = self.kernel(a, d)
-                _s16: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)
-                d = self.kernel(a, d)
-                _s17: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)
-                d = self.kernel(a, d)
-                _s18: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)
-                d = self.kernel(a, d)
-                _s19: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)
-                d = self.kernel(a, d)
+                for _ in pl.range(2):
+                    _s0: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)
+                    d = self.kernel(a, d)
+                    _s1: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)
+                    d = self.kernel(a, d)
+                    _s2: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)
+                    d = self.kernel(a, d)
+                    _s3: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)
+                    d = self.kernel(a, d)
+                    _s4: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)
+                    d = self.kernel(a, d)
+                    _s5: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)
+                    d = self.kernel(a, d)
+                    _s6: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)
+                    d = self.kernel(a, d)
+                    _s7: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)
+                    d = self.kernel(a, d)
+                    _s8: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)
+                    d = self.kernel(a, d)
+                    _s9: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)
+                    d = self.kernel(a, d)
+                    _s10: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)
+                    d = self.kernel(a, d)
+                    _s11: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)
+                    d = self.kernel(a, d)
+                    _s12: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)
+                    d = self.kernel(a, d)
+                    _s13: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)
+                    d = self.kernel(a, d)
+                    _s14: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)
+                    d = self.kernel(a, d)
+                    _s15: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)
+                    d = self.kernel(a, d)
+                    _s16: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)
+                    d = self.kernel(a, d)
+                    _s17: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)
+                    d = self.kernel(a, d)
+                    _s18: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)
+                    d = self.kernel(a, d)
+                    _s19: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)
+                    d = self.kernel(a, d)
                 for _ in pl.range(1024):
                     d = self.kernel(a, d)
                 with pl.at(level=pl.Level.CORE_GROUP):
@@ -1498,7 +2002,7 @@ class TestBoundaryLegality:
                 c = self.layer(a, c, d)
                 return c
 
-        with pytest.raises(ValueError, match="launches 1047 tasks"):
+        with pytest.raises(ValueError, match="launches 1069 tasks"):
             _legalize_outlined(Before)
 
     def test_batchable_gm_pipe_allocations_are_not_charged_individually(self):
@@ -1517,9 +2021,14 @@ class TestBoundaryLegality:
         Pinned through the over-limit total, since both countings accept a small
         Graph:
 
-            launches = 1024 in the loop + 1 for the scope
-            batched  = ceil(40 / 16) = 3        -> 1028
-            per-create = 40                     -> 1065
+        The run sits under a two-trip loop so that Step C leaves it in the
+        region — it hoists a *top-level* allocation to the call site, and one it
+        hoists is a node the emitted region no longer has. The loop body is
+        still one statement list, and two trips rather than one because
+        `Simplify` collapses a single-trip loop into its body.
+
+            batched    = 2 * ceil(40 / 16) = 6 + 1024 + 1 for the scope -> 1031
+            per-create = 2 * 40 = 80 + 1025                             -> 1105
         """
 
         @pl.program
@@ -1542,46 +2051,47 @@ class TestBoundaryLegality:
                 c: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
                 d: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
             ) -> pl.Tensor[[128, 128], pl.FP32]:
-                gm_pipe_buffer_0: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
-                gm_pipe_buffer_1: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
-                gm_pipe_buffer_2: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
-                gm_pipe_buffer_3: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
-                gm_pipe_buffer_4: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
-                gm_pipe_buffer_5: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
-                gm_pipe_buffer_6: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
-                gm_pipe_buffer_7: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
-                gm_pipe_buffer_8: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
-                gm_pipe_buffer_9: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
-                gm_pipe_buffer_10: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
-                gm_pipe_buffer_11: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
-                gm_pipe_buffer_12: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
-                gm_pipe_buffer_13: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
-                gm_pipe_buffer_14: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
-                gm_pipe_buffer_15: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
-                gm_pipe_buffer_16: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
-                gm_pipe_buffer_17: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
-                gm_pipe_buffer_18: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
-                gm_pipe_buffer_19: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
-                gm_pipe_buffer_20: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
-                gm_pipe_buffer_21: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
-                gm_pipe_buffer_22: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
-                gm_pipe_buffer_23: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
-                gm_pipe_buffer_24: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
-                gm_pipe_buffer_25: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
-                gm_pipe_buffer_26: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
-                gm_pipe_buffer_27: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
-                gm_pipe_buffer_28: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
-                gm_pipe_buffer_29: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
-                gm_pipe_buffer_30: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
-                gm_pipe_buffer_31: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
-                gm_pipe_buffer_32: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
-                gm_pipe_buffer_33: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
-                gm_pipe_buffer_34: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
-                gm_pipe_buffer_35: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
-                gm_pipe_buffer_36: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
-                gm_pipe_buffer_37: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
-                gm_pipe_buffer_38: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
-                gm_pipe_buffer_39: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
+                for _ in pl.range(2):
+                    gm_pipe_buffer_0: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
+                    gm_pipe_buffer_1: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
+                    gm_pipe_buffer_2: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
+                    gm_pipe_buffer_3: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
+                    gm_pipe_buffer_4: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
+                    gm_pipe_buffer_5: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
+                    gm_pipe_buffer_6: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
+                    gm_pipe_buffer_7: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
+                    gm_pipe_buffer_8: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
+                    gm_pipe_buffer_9: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
+                    gm_pipe_buffer_10: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
+                    gm_pipe_buffer_11: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
+                    gm_pipe_buffer_12: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
+                    gm_pipe_buffer_13: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
+                    gm_pipe_buffer_14: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
+                    gm_pipe_buffer_15: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
+                    gm_pipe_buffer_16: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
+                    gm_pipe_buffer_17: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
+                    gm_pipe_buffer_18: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
+                    gm_pipe_buffer_19: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
+                    gm_pipe_buffer_20: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
+                    gm_pipe_buffer_21: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
+                    gm_pipe_buffer_22: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
+                    gm_pipe_buffer_23: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
+                    gm_pipe_buffer_24: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
+                    gm_pipe_buffer_25: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
+                    gm_pipe_buffer_26: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
+                    gm_pipe_buffer_27: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
+                    gm_pipe_buffer_28: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
+                    gm_pipe_buffer_29: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
+                    gm_pipe_buffer_30: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
+                    gm_pipe_buffer_31: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
+                    gm_pipe_buffer_32: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
+                    gm_pipe_buffer_33: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
+                    gm_pipe_buffer_34: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
+                    gm_pipe_buffer_35: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
+                    gm_pipe_buffer_36: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
+                    gm_pipe_buffer_37: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
+                    gm_pipe_buffer_38: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
+                    gm_pipe_buffer_39: pl.Tensor[[16], pl.FP32] = pl.create_tensor([16], pl.FP32)  # noqa: F841
                 for _ in pl.range(1024):
                     d = self.kernel(a, d)
                 with pl.at(level=pl.Level.CORE_GROUP):
@@ -1599,7 +2109,7 @@ class TestBoundaryLegality:
                 c = self.layer(a, c, d)
                 return c
 
-        with pytest.raises(ValueError, match="launches 1028 tasks"):
+        with pytest.raises(ValueError, match="launches 1031 tasks"):
             _legalize_outlined(Before)
 
     def test_constant_shaped_allocation_is_allowed(self):


### PR DESCRIPTION
## Summary

`LegalizeGraphBoundary` collected Step C — the tensors a Graph region allocates
for itself — but `BuildPlan` never read `collector.creates()`, so every
`pl.create_tensor` stayed inside the region and became a recorded
`alloc_tensors` node. Recording one is *correct*, but the buffer comes off the
graph heap, and `task_allocator.h` reclaims nothing there until the run ends
("The whole graph must fit at once; nothing is reclaimed mid-run"), so the live
set grows with the number of submissions instead of staying flat — a Qwen3-14B
decoder layer holding 14 intermediates costs 14 × N over N recorded layers.
simpler's hand-written `qwen3_14b_decode` scene avoids this by hand, for the
same stated reason.

Step C now moves each top-level allocation to the call site as an `InOut`
boundary tensor. A Graph that allocated for itself gains one appended `InOut`
parameter per allocation and its emitted region carries no allocation node;
existing parameters keep their indices, and a Graph that allocates nothing is
unaffected.

The doc previously recorded Step C as deliberately unwired, blocked on the
return-alias mapping. That blocker was real; **PR #2618 removed it** by
canonicalizing a Graph's param-writeback returns. This PR is rebased on that
and depends on it rather than carrying it.

## Changes

- `src/ir/transforms/legalize_graph_boundary_pass.cpp` — Step C wiring. A
  top-level `tensor.create` becomes an appended `InOut` parameter and is emitted
  at the call site. It also becomes its own boundary root, so a view of it faces
  the same Step B rule as a view of any other boundary tensor: the
  `GraphBoundaryLegalized` verifier holds every tensor parameter to that rule,
  and one left in place with a window that can move would make the pass produce
  IR its own verifier rejects.

  `InOut` rather than `In` because the region writes the buffer — declared `In`,
  codegen emits `add_input`, the launch never registers as a writer, and a
  caller that hoisted the create out of its own loop would get no ordering
  between successive launches. `Out` is unavailable: on a Graph boundary it
  means the runtime allocates, which `rt_graph_args_cacheable` refuses.

  Two allocations stay where they are, deliberately: `tensor.full` (orchestration
  codegen has no lowering for it at the call site either, and Step D already
  rejects it) and a create under a loop (a fresh buffer per iteration; collapsing
  N into one parameter would make iterations alias, and the cross-task edges that
  would have to re-serialise them were derived well upstream of this pass).

- `src/ir/transforms/legalize_graph_boundary_pass.cpp`,
  `src/ir/verifier/verify_graph_functions.cpp` — **boundary provenance now
  crosses an in-place call rebind.** `tmp = kernel(a, tmp)` binds a fresh SSA
  name to the same buffer; tracking only bare `alias = var` assignments lost the
  boundary root there, so Step B skipped a view of the rebound name outright —
  no hoist and no check — and a call-varying offset stayed in the region with the
  first call's window frozen into the recording.

  Provenance follows the writeback through `ExplicitReturnedParamIndices`, the
  same return-position → parameter map orchestration codegen aliases a call
  result on, so the two cannot disagree about which buffer a result names. It
  covers single results and tuple elements (`pl.submit` / `pl.spmd_submit`), is
  memoized per callee, and bails when `args_.size() != params_.size()` because a
  `Submit` prefix plus a `CommCtx` suffix breaks the positional mapping.

  The verifier's `TrackTensorAlias` had the identical blind spot, so nothing
  caught this. Fixed alongside, re-derived rather than shared, so the check stays
  independent.

  **This hole predates Step C.** It is the `tensor_root_` lookup that fails, so a
  view of a rebound boundary *parameter* escaped the same way with no allocation
  involved. Both shapes are pinned by tests.

- Node counting moved to run on the rewritten program. Step C *removes*
  allocation nodes, so counting the pre-hoist body would reject a Graph that
  fits, and would disagree with the verifier, which re-derives the same count
  from the rewritten IR.

- `docs/{en,zh}/dev/passes/45-legalize_graph_boundary.md` — Step C rewritten
  from "not done, and here is the blocker" to what it now does, plus the two
  deliberate exclusions, the new counting position, the provenance rule, and a
  narrowed "Not yet handled". The section names PR #2618 as the dependency it
  relies on rather than claiming it.

  `26-normalize_return_order.md` (both locales) keeps one correction on top of
  #2618: it still said the pass is "a no-op for any program with no InCore
  functions", which stopped being true once Step A0 covered `Graph`.

- Tests. New: Step C parameter/direction/call-site coverage, a view of a hoisted
  allocation with a moving window (rejected), a loop-nested allocation (left in
  place), the three in-place-rebind cases (allocation, plain parameter, and a
  moving window that is now rejected rather than skipped), a guard on the #2618
  dependency, and a codegen test asserting the emitted region carries no
  `alloc_tensors` while the entry allocates and passes the buffers `add_inout`.

  `_legalize_outlined` now runs `NormalizeReturnOrder`. It did not before, which
  meant the return→param map was all-nullopt in the harness and a test written
  against the rebind fix would have passed for the wrong reason. It also matches
  the real pipeline, where that pass runs at 26 and this one at 45.

  Updated expectations: `test_a_region_local_slice_is_left_alone` becomes
  `test_a_view_of_a_hoisted_allocation_moves_out_with_it` — its premise is what
  this change reverses. Three node-counting cases and the codegen batching case
  put their creates under a two-trip loop so they stay in the region and keep
  testing the counting/batching rule; two trips rather than one because
  `Simplify` collapses a single-trip loop into its body. The batching and
  launch-count numbers under test are otherwise recomputed, not relaxed.

## Verification

- `cmake --build build --parallel 32`: exit 0.
- `pytest tests/ut -n 16` (via the push transaction's validation runner, bound
  to the pushed OID): **11087 passed, 8 skipped, 1 xfailed, 0 failed**. One case is
  deselected — `TestUnifiedSlicePadValue::test_symlinked_import_path_still_names_the_caller`
  asserts a subprocess resolves `pypto` through a symlinked `PYTHONPATH`, which
  this machine's editable meta-finder redirects regardless of the change under
  test.
- Focused suites (`test_legalize_graph_boundary`, `test_orchestration_codegen_graph`,
  `test_graph_boundary_legalized`, `test_normalize_return_order`,
  `test_orchestration_returned_param_map`): exit 0.
- The provenance fix is load-bearing, checked by disabling it and rebuilding:
  the three rebind regression tests fail without it and pass with it.
- clang-format 21.1.0 `--dry-run --Werror`, clang-tidy 21.1.0
  `--strict-version --diff-base`, ruff 0.14.8 (`format --check` + `check`),
  markdownlint-cli2 0.20.0, and the ten `tests/lint/*.py` checks: all clean.
- **On device**: `test_graph_execution.py` — 13/13 passed on a2a3 in CI,
  including `test_region_alloc`, this change's end-to-end case.

Closes #2604
