### PR TITLE
fix(jit): resolve a dep call site by its binding name, not __name__

### DIFF
--- a/docs/en/user/language/01-functions.md
+++ b/docs/en/user/language/01-functions.md
@@ -75,7 +75,10 @@ core levels:
 | `@pl.jit.graph` | `Graph` | A recordable orchestration fragment — the `host_build_graph` runtime records its task topology on the first call and replays it after, so N calls cost one graph build rather than N. Requires compiling under `RuntimeKind.HOST_BUILD_GRAPH` |
 
 Sub-function dependencies (`.incore` / `.inline` / `.opaque` / `.graph`) are auto-discovered from
-the entry's body — call them by name. A `@pl.jit.host` entry additionally discovers
+the entry's body — call them by name. The name you call is resolved in the entry's own
+namespace, so an aliased import (`from kernels import matmul as mm`, or a plain
+`mm = matmul` rebinding) is discovered like any other binding; the generated program still
+names the function after its `def`. A `@pl.jit.host` entry additionally discovers
 `@pl.jit` chip-orchestration dependencies, so a full distributed program needs no
 `@pl.program` class.
 

--- a/docs/zh/user/language/01-functions.md
+++ b/docs/zh/user/language/01-functions.md
@@ -60,7 +60,7 @@ def entry(
 | `@pl.jit.opaque` | `Opaque` | 独立 IR 函数，可包含编排循环与 `pl.at` 作用域 |
 | `@pl.jit.graph` | `Graph` | 可录制的编排片段 —— `host_build_graph` runtime 在首次调用时录制其 task 拓扑、之后回放，因此 N 次调用只付一次建图代价。需要在 `RuntimeKind.HOST_BUILD_GRAPH` 下编译 |
 
-子函数依赖（`.incore` / `.inline` / `.opaque` / `.graph`）从入口函数体自动发现 —— 按名字调用即可。`@pl.jit.host` 入口还会额外发现 `@pl.jit`（chip 编排）依赖，因此一个完整的分布式程序无需任何 `@pl.program` 类。
+子函数依赖（`.incore` / `.inline` / `.opaque` / `.graph`）从入口函数体自动发现 —— 按名字调用即可。这里的名字在入口函数自身的命名空间中解析，因此别名导入（`from kernels import matmul as mm`，或普通的 `mm = matmul` 重绑定）与其他绑定一样能被发现；生成的程序仍以其 `def` 名字命名该函数。`@pl.jit.host` 入口还会额外发现 `@pl.jit`（chip 编排）依赖，因此一个完整的分布式程序无需任何 `@pl.program` 类。
 
 下面这段只展示发现结构 —— kernel 体已省略，它用到的分布式类型见[分布式](../distributed/index.md)：
 

--- a/python/pypto/jit/decorator.py
+++ b/python/pypto/jit/decorator.py
@@ -601,7 +601,7 @@ def _compute_per_func_dyndim_maps(
     entry_func: Any,
     entry_param_names: list[str],
     deps: list[Any],
-    callers_by_dep_id: dict[int, list[Any]],
+    callers_by_dep_id: dict[int, list[tuple[Any, str]]],
     call_args_cache: dict[tuple[int, str], list[tuple[str | None, str | _SlicedArg | None]] | None],
 ) -> dict[int, dict[str, dict[int, DynDim]]]:
     """Per JIT function in the dep graph, return ``param → dim_idx → DynDim``.
@@ -634,8 +634,8 @@ def _compute_per_func_dyndim_maps(
         dep_map = out[id(dep._func)]
         if not dep_map:
             continue
-        for caller_func in callers_by_dep_id.get(id(dep._func), ()):
-            call_args = call_args_cache.get((id(caller_func), dep.__name__))
+        for caller_func, call_name in callers_by_dep_id.get(id(dep._func), ()):
+            call_args = call_args_cache.get((id(caller_func), call_name))
             if call_args is None:
                 continue
             param_mapping = _build_param_mapping(dep._param_names(), call_args)
@@ -687,11 +687,30 @@ def _build_dynvar_anchor_index(
     return anchors
 
 
+class _DepBinding(NamedTuple):
+    """A JIT dep together with the name its caller's source calls it by.
+
+    The two differ whenever the caller reaches the dep through a rebinding —
+    ``from mod import kernel as kern``, or a module-level ``kern = kernel``.
+    Anything that has to *find the call site* (argument extraction, ``Out``
+    param propagation, the ``self.<dep>(...)`` rewrite) must key on
+    ``call_name``; anything that names the *function* (the generated
+    ``@pl.function``, diagnostics, the source hash) keys on ``dep.__name__``.
+    """
+
+    call_name: str
+    dep: JITFunction
+
+
 def _scan_dep_io(
     func: Any, caller_func_type: str = "orchestration"
 ) -> dict[str, tuple[list[str], list[str]]]:
-    """Return ``dep_name → (param_names, output_param_names)`` for every @pl.jit
+    """Return ``call_name → (param_names, output_param_names)`` for every @pl.jit
     dep called from ``func``'s body.
+
+    Keyed by the name the body *calls* the dep by, so an aliased import
+    (``from mod import kernel as kern``) still matches the ``ast.Name`` at the
+    call site.
 
     Used by ``_extract_local_tensor_metas`` to propagate metas through
     ``v1, ..., vk = dep(args)`` assignments (each ``vi`` inherits the meta of
@@ -706,7 +725,7 @@ def _scan_dep_io(
     orchestrator also admits ``orchestration`` deps (its chip orchestrators).
     """
     out: dict[str, tuple[list[str], list[str]]] = {}
-    for dep in _discover_deps(func, caller_func_type):
+    for call_name, dep in _discover_dep_bindings(func, caller_func_type):
         try:
             out_params, inout_params, _, _, _ = _classify_params(_get_func_def(dep._func))
         except OSError:
@@ -714,7 +733,7 @@ def _scan_dep_io(
         param_names = dep._param_names()
         output_set = set(out_params) | set(inout_params)
         output_params = [p for p in param_names if p in output_set]
-        out[dep.__name__] = (param_names, output_params)
+        out[call_name] = (param_names, output_params)
     return out
 
 
@@ -1347,6 +1366,7 @@ def _resolve_dep_call_metadata(
     caller_scalar_dtypes: dict[str, DataType],
     dep_dyn_map: dict[str, dict[int, DynDim]],
     caller_func_type: str = "orchestration",
+    dep_call_name: str | None = None,
 ) -> tuple[
     dict[str, TensorMeta],
     dict[str, int | float | bool],
@@ -1366,15 +1386,21 @@ def _resolve_dep_call_metadata(
     ``caller_func_type`` is forwarded to ``_extract_local_tensor_metas``
     so a host orchestrator's body can also recognise chip-orchestrator deps
     when walking ``v = chip_orch(...)`` return-capture assignments.
+
+    ``dep_call_name`` is the name ``caller_func``'s source calls the dep by;
+    it differs from ``dep.__name__`` under an aliased import or any other
+    rebinding. Defaults to ``dep.__name__`` for callers that resolve a dep
+    reached under its own name.
     """
     dep_param_names = dep._param_names()
-    call_args = _extract_call_args_for_dep(caller_func, dep.__name__)
+    call_name = dep_call_name or dep.__name__
+    call_args = _extract_call_args_for_dep(caller_func, call_name)
     intermediate_metas = _extract_local_tensor_metas(
         caller_func,
         seed_meta=caller_tensor_meta,
         seed_scalars=caller_scalar_values,
         caller_func_type=caller_func_type,
-        stop_at_dep=dep.__name__ if call_args is not None else None,
+        stop_at_dep=call_name if call_args is not None else None,
     )
     # The extractor starts from caller_tensor_meta, then applies source-ordered
     # rebindings. Its result is therefore the authoritative state at the call.
@@ -1768,7 +1794,7 @@ class JITFunction:
         self,
     ) -> tuple[
         list[JITFunction],
-        dict[int, list[Any]],
+        dict[int, list[tuple[Any, str]]],
         dict[int, list[str]],
         dict[tuple[int, str], list[tuple[str | None, str | _SlicedArg | None]] | None],
     ]:
@@ -1780,10 +1806,12 @@ class JITFunction:
         - ``deps_topo``: every reachable dep in leaf-first topological order
           (deduplicated by underlying Python function identity). The entry
           function is NOT included.
-        - ``callers_by_dep_id``: for each dep, the list of Python functions
-          whose bodies contain a call site to it. Recorded in DFS-discovery
-          order; deduplicated within each list. The entry has no caller and
-          does not appear as a key.
+        - ``callers_by_dep_id``: for each dep, the list of
+          ``(caller_func, call_name)`` pairs whose bodies contain a call site
+          to it — ``call_name`` being the name that caller's source calls it
+          by, which differs from ``dep.__name__`` under an aliased import.
+          Recorded in DFS-discovery order; deduplicated within each list. The
+          entry has no caller and does not appear as a key.
 
           Tensor / scalar metadata for a shared dep is still resolved
           through the first-recorded caller — call sites in other branches
@@ -1791,11 +1819,11 @@ class JITFunction:
           have to differ from another, which the one-context-per-function
           design doesn't support).
         - ``callees_by_func_id``: for each function (entry + every reached
-          dep), the names of JIT deps it directly calls. Used to set each
-          context's ``dep_names`` so the body transformer rewrites nested
-          dep calls into the ``self.<dep>(...)`` form required by
+          dep), the *call names* of the JIT deps it directly calls. Used to
+          set each context's ``dep_names`` so the body transformer rewrites
+          nested dep calls into the ``self.<dep>(...)`` form required by
           multi-function ``@pl.program``.
-        - ``call_args_cache``: ``(id(caller_func), dep_name)`` → unified
+        - ``call_args_cache``: ``(id(caller_func), call_name)`` → unified
           call-site arg list (see ``_extract_call_args_for_dep``) or
           ``None`` if the call site isn't found. Cached so metadata
           resolution doesn't re-walk caller ASTs on every JIT call.
@@ -1810,20 +1838,23 @@ class JITFunction:
             ] = {}
 
             def visit(func: Any, caller_func_type: str) -> None:
-                direct = _discover_deps(func, caller_func_type)
-                callees_by_func_id[id(func)] = [d.__name__ for d in direct]
-                for dep in direct:
+                direct = _discover_dep_bindings(func, caller_func_type)
+                # Call names, not ``__name__``: these become ``ctx.dep_names``,
+                # which the body transformer matches against the ``ast.Name``
+                # the source actually calls.
+                callees_by_func_id[id(func)] = [b.call_name for b in direct]
+                for call_name, dep in direct:
                     # Key everything off ``id(dep._func)`` (the underlying
                     # Python function) — same key the downstream helpers
                     # use, and stable across multiple wrapper objects for
                     # the same source function.
                     callers = callers_by_dep_id.setdefault(id(dep._func), [])
-                    if func not in callers:
-                        callers.append(func)
-                    # Memoise per-(caller, dep) call-site args once.
-                    cache_key = (id(func), dep.__name__)
+                    if (func, call_name) not in callers:
+                        callers.append((func, call_name))
+                    # Memoise per-(caller, call name) call-site args once.
+                    cache_key = (id(func), call_name)
                     if cache_key not in call_args_cache:
-                        call_args_cache[cache_key] = _extract_call_args_for_dep(func, dep.__name__)
+                        call_args_cache[cache_key] = _extract_call_args_for_dep(func, call_name)
                     if id(dep._func) in seen:
                         continue
                     # Mark before recursing — this also serves as a cycle
@@ -2526,9 +2557,12 @@ class JITFunction:
           entry. DynDim entries inside the metas propagate naturally as
           metas are forwarded into deps via ``_resolve_dep_call_metadata``.
         - Each context's ``dep_names`` is the set of JIT deps that the
-          context's function *directly* calls. The body transformer uses
-          this to rewrite nested ``dep(args)`` calls into the
-          ``self.dep(args)`` form required by multi-function ``@pl.program``.
+          context's function *directly* calls, named as its source calls
+          them. The body transformer uses this — plus ``dep_func_names``,
+          which maps those call names onto the generated function names they
+          differ from under an aliased import — to rewrite nested
+          ``dep(args)`` calls into the ``self.dep(args)`` form required by
+          multi-function ``@pl.program``.
 
         The returned list is in leaf-first order (deps before their
         callers) so the generated source defines callees before callers.
@@ -2558,13 +2592,21 @@ class JITFunction:
         # caller metadata is already resolved when we get to it; collect
         # contexts caller-first, then reverse to restore leaf-first emit
         # order.
+        # Per caller, ``call name → generated function name``. They differ
+        # under an aliased import: the body calls ``kern(...)`` while the
+        # generated ``@pl.function`` is named after ``dep.__name__``.
+        dep_func_names_by_caller: dict[int, dict[str, str]] = {}
+        for dep in deps_topo:
+            for caller_func, call_name in callers_by_id.get(id(dep._func), ()):
+                dep_func_names_by_caller.setdefault(id(caller_func), {})[call_name] = dep.__name__
+
         dep_contexts: list[SpecializeContext] = []
         for dep in reversed(deps_topo):
             # For metadata resolution we use the first-recorded caller. In a
             # diamond ``entry -> {A, B} -> shared`` only one specialization
             # of ``shared`` is emitted, so the call sites in other branches
             # must agree on shapes/dtypes anyway.
-            caller_func = callers_by_id[id(dep._func)][0]
+            caller_func, dep_call_name = callers_by_id[id(dep._func)][0]
             c_meta, c_sv, c_sd = resolved[id(caller_func)]
             caller_ftype = func_type_by_id.get(id(caller_func), "orchestration")
             dep_meta, dep_sv, dep_sd = _resolve_dep_call_metadata(
@@ -2575,6 +2617,7 @@ class JITFunction:
                 c_sd,
                 per_func_dyn.get(id(dep._func), empty_dyn),
                 caller_func_type=caller_ftype,
+                dep_call_name=dep_call_name,
             )
             resolved[id(dep._func)] = (dep_meta, dep_sv, dep_sd)
             dep_contexts.append(
@@ -2587,6 +2630,7 @@ class JITFunction:
                     scalar_values=dep_sv,
                     scalar_dtypes=dep_sd,
                     dep_names=callees_by_id[id(dep._func)],
+                    dep_func_names=dep_func_names_by_caller.get(id(dep._func), {}),
                     auto_scope=dep._auto_scope,
                     external_core_type=dep._external_core_type,
                     external_aic_source=dep._external_aic_source,
@@ -2606,6 +2650,7 @@ class JITFunction:
             scalar_values=scalar_values,
             scalar_dtypes=scalar_dtypes,
             dep_names=callees_by_id[id(self._func)],
+            dep_func_names=dep_func_names_by_caller.get(id(self._func), {}),
             auto_scope=self._auto_scope,
         )
         return dep_contexts + [entry_ctx]
@@ -2619,8 +2664,8 @@ class JITFunction:
 # ---------------------------------------------------------------------------
 
 
-def _discover_deps(func: Any, caller_func_type: str = "orchestration") -> list[JITFunction]:
-    """Discover JIT dep functions called by ``func``.
+def _discover_dep_bindings(func: Any, caller_func_type: str = "orchestration") -> list[_DepBinding]:
+    """Discover JIT dep functions called by ``func``, with their call names.
 
     Scans the function's AST for bare function calls, then resolves each name
     against both module globals and closure variables (for deps defined in an
@@ -2663,14 +2708,24 @@ def _discover_deps(func: Any, caller_func_type: str = "orchestration") -> list[J
     if caller_func_type == "host":
         allowed_dep_types.add("orchestration")
 
-    deps: list[JITFunction] = []
+    deps: list[_DepBinding] = []
     seen: set[str] = set()
     for name in called_names:
         obj = all_vars.get(name)
         if isinstance(obj, JITFunction) and obj._func_type in allowed_dep_types and name not in seen:
-            deps.append(obj)
+            deps.append(_DepBinding(call_name=name, dep=obj))
             seen.add(name)
     return deps
+
+
+def _discover_deps(func: Any, caller_func_type: str = "orchestration") -> list[JITFunction]:
+    """Discover JIT dep functions called by ``func``, dropping their call names.
+
+    Thin view over :func:`_discover_dep_bindings` for callers that only need
+    the functions themselves. Anything that has to find the call site in the
+    caller's source must use the bindings instead — see ``_DepBinding``.
+    """
+    return [binding.dep for binding in _discover_dep_bindings(func, caller_func_type)]
 
 
 # ---------------------------------------------------------------------------

--- a/python/pypto/jit/specializer.py
+++ b/python/pypto/jit/specializer.py
@@ -130,7 +130,13 @@ class SpecializeContext:
         tensor_meta: TensorMeta per tensor param name.
         scalar_values: Concrete value per scalar param name.
         scalar_dtypes: DataType annotation per scalar param name.
-        dep_names: Names of dep functions called from this function.
+        dep_names: Names this function's source calls its deps by. Under an
+            aliased import (``from mod import kernel as kern``) that is the
+            alias, not the callee's ``__name__`` — see ``dep_func_names``.
+        dep_func_names: ``call name -> generated function name``, for every
+            call name that differs from the function it resolves to. The body
+            transformer consults it when rewriting ``kern(...)`` into
+            ``self.kernel(...)``; an absent entry means the two agree.
         py_globals: Every name visible to the originating function — its
             ``__globals__`` merged with its closure free vars, as built by
             :func:`func_name_lookup`. The specializer uses this to resolve
@@ -181,6 +187,9 @@ class SpecializeContext:
     external_aiv_source: str | None = None
     external_dual_aiv_dispatch: bool = False
     external_include_dirs: tuple[str, ...] = ()
+    # Also appended at the tail (see above): ``call name -> generated function
+    # name`` for the deps this function reaches under a different name.
+    dep_func_names: dict[str, str] = field(default_factory=dict)
 
     @property
     def dynamic_dims(self) -> set[tuple[str, int]]:
@@ -552,11 +561,17 @@ class _BodyTransformer(ast.NodeTransformer):
         initial_used_names: set[str] | None = None,
         py_globals: dict[str, Any] | None = None,
         dep_param_names: dict[str, list[str]] | None = None,
+        dep_func_names: dict[str, str] | None = None,
     ) -> None:
         super().__init__()
         self._meta = tensor_meta
         self._scalars = scalar_values
         self._dep_names = dep_names
+        # Call name → generated function name, for deps this body reaches
+        # under a different name (an aliased import). ``visit_Call`` resolves
+        # through it so ``kern(...)`` becomes ``self.kernel(...)``; a name
+        # absent from the map is its own generated name.
+        self._dep_func_names = dep_func_names or {}
         # DynVar name → (anchor_param, anchor_dim_idx). ``visit_Name`` uses
         # this to rewrite runtime references like ``pl.create_tensor([M, ...])``
         # via ``_dyn_dim_expr`` so the annotation-only DynVar doesn't leak past
@@ -915,13 +930,17 @@ class _BodyTransformer(ast.NodeTransformer):
     def visit_Call(self, node: ast.Call) -> ast.expr:
         """Rewrite dep_func(args) → self.dep_func(args) for multi-function JIT.
 
+        The attribute is the dep's *generated* function name, which differs
+        from the name at the call site when the body reaches the dep through
+        an aliased import (``kern(...)`` → ``self.kernel(...)``).
+
         Keyword args are normalised to positional based on the dep's
         parameter order (so ``dep(a, out=out)`` becomes ``self.dep(a, out)``).
         Inter-function calls inside ``@pl.program`` only accept positional
         args — preserving keyword form would make the parser reject the call.
         """
         if isinstance(node.func, ast.Name) and node.func.id in self._dep_names:
-            dep_name = node.func.id
+            dep_name = self._dep_func_names.get(node.func.id, node.func.id)
             new_func = ast.Attribute(
                 value=ast.Name(id="self", ctx=ast.Load()),
                 attr=dep_name,
@@ -1812,6 +1831,7 @@ class Specializer:
             initial_used_names=all_defined,
             py_globals=ctx.py_globals,
             dep_param_names=self._dep_param_names,
+            dep_func_names=ctx.dep_func_names,
         )
         new_body = [transformer.visit(stmt) for stmt in func_def.body]
         # Accumulate alias→original renames for error message rewriting.
@@ -2031,11 +2051,13 @@ class Specializer:
                 meta = ctx.tensor_meta.get(name)
                 if meta is None:
                     raise ValueError(
-                        f"@pl.jit: missing inferred tensor metadata for parameter '{name}'. "
-                        "This usually means the tensor's shape/dtype could not be statically "
-                        "determined. Pass the tensor directly as a function argument, or "
-                        "ensure any intermediate pl.create_tensor() used for this parameter "
-                        "has a statically inferable shape and dtype."
+                        f"@pl.jit: missing inferred tensor metadata for parameter '{name}' "
+                        f"of '{ctx.func_name}'. This usually means the tensor's shape/dtype "
+                        "could not be statically determined, or that the call site passing it "
+                        f"was not resolved (no call to '{ctx.func_name}' found in its caller). "
+                        "Pass the tensor directly as a function argument, or ensure any "
+                        "intermediate pl.create_tensor() used for this parameter has a "
+                        "statically inferable shape and dtype."
                     )
                 ann = _build_tensor_annotation(
                     meta, is_out=is_out, is_distributed=is_distributed, is_inout=is_inout
@@ -2090,6 +2112,7 @@ def build_specialize_context(  # noqa: PLR0913 — pass-through assembler; each 
     external_aiv_source: str | None = None,
     external_dual_aiv_dispatch: bool = False,
     external_include_dirs: tuple[str, ...] = (),
+    dep_func_names: dict[str, str] | None = None,
 ) -> SpecializeContext:
     """Build a SpecializeContext from a Python function and call-site data.
 
@@ -2101,11 +2124,15 @@ def build_specialize_context(  # noqa: PLR0913 — pass-through assembler; each 
         tensor_meta: TensorMeta per tensor param name.
         scalar_values: Concrete scalar values from the call site.
         scalar_dtypes: DataType per scalar param name.
-        dep_names: Names of @pl.jit.incore functions called from this function.
+        dep_names: Names this function's source calls its @pl.jit deps by
+            (the alias, under an aliased import).
         auto_scope: Whether the compiler auto-inserts AUTO runtime scopes.
             Forwarded to the generated ``@pl.function`` decorator; the
             Orchestration entry, HOST orchestrator, and inline sub-functions
             honor ``False``.
+        dep_func_names: ``call name -> generated function name`` for the deps
+            this function reaches under a different name; names that agree may
+            be omitted.
 
     Dynamic dims live inside ``tensor_meta`` as :class:`DynDim` entries —
     no separate set is passed in.
@@ -2144,6 +2171,7 @@ def build_specialize_context(  # noqa: PLR0913 — pass-through assembler; each 
         scalar_values=scalar_values,
         scalar_dtypes=scalar_dtypes,
         dep_names=dep_names,
+        dep_func_names=dep_func_names or {},
         auto_scope=auto_scope,
         # Closure-aware: a factory-defined kernel captures its constants as free
         # vars, which never appear in __globals__. Folding must see them or they

--- a/tests/ut/jit/_alias_dep_fixture.py
+++ b/tests/ut/jit/_alias_dep_fixture.py
@@ -1,0 +1,27 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Fixture for the aliased-import dep case.
+
+A ``@pl.jit.incore`` kernel that lives in its *own module*, so a caller can
+reach it through ``from _alias_dep_fixture import copy_incore as kern`` — the
+shape that made specialization fail with a misleading "missing inferred tensor
+metadata" error. Its parameters are named unlike any caller variable, so
+nothing can resolve by name coincidence.
+"""
+
+import pypto.language as pl
+from pypto.jit.decorator import jit
+
+
+@jit.incore
+def copy_incore(src: pl.Tensor, dst: pl.Out[pl.Tensor]) -> pl.Tensor:
+    tile = pl.load(src, [0, 0], [64, 64])
+    pl.store(tile, [0, 0], dst)
+    return dst

--- a/tests/ut/jit/test_decorator.py
+++ b/tests/ut/jit/test_decorator.py
@@ -26,6 +26,7 @@ from pypto.jit.decorator import (
     _arg_ref,
     _build_param_mapping,
     _compute_per_func_dyndim_maps,
+    _discover_dep_bindings,
     _discover_deps,
     _extract_call_args_for_dep,
     _extract_local_tensor_metas,
@@ -646,6 +647,211 @@ class TestMultiFuncDepDiscovery:
 
         deps = _discover_deps(entry._func)
         assert len(deps) == 0
+
+
+class TestAliasedDepCallName:
+    """A dep reached under a name other than its own.
+
+    ``from mod import kernel as kern`` (and the equivalent ``kern = kernel``
+    rebinding) leaves the caller's AST calling ``kern``, while the callee's
+    ``__name__`` stays ``kernel``. Every call-site lookup must key on the
+    former; only the generated ``@pl.function`` keeps the latter.
+    """
+
+    @staticmethod
+    def _aliased_entry():
+        """Return ``(entry, dep)`` where ``entry`` calls ``dep`` via an alias.
+
+        The dep's parameters are deliberately named differently from the
+        caller's variables, so nothing resolves by coincidence of names.
+        """
+
+        @jit.incore
+        def copy_incore(src: pl.Tensor, dst: pl.Out[pl.Tensor]) -> pl.Tensor:
+            tile = pl.load(src, [0, 0], [64, 64])
+            pl.store(tile, [0, 0], dst)
+            return dst
+
+        kern = copy_incore  # the alias an ``import ... as`` would bind
+
+        @jit
+        def entry(a: pl.Tensor, c: pl.Out[pl.Tensor]):
+            kern(a, c)
+            return c
+
+        return entry, copy_incore
+
+    def test_discovery_reports_call_name_and_func_name(self):
+        entry, dep = self._aliased_entry()
+        bindings = _discover_dep_bindings(entry._func)
+        assert [(b.call_name, b.dep.__name__) for b in bindings] == [("kern", "copy_incore")]
+        assert bindings[0].dep is dep
+
+    def test_discover_deps_view_drops_call_names(self):
+        entry, dep = self._aliased_entry()
+        assert _discover_deps(entry._func) == [dep]
+
+    def test_scan_dep_io_keyed_by_call_name(self):
+        """``_dep_out_metas`` looks the entry up by the AST's ``ast.Name``."""
+        entry, _ = self._aliased_entry()
+        io = _scan_dep_io(entry._func)
+        assert "kern" in io
+        assert "copy_incore" not in io
+        param_names, output_params = io["kern"]
+        assert param_names == ["src", "dst"]
+        assert output_params == ["dst"]
+
+    def test_dep_metadata_resolves_through_alias(self):
+        """The reported failure: metadata came back empty, blaming the shapes."""
+        entry, dep = self._aliased_entry()
+        caller_meta = {
+            "a": TensorMeta(shape=(64, 64), dtype=DataType.FP32),
+            "c": TensorMeta(shape=(64, 64), dtype=DataType.FP32),
+        }
+        dep_meta, _, _ = _resolve_dep_call_metadata(
+            dep, entry._func, caller_meta, {}, {}, {}, dep_call_name="kern"
+        )
+        # Positional call-site mapping, not the name-based fallback: the dep's
+        # own parameter names appear nowhere in the caller.
+        assert dep_meta["src"].shape == (64, 64)
+        assert dep_meta["dst"].shape == (64, 64)
+
+    def test_context_carries_call_name_and_generated_name(self):
+        torch = pytest.importorskip("torch")
+        entry, _ = self._aliased_entry()
+        a = torch.empty(64, 64)
+        c = torch.empty(64, 64)
+        _pn, _, tmeta, sv, sd, pfd = entry._bind_args((a, c), {})
+        contexts = entry._build_contexts(tmeta, sv, sd, pfd)
+
+        dep_ctx = next(ctx for ctx in contexts if ctx.func_name == "copy_incore")
+        assert dep_ctx.tensor_meta["src"].shape == (64, 64)
+
+        entry_ctx = next(ctx for ctx in contexts if ctx.func_name == "entry")
+        assert entry_ctx.dep_names == ["kern"]
+        assert entry_ctx.dep_func_names == {"kern": "copy_incore"}
+
+    def test_generated_source_calls_the_generated_name(self):
+        """The body rewrite must target ``self.copy_incore``, not ``self.kern``."""
+        torch = pytest.importorskip("torch")
+        entry, _ = self._aliased_entry()
+        a = torch.empty(64, 64)
+        c = torch.empty(64, 64)
+        _pn, _, tmeta, sv, sd, pfd = entry._bind_args((a, c), {})
+        contexts = entry._build_contexts(tmeta, sv, sd, pfd)
+        source = Specializer("_jit_entry", contexts).specialize()
+
+        assert "self.copy_incore(a, c)" in source
+        assert "kern" not in source
+        # And it still parses — an unrewritten bare call does not.
+        assert isinstance(pl.parse(source), ir.Program)
+
+    def test_two_aliases_for_one_dep_both_rewrite(self):
+        """Both call names map onto the single generated function."""
+        torch = pytest.importorskip("torch")
+
+        @jit.incore
+        def copy_incore(src: pl.Tensor, dst: pl.Out[pl.Tensor]) -> pl.Tensor:
+            tile = pl.load(src, [0, 0], [64, 64])
+            pl.store(tile, [0, 0], dst)
+            return dst
+
+        first = copy_incore
+        second = copy_incore
+
+        @jit
+        def entry(a: pl.Tensor, c: pl.Out[pl.Tensor]):
+            first(a, c)
+            second(a, c)
+            return c
+
+        a = torch.empty(64, 64)
+        c = torch.empty(64, 64)
+        _pn, _, tmeta, sv, sd, pfd = entry._bind_args((a, c), {})
+        contexts = entry._build_contexts(tmeta, sv, sd, pfd)
+        entry_ctx = next(ctx for ctx in contexts if ctx.func_name == "entry")
+        assert entry_ctx.dep_func_names == {"first": "copy_incore", "second": "copy_incore"}
+
+        source = Specializer("_jit_entry", contexts).specialize()
+        assert source.count("self.copy_incore(a, c)") == 2
+        # One generated function, called twice.
+        assert source.count("def copy_incore(self") == 1
+
+    def test_module_global_alias_from_import(self):
+        """The reported shape: ``from mod import kernel as kern`` at module scope.
+
+        Discovery reads the entry's ``__globals__``, so the alias must resolve
+        there too — not only through the closure path the other cases use.
+        """
+        import importlib.util  # noqa: PLC0415
+        import types  # noqa: PLC0415
+        from pathlib import Path  # noqa: PLC0415
+
+        torch = pytest.importorskip("torch")
+
+        fixture_path = Path(__file__).parent / "_alias_dep_fixture.py"
+        spec = importlib.util.spec_from_file_location("_alias_dep_fixture", fixture_path)
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+        def _entry_raw(a: pl.Tensor, c: pl.Out[pl.Tensor]):
+            # Bound below, as ``import ... as kern`` would, via the rebuilt globals.
+            kern(a, c)  # noqa: F821  # pyright: ignore[reportUndefinedVariable]
+            return c
+
+        # ``from _alias_dep_fixture import copy_incore as kern`` binds the dep
+        # under ``kern`` in the importing module's globals.
+        new_globals = {**_entry_raw.__globals__, "kern": module.copy_incore}
+        entry = JITFunction(
+            types.FunctionType(
+                _entry_raw.__code__,
+                new_globals,
+                _entry_raw.__name__,
+                _entry_raw.__defaults__,
+                _entry_raw.__closure__,
+            ),
+            func_type="orchestration",
+        )
+
+        a = torch.empty(64, 64)
+        c = torch.empty(64, 64)
+        _pn, _, tmeta, sv, sd, pfd = entry._bind_args((a, c), {})
+        contexts = entry._build_contexts(tmeta, sv, sd, pfd)
+
+        dep_ctx = next(ctx for ctx in contexts if ctx.func_name == "copy_incore")
+        assert dep_ctx.tensor_meta["src"].shape == (64, 64)
+        source = Specializer("_jit_entry_raw", contexts).specialize()
+        assert "self.copy_incore(a, c)" in source
+        assert isinstance(pl.parse(source), ir.Program)
+
+    def test_aliased_dep_out_metadata_propagates_to_capture(self):
+        """``out = kern(a, buf)`` inherits the meta of the arg bound to ``dst``."""
+
+        @jit.incore
+        def copy_incore(src: pl.Tensor, dst: pl.Out[pl.Tensor]) -> pl.Tensor:
+            tile = pl.load(src, [0, 0], [64, 64])
+            pl.store(tile, [0, 0], dst)
+            return dst
+
+        kern = copy_incore
+
+        @jit
+        def entry(a: pl.Tensor, c: pl.Out[pl.Tensor]):
+            buf = pl.create_tensor([32, 16], dtype=pl.FP32)
+            out = kern(a, buf)
+            return out
+
+        metas = _extract_local_tensor_metas(
+            entry._func,
+            seed_meta={
+                "a": TensorMeta(shape=(64, 64), dtype=DataType.FP32),
+                "c": TensorMeta(shape=(64, 64), dtype=DataType.FP32),
+            },
+        )
+        # ``out`` captures the dep's Out param, which the call site bound to
+        # ``buf`` — resolvable only if _scan_dep_io keyed the dep by "kern".
+        assert metas["out"].shape == (32, 16)
 
 
 class TestMultiFuncIntegration:
@@ -1649,7 +1855,7 @@ class TestSlicedDispatchMetadata:
             entry_func=_per_rank_dispatch_body,
             entry_param_names=["inputs", "outputs"],
             deps=[_dyn_sliced_chip],
-            callers_by_dep_id={id(_dyn_sliced_chip._func): [_per_rank_dispatch_body]},
+            callers_by_dep_id={id(_dyn_sliced_chip._func): [(_per_rank_dispatch_body, "_dyn_sliced_chip")]},
             call_args_cache=call_args_cache,
         )
         host_map = maps[id(_per_rank_dispatch_body)]
@@ -1785,8 +1991,9 @@ class TestInlineFuncIntegration:
 
         deps_topo, callers_by_id, callees_by_id, _ = entry._get_dep_graph()
         assert [d.__name__ for d in deps_topo] == ["leaf", "mid"]
-        assert callers_by_id[id(leaf._func)] == [mid._func]
-        assert callers_by_id[id(mid._func)] == [entry._func]
+        # Callers are recorded with the name their source calls the dep by.
+        assert callers_by_id[id(leaf._func)] == [(mid._func, "leaf")]
+        assert callers_by_id[id(mid._func)] == [(entry._func, "mid")]
         assert callees_by_id[id(entry._func)] == ["mid"]
         assert callees_by_id[id(mid._func)] == ["leaf"]
         assert callees_by_id[id(leaf._func)] == []
@@ -1861,9 +2068,10 @@ class TestInlineFuncIntegration:
         # shared leaf, so dyn-dim / dynvar propagation visits every branch
         # rather than just the first DFS path.
         shared_callers = callers_by_id[id(shared._func)]
-        assert {c.__name__ for c in shared_callers} == {"a_helper", "b_helper"}
-        assert callers_by_id[id(a_helper._func)] == [entry_diamond._func]
-        assert callers_by_id[id(b_helper._func)] == [entry_diamond._func]
+        assert {c.__name__ for c, _ in shared_callers} == {"a_helper", "b_helper"}
+        assert {name for _, name in shared_callers} == {"shared"}
+        assert callers_by_id[id(a_helper._func)] == [(entry_diamond._func, "a_helper")]
+        assert callers_by_id[id(b_helper._func)] == [(entry_diamond._func, "b_helper")]
 
         a = torch.randn(32, 32)
         out = torch.empty(32, 32)


### PR DESCRIPTION
## What

`@pl.jit` now resolves a dep's call site by the **name the caller's source calls it by**, so a dep reached through an aliased import specializes like any other.

```python
from kernels import matmul as mm     # previously broke specialization
@pl.jit
def entry(y: pl.Out[pl.Tensor[[16, 256], pl.FP32]]):
    x = pl.create_tensor([16, 256], dtype=pl.FP32)
    mm(x, y)
    return y
```

## Why

Discovery already resolved the call-site name against the entry's globals and closure vars, so the dep *was* found and emitted. It then dropped the binding name, and every later lookup re-derived it as `dep.__name__` — a name that no longer appears in the caller's AST. Two failures followed, which one you hit depended on whether the callee's parameter names happened to match the caller's variables:

| Callee params vs. caller vars | Symptom |
| --- | --- |
| different | `ValueError: @pl.jit: missing inferred tensor metadata for parameter 'src'` — `_extract_call_args_for_dep` found no call site, so metadata fell back to name-based matching and came back empty, blaming shapes that were fully static |
| identical | `Error: Unsupported function call: kern(x, y)` — `ctx.dep_names` held `__name__`, so the body transformer never rewrote `kern(...)` to `self.kernel(...)` |

The name-based fallback is why this looked shape-dependent: when the names coincide it silently succeeds with metas matched by *coincidence of naming* rather than by argument position.

Generated program before the fix — dep emitted, call site untouched:

```python
@pl.program
class _jit_entry:
    @pl.function(type=pl.FunctionType.Inline, auto_scope=False)
    def my_kernel(self, x, y) -> ...: ...
    @pl.function(type=pl.FunctionType.Orchestration, auto_scope=False)
    def entry(self, y) -> ...:
        kern(x, y)        # never rewritten
```

## How

The binding name is threaded through; only function identity keeps `__name__`.

| Site | Change |
| --- | --- |
| `_discover_dep_bindings` (new) | returns `_DepBinding(call_name, dep)` pairs; `_discover_deps` is a thin view over it |
| `_scan_dep_io` | keyed by `call_name`, so `v = kern(...)` `Out`-param propagation matches the AST |
| `_resolve_dep_call_metadata` | new `dep_call_name` drives arg extraction and `stop_at_dep` |
| `_get_dep_graph` | `callers_by_dep_id` holds `(caller_func, call_name)`; `call_args_cache` keyed `(caller, call_name)` |
| `SpecializeContext` | `dep_names` = call names; new `dep_func_names` maps call name → generated function name |
| `_BodyTransformer.visit_Call` | emits `self.<generated name>`; several aliases for one dep collapse onto its single generated function |

`_build_params`' diagnostic now names the callee and says the call site may not have resolved, so a future gap reports itself instead of pointing at tensor shapes.

## Tests

`TestAliasedDepCallName` (9 cases) covers binding discovery, `_scan_dep_io` keying, positional metadata resolution through an alias, the context fields, the `self.<name>` rewrite plus a parse of the generated source, two aliases onto one dep, `Out`-capture propagation, and a real cross-module `import ... as` through the new `tests/ut/jit/_alias_dep_fixture.py`.

## For the reviewer

Three existing tests asserted the internal shape of `callers_by_dep_id` (a bare list of caller functions). That type intentionally becomes `(caller_func, call_name)` pairs, so `test_nested_inline_dep_graph`, `test_nested_inline_diamond` and `test_dyndim_cascade_skips_sliced_arg` were updated — same assertions, now also pinning the recorded call name. No expectation was weakened.

Not addressed here: two *distinct* deps sharing a `__name__` still collide in the generated program. The parser refuses it (`Duplicate function name`), so nothing miscompiles, but the message names neither module. Pre-existing and orthogonal.

Verified with `tests/ut` (11042 passed, 3 skipped, 1 xfailed) and a `compile()` of the original repro, which previously failed.
