### PR TITLE
fix(ir): carry the split through an IfStmt's merge variable

### DIFF
--- a/docs/en/dev/passes/21-lower_auto_vector_split.md
+++ b/docs/en/dev/passes/21-lower_auto_vector_split.md
@@ -769,9 +769,9 @@ A position that is scratch only in *some* arities cannot be declared:
 and workspace in a 2-way one, and the arity is the positional argument count.
 Such a position stays unclassified and a full-width one is rejected.
 
-### Carries and dropped axes
+### Carries, merges and dropped axes
 
-Two places rewrite state *around* the halving rather than in it, and both must
+Three places rewrite state *around* the halving rather than in it, and each must
 follow the same axis and tracking rules or the conditions above misfire:
 
 - **Loop carries.** An `iter_arg` inherits its init value's tracking, so a halved
@@ -781,6 +781,17 @@ follow the same axis and tracking rules or the conditions above misfire:
   arm recurses through its own walk and cannot reach the explicit path's `ForStmt`
   branch, so without this a legal tile accumulator has its carry reported as a
   full-width operand.
+- **Branch merges.** An `IfStmt`'s merge variable (`return_vars_`, a `DefField`)
+  is lane-local exactly when the values its branches yield are. Left at its
+  declared full width it contradicts both `Yield` values *and* stays untracked,
+  so a following `tile.store` gets no lane offset and both AIV lanes write from
+  output row 0 — overlapping writes instead of a half each. `RepairIfReturnVars`
+  retypes it from the lowered branches, and both arms call it for the same reason
+  the loop carries need two call sites. The branches must agree: one yielding a
+  halved value while the other yields a full-width one has no single merge type,
+  and is rejected rather than resolved by picking a side. Both branches always
+  exist here: SSA requires an else wherever `return_vars_` are defined, and
+  `ConvertToSSA` synthesizes the else `Yield` for a source-level no-else phi.
 - **`tile.slice` with `drop_dims`.** `shape` / `offset` / `valid_shape` are
   indexed in the **pre-drop** rank, while the split dim indexes the result.
   `drop_dims` erases axes afterwards and pads back to 2D by *prepending* unit

--- a/docs/zh/dev/passes/21-lower_auto_vector_split.md
+++ b/docs/zh/dev/passes/21-lower_auto_vector_split.md
@@ -648,9 +648,9 @@ picked = pl.tile.gather(src, indices, tmp)   # 被拒绝：表被折半了
 在 3/4 路归并里是第三个已排序输入、在 2 路里才是工作区，而 arity 由位置实参个数决定。
 这类位置保持未分类，全宽时按拒绝处理。
 
-### 循环携带值与被丢弃的轴
+### 循环携带值、分支归并与被丢弃的轴
 
-有两处是在折半**周围**改写状态而非折半本身，它们必须遵循同样的轴映射与跟踪规则，
+有三处是在折半**周围**改写状态而非折半本身，它们必须遵循同样的轴映射与跟踪规则，
 否则上面的条件会误判：
 
 - **循环携带值。** `iter_arg` 继承其 init 的跟踪信息，因此 init 被折半时携带值也变为
@@ -658,6 +658,14 @@ picked = pl.tile.gather(src, indices, tmp)   # 被拒绝：表被折半了
   显式路径与 AUTO 亲和性门控路径共用 `RepairIterArgs` / `RepairReturnVars`——AUTO 走的是
   自己的遍历，够不到显式路径的 `ForStmt` 分支，缺了这一步就会把合法的 tile 累加器的携带值
   当成全宽操作数报错。
+- **分支归并值。** `IfStmt` 的归并变量（`return_vars_`，一个 `DefField`）是否 lane 局部，
+  取决于两个分支 yield 的值是否 lane 局部。保持声明的全宽会同时与两个 `Yield` 矛盾，
+  而且因为它从不被登记进 `tile_vars`，后续 `tile.store` 拿不到 lane 偏移——**两条 AIV
+  lane 都从输出第 0 行开始写**，是覆盖写而不是各写一半。`RepairIfReturnVars` 依据降级后
+  的分支重新定型，两条路径都要调用它，原因和循环携带值需要两个调用点相同。两个分支必须
+  一致：一个 yield 被折半的值、另一个 yield 全宽值时不存在唯一的归并类型，此时直接拒绝，
+  而不是任选一边。这里两个分支必然都存在：只要定义了 `return_vars_`，SSA 就要求有 else，
+  而源码层没有 else 的 phi 会由 `ConvertToSSA` 合成 else `Yield`。
 - **带 `drop_dims` 的 `tile.slice`。** `shape` / `offset` / `valid_shape` 按**丢弃前**的
   rank 索引，而拆分维按结果索引。`drop_dims` 之后才擦除轴，并通过在前面补单元素轴回到 2D，
   因此 `slice([1, 256, 128], drop_dims=[0]) -> [256, 128]` 的结果维 0 对应源的维 1。

--- a/include/pypto/ir/transforms/utils/split_axis_utils.h
+++ b/include/pypto/ir/transforms/utils/split_axis_utils.h
@@ -357,6 +357,23 @@ std::vector<VarPtr> RepairReturnVars(const std::vector<VarPtr>& return_vars,
                                      std::unordered_map<const Var*, VarPtr>& var_replacements,
                                      const ExprPtr& subblock_idx, const ExprPtr& lane_stride);
 
+/// Give each IfStmt merge variable the tile info its branches yield, so it stops
+/// contradicting them and a later tile.store on it gets the per-lane offset.
+/// Call AFTER lowering both branch bodies, with the LOWERED bodies: the merge is
+/// decided by what the branches actually yield, not by what they started as.
+///
+/// Both branches must exist and agree. SSA requires an else wherever return_vars
+/// are defined, so a missing one is a compiler bug. One branch yielding a halved
+/// value while the other yields a full-width one has no single merge type, and
+/// picking either silently gives one AIV lane the wrong extent -- so that is
+/// rejected rather than merged.
+std::vector<VarPtr> RepairIfReturnVars(const std::vector<VarPtr>& return_vars, const StmtPtr& new_then_body,
+                                       const std::optional<StmtPtr>& new_else_body,
+                                       std::unordered_map<const Var*, TileInfo>& tile_vars,
+                                       std::unordered_map<const Var*, VarPtr>& var_replacements,
+                                       const ExprPtr& subblock_idx, const ExprPtr& lane_stride,
+                                       const Span& span);
+
 std::vector<StmtPtr> ProcessStmts(const std::vector<StmtPtr>& stmts, SplitMode mode, int split_dim,
                                   std::unordered_map<const Var*, TileInfo>& tile_vars, bool is_aiv,
                                   const ExprPtr& subblock_idx,

--- a/src/ir/transforms/lower_auto_vector_split_pass.cpp
+++ b/src/ir/transforms/lower_auto_vector_split_pass.cpp
@@ -582,9 +582,18 @@ std::vector<StmtPtr> LowerStmts(const std::vector<StmtPtr>& stmts, SplitMode mod
                                          var_replacements, used_names, lane_stride);
         new_else = loop_repair::MakeBody(new_else_stmts, if_stmt->span_);
       }
+      // Same merge repair as split_axis::ProcessStmt's IfStmt branch. This arm
+      // recurses through LowerStmts and cannot reach that branch, so without it
+      // a branch-merged tile keeps its full-width declared type and stays
+      // untracked -- both AIV lanes then write from output row 0.
+      auto new_then_body = loop_repair::MakeBody(new_then, if_stmt->span_);
+      auto new_return_vars =
+          split_axis::RepairIfReturnVars(if_stmt->return_vars_, new_then_body, new_else, tile_vars,
+                                         var_replacements, subblock_idx, lane_stride, if_stmt->span_);
       auto new_if = MutableCopy(if_stmt);
-      new_if->then_body_ = loop_repair::MakeBody(new_then, if_stmt->span_);
+      new_if->then_body_ = new_then_body;
       new_if->else_body_ = new_else;
+      new_if->return_vars_ = new_return_vars;
       result.push_back(new_if);
       continue;
     }

--- a/src/ir/transforms/utils/split_axis_utils.cpp
+++ b/src/ir/transforms/utils/split_axis_utils.cpp
@@ -1403,9 +1403,17 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_dim,
       new_else = (new_else_stmts.size() == 1) ? new_else_stmts[0]
                                               : std::make_shared<SeqStmts>(new_else_stmts, if_stmt->span_);
     }
+    // Repair the merge the same way the ForStmt arm repairs its carry: a merge
+    // variable whose branches both yield a lane-local value is lane-local too.
+    // Left alone it contradicts both Yield values AND stays untracked, so a
+    // following tile.store gets no lane offset and both AIV lanes write from
+    // output row 0.
+    auto new_return_vars = RepairIfReturnVars(if_stmt->return_vars_, new_then_body, new_else, tile_vars,
+                                              var_replacements, subblock_idx, lane_stride, if_stmt->span_);
     auto new_if = MutableCopy(if_stmt);
     new_if->then_body_ = new_then_body;
     new_if->else_body_ = new_else;
+    new_if->return_vars_ = new_return_vars;
     return new_if;
   }
 
@@ -1495,6 +1503,79 @@ std::vector<VarPtr> RepairReturnVars(const std::vector<VarPtr>& return_vars,
           std::make_shared<Var>(new_return_vars[i]->name_hint_, new_type, new_return_vars[i]->span_);
       new_return_vars[i] = new_return_var;
       tile_vars[new_return_var.get()] = it->second;
+      var_replacements[return_vars[i].get()] = new_return_var;
+    }
+  }
+  return new_return_vars;
+}
+
+namespace {
+
+// The tile info a branch's Yield carries for merge slot ``index``, or nullopt
+// when that slot is not lane-local. A Yield value is left referencing the
+// pre-halving var (the trailing Substitute rewrites it later), and the halving
+// path registers BOTH the old and the new var in ``tile_vars`` -- so looking the
+// yielded value up there is what tells the two apart.
+std::optional<TileInfo> YieldedTileInfo(const YieldStmtPtr& yield, size_t index,
+                                        const std::unordered_map<const Var*, TileInfo>& tile_vars) {
+  if (!yield || index >= yield->value_.size()) return std::nullopt;
+  auto value_var = AsVarLike(yield->value_[index]);
+  if (!value_var) return std::nullopt;
+  auto it = tile_vars.find(value_var.get());
+  if (it == tile_vars.end()) return std::nullopt;
+  return it->second;
+}
+
+bool SameTileInfo(const TileInfo& a, const TileInfo& b) {
+  return a.split_dim == b.split_dim && structural_equal(a.half_dim_size, b.half_dim_size);
+}
+
+}  // namespace
+
+std::vector<VarPtr> RepairIfReturnVars(const std::vector<VarPtr>& return_vars, const StmtPtr& new_then_body,
+                                       const std::optional<StmtPtr>& new_else_body,
+                                       std::unordered_map<const Var*, TileInfo>& tile_vars,
+                                       std::unordered_map<const Var*, VarPtr>& var_replacements,
+                                       const ExprPtr& subblock_idx, const ExprPtr& lane_stride,
+                                       const Span& span) {
+  std::vector<VarPtr> new_return_vars = return_vars;
+  if (return_vars.empty()) return new_return_vars;
+
+  // An IfStmt that defines return_vars must have an else branch -- SSAVerifier
+  // rejects the else-less shape outright, and ConvertToSSA synthesizes the else
+  // Yield for a source-level no-else phi. So both definitions exist by the time
+  // this pass runs, and a missing one is a compiler bug rather than a shape to
+  // support.
+  INTERNAL_CHECK_SPAN(new_else_body.has_value(), span)
+      << "Internal error: LowerAutoVectorSplit found an IfStmt defining " << new_return_vars.size()
+      << " return var(s) with no else branch; SSA requires both branches to define the merge.";
+
+  auto then_yield = transform_utils::GetLastYieldStmt(new_then_body);
+  auto else_yield = transform_utils::GetLastYieldStmt(*new_else_body);
+
+  for (size_t i = 0; i < new_return_vars.size(); ++i) {
+    auto then_info = YieldedTileInfo(then_yield, i, tile_vars);
+    auto else_info = YieldedTileInfo(else_yield, i, tile_vars);
+
+    if (!then_info.has_value() && !else_info.has_value()) continue;
+    CHECK_SPAN(then_info.has_value() && else_info.has_value() && SameTileInfo(*then_info, *else_info), span)
+        << "LowerAutoVectorSplit: the branches of an if inside the automatically split vector region "
+           "disagree about merge variable '"
+        << new_return_vars[i]->name_hint_
+        << "': one yields a value the split made lane-local while the other does not (or they are split "
+           "along different axes). There is no single per-lane type for the merged value, and picking "
+           "either one silently gives one AIV lane the wrong extent. Make both branches yield values "
+           "derived the same way -- load or slice inside the region on both sides, or keep the value "
+           "shared by both lanes on both sides -- or move the if outside the automatically split region.";
+
+    tile_vars[new_return_vars[i].get()] = *then_info;
+    auto new_type = ApplyTrackedTileShape(new_return_vars[i]->GetType(), then_info->split_dim,
+                                          then_info->half_dim_size, subblock_idx, lane_stride);
+    if (new_type != new_return_vars[i]->GetType()) {
+      auto new_return_var =
+          std::make_shared<Var>(new_return_vars[i]->name_hint_, new_type, new_return_vars[i]->span_);
+      new_return_vars[i] = new_return_var;
+      tile_vars[new_return_var.get()] = *then_info;
       var_replacements[return_vars[i].get()] = new_return_var;
     }
   }

--- a/tests/ut/ir/transforms/test_lower_auto_vector_split.py
+++ b/tests/ut/ir/transforms/test_lower_auto_vector_split.py
@@ -4209,5 +4209,123 @@ def test_e2e_none_region_c2v_crossing_lowers_to_split_zero_transport():
     assert "pl.tile.aiv_shard" not in aic and "pl.tile.aiv_shard" not in aiv
 
 
+def test_if_merge_variable_is_retyped_and_tracked():
+    """An IfStmt that merges a tile must carry the split through its merge var.
+
+    Both branches yield a value the split halved, so the merge variable is
+    lane-local too. Left at its declared full width it disagrees with both
+    ``Yield`` values, and — because it is never registered in ``tile_vars`` — a
+    following ``tile.store`` gets no lane offset, so both AIV lanes write from
+    output row 0 instead of taking a half each.
+    """
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def split_auto(
+            cube_seed: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat],
+            data: pl.Tensor[[128, 128], pl.FP32],
+            flag: pl.Scalar[pl.INT64],
+            out_0: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+        ) -> pl.Tensor[[128, 128], pl.FP32]:
+            seed_vec = pl.tile.move(cube_seed, target_memory=pl.Mem.Vec)  # noqa: F841
+            v = pl.tile.load(data, [0, 0], [128, 128], target_memory=pl.Mem.Vec)
+            if flag > 0:
+                doubled = pl.tile.add(v, v)
+                merged: pl.Tile[[128, 128], pl.FP32, pl.Mem.Vec] = pl.yield_(doubled)
+            else:
+                merged: pl.Tile[[128, 128], pl.FP32, pl.Mem.Vec] = pl.yield_(v)
+            out_store = pl.tile.store(merged, [0, 0], out_0)
+            return out_store
+
+    printed = _lower(Before).as_python()
+    # The merge variable is halved with its branches...
+    assert "merged: pl.Tile[[64, 128], pl.FP32, pl.Mem.Vec]" in printed
+    # ...and the store that consumes it takes this lane's half of the output.
+    assert "pl.tile.store(merged, [0 + subblock_idx * 64, 0], out_0)" in printed
+
+
+def test_if_branches_disagreeing_on_the_merge_are_rejected():
+    """One halved branch and one full-width branch have no single merge type.
+
+    ``v`` is loaded inside the region and halved; ``shared`` is a full-width
+    parameter nothing partitions. Halving the merge variable would be wrong for
+    the else path and leaving it full width wrong for the then path, so neither
+    choice is a merge — take the rejection instead of silently giving one AIV
+    lane the wrong extent.
+    """
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def split_auto(
+            cube_seed: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat],
+            data: pl.Tensor[[128, 128], pl.FP32],
+            shared: pl.Tile[[128, 128], pl.FP32, pl.Mem.Vec],
+            flag: pl.Scalar[pl.INT64],
+            out_0: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+        ) -> pl.Tensor[[128, 128], pl.FP32]:
+            seed_vec = pl.tile.move(cube_seed, target_memory=pl.Mem.Vec)  # noqa: F841
+            v = pl.tile.load(data, [0, 0], [128, 128], target_memory=pl.Mem.Vec)
+            if flag > 0:
+                merged: pl.Tile[[128, 128], pl.FP32, pl.Mem.Vec] = pl.yield_(v)
+            else:
+                merged: pl.Tile[[128, 128], pl.FP32, pl.Mem.Vec] = pl.yield_(shared)
+            out_store = pl.tile.store(merged, [0, 0], out_0)
+            return out_store
+
+    with pytest.raises(ValueError, match="disagree about merge variable") as exc_info:
+        _lower(Before)
+    assert "'merged'" in str(exc_info.value)
+
+
+def test_source_level_no_else_phi_still_merges_after_ssa_conversion():
+    """A source-level ``if`` with no ``else`` reaches this pass *with* one.
+
+    ``SSAVerifier::VerifyIfStmt`` rejects an ``IfStmt`` that defines
+    ``return_vars_`` without an else branch, and ``ConvertToSSA`` synthesizes the
+    else ``Yield`` (from the binding the merge shadows) precisely so the shape
+    below is legal by the time any later pass sees it. So the merge repair needs
+    no else-less special case — it only has to handle what SSA guarantees.
+
+    Running the real conversion here rather than hand-shaping the ``IfStmt`` is
+    the point: it is what proves the guarantee holds for the source form users
+    actually write.
+    """
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def split_auto(
+            cube_seed: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat],
+            data: pl.Tensor[[128, 128], pl.FP32],
+            flag: pl.Scalar[pl.INT64],
+            out_0: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+        ) -> pl.Tensor[[128, 128], pl.FP32]:
+            seed_vec = pl.tile.move(cube_seed, target_memory=pl.Mem.Vec)  # noqa: F841
+            merged = pl.tile.load(data, [0, 0], [128, 128], target_memory=pl.Mem.Vec)
+            if flag > 0:
+                merged = pl.tile.add(merged, merged)
+            out_store = pl.tile.store(merged, [0, 0], out_0)
+            return out_store
+
+    in_ssa = passes.convert_to_ssa()(Before)
+    converted = in_ssa.get_function("split_auto")
+    assert converted is not None
+    body = converted.body
+    stmts = body.stmts if isinstance(body, ir.SeqStmts) else [body]
+    if_stmt = next(s for s in stmts if isinstance(s, ir.IfStmt))
+    # The guarantee this test rests on: the conversion supplied the else branch.
+    assert if_stmt.return_vars, "expected the rebind to become an IfStmt merge"
+    assert if_stmt.else_body is not None, "ConvertToSSA must synthesize the else for a no-else phi"
+
+    # SSA renames, so anchor on the merge's own name rather than the source spelling.
+    merge_name = if_stmt.return_vars[0].name_hint
+    printed = _lower(in_ssa).as_python()
+    assert f"{merge_name}: pl.Tile[[64, 128], pl.FP32, pl.Mem.Vec]" in printed
+    store_line = next(line for line in printed.splitlines() if "pl.tile.store(" in line)
+    assert f"pl.tile.store({merge_name}, [0 + subblock_idx * 64, 0]" in store_line
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

`LowerAutoVectorSplit` rebuilds and tracks a `ForStmt`'s loop-carried state so a halved carry stays lane-local, but did the same for **no** `IfStmt`. Both branch bodies were lowered and their `Yield` values substituted, while `IfStmt::return_vars_` kept its original full-width type, was never added to `tile_vars`, and got no old→new replacement.

Two things went wrong at once:

```python
v: pl.Tile[[64, 128], ...] = pl.tile.load(data, [0 + subblock_idx * 64, 0], ...)
if flag > 0:
    merged: pl.Tile[[128, 128], ...] = pl.yield_(doubled)   # branches are halved
else:
    merged: pl.Tile[[128, 128], ...] = pl.yield_(v)
out_store = pl.tile.store(merged, [0, 0], out_0)            # BOTH lanes write row 0
```

- the merge variable contradicts both `Yield` values — the same declared-type-versus-operand defect as #2203, on the merge path;
- because it stays untracked, the following `tile.store` gets **no lane offset**, so the two AIV lanes overlap their writes instead of taking a half each.

Behavior change: a branch-merged tile inside an automatically split region is now halved and lane-offset correctly; a merge whose branches disagree is rejected at compile time with a `ValueError`. No in-contract program changes behavior. No interface or migration step.

## Changes

- `src/ir/transforms/utils/split_axis_utils.{h,cpp}`: add `RepairIfReturnVars`, mirroring what `RepairIterArgs` / `RepairReturnVars` do for loop carries — retype the merge to the per-lane extent, register it in `tile_vars`, record the replacement. A `Yield` value still references the pre-halving var, and the halving path registers *both* the old and the new var in `tile_vars`, so looking the yielded value up there is what tells a lane-local branch value from a shared one.
- `src/ir/transforms/utils/split_axis_utils.cpp`: call it from `ProcessStmt`'s `IfStmt` branch.
- `src/ir/transforms/lower_auto_vector_split_pass.cpp`: call it from the AUTO affinity-gated arm too — that arm recurses through its own walk and cannot reach `ProcessStmt`'s `IfStmt` branch, the same reason the loop carries needed two call sites.
- `docs/{en,zh}/dev/passes/21-lower_auto_vector_split.md`: the "Carries and dropped axes" section becomes "Carries, merges and dropped axes" and documents the merge rule.
- `tests/ut/ir/transforms/test_lower_auto_vector_split.py`: three cases (below).

### The two rules the merge needs

**Branches must agree.** One yielding a halved value while the other yields a full-width one has no single merge type: halving is wrong for the else path, not halving is wrong for the then path, and picking either silently gives one AIV lane the wrong extent. Rejected, with the merge variable named.

**An `if` with no `else` is not a disagreement.** `return_vars_` is a `DefField`, so an else-less `if` defines the merge name on the taken path only — its one branch is the sole constraint on the type, and following it is what makes that path well-typed. (Verified that shape parses and reaches the pass; it does.)

## Verification

Run at the pushed commit, in a worktree-local build:

- `pytest tests/ut/ir/transforms/ tests/ut/ir/operators/ tests/ut/codegen/ -q -n 16 -p no:randomly`: 6050 passed, 2 skipped.
- 12 `tests/lint/` checks: all passed.
- `clang-format --dry-run --Werror`, `ruff check`, `ruff format --check` on the changed sources: passed.

Two pre-existing failures on this machine, both reproduced with **every change in this PR reverted** and therefore unrelated:

- `tests/ut/language/test_unified_ops.py::...::test_symlinked_import_path_still_names_the_caller` — the editable install's meta-path finder hijacks the subprocess's symlinked `import pypto`.
- `tests/ut/codegen/test_orchestration_codegen_graph.py::test_generated_orchestration_compiles_against_the_pinned_runtime` — the local `runtime` submodule is checked out at `dbdd041e` while the branch pins `15f5cbd9`, so the generated file is type-checked against the wrong headers (`static assertion failed: all arguments must be simpler::hbg::Tensor`). The submodule is deliberately left unstaged.

### Tests added

- `test_if_merge_variable_is_retyped_and_tracked` — both branches yield a halved value; asserts the merge is `[64, 128]` and the store carries `+ subblock_idx * 64`. Fails on `main` with the merge left at `[128, 128]` and the store at `[0, 0]`.
- `test_if_branches_disagreeing_on_the_merge_are_rejected` — one halved branch, one full-width parameter; asserts the diagnostic names `merged`.
- `test_if_without_else_takes_the_merge_type_from_its_only_branch` — pins the else-less rule.

No system tests were run locally; CI covers them.

Closes #2608
