### PR TITLE
feat(jit): add specialize() for pre-pass IR, and an ST case surface built on it

### DIFF
--- a/docs/en/user/language/01-functions.md
+++ b/docs/en/user/language/01-functions.md
@@ -250,6 +250,30 @@ check. Both accept `config=RunConfig(...)`, but `lower()` ignores the runtime an
 fields. Compile options are in [Compiling](../execution/00-compile.md) and the runtime surface in
 [Running](../execution/01-run.md).
 
+`specialize(*sample_args)` stops one stage earlier still: entry and deps are specialized
+into `@pl.program` source and parsed, and the **pre-pass** `ir.Program` comes back
+untransformed. Reach for it only when something downstream runs the pass pipeline itself
+— most of all `ir.compile(program, output_dir=...)`, which runs passes *and* code
+generation, so handing it `lower()`'s output would run the pipeline twice.
+
+```python
+program = my_kernel.specialize(sample_x, sample_w, sample_out)
+ir.compile(program, output_dir="build/out", backend_type=BackendType.Ascend910B)
+```
+
+It takes no `config=`: no pass runs here, so a `RunConfig` would have nothing to
+configure. Sample arguments may be omitted only when every tensor parameter is annotated
+with full shapes — a bare `pl.Tensor` has none to read.
+
+> Two kernels that specialize to the same program compare equal **after** passes, not
+> before: the specializer renames SSA-rebound locals (`out` becomes `out_v1`), and
+> canonicalization removes the difference. Compare `lower()` output when asserting
+> equivalence against a hand-written `@pl.program`.
+
+Three accessors describe the signature without specializing anything: `param_names` (in
+declaration order), `output_param_names` (the `pl.Out[...]` and `pl.InOut[...]` params,
+also in declaration order), and `__name__`.
+
 ### External C++ kernels
 
 A hand-written C++ kernel can be called like any other function. See

--- a/docs/zh/user/language/01-functions.md
+++ b/docs/zh/user/language/01-functions.md
@@ -197,6 +197,19 @@ print("artifacts in:", compiled.output_dir)
 
 `lower(*sample_args)` 比它早停一站：只跑 Pass 并返回 Pass 后的 `ir.Program`，不做代码生成、不调 `ptoas`、不写产物、不写缓存。要读降级后的 IR 就用它；要检查代码生成本身就用 `compile()`。两者都接受 `config=RunConfig(...)`，但 `lower()` 会忽略其中的运行时与产物字段。编译选项见 [编译](../execution/00-compile.md)，运行时接口见 [运行](../execution/01-run.md)。
 
+`specialize(*sample_args)` 比它还要早停一站：把入口及其依赖特化成 `@pl.program` 源码并解析，返回**未经任何 Pass** 的 `ir.Program`。只有当下游要自己跑 Pass 流水线时才需要它 —— 最主要的场景是 `ir.compile(program, output_dir=...)`，它会同时跑 Pass 和代码生成，把 `lower()` 的结果喂给它会让流水线跑两遍。
+
+```python
+program = my_kernel.specialize(sample_x, sample_w, sample_out)
+ir.compile(program, output_dir="build/out", backend_type=BackendType.Ascend910B)
+```
+
+它不接受 `config=`：这里不跑任何 Pass，`RunConfig` 没有可配置的东西。只有当每个张量参数都带完整形状注解时才能省略采样实参 —— 裸 `pl.Tensor` 没有形状可读。
+
+> 两个特化出相同程序的 kernel，是在 **Pass 之后**才相等，而不是之前：特化器会重命名 SSA 重绑定的局部量（`out` 变成 `out_v1`），规范化会消除这个差异。要和手写 `@pl.program` 断言等价，请比较 `lower()` 的结果。
+
+另有三个访问器可以在不做任何特化的情况下读取签名：`param_names`（按声明顺序）、`output_param_names`（`pl.Out[...]` 与 `pl.InOut[...]` 参数，同样按声明顺序）、以及 `__name__`。
+
 ### 外部 C++ kernel
 
 手写的 C++ kernel 可以像普通函数一样被调用。见 [集成手写 C++ Kernel](../../dev/language/04-external-kernels.md)。

--- a/python/pypto/jit/decorator.py
+++ b/python/pypto/jit/decorator.py
@@ -2433,9 +2433,20 @@ class JITFunction:
 
         Returns:
             The parsed ``ir.Program``, before any pass has run.
+
+        Raises:
+            TypeError: ``config=`` was passed. Accepting it silently would let
+                a caller believe a strategy or diagnostics setting shaped the
+                returned IR, when no pass ran to read it.
         """
         import pypto.language as pl  # noqa: PLC0415
 
+        if "config" in kwargs:
+            raise TypeError(
+                f"@pl.jit function '{self.__name__}': specialize() does not accept config=. "
+                "No pass runs here, so a RunConfig would have nothing to configure. Use "
+                "lower(config=...) for post-pass IR, or compile(config=...) to build an artifact."
+            )
         specialization, _ = self._resolve_specialization(args, kwargs, allow_signature_mode=True)
         return self._compile_to_program(
             specialization.tensor_meta,

--- a/python/pypto/jit/decorator.py
+++ b/python/pypto/jit/decorator.py
@@ -2402,6 +2402,66 @@ class JITFunction:
         compiled, _ordered_args, _run_config = self._resolve_compiled(args, kwargs, allow_signature_mode=True)
         return compiled
 
+    def specialize(self, *args: Any, **kwargs: Any) -> _ir.Program:
+        """Specialize this JIT function and return its **pre-pass** IR.
+
+        The step [`lower`][pypto.language.JITFunction.lower] takes before it
+        runs the pass pipeline: entry and every transitive dep are specialized
+        into ``@pl.program`` source and parsed, and the parsed program is
+        returned untransformed. No passes, no code generation, no ``ptoas``, no
+        device, and the compiled-program cache is neither read nor written.
+
+        Use this to hand a JIT kernel to a consumer that wants to drive the
+        pass pipeline itself — most notably ``ir.compile(program,
+        output_dir=...)``, which runs passes *and* code generation and so must
+        be given the program before any pass has touched it. Passing
+        ``lower()``'s result there would run the pipeline a second time.
+
+        Two JIT kernels that specialize to the same program compare equal
+        *after* passes, not before: the specializer renames SSA-rebound locals
+        (``out`` becomes ``out_v1``), which canonicalization removes. Compare
+        ``lower()`` output when asserting equivalence against a hand-written
+        ``@pl.program``.
+
+        Args:
+            *args: Positional sample arguments matching the decorated function.
+                Omit tensor samples to specialize from the annotations, which
+                then must carry full shapes.
+            **kwargs: Keyword sample arguments. Unlike ``lower()`` there is no
+                ``config``: the pass pipeline never runs here, so a
+                ``RunConfig`` would have nothing to configure.
+
+        Returns:
+            The parsed ``ir.Program``, before any pass has run.
+        """
+        import pypto.language as pl  # noqa: PLC0415
+
+        specialization, _ = self._resolve_specialization(args, kwargs, allow_signature_mode=True)
+        return self._compile_to_program(
+            specialization.tensor_meta,
+            specialization.scalar_values,
+            specialization.scalar_dtypes,
+            specialization.per_func_dyn,
+            pl,
+        )
+
+    @property
+    def param_names(self) -> tuple[str, ...]:
+        """Declared parameter names, in signature order (``self`` excluded)."""
+        return tuple(self._param_names())
+
+    @property
+    def output_param_names(self) -> tuple[str, ...]:
+        """Parameters the kernel writes — ``pl.Out[...]`` and ``pl.InOut[...]``.
+
+        In declaration order, so the tuple stays aligned with the callee's
+        return order. A caller that materialises tensors for this kernel uses
+        it to decide which of them are results to validate.
+        """
+        out_params, inout_params, _, _, _ = _classify_params(_get_func_def(self._func))
+        written = set(out_params) | set(inout_params)
+        return tuple(p for p in self._param_names() if p in written)
+
     def lower(self, *args: Any, **kwargs: Any) -> _ir.Program:
         """Specialize this JIT function and return its post-pass IR.
 

--- a/tests/st/conftest.py
+++ b/tests/st/conftest.py
@@ -39,6 +39,7 @@ if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
 
 import pytest  # noqa: E402
+from harness.core.case import Case  # noqa: E402
 from harness.core.environment import (  # noqa: E402
     get_simpler_python_path,
     get_simpler_scripts_path,
@@ -53,6 +54,10 @@ from harness.core.test_runner import (  # noqa: E402
     shutdown_pipeline,
     start_pipeline,
 )
+
+# ``case_run`` is re-exported here so pytest discovers it as a session-wide
+# fixture; the tests themselves import only ``harness.st``.
+from harness.st import case_run  # noqa: E402,F401
 from pypto import LogLevel  # noqa: E402
 from pypto.pypto_core import _clear_thread_log_level, _set_thread_log_level  # noqa: E402
 from pypto.pypto_core.passes import MemoryPlanner  # noqa: E402
@@ -759,7 +764,11 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
     item carries that platform instead of falling back to the first CLI id.
     """
     direct = _direct_argnames(metafunc.function)
-    if "test_runner" not in direct:
+    # ``case_run`` reaches the runner too, and it is function-scoped, so a
+    # ``@st.cases(...)`` test expands over the matrix exactly like one taking
+    # ``test_runner`` directly. Without it those tests would silently run on
+    # the session's first platform only.
+    if not direct & {"test_runner", "case_run"}:
         return
     if "platform" in metafunc.fixturenames:
         return
@@ -939,13 +948,24 @@ def _collect_test_case_from_item(
     if any(m.name == "skip" for m in item.iter_markers()):
         return
 
+    callspec = getattr(item, "callspec", None)
+    params: dict[str, Any] = callspec.params if callspec else {}
+
+    # A case declared with ``@st.cases(...)`` is already a collection-time
+    # value: read it straight out of the parametrize params. No source parsing,
+    # no re-construction, and no silent fallback — if the declaration is there,
+    # this is the whole discovery step.
+    declared = params.get("_st_case")
+    if isinstance(declared, Case):
+        platform = params.get("platform") or params.get("_st_platform") or session_platform
+        declared.bind_platform(platform)
+        seen.setdefault(_cache_key(declared, platform, session_memory_planner), declared)
+        return
+
     module = item.module
     if module is None:
         return
     globalns = vars(module)
-
-    callspec = getattr(item, "callspec", None)
-    params: dict[str, Any] = callspec.params if callspec else {}
 
     try:
         source = textwrap.dedent(inspect.getsource(item.function))

--- a/tests/st/conftest.py
+++ b/tests/st/conftest.py
@@ -844,6 +844,11 @@ def pytest_collection_modifyitems(config, items):
     the variant's own platform must lie inside the effective allowed set.
     Items without a platform parameter pass as long as the effective set is
     non-empty.
+
+    A third layer applies to a declared ``Case`` that pinned its own platform:
+    since that pin outranks the item's, only the matrix variant the pin names
+    is kept. Without it the other variants would run the pinned platform and
+    report themselves as covering one they never touched.
     """
     cli_platforms = _parse_platform_filter(config.getoption("--platform"))
     cli_filter = set(cli_platforms or ALL_PLATFORM_IDS)
@@ -863,6 +868,19 @@ def pytest_collection_modifyitems(config, items):
         callspec = getattr(item, "callspec", None)
         params = callspec.params if callspec else {}
         platform_param = params.get("platform") or params.get("_st_platform")
+
+        # A declared case may pin its own platform, and that pin outranks the
+        # item's in `_resolve_platform`. Left alone, every variant of such a
+        # case would compile and run the pinned platform while reporting itself
+        # as the variant's -- an A2A3 item claiming coverage it never had. Keep
+        # only the variant the pin names. This runs before
+        # `pytest_collection_finish`, so `_st_case` is still the author's
+        # declaration and `get_platform()` is exactly the pin, or None.
+        declared_case = params.get("_st_case")
+        case_pin = declared_case.get_platform() if isinstance(declared_case, Case) else None
+        if case_pin is not None and platform_param is not None and case_pin != platform_param:
+            deselected.append(item)
+            continue
 
         if platform_param is not None:
             if platform_param in allowed:
@@ -967,7 +985,15 @@ def _collect_test_case_from_item(
         bound = declared.for_platform(platform)
         if bound is not declared and callspec is not None:
             callspec.params["_st_case"] = bound
-        seen.setdefault(_cache_key(bound, platform, session_memory_planner), bound)
+        # Key on the case's *effective* platform, not the item's. A case that
+        # pinned one keeps it, and `_resolve_platform` lets that pin outrank the
+        # item -- so keying by the item's platform would file one object under a
+        # key per matrix variant, and the pipeline would then resolve every one
+        # of them back to the pin and compile the same artifact directory
+        # concurrently. `pytest_collection_modifyitems` already drops the
+        # variants a pin excludes; this keeps the surviving one keyed by what it
+        # will actually be built for.
+        seen.setdefault(_cache_key(bound, bound.get_platform() or platform, session_memory_planner), bound)
         return
 
     module = item.module
@@ -1027,7 +1053,13 @@ def _collect_test_case_from_item(
         # on the session platform, which is what the pipeline resolves for it.
         platform = params.get("platform") or params.get("_st_platform") or session_platform
         instance.bind_platform(platform)
-        seen.setdefault(_cache_key(instance, platform, session_memory_planner), instance)
+        # Effective platform, for the same reason as the declared branch above:
+        # a case constructed with platform=... keeps its own, and bind_platform
+        # leaves it alone.
+        seen.setdefault(
+            _cache_key(instance, instance.get_platform() or platform, session_memory_planner),
+            instance,
+        )
 
 
 def pytest_collection_finish(session: pytest.Session) -> None:

--- a/tests/st/conftest.py
+++ b/tests/st/conftest.py
@@ -958,8 +958,16 @@ def _collect_test_case_from_item(
     declared = params.get("_st_case")
     if isinstance(declared, Case):
         platform = params.get("platform") or params.get("_st_platform") or session_platform
-        declared.bind_platform(platform)
-        seen.setdefault(_cache_key(declared, platform, session_memory_planner), declared)
+        # One Case object is declared per st.cases() entry and pytest hands that
+        # same object to every platform variant of the item, so the binding goes
+        # onto a per-item copy (see Case.for_platform) and the copy replaces the
+        # shared declaration in this item's params. Binding in place would pin
+        # the first variant's platform for all of them, and every variant would
+        # compile and run that first platform's artifact.
+        bound = declared.for_platform(platform)
+        if bound is not declared and callspec is not None:
+            callspec.params["_st_case"] = bound
+        seen.setdefault(_cache_key(bound, platform, session_memory_planner), bound)
         return
 
     module = item.module

--- a/tests/st/examples/00_hello_world/test_hello_world.py
+++ b/tests/st/examples/00_hello_world/test_hello_world.py
@@ -16,25 +16,21 @@ Verifies the simplest end-to-end @pl.jit kernel: load → add → store.
 import pytest
 import torch
 from examples.beginner.hello_world import tile_add
+from harness import st
 
 
-class TestHelloWorld:
-    """Hello World test suite — verifies the simplest PyPTO kernel."""
+def _add_case():
+    """Element-wise addition: c = a + b."""
+    a = torch.full((128, 128), 2.0, dtype=torch.float32)
+    b = torch.full((128, 128), 3.0, dtype=torch.float32)
+    c = torch.zeros((128, 128), dtype=torch.float32)
+    return st.case(tile_add, a, b, c, name="hello_world_add", golden=lambda _: a + b)
 
-    def test_hello_world_add(self, test_config):
-        """Compile and run element-wise addition; compare result to torch reference."""
-        tile_add._cache.clear()
 
-        a = torch.full((128, 128), 2.0, dtype=torch.float32)
-        b = torch.full((128, 128), 3.0, dtype=torch.float32)
-        c = torch.zeros((128, 128), dtype=torch.float32)
-
-        tile_add(a, b, c, config=test_config)
-
-        expected = a + b
-        assert torch.allclose(c, expected, rtol=1e-5, atol=1e-5), (
-            f"Hello world add failed: max diff = {(c - expected).abs().max().item()}"
-        )
+@st.cases(_add_case())
+def test_hello_world_add(case_run):
+    """Compile and run element-wise addition; compare result to torch reference."""
+    case_run.assert_passed()
 
 
 if __name__ == "__main__":

--- a/tests/st/examples/01_beginner/basic/test_basic_ops.py
+++ b/tests/st/examples/01_beginner/basic/test_basic_ops.py
@@ -19,6 +19,12 @@ Four fused operation patterns are demonstrated:
   2. fused_add_relu      — vector: c = relu(a + b)
   3. fused_matmul_bias   — cube + vector: c = matmul(a, b) + bias
   4. fused_linear_relu   — cube + vector: y = relu(matmul(x, w) + bias)
+
+Verifies that fused kernels produce results matching PyTorch reference
+implementations across three fusion patterns:
+  - Vector-only fusion (add+scale, add+relu)
+  - Cube+vector fusion (matmul+bias)
+  - Full linear layer (matmul+bias+relu)
 """
 
 import pytest
@@ -26,69 +32,69 @@ import torch
 from examples.beginner.activation import fused_add_relu
 from examples.beginner.scalar_ops import fused_add_scale
 from examples.intermediate.fused_linear import fused_linear_relu, fused_matmul_bias
+from harness import st
 
 
-class TestBasicFusedOps:
-    """System tests for basic fused operator kernels.
+def _add_scale_case():
+    """Fused add and scale: c = (a + b) * 2.0."""
+    a = torch.full((128, 128), 2.0, dtype=torch.float32)
+    b = torch.full((128, 128), 3.0, dtype=torch.float32)
+    c = torch.zeros((128, 128), dtype=torch.float32)
+    return st.case(fused_add_scale, a, b, c, name="fused_add_scale", golden=lambda _: (a + b) * 2.0)
 
-    Verifies that fused kernels produce results matching PyTorch reference
-    implementations across three fusion patterns:
-      - Vector-only fusion (add+scale, add+relu)
-      - Cube+vector fusion (matmul+bias)
-      - Full linear layer (matmul+bias+relu)
-    """
 
-    def test_fused_add_scale(self, test_config):
-        """Test fused add and scale: c = (a + b) * 2.0"""
-        fused_add_scale._cache.clear()
-        a = torch.full((128, 128), 2.0, dtype=torch.float32)
-        b = torch.full((128, 128), 3.0, dtype=torch.float32)
-        c = torch.zeros((128, 128), dtype=torch.float32)
-        fused_add_scale(a, b, c, config=test_config)
-        expected = (a + b) * 2.0
-        assert torch.allclose(c, expected, rtol=1e-5, atol=1e-5), (
-            f"Fused add+scale failed: max diff = {(c - expected).abs().max().item()}"
-        )
+def _add_relu_case():
+    """Fused add and relu: c = relu(a + b)."""
+    a = torch.full((128, 128), 2.0, dtype=torch.float32)
+    b = torch.full((128, 128), 3.0, dtype=torch.float32)
+    c = torch.zeros((128, 128), dtype=torch.float32)
+    return st.case(fused_add_relu, a, b, c, name="fused_add_relu", golden=lambda _: torch.relu(a + b))
 
-    def test_fused_add_relu(self, test_config):
-        """Test fused add and relu: c = relu(a + b)"""
-        fused_add_relu._cache.clear()
-        a = torch.full((128, 128), 2.0, dtype=torch.float32)
-        b = torch.full((128, 128), 3.0, dtype=torch.float32)
-        c = torch.zeros((128, 128), dtype=torch.float32)
-        fused_add_relu(a, b, c, config=test_config)
-        expected = torch.relu(a + b)
-        assert torch.allclose(c, expected, rtol=1e-5, atol=1e-5), (
-            f"Fused add+relu failed: max diff = {(c - expected).abs().max().item()}"
-        )
 
-    def test_fused_matmul_bias(self, test_config):
-        """Test fused matmul and bias add: c = matmul(a, b) + bias"""
-        fused_matmul_bias._cache.clear()
-        torch.manual_seed(0)
-        a = torch.full((64, 64), 2.0, dtype=torch.float32)
-        b = torch.full((64, 64), 3.0, dtype=torch.float32)
-        bias = torch.randn(64, 64, dtype=torch.float32)
-        c = torch.zeros((64, 64), dtype=torch.float32)
-        fused_matmul_bias(a, b, bias, c, config=test_config)
-        expected = torch.matmul(a, b) + bias
-        assert torch.allclose(c, expected, rtol=1e-3, atol=1e-3), (
-            f"Fused matmul+bias failed: max diff = {(c - expected).abs().max().item()}"
-        )
+def _matmul_bias_case():
+    """Fused matmul and bias add: c = matmul(a, b) + bias."""
+    torch.manual_seed(0)
+    a = torch.full((64, 64), 2.0, dtype=torch.float32)
+    b = torch.full((64, 64), 3.0, dtype=torch.float32)
+    bias = torch.randn(64, 64, dtype=torch.float32)
+    c = torch.zeros((64, 64), dtype=torch.float32)
+    return st.case(
+        fused_matmul_bias,
+        a,
+        b,
+        bias,
+        c,
+        name="fused_matmul_bias",
+        golden=lambda _: torch.matmul(a, b) + bias,
+        rtol=1e-3,
+        atol=1e-3,
+    )
 
-    def test_fused_linear_relu(self, test_config):
-        """Test fused linear layer with relu: y = relu(matmul(x, w) + bias)"""
-        fused_linear_relu._cache.clear()
-        torch.manual_seed(0)
-        x = torch.full((64, 64), 2.0, dtype=torch.float32)
-        w = torch.full((64, 64), 3.0, dtype=torch.float32)
-        bias = torch.randn(64, 64, dtype=torch.float32)
-        y = torch.zeros((64, 64), dtype=torch.float32)
-        fused_linear_relu(x, w, bias, y, config=test_config)
-        expected = torch.relu(torch.matmul(x, w) + bias)
-        assert torch.allclose(y, expected, rtol=1e-3, atol=1e-3), (
-            f"Fused linear+relu failed: max diff = {(y - expected).abs().max().item()}"
-        )
+
+def _linear_relu_case():
+    """Fused linear layer with relu: y = relu(matmul(x, w) + bias)."""
+    torch.manual_seed(0)
+    x = torch.full((64, 64), 2.0, dtype=torch.float32)
+    w = torch.full((64, 64), 3.0, dtype=torch.float32)
+    bias = torch.randn(64, 64, dtype=torch.float32)
+    y = torch.zeros((64, 64), dtype=torch.float32)
+    return st.case(
+        fused_linear_relu,
+        x,
+        w,
+        bias,
+        y,
+        name="fused_linear_relu",
+        golden=lambda _: torch.relu(torch.matmul(x, w) + bias),
+        rtol=1e-3,
+        atol=1e-3,
+    )
+
+
+@st.cases(_add_scale_case(), _add_relu_case(), _matmul_bias_case(), _linear_relu_case())
+def test_basic_fused_ops(case_run):
+    """Each fused kernel matches its PyTorch reference."""
+    case_run.assert_passed()
 
 
 if __name__ == "__main__":

--- a/tests/st/examples/02_intermediate/test_activation.py
+++ b/tests/st/examples/02_intermediate/test_activation.py
@@ -10,7 +10,7 @@
 """
 Activation Function System Tests for PyPTO.
 
-Four activation patterns are demonstrated:
+Four activation patterns are demonstrated, all on 32x128 input:
   1. SiLU   — x * sigmoid(x)
   2. GELU   — x * sigmoid(1.702 * x)
   3. SwiGLU — gate * sigmoid(gate) * up
@@ -20,68 +20,37 @@ Four activation patterns are demonstrated:
 import pytest
 import torch
 from examples.beginner.activation import geglu, gelu, silu, swiglu
+from harness import st
+
+SHAPE = (32, 128)
 
 
-class TestSiluActivation:
-    """SiLU (Swish) activation with 32x128 input: output = x * sigmoid(x)."""
-
-    def test_silu_activation(self, test_config):
-        silu._cache.clear()
-        torch.manual_seed(0)
-        x = torch.randn(32, 128, dtype=torch.float32)
-        output = torch.zeros_like(x)
-        silu(x, output, config=test_config)
-        expected = x * torch.sigmoid(x)
-        assert torch.allclose(output, expected, rtol=1e-5, atol=1e-5), (
-            f"silu failed: max diff = {(output - expected).abs().max().item()}"
-        )
+def _unary_case(kernel, name, golden_of_x):
+    """A one-input activation: output = f(x)."""
+    torch.manual_seed(0)
+    x = torch.randn(*SHAPE, dtype=torch.float32)
+    output = torch.zeros_like(x)
+    return st.case(kernel, x, output, name=name, golden=lambda _: golden_of_x(x))
 
 
-class TestGeluActivation:
-    """GELU activation with 32x128 input: output = x * sigmoid(1.702 * x)."""
-
-    def test_gelu_activation(self, test_config):
-        gelu._cache.clear()
-        torch.manual_seed(0)
-        x = torch.randn(32, 128, dtype=torch.float32)
-        output = torch.zeros_like(x)
-        gelu(x, output, config=test_config)
-        expected = x * torch.sigmoid(1.702 * x)
-        assert torch.allclose(output, expected, rtol=1e-5, atol=1e-5), (
-            f"gelu failed: max diff = {(output - expected).abs().max().item()}"
-        )
+def _gated_case(kernel, name, golden_of_gate_up):
+    """A gated activation: output = f(gate, up)."""
+    torch.manual_seed(0)
+    gate = torch.randn(*SHAPE, dtype=torch.float32)
+    up = torch.randn(*SHAPE, dtype=torch.float32)
+    output = torch.zeros_like(gate)
+    return st.case(kernel, gate, up, output, name=name, golden=lambda _: golden_of_gate_up(gate, up))
 
 
-class TestSwigluActivation:
-    """SwiGLU activation with 32x128 input: output = gate * sigmoid(gate) * up."""
-
-    def test_swiglu_activation(self, test_config):
-        swiglu._cache.clear()
-        torch.manual_seed(0)
-        gate = torch.randn(32, 128, dtype=torch.float32)
-        up = torch.randn(32, 128, dtype=torch.float32)
-        output = torch.zeros_like(gate)
-        swiglu(gate, up, output, config=test_config)
-        expected = gate * torch.sigmoid(gate) * up
-        assert torch.allclose(output, expected, rtol=1e-5, atol=1e-5), (
-            f"swiglu failed: max diff = {(output - expected).abs().max().item()}"
-        )
-
-
-class TestGegluActivation:
-    """GeGLU activation with 32x128 input: output = gate * sigmoid(1.702 * gate) * up."""
-
-    def test_geglu_activation(self, test_config):
-        geglu._cache.clear()
-        torch.manual_seed(0)
-        gate = torch.randn(32, 128, dtype=torch.float32)
-        up = torch.randn(32, 128, dtype=torch.float32)
-        output = torch.zeros_like(gate)
-        geglu(gate, up, output, config=test_config)
-        expected = gate * torch.sigmoid(1.702 * gate) * up
-        assert torch.allclose(output, expected, rtol=1e-5, atol=1e-5), (
-            f"geglu failed: max diff = {(output - expected).abs().max().item()}"
-        )
+@st.cases(
+    _unary_case(silu, "silu", lambda x: x * torch.sigmoid(x)),
+    _unary_case(gelu, "gelu", lambda x: x * torch.sigmoid(1.702 * x)),
+    _gated_case(swiglu, "swiglu", lambda gate, up: gate * torch.sigmoid(gate) * up),
+    _gated_case(geglu, "geglu", lambda gate, up: gate * torch.sigmoid(1.702 * gate) * up),
+)
+def test_activation(case_run):
+    """Each activation kernel matches its torch reference."""
+    case_run.assert_passed()
 
 
 if __name__ == "__main__":

--- a/tests/st/examples/02_intermediate/test_ffn_activations.py
+++ b/tests/st/examples/02_intermediate/test_ffn_activations.py
@@ -19,63 +19,58 @@ Three FFN patterns are demonstrated (all on 64x64 tiles):
 import pytest
 import torch
 from examples.models.ffn import ffn_gelu, ffn_relu, ffn_swiglu
+from harness import st
+
+SHAPE = (64, 64)
+# Two chained matmuls in FP32 on 64x64 — looser than the 1e-5 an elementwise
+# kernel gets, and unchanged from before the migration.
+TOL = {"rtol": 3e-3, "atol": 3e-3}
 
 
-class TestFFNActivationOperations:
-    """Test suite for FFN module operations."""
+def _ungated_case(kernel, name, activation):
+    """FFN whose gate projection feeds one activation: activation(hidden @ gate) @ down."""
+    torch.manual_seed(0)
+    hidden = torch.randn(*SHAPE, dtype=torch.float32)
+    gate = torch.randn(*SHAPE, dtype=torch.float32)
+    down = torch.randn(*SHAPE, dtype=torch.float32)
+    output = torch.zeros(*SHAPE, dtype=torch.float32)
+    return st.case(
+        kernel,
+        hidden,
+        gate,
+        down,
+        output,
+        name=name,
+        golden=lambda _: activation(hidden @ gate) @ down,
+        **TOL,
+    )
 
-    def test_ffn_gelu_64x64(self, test_config):
-        """Test FFN with GELU activation: GELU(hidden @ gate_proj) @ down_proj."""
-        ffn_gelu._cache.clear()
-        torch.manual_seed(0)
-        hidden = torch.randn(64, 64, dtype=torch.float32)
-        gate = torch.randn(64, 64, dtype=torch.float32)
-        down = torch.randn(64, 64, dtype=torch.float32)
-        output = torch.zeros(64, 64, dtype=torch.float32)
 
-        ffn_gelu(hidden, gate, down, output, config=test_config)
+def _swiglu_case():
+    """FFN + SwiGLU: (gate_out * sigmoid(gate_out) * up_out) @ down."""
+    torch.manual_seed(0)
+    hidden = torch.randn(*SHAPE, dtype=torch.float32)
+    gate = torch.randn(*SHAPE, dtype=torch.float32)
+    up = torch.randn(*SHAPE, dtype=torch.float32)
+    down = torch.randn(*SHAPE, dtype=torch.float32)
+    output = torch.zeros(*SHAPE, dtype=torch.float32)
 
-        gate_out = hidden @ gate
-        expected = (gate_out * torch.sigmoid(1.702 * gate_out)) @ down
-        assert torch.allclose(output, expected, rtol=3e-3, atol=3e-3), (
-            f"ffn_gelu failed: max diff = {(output - expected).abs().max().item()}"
-        )
-
-    def test_ffn_swiglu_64x64(self, test_config):
-        """Test FFN with SwiGLU activation: SwiGLU(gate, up) @ down_proj."""
-        ffn_swiglu._cache.clear()
-        torch.manual_seed(0)
-        hidden = torch.randn(64, 64, dtype=torch.float32)
-        gate = torch.randn(64, 64, dtype=torch.float32)
-        up = torch.randn(64, 64, dtype=torch.float32)
-        down = torch.randn(64, 64, dtype=torch.float32)
-        output = torch.zeros(64, 64, dtype=torch.float32)
-
-        ffn_swiglu(hidden, gate, up, down, output, config=test_config)
-
+    def golden(_):
         gate_out = hidden @ gate
         up_out = hidden @ up
-        expected = (gate_out * torch.sigmoid(gate_out) * up_out) @ down
-        assert torch.allclose(output, expected, rtol=3e-3, atol=3e-3), (
-            f"ffn_swiglu failed: max diff = {(output - expected).abs().max().item()}"
-        )
+        return (gate_out * torch.sigmoid(gate_out) * up_out) @ down
 
-    def test_ffn_relu_64x64(self, test_config):
-        """Test FFN with ReLU activation: ReLU(hidden @ gate_proj) @ down_proj."""
-        ffn_relu._cache.clear()
-        torch.manual_seed(0)
-        hidden = torch.randn(64, 64, dtype=torch.float32)
-        gate = torch.randn(64, 64, dtype=torch.float32)
-        down = torch.randn(64, 64, dtype=torch.float32)
-        output = torch.zeros(64, 64, dtype=torch.float32)
+    return st.case(ffn_swiglu, hidden, gate, up, down, output, name="ffn_swiglu_64x64", golden=golden, **TOL)
 
-        ffn_relu(hidden, gate, down, output, config=test_config)
 
-        gate_out = hidden @ gate
-        expected = torch.relu(gate_out) @ down
-        assert torch.allclose(output, expected, rtol=3e-3, atol=3e-3), (
-            f"ffn_relu failed: max diff = {(output - expected).abs().max().item()}"
-        )
+@st.cases(
+    _ungated_case(ffn_gelu, "ffn_gelu_64x64", lambda h: h * torch.sigmoid(1.702 * h)),
+    _swiglu_case(),
+    _ungated_case(ffn_relu, "ffn_relu_64x64", torch.relu),
+)
+def test_ffn_activation(case_run):
+    """Each FFN variant matches its torch reference."""
+    case_run.assert_passed()
 
 
 if __name__ == "__main__":

--- a/tests/st/examples/02_intermediate/test_layer_norm.py
+++ b/tests/st/examples/02_intermediate/test_layer_norm.py
@@ -17,31 +17,34 @@ One layer normalization pattern is demonstrated:
 import pytest
 import torch
 from examples.intermediate.normalization import layer_norm
+from harness import st
+
+HIDDEN_SIZE = 64
+EPS = 1e-5
 
 
-class TestLayerNormCore:
+def _layer_norm_case():
     """LayerNorm with 32x64 input: normalize across hidden dim, then scale and shift."""
+    torch.manual_seed(0)
+    x = torch.randn(32, HIDDEN_SIZE, dtype=torch.float32)
+    gamma = torch.randn(1, HIDDEN_SIZE, dtype=torch.float32)
+    beta = torch.randn(1, HIDDEN_SIZE, dtype=torch.float32)
+    output = torch.zeros_like(x)
 
-    def test_layer_norm_core(self, test_config):
-        layer_norm._cache.clear()
-        torch.manual_seed(0)
-        x = torch.randn(32, 64, dtype=torch.float32)
-        gamma = torch.randn(1, 64, dtype=torch.float32)
-        beta = torch.randn(1, 64, dtype=torch.float32)
-        output = torch.zeros_like(x)
-        layer_norm(x, gamma, beta, output, config=test_config)
-
-        hidden_size = 64
-        eps = 1e-5
-        mean = x.sum(dim=-1, keepdim=True) / hidden_size
+    def golden(_):
+        mean = x.sum(dim=-1, keepdim=True) / HIDDEN_SIZE
         centered = x - mean
-        var = (centered**2).sum(dim=-1, keepdim=True) / hidden_size
-        std = torch.sqrt(var + eps)
-        expected = (centered / std) * gamma + beta
+        var = (centered**2).sum(dim=-1, keepdim=True) / HIDDEN_SIZE
+        std = torch.sqrt(var + EPS)
+        return (centered / std) * gamma + beta
 
-        assert torch.allclose(output, expected, rtol=1e-5, atol=1e-5), (
-            f"layer_norm failed: max diff = {(output - expected).abs().max().item()}"
-        )
+    return st.case(layer_norm, x, gamma, beta, output, name="layer_norm_core", golden=golden)
+
+
+@st.cases(_layer_norm_case())
+def test_layer_norm_core(case_run):
+    """LayerNorm matches the torch reference."""
+    case_run.assert_passed()
 
 
 if __name__ == "__main__":

--- a/tests/st/examples/02_intermediate/test_rms_norm.py
+++ b/tests/st/examples/02_intermediate/test_rms_norm.py
@@ -17,28 +17,31 @@ One RMS normalization pattern is demonstrated:
 import pytest
 import torch
 from examples.intermediate.normalization import rms_norm
+from harness import st
+
+HIDDEN_SIZE = 64
+EPS = 1e-5
 
 
-class TestRMSNormCore:
+def _rms_norm_case():
     """RMSNorm with 32x64 input: normalize by RMS across hidden dim, then scale by gamma."""
+    torch.manual_seed(0)
+    x = torch.randn(32, HIDDEN_SIZE, dtype=torch.float32)
+    gamma = torch.randn(1, HIDDEN_SIZE, dtype=torch.float32)
+    output = torch.zeros_like(x)
 
-    def test_rms_norm_core(self, test_config):
-        rms_norm._cache.clear()
-        torch.manual_seed(0)
-        x = torch.randn(32, 64, dtype=torch.float32)
-        gamma = torch.randn(1, 64, dtype=torch.float32)
-        output = torch.zeros_like(x)
-        rms_norm(x, gamma, output, config=test_config)
+    def golden(_):
+        mean_sq = (x**2).sum(dim=-1, keepdim=True) / HIDDEN_SIZE
+        rms = torch.sqrt(mean_sq + EPS)
+        return (x / rms) * gamma
 
-        hidden_size = 64
-        eps = 1e-5
-        mean_sq = (x**2).sum(dim=-1, keepdim=True) / hidden_size
-        rms = torch.sqrt(mean_sq + eps)
-        expected = (x / rms) * gamma
+    return st.case(rms_norm, x, gamma, output, name="rms_norm_core", golden=golden)
 
-        assert torch.allclose(output, expected, rtol=1e-5, atol=1e-5), (
-            f"rms_norm failed: max diff = {(output - expected).abs().max().item()}"
-        )
+
+@st.cases(_rms_norm_case())
+def test_rms_norm_core(case_run):
+    """RMSNorm matches the torch reference."""
+    case_run.assert_passed()
 
 
 if __name__ == "__main__":

--- a/tests/st/examples/02_intermediate/test_softmax.py
+++ b/tests/st/examples/02_intermediate/test_softmax.py
@@ -17,21 +17,21 @@ One tile reduction pattern is demonstrated:
 import pytest
 import torch
 from examples.intermediate.softmax import tile_softmax
+from harness import st
 
 
-class TestTileSoftmax:
-    """Row-wise softmax: output[i] = exp(a[i] - max(a[i])) / sum(exp(a[i] - max(a[i])))."""
+def _softmax_case():
+    """Row-wise softmax over a 64x64 tile."""
+    torch.manual_seed(0)
+    a = torch.randn(64, 64, dtype=torch.float32)
+    output = torch.zeros_like(a)
+    return st.case(tile_softmax, a, output, name="tile_softmax", golden=lambda _: torch.softmax(a, dim=-1))
 
-    def test_tile_softmax(self, test_config):
-        tile_softmax._cache.clear()
-        torch.manual_seed(0)
-        a = torch.randn(64, 64, dtype=torch.float32)
-        output = torch.zeros_like(a)
-        tile_softmax(a, output, config=test_config)
-        expected = torch.softmax(a, dim=-1)
-        assert torch.allclose(output, expected, rtol=1e-5, atol=1e-5), (
-            f"tile_softmax failed: max diff = {(output - expected).abs().max().item()}"
-        )
+
+@st.cases(_softmax_case())
+def test_tile_softmax(case_run):
+    """Row-wise softmax matches the torch reference."""
+    case_run.assert_passed()
 
 
 if __name__ == "__main__":

--- a/tests/st/harness/core/case.py
+++ b/tests/st/harness/core/case.py
@@ -241,6 +241,21 @@ class Case:
         return f"Case({self.name!r}, {self.kernel!r})"
 
 
+def _legacy_memory_planner(test_case: PTOTestCase) -> MemoryPlanner | None:
+    """Return the planner a legacy case selects, by the harness's own precedence.
+
+    ``_resolve_case_memory_planner`` reads two channels: ``get_memory_planner()``
+    first, then a planner carried on the case's own ``RunConfig``. A ``Case``
+    rebuilds that ``RunConfig`` from ``rtol`` / ``atol`` alone, so the second
+    channel has to be folded into the first here or the wrapped case would
+    silently fall through to the session planner.
+    """
+    planner = test_case.get_memory_planner()
+    if planner is not None:
+        return planner
+    return getattr(getattr(test_case, "config", None), "memory_planner", None)
+
+
 def from_legacy(test_case: PTOTestCase) -> Case:
     """Wrap an existing ``PTOTestCase`` instance as a :class:`Case`.
 
@@ -257,7 +272,7 @@ def from_legacy(test_case: PTOTestCase) -> Case:
         scalars=list(test_case.scalar_specs),
         platform=test_case.get_platform(),
         strategy=test_case.get_strategy(),
-        memory_planner=test_case.get_memory_planner(),
+        memory_planner=_legacy_memory_planner(test_case),
         enable_pypto_l0c_double_buffer=test_case.get_enable_pypto_l0c_double_buffer(),
         rtol=test_case.config.rtol,
         atol=test_case.config.atol,

--- a/tests/st/harness/core/case.py
+++ b/tests/st/harness/core/case.py
@@ -1,0 +1,221 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""A test case as a value.
+
+``PTOTestCase`` welds three unrelated questions into one abstract base class —
+where the IR comes from, what the data and golden are, and how it executes.
+A ``Case`` separates them: it *composes* a
+:class:`~harness.core.kernel_source.KernelSource` with a tensor list and a
+golden callable, and says nothing at all about execution.  The harness decides
+that.
+
+The golden is an ordinary Python callable — a lambda or a closure is fine.
+That works because the golden runs in the **parent** process during
+pre-compilation and its result is persisted to ``data/out/*.pt``; the batched
+device run in the task-submit child only compares against those files (see
+``_write_golden_for_test_case`` and ``pypto.runtime.runner``). Nothing about
+the golden has to survive a process boundary.
+
+A ``Case`` implements the same duck-typed surface the compile pipeline already
+calls on a ``PTOTestCase``, so it flows through the existing pipeline
+unchanged. That is deliberate: the pipeline was never the thing that required
+subclassing.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import torch
+from pypto.ir.pass_manager import OptimizationStrategy
+from pypto.pypto_core.passes import MemoryPlanner
+from pypto.runtime.runner import RunConfig
+from pypto.runtime.tensor_spec import ScalarSpec
+
+from harness.core.harness import ALL_PLATFORM_IDS, PTOTestCase, TensorSpec
+from harness.core.kernel_source import IRKernel, JitKernel, KernelSource, ProgramKernel
+
+
+@dataclass(eq=False)
+class Case:
+    """One executable system-test case.
+
+    Attributes:
+        kernel: Where the IR comes from — a :class:`JitKernel`,
+            :class:`ProgramKernel`, or :class:`IRKernel`.
+        name: Identity of the case. Used for the artifact cache key and the
+            pytest parametrize id, so it must be unique within a run.
+        tensors: The case's tensors. ``None`` asks the kernel source to derive
+            them, which :class:`JitKernel` can do from its sample arguments.
+        golden: Called once in the parent process with a dict of all tensors by
+            name. It returns the single output tensor, a dict of output name
+            to tensor, or ``None`` after mutating *tensors* in place.
+            ``None`` means the case has no golden (a compile-only case).
+        scalars: Scalar TaskArg slots, appended after all tensor slots.
+        platform: Pin the case to one platform, or ``None`` to let the item's
+            parametrize variant (or the session ``--platform``) decide.
+        strategy / memory_planner / enable_pypto_l0c_double_buffer: Compile
+            knobs, applied identically whichever kernel source is used.
+        rtol / atol: Comparison tolerance, applied in the parent after the
+            device run persists its actual outputs.
+    """
+
+    kernel: KernelSource
+    name: str
+    tensors: list[TensorSpec] | None = None
+    golden: Any | None = None
+    scalars: "list[ScalarSpec]" = field(default_factory=list)
+    platform: str | None = None
+    strategy: OptimizationStrategy = OptimizationStrategy.Default
+    memory_planner: MemoryPlanner | None = None
+    enable_pypto_l0c_double_buffer: bool | None = None
+    rtol: float = 1e-5
+    atol: float = 1e-5
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.kernel, (JitKernel, ProgramKernel, IRKernel)):
+            raise TypeError(
+                f"Case '{self.name}': kernel must be a JitKernel / ProgramKernel / IRKernel, "
+                f"got {type(self.kernel).__name__}"
+            )
+        if self.platform is not None and self.platform not in ALL_PLATFORM_IDS:
+            raise ValueError(
+                f"Case '{self.name}': unknown platform '{self.platform}'. Expected one of {ALL_PLATFORM_IDS}."
+            )
+        if self.tensors is None:
+            self.tensors = self.kernel.tensor_specs()
+        if self.tensors is None:
+            raise ValueError(
+                f"Case '{self.name}': no tensors. {self.kernel!r} cannot derive them "
+                "(a @pl.program source never can, and a JitKernel needs a sample tensor for "
+                "every tensor parameter), so pass tensors=[TensorSpec(...), ...]."
+            )
+        outputs = [t for t in self.tensors if t.is_output]
+        if not outputs:
+            raise ValueError(
+                f"Case '{self.name}': no output tensor. Mark the result with is_output=True, "
+                "or annotate the kernel parameter pl.Out[...] / pl.InOut[...] so it is derived."
+            )
+        self.config = RunConfig(rtol=self.rtol, atol=self.atol)
+
+    # -- KernelSource / data ------------------------------------------------
+
+    @property
+    def tensor_specs(self) -> "list[TensorSpec]":
+        """The case's tensors (pipeline surface; mirrors ``PTOTestCase``)."""
+        assert self.tensors is not None  # established in __post_init__
+        return self.tensors
+
+    @property
+    def scalar_specs(self) -> "list[ScalarSpec]":
+        return self.scalars
+
+    def get_name(self) -> str:
+        return self.name
+
+    def get_program(self) -> Any:
+        return self.kernel.build_program()
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return self.strategy
+
+    def get_memory_planner(self) -> MemoryPlanner | None:
+        return self.memory_planner
+
+    def get_enable_pypto_l0c_double_buffer(self) -> bool | None:
+        return self.enable_pypto_l0c_double_buffer
+
+    def get_platform(self) -> str | None:
+        return self.platform
+
+    def bind_platform(self, platform: str) -> None:
+        """Bind *platform* unless the case pinned one itself."""
+        if platform not in ALL_PLATFORM_IDS:
+            raise ValueError(f"Unknown platform '{platform}'. Expected one of {ALL_PLATFORM_IDS}.")
+        if self.platform is None:
+            self.platform = platform
+
+    # -- golden -------------------------------------------------------------
+
+    def compute_expected(
+        self, tensors: dict[str, torch.Tensor], params: dict[str, Any] | None = None
+    ) -> None:
+        """Write the expected outputs into *tensors*, in place.
+
+        Adapts the case's ``golden`` callable to the in-place contract the
+        pipeline uses. Runs in the parent process, so the callable may close
+        over anything.
+        """
+        del params  # the golden closes over what it needs; no params channel
+        if self.golden is None:
+            raise ValueError(
+                f"Case '{self.name}' has no golden, so its outputs cannot be validated. "
+                "Pass golden=... , or route the case through a compile-only check."
+            )
+        produced = self.golden(tensors)
+        if produced is None:
+            return  # the callable mutated *tensors* itself
+        output_names = [t.name for t in self.tensor_specs if t.is_output]
+        if isinstance(produced, torch.Tensor):
+            if len(output_names) != 1:
+                raise ValueError(
+                    f"Case '{self.name}': golden returned one tensor but the kernel has "
+                    f"{len(output_names)} outputs {output_names}. Return a dict keyed by output name."
+                )
+            tensors[output_names[0]][:] = produced.to(tensors[output_names[0]].dtype)
+            return
+        if isinstance(produced, dict):
+            unknown = sorted(set(produced) - set(output_names))
+            if unknown:
+                raise ValueError(
+                    f"Case '{self.name}': golden returned unknown output(s) {unknown}. "
+                    f"Kernel outputs are {output_names}."
+                )
+            missing = sorted(set(output_names) - set(produced))
+            if missing:
+                raise ValueError(
+                    f"Case '{self.name}': golden did not produce output(s) {missing}. "
+                    f"Kernel outputs are {output_names}."
+                )
+            for out_name, value in produced.items():
+                tensors[out_name][:] = value.to(tensors[out_name].dtype)
+            return
+        raise TypeError(
+            f"Case '{self.name}': golden returned {type(produced).__name__}; expected a torch.Tensor, "
+            "a dict of output name -> tensor, or None after mutating the tensors in place."
+        )
+
+    def __repr__(self) -> str:
+        return f"Case({self.name!r}, {self.kernel!r})"
+
+
+def from_legacy(test_case: PTOTestCase) -> Case:
+    """Wrap an existing ``PTOTestCase`` instance as a :class:`Case`.
+
+    Lets the 88 existing ``PTOTestCase`` files move to the collection-time
+    declaration (``st.cases(...)``) without rewriting their bodies: the case
+    keeps its own ``get_program`` / ``define_tensors`` / ``compute_expected``,
+    and only how the harness *finds* it changes.
+    """
+    return Case(
+        kernel=ProgramKernel(test_case.get_program, name=test_case.get_name()),
+        name=test_case.get_name(),
+        tensors=list(test_case.tensor_specs),
+        golden=lambda tensors: test_case.compute_expected(tensors),
+        scalars=list(test_case.scalar_specs),
+        platform=test_case.get_platform(),
+        strategy=test_case.get_strategy(),
+        memory_planner=test_case.get_memory_planner(),
+        enable_pypto_l0c_double_buffer=test_case.get_enable_pypto_l0c_double_buffer(),
+        rtol=test_case.config.rtol,
+        atol=test_case.config.atol,
+    )
+
+
+__all__ = ["Case", "from_legacy"]

--- a/tests/st/harness/core/case.py
+++ b/tests/st/harness/core/case.py
@@ -62,8 +62,16 @@ class Case:
             parametrize variant (or the session ``--platform``) decide.
         strategy / memory_planner / enable_pypto_l0c_double_buffer: Compile
             knobs, applied identically whichever kernel source is used.
-        rtol / atol: Comparison tolerance, applied in the parent after the
-            device run persists its actual outputs.
+        rtol / atol: Comparison tolerance for the default elementwise check,
+            applied in the parent after the device run persists its actual
+            outputs. Ignored when *compare* is set.
+        compare: Replace the elementwise check entirely. Called in the parent
+            with ``(actual, expected)`` — both dicts of output name to tensor,
+            read back from ``data/actual`` and ``data/out`` — and raises
+            ``AssertionError`` to fail the case, exactly as the test's own
+            ``assert`` did before it became a case. Use it when the assertion is
+            not per-element: a Frobenius relative error over the whole tensor,
+            a rank or sparsity property, a tolerance that varies by region.
     """
 
     kernel: KernelSource
@@ -77,6 +85,7 @@ class Case:
     enable_pypto_l0c_double_buffer: bool | None = None
     rtol: float = 1e-5
     atol: float = 1e-5
+    compare: Any | None = None
 
     def __post_init__(self) -> None:
         if not isinstance(self.kernel, (JitKernel, ProgramKernel, IRKernel)):
@@ -101,6 +110,11 @@ class Case:
             raise ValueError(
                 f"Case '{self.name}': no output tensor. Mark the result with is_output=True, "
                 "or annotate the kernel parameter pl.Out[...] / pl.InOut[...] so it is derived."
+            )
+        if self.compare is not None and not callable(self.compare):
+            raise TypeError(
+                f"Case '{self.name}': compare must be callable as compare(actual, expected), "
+                f"got {type(self.compare).__name__}"
             )
         self.config = RunConfig(rtol=self.rtol, atol=self.atol)
 

--- a/tests/st/harness/core/case.py
+++ b/tests/st/harness/core/case.py
@@ -29,6 +29,7 @@ unchanged. That is deliberate: the pipeline was never the thing that required
 subclassing.
 """
 
+import copy
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -154,6 +155,37 @@ class Case:
             raise ValueError(f"Unknown platform '{platform}'. Expected one of {ALL_PLATFORM_IDS}.")
         if self.platform is None:
             self.platform = platform
+
+    def for_platform(self, platform: str) -> "Case":
+        """Return this case bound to *platform*, without mutating the original.
+
+        A case is declared once, at collection time, and pytest hands that same
+        object to every platform variant of the item. Binding onto it in place
+        would pin the *first* variant's platform for all of them — and a case's
+        own platform outranks the item's in ``_resolve_platform``, so every
+        variant would then key, compile and run the first platform's artifact
+        instead of its own. Each variant therefore gets its own copy, exactly
+        as the legacy ``PTOTestCase`` path gets a freshly constructed instance
+        per item.
+
+        A case that pinned a platform itself is returned unchanged: the pin is
+        the author's statement that this case runs nowhere else, and it must
+        keep outranking the item.
+
+        Args:
+            platform: The platform resolved for the item being bound.
+
+        Returns:
+            ``self`` when the case pinned a platform, otherwise a copy bound to
+            *platform*. The copy differs in that one field only; the kernel
+            source, tensors and golden are deliberately shared, since they are
+            read-only for the duration of a run.
+        """
+        if self.platform is not None:
+            return self
+        bound = copy.copy(self)
+        bound.bind_platform(platform)
+        return bound
 
     # -- golden -------------------------------------------------------------
 

--- a/tests/st/harness/core/kernel_source.py
+++ b/tests/st/harness/core/kernel_source.py
@@ -1,0 +1,302 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Where a test case's IR comes from.
+
+The compile pipeline needs exactly one thing from a test case: an
+``ir.Program`` that **no pass has run on yet**, because ``ir.compile()`` runs
+the pass pipeline *and* code generation itself.  Everything else about how the
+kernel was authored is irrelevant to it.
+
+``KernelSource`` is that one thing, so the three authoring surfaces stop being
+three execution paths:
+
+======================  =========================================
+Authoring surface       KernelSource
+======================  =========================================
+``@pl.jit`` entry       :class:`JitKernel`
+``@pl.program`` class   :class:`ProgramKernel`
+an ``ir.Program``       :class:`IRKernel`
+======================  =========================================
+
+A source may also derive its own :class:`~harness.core.harness.TensorSpec`
+list.  ``JitKernel`` can — parameter directions come from the kernel's
+``pl.Out`` / ``pl.InOut`` annotations and shapes come from the sample tensors —
+so a JIT-authored case never writes its shapes a second time.  The other two
+return ``None`` and let the case declare them.
+"""
+
+import threading
+from typing import Any, Protocol, runtime_checkable
+
+import torch
+from pypto.jit import JITFunction
+
+from harness.core.harness import DataType, TensorSpec
+
+# Serialises every program build across the compile pool.
+#
+# Neither authoring surface is thread-safe: the ``@pl.program`` decorator
+# mutates module-level builder state, and ``JITFunction``'s specializer walks
+# and memoises a shared dep graph.  The compile pool runs ``build_program()``
+# under this lock and everything after it — ``ir.compile()``, golden
+# materialisation, the .so build — concurrently, which is where the parallelism
+# actually is.
+#
+# One lock for all sources, on purpose: a per-source lock would let a
+# ``@pl.program`` build race a JIT specialization, and the JIT specializer
+# emits ``@pl.program`` source.
+#
+# Reentrant, because the acquisition nests: ``_compile_for_cache`` takes the
+# lock around ``get_program()``, and for a ``Case`` that call lands right back
+# here in ``build_program()``. Re-entering from the owning thread is safe by
+# construction — the thread already has exclusive access and the nested build
+# finishes before it releases — whereas a plain Lock self-deadlocks.
+program_build_lock = threading.RLock()
+
+
+@runtime_checkable
+class KernelSource(Protocol):
+    """Supplies the pre-pass IR for one test case."""
+
+    def build_program(self) -> Any:
+        """Return the ``ir.Program`` to compile, before any pass has run.
+
+        Called on a compile-pool worker. Implementations MUST hold
+        :data:`program_build_lock` for the duration of the build.
+        """
+        ...
+
+    def tensor_specs(self) -> list[TensorSpec] | None:
+        """Return the case's tensors, or ``None`` to let the case declare them."""
+        ...
+
+    def cache_id(self) -> str:
+        """Stable identity for the compiled artifact of this kernel."""
+        ...
+
+
+# ---------------------------------------------------------------------------
+# torch dtype -> harness DataType
+# ---------------------------------------------------------------------------
+
+# ``DataType.torch_dtype`` is many-to-one (UINT32 and INT32 both map to
+# torch.int32, UINT16 and INT16 both to torch.int16), so the reverse map is
+# built explicitly and resolves each collision to the signed member. A test
+# that needs the unsigned reading declares that TensorSpec itself.
+_TORCH_TO_DATATYPE: "dict[torch.dtype, DataType]" = {}
+for _member in DataType:
+    try:
+        _torch_dtype = _member.torch_dtype
+    except (ValueError, KeyError):
+        continue  # optional MX dtype this torch build does not provide
+    _TORCH_TO_DATATYPE.setdefault(_torch_dtype, _member)
+del _member
+
+
+def datatype_from_torch(dtype: torch.dtype) -> DataType:
+    """Return the harness :class:`DataType` matching a torch dtype.
+
+    Raises:
+        ValueError: The dtype has no harness equivalent, naming what was
+            received and what is available.
+    """
+    try:
+        return _TORCH_TO_DATATYPE[dtype]
+    except KeyError:
+        known = ", ".join(sorted(str(d) for d in _TORCH_TO_DATATYPE))
+        raise ValueError(f"No harness DataType for torch dtype {dtype}. Known dtypes: {known}") from None
+
+
+# ---------------------------------------------------------------------------
+# Sources
+# ---------------------------------------------------------------------------
+
+
+class JitKernel:
+    """A ``@pl.jit`` entry plus the sample arguments that specialize it.
+
+    The sample arguments carry the shape/dtype contract, exactly as they do
+    when a test calls the kernel directly.  They are the case's real inputs, so
+    :meth:`tensor_specs` derives the whole tensor list from them and the test
+    never restates a shape.
+
+    Sample arguments may be omitted only when every tensor parameter carries a
+    fully-shaped annotation (``pl.Tensor[[128, 128], pl.FP32]``); a bare
+    ``pl.Tensor`` has no shape to read and ``specialize()`` says so.
+    """
+
+    def __init__(self, entry: Any, *args: Any, **kwargs: Any):
+        # ``entry`` is typed Any because the guard below is what test authors
+        # actually hit: passing a @pl.program class here is the natural mistake,
+        # and it must fail with a message that names the right source.
+        if not isinstance(entry, JITFunction):
+            raise TypeError(
+                f"JitKernel expects a @pl.jit function, got {type(entry).__name__}. "
+                "Use ProgramKernel for a @pl.program class or IRKernel for an ir.Program."
+            )
+        if "config" in kwargs:
+            raise ValueError(
+                f"JitKernel({entry.__name__}) does not take config=: compile knobs "
+                "(strategy, memory_planner, platform) belong on the Case, which applies "
+                "them to ir.compile() for every source alike."
+            )
+        self.entry: JITFunction = entry
+        self.args = args
+        self.kwargs = kwargs
+        self._classified: tuple[set[str], set[str]] | None = None
+
+    def build_program(self) -> Any:
+        with program_build_lock:
+            return self.entry.specialize(*self.args, **self.kwargs)
+
+    def tensor_specs(self) -> list[TensorSpec] | None:
+        """Derive the tensor list from the kernel signature and sample args.
+
+        A parameter is an output when the kernel annotates it ``pl.Out[...]``
+        or ``pl.InOut[...]``.  ``pl.InOut`` additionally keeps its incoming
+        data, so it is materialised from the sample tensor rather than zeroed.
+
+        Returns ``None`` when the sample arguments do not cover every tensor
+        parameter (annotation-only specialization) — the case declares its
+        tensors in that case.
+        """
+        bound = self._bound_tensors()
+        if bound is None:
+            return None
+        outputs = set(self.entry.output_param_names)
+        inout_names = self._classify()[0]
+        specs: list[TensorSpec] = []
+        for name, value in bound.items():
+            is_output = name in outputs
+            # An Out param's incoming buffer is scratch, so it is left to be
+            # zero-initialised; an InOut param's is live input and is seeded.
+            keep_input = not is_output or name in inout_names
+            specs.append(
+                TensorSpec(
+                    name=name,
+                    shape=list(value.shape),
+                    dtype=datatype_from_torch(value.dtype),
+                    init_value=value if keep_input else None,
+                    is_output=is_output,
+                )
+            )
+        return specs
+
+    def cache_id(self) -> str:
+        parts = [self.entry.__name__]
+        bound = self._bound_tensors() or {}
+        for name in self.entry.param_names:
+            value = bound.get(name)
+            if value is not None:
+                shape = "x".join(str(d) for d in value.shape)
+                parts.append(f"{name}_{shape}_{datatype_from_torch(value.dtype).value}")
+        for name, value in sorted(self.kwargs.items()):
+            if not isinstance(value, torch.Tensor):
+                parts.append(f"{name}_{value}")
+        return "__".join(parts)
+
+    def _classify(self) -> "tuple[set[str], set[str]]":
+        """Return ``(inout_param_names, tensor_param_names)``, parsed once.
+
+        ``output_param_names`` already covers Out and InOut together; what it
+        cannot say is which of those *also* read their incoming data, and which
+        params own a tensor slot at all. Both come from the same annotation
+        walk, so it runs once per kernel and is cached.
+        """
+        if self._classified is None:
+            from pypto.jit.decorator import _get_func_def  # noqa: PLC0415
+            from pypto.jit.specializer import _classify_params  # noqa: PLC0415
+
+            classified = _classify_params(_get_func_def(self.entry._func))
+            self._classified = (set(classified[1]), set(classified[2]))
+        return self._classified
+
+    def _bound_tensors(self) -> dict[str, torch.Tensor] | None:
+        """Sample tensors keyed by parameter name, or ``None`` if incomplete."""
+        names = self.entry.param_names
+        bound: dict[str, torch.Tensor] = {}
+        for name, value in zip(names, self.args):
+            if isinstance(value, torch.Tensor):
+                bound[name] = value
+        for name, value in self.kwargs.items():
+            if isinstance(value, torch.Tensor):
+                bound[name] = value
+        # Every *tensor* parameter must be covered. A scalar parameter is
+        # specialized as a literal and owns no tensor slot, so it is not
+        # missing when absent from ``bound``.
+        tensor_params = self._classify()[1]
+        missing = [n for n in names if n not in bound and n in tensor_params]
+        return None if missing else {n: bound[n] for n in names if n in bound}
+
+    def __repr__(self) -> str:
+        return f"JitKernel({self.entry.__name__})"
+
+
+class ProgramKernel:
+    """A ``@pl.program`` class (or a zero-argument factory returning one)."""
+
+    def __init__(self, program: Any, *, name: str | None = None):
+        if program is None:
+            raise ValueError("ProgramKernel requires a @pl.program class or a factory returning one")
+        self.program = program
+        self._name = name or getattr(program, "__name__", type(program).__name__)
+
+    def build_program(self) -> Any:
+        # A @pl.program class is itself the program, so only a *plain* callable
+        # (``PTOTestCase.get_program``, a factory) is invoked here.
+        is_factory = callable(self.program) and not isinstance(self.program, type)
+        with program_build_lock:
+            built = self.program() if is_factory else self.program
+            if built is None:
+                raise ValueError(f"ProgramKernel({self._name}) factory returned None")
+            return built
+
+    def tensor_specs(self) -> list[TensorSpec] | None:
+        # A @pl.program's parameter shapes live in its annotations, but the
+        # initial values do not; the case declares the tensors.
+        return None
+
+    def cache_id(self) -> str:
+        return self._name
+
+    def __repr__(self) -> str:
+        return f"ProgramKernel({self._name})"
+
+
+class IRKernel:
+    """An already-built ``ir.Program`` — parser round-trips, hand-built IR."""
+
+    def __init__(self, program: Any, *, name: str):
+        if program is None:
+            raise ValueError("IRKernel requires an ir.Program")
+        self.program = program
+        self._name = name
+
+    def build_program(self) -> Any:
+        return self.program
+
+    def tensor_specs(self) -> list[TensorSpec] | None:
+        return None
+
+    def cache_id(self) -> str:
+        return self._name
+
+    def __repr__(self) -> str:
+        return f"IRKernel({self._name})"
+
+
+__all__ = [
+    "IRKernel",
+    "JitKernel",
+    "KernelSource",
+    "ProgramKernel",
+    "datatype_from_torch",
+    "program_build_lock",
+]

--- a/tests/st/harness/core/kernel_source.py
+++ b/tests/st/harness/core/kernel_source.py
@@ -150,7 +150,7 @@ class JitKernel:
         self.entry: JITFunction = entry
         self.args = args
         self.kwargs = kwargs
-        self._classified: tuple[set[str], set[str]] | None = None
+        self._tensor_params: set[str] | None = None
 
     def build_program(self) -> Any:
         with program_build_lock:
@@ -160,8 +160,17 @@ class JitKernel:
         """Derive the tensor list from the kernel signature and sample args.
 
         A parameter is an output when the kernel annotates it ``pl.Out[...]``
-        or ``pl.InOut[...]``.  ``pl.InOut`` additionally keeps its incoming
-        data, so it is materialised from the sample tensor rather than zeroed.
+        or ``pl.InOut[...]``.
+
+        **Every** tensor is seeded from its sample argument, outputs included.
+        The sample argument is the buffer the test itself prepared, so its
+        contents are the test's statement of what the kernel starts from —
+        usually zeros, but not always. An atomic-add kernel accumulates onto
+        the destination it is handed, so zeroing a ``pl.Out`` buffer here
+        because the annotation says "output" would silently discard the
+        baseline the test set up and compare against a golden that assumed it.
+        Seeding costs one small host-to-device copy for a buffer the kernel
+        overwrites anyway.
 
         Returns ``None`` when the sample arguments do not cover every tensor
         parameter (annotation-only specialization) — the case declares its
@@ -171,20 +180,15 @@ class JitKernel:
         if bound is None:
             return None
         outputs = set(self.entry.output_param_names)
-        inout_names = self._classify()[0]
         specs: list[TensorSpec] = []
         for name, value in bound.items():
-            is_output = name in outputs
-            # An Out param's incoming buffer is scratch, so it is left to be
-            # zero-initialised; an InOut param's is live input and is seeded.
-            keep_input = not is_output or name in inout_names
             specs.append(
                 TensorSpec(
                     name=name,
                     shape=list(value.shape),
                     dtype=datatype_from_torch(value.dtype),
-                    init_value=value if keep_input else None,
-                    is_output=is_output,
+                    init_value=value,
+                    is_output=name in outputs,
                 )
             )
         return specs
@@ -202,21 +206,19 @@ class JitKernel:
                 parts.append(f"{name}_{value}")
         return "__".join(parts)
 
-    def _classify(self) -> "tuple[set[str], set[str]]":
-        """Return ``(inout_param_names, tensor_param_names)``, parsed once.
+    def _tensor_param_names(self) -> set[str]:
+        """Names of parameters that own a tensor slot, parsed once.
 
-        ``output_param_names`` already covers Out and InOut together; what it
-        cannot say is which of those *also* read their incoming data, and which
-        params own a tensor slot at all. Both come from the same annotation
-        walk, so it runs once per kernel and is cached.
+        A scalar parameter is specialized as a literal and owns no slot, so it
+        is not "missing" when no sample tensor is supplied for it.
+        ``param_names`` alone cannot tell the two apart.
         """
-        if self._classified is None:
+        if self._tensor_params is None:
             from pypto.jit.decorator import _get_func_def  # noqa: PLC0415
             from pypto.jit.specializer import _classify_params  # noqa: PLC0415
 
-            classified = _classify_params(_get_func_def(self.entry._func))
-            self._classified = (set(classified[1]), set(classified[2]))
-        return self._classified
+            self._tensor_params = set(_classify_params(_get_func_def(self.entry._func))[2])
+        return self._tensor_params
 
     def _bound_tensors(self) -> dict[str, torch.Tensor] | None:
         """Sample tensors keyed by parameter name, or ``None`` if incomplete."""
@@ -228,10 +230,8 @@ class JitKernel:
         for name, value in self.kwargs.items():
             if isinstance(value, torch.Tensor):
                 bound[name] = value
-        # Every *tensor* parameter must be covered. A scalar parameter is
-        # specialized as a literal and owns no tensor slot, so it is not
-        # missing when absent from ``bound``.
-        tensor_params = self._classify()[1]
+        # Every tensor parameter must be covered; see _tensor_param_names.
+        tensor_params = self._tensor_param_names()
         missing = [n for n in names if n not in bound and n in tensor_params]
         return None if missing else {n: bound[n] for n in names if n in bound}
 

--- a/tests/st/harness/core/kernel_source.py
+++ b/tests/st/harness/core/kernel_source.py
@@ -194,16 +194,33 @@ class JitKernel:
         return specs
 
     def cache_id(self) -> str:
+        """Stable identity for this kernel's specialization.
+
+        Covers **every** bound argument, in declaration order, because every one
+        of them shapes the specialized program: a tensor through its shape and
+        dtype, anything else through its type and value.
+
+        A scalar passed *positionally* used to be omitted entirely -- only
+        keyword scalars were recorded -- so two declarations differing solely in
+        such a scalar produced the same id. That id is the default ``Case``
+        name, and the name is the artifact cache key, so the second declaration
+        silently reused the first one's compiled artifact and could pass against
+        a specialization that was never built for it.
+
+        The type is part of the id rather than the value alone: ``1`` and
+        ``1.0`` specialize to different dtypes and must not collide.
+        """
         parts = [self.entry.__name__]
-        bound = self._bound_tensors() or {}
+        bound = self._bound_arguments()
         for name in self.entry.param_names:
-            value = bound.get(name)
-            if value is not None:
+            if name not in bound:
+                continue
+            value = bound[name]
+            if isinstance(value, torch.Tensor):
                 shape = "x".join(str(d) for d in value.shape)
                 parts.append(f"{name}_{shape}_{datatype_from_torch(value.dtype).value}")
-        for name, value in sorted(self.kwargs.items()):
-            if not isinstance(value, torch.Tensor):
-                parts.append(f"{name}_{value}")
+            else:
+                parts.append(f"{name}_{type(value).__name__}_{value}")
         return "__".join(parts)
 
     def _tensor_param_names(self) -> set[str]:
@@ -219,6 +236,17 @@ class JitKernel:
 
             self._tensor_params = set(_classify_params(_get_func_def(self.entry._func))[2])
         return self._tensor_params
+
+    def _bound_arguments(self) -> "dict[str, Any]":
+        """Every supplied argument keyed by parameter name, positional and keyword.
+
+        :meth:`_bound_tensors` keeps only tensors, which is the right question
+        for the tensor list and the wrong one for identity: a scalar
+        specializes the kernel into different IR whichever way it was passed.
+        """
+        bound: dict[str, Any] = dict(zip(self.entry.param_names, self.args))
+        bound.update(self.kwargs)
+        return bound
 
     def _bound_tensors(self) -> dict[str, torch.Tensor] | None:
         """Sample tensors keyed by parameter name, or ``None`` if incomplete."""

--- a/tests/st/harness/core/test_runner.py
+++ b/tests/st/harness/core/test_runner.py
@@ -838,28 +838,69 @@ def _run_batch_via_task_submit(
     return results
 
 
+def _case_comparator(tc: Any) -> "Any | None":
+    """Return the case's own output comparator, or ``None`` for the default check.
+
+    Only a ``Case`` can carry one; a ``PTOTestCase`` has no such attribute and
+    always takes the elementwise rtol/atol path.
+    """
+    return getattr(tc, "compare", None)
+
+
+def _compare_persisted_outputs(work_dir: Path, comparator: Any) -> None:
+    """Read back the persisted outputs and hand them to *comparator*.
+
+    The device run leaves its actual outputs under ``data/actual`` and the
+    parent-computed golden under ``data/out``, both keyed by the output names
+    ``golden.py`` declares. This loads both and calls
+    ``comparator(actual, expected)``, which raises to fail the case.
+
+    Raises:
+        AssertionError: Either directory is missing its outputs, or the
+            comparator rejected them.
+    """
+    from pypto.runtime.runner import (  # noqa: PLC0415
+        _load_golden_from_data_dir,
+        _load_golden_module,
+    )
+
+    golden_module = _load_golden_module(work_dir / "golden.py")
+    output_names = set(getattr(golden_module, "__outputs__", []))
+    actual = _load_golden_from_data_dir(work_dir / "data" / "actual", output_names)
+    expected = _load_golden_from_data_dir(work_dir / "data" / "out", output_names)
+    if actual is None or expected is None:
+        raise AssertionError(
+            f"custom compare: missing persisted outputs under {work_dir}/data "
+            f"(actual={'ok' if actual else 'missing'}, expected={'ok' if expected else 'missing'})"
+        )
+    comparator(actual, expected)
+
+
 def _validate_after_device_run(
     tc: "PTOTestCase",
     work_dir: Path,
     execution_time: float,
 ) -> RunResult:
-    """Validate persisted device outputs with *tc*'s real tolerance (split path).
+    """Validate persisted device outputs with *tc*'s real check (split path).
 
     The task-submit device run is validation-free (``--no-validate``); it leaves
     the actual outputs under ``work_dir/data/actual``.  This compares them
-    against the golden using the test's ``RunConfig`` rtol/atol — the tolerance
-    is applied here, in pytest's per-item lifecycle, not in the eager run.
+    against the golden here, in pytest's per-item lifecycle rather than in the
+    eager run — with the case's own comparator when it has one, otherwise
+    elementwise at its ``RunConfig`` rtol/atol.
     """
+    comparator = _case_comparator(tc)
     try:
-        validate_persisted_outputs(work_dir, tc.config.rtol, tc.config.atol)
+        if comparator is not None:
+            _compare_persisted_outputs(work_dir, comparator)
+        else:
+            validate_persisted_outputs(work_dir, tc.config.rtol, tc.config.atol)
     except Exception as exc:  # noqa: BLE001 — surfaced as a test failure
+        how = "custom compare" if comparator is not None else f"rtol={tc.config.rtol}, atol={tc.config.atol}"
         return RunResult(
             passed=False,
             test_name=tc.get_name(),
-            error=(
-                f"golden validation failed (rtol={tc.config.rtol}, atol={tc.config.atol}):\n"
-                f"{exc}\n{traceback.format_exc()}"
-            ),
+            error=f"golden validation failed ({how}):\n{exc}\n{traceback.format_exc()}",
             execution_time=execution_time,
         )
     return RunResult(passed=True, test_name=tc.get_name(), execution_time=execution_time)
@@ -899,8 +940,14 @@ def _fused_execute_task(
     # task-submit's onboard device runs go through the batch submitter, not here.
     assert _device_pool is not None, "device pool not initialised"
     device_id = _device_pool.get()
+    comparator = _case_comparator(tc)
     try:
         _executed_device[cache_key] = device_id
+        # A case with its own comparator runs validation-free and persists the
+        # actual outputs, so the comparator sees the same (actual, expected)
+        # pair here as it does on the batched path. Without the split,
+        # _execute_golden_case would apply golden.py's elementwise rtol/atol and
+        # the comparator would never be consulted.
         _execute_golden_case(
             artifact.work_dir,
             artifact.work_dir / "golden.py",
@@ -910,7 +957,11 @@ def _fused_execute_task(
             device_id,
             dfx=_pipeline_ctx.get("dfx", _DfxOpts()),
             enable_sdma=artifact.enable_sdma,
+            validate=comparator is None,
+            actual_out_dir=(artifact.work_dir / "data" / "actual") if comparator is not None else None,
         )
+        if comparator is not None:
+            _compare_persisted_outputs(artifact.work_dir, comparator)
         return RunResult(
             passed=True,
             test_name=name,
@@ -1548,6 +1599,10 @@ class TestRunner:
                 return _validate_after_device_run(test_case, work_dir, time.time() - start_time)
             # RunTiming was dropped (simpler #1177): _execute_golden_case returns
             # None now; timing is read from the runtime's [STRACE] log markers.
+            # A case carrying its own comparator runs validation-free and
+            # persists its actual outputs, so the comparator sees the same
+            # (actual, expected) pair the batched path gives it.
+            comparator = _case_comparator(test_case)
             _execute_golden_case(
                 work_dir,
                 golden_path,
@@ -1557,7 +1612,11 @@ class TestRunner:
                 self.config.device_id,
                 dfx=_DfxOpts.from_run_config(self.config),
                 enable_sdma=enable_sdma,
+                validate=comparator is None,
+                actual_out_dir=(work_dir / "data" / "actual") if comparator is not None else None,
             )
+            if comparator is not None:
+                _compare_persisted_outputs(work_dir, comparator)
 
             return RunResult(
                 passed=True,

--- a/tests/st/harness/core/test_runner.py
+++ b/tests/st/harness/core/test_runner.py
@@ -841,10 +841,15 @@ def _run_batch_via_task_submit(
 def _case_comparator(tc: Any) -> "Any | None":
     """Return the case's own output comparator, or ``None`` for the default check.
 
-    Only a ``Case`` can carry one; a ``PTOTestCase`` has no such attribute and
-    always takes the elementwise rtol/atol path.
+    Matched by type, not by attribute: a comparator is a ``Case`` concept and
+    nothing else defines one, while ``getattr(tc, "compare", None)`` answers
+    truthily for any object that auto-creates attributes — a ``Mock`` in a unit
+    test being the case that found this — and would send it down the
+    persist-then-compare path with no artifacts to read.
     """
-    return getattr(tc, "compare", None)
+    from harness.core.case import Case  # noqa: PLC0415 — avoids a module-level cycle
+
+    return tc.compare if isinstance(tc, Case) else None
 
 
 def _compare_persisted_outputs(work_dir: Path, comparator: Any) -> None:

--- a/tests/st/harness/core/test_runner.py
+++ b/tests/st/harness/core/test_runner.py
@@ -64,6 +64,7 @@ from pypto.runtime.runner import (
 from pypto.runtime.tensor_spec import TensorSpec as RuntimeTensorSpec
 
 from harness.core.harness import PTOTestCase, platform_to_backend
+from harness.core.kernel_source import program_build_lock as _get_program_lock
 
 # tests/st/harness/core/test_runner.py -> tests/st/ -> project root
 _ST_DIR = Path(__file__).parent.parent.parent
@@ -136,10 +137,9 @@ _pipeline_ctx: dict = {}
 _MAX_TASK_SUBMIT_INFLIGHT = 512
 
 # set_backend_type is called once per backend-type group before the thread pool
-# starts.  Only get_program() needs serialisation because the @pl.program
-# decorator is not thread-safe; ir.compile() writes to isolated dirs and
-# runs concurrently.
-_get_program_lock = threading.Lock()
+# starts.  Only the program build needs serialisation, under the shared
+# ``program_build_lock`` imported above (which owns the rationale); ir.compile()
+# writes to isolated dirs and runs concurrently.
 
 
 def _cache_key(
@@ -1208,6 +1208,36 @@ def start_pipeline(  # noqa: PLR0913
             name="pypto-batch-submitter",
             daemon=True,
         ).start()
+
+
+def artifact_work_dir(test_case: Any) -> "Path | None":
+    """Return the compiled artifact directory for *test_case*, if it has one.
+
+    Where the generated kernels, ``golden.py``, ``data/`` and any
+    ``dfx_outputs/`` for this case live. Only populated for a case the
+    pre-compile pipeline picked up; a case that fell to the inline path
+    compiles into a directory it does not publish, so this returns ``None``.
+
+    Args:
+        test_case: The case to look up — anything with the ``get_name`` /
+            ``get_platform`` / ``get_memory_planner`` surface.
+
+    Returns:
+        The artifact directory, or ``None`` when the case was not pre-compiled
+        or its compile task failed.
+    """
+    try:
+        cache_k = _cache_key(test_case, None, _pipeline_ctx.get("memory_planner"))
+    except ValueError:
+        return None  # no platform bound yet — nothing was compiled for it
+    fut = _compile_futures.get(cache_k)
+    if fut is None or not fut.done():
+        return None
+    try:
+        artifact = fut.result()
+    except Exception:  # noqa: BLE001 — a crashed compile has no artifact to point at
+        return None
+    return artifact.work_dir if artifact.error is None else None
 
 
 def configure_inline_task_submit(

--- a/tests/st/harness/st.py
+++ b/tests/st/harness/st.py
@@ -127,24 +127,66 @@ def case(  # noqa: PLR0913 — every knob mirrors one Case field; grouping them 
     )
 
 
-def cases(*case_objs: Case) -> Any:
-    """Parametrize a test over *case_objs*, one item per case.
+def _unwrap_entry(entry: Any) -> "tuple[Case, str]":
+    """Return ``(case, id)`` for one :func:`cases` entry.
+
+    An entry is either a bare :class:`Case` or a ``pytest.param(case, marks=...)``
+    wrapping one. ``pytest.param`` returns a ``ParameterSet`` namedtuple carrying
+    ``values`` / ``marks`` / ``id``; it is matched structurally rather than by
+    importing pytest's private class.
+    """
+    if isinstance(entry, Case):
+        return entry, entry.name
+    values = getattr(entry, "values", None)
+    if values is not None and hasattr(entry, "marks"):
+        if len(values) != 1 or not isinstance(values[0], Case):
+            raise ValueError(
+                "st.cases(): pytest.param(...) must wrap exactly one Case, got "
+                f"{[type(v).__name__ for v in values]}"
+            )
+        return values[0], entry.id or values[0].name
+    raise TypeError(
+        f"st.cases(): expected a Case or pytest.param(Case, marks=...), got {type(entry).__name__}"
+    )
+
+
+def cases(*entries: Any) -> Any:
+    """Parametrize a test over *entries*, one item per case.
+
+    Per-case markers go through pytest's own mechanism::
+
+        @st.cases(
+            st.case(kernel_a, x, out, golden=...),
+            pytest.param(
+                st.case(kernel_b, x, out, golden=...),
+                marks=pytest.mark.skip(reason="codegen bug: ..."),
+            ),
+        )
+        def test_kernels(case_run):
+            case_run.assert_passed()
+
+    A skipped case is also left out of pre-compilation, so it costs nothing.
+    Markers that apply to every case (``@pytest.mark.platforms``) stay on the
+    test function or its class as usual.
 
     Args:
-        *case_objs: The cases, each built by :func:`case`.
+        *entries: Each a :class:`Case` from :func:`case`, or a
+            ``pytest.param(case, marks=...)`` wrapping one.
 
     Returns:
         A ``pytest.mark.parametrize`` decorator binding the harness-owned
         ``_st_case`` argument; tests reach the case through ``case_run``.
 
     Raises:
-        ValueError: No cases were given, or two share a name — duplicate names
-            would collide in the artifact cache and produce indistinguishable
-            pytest ids.
+        ValueError: No entries were given, an entry wraps something other than a
+            single case, or two cases share a name — duplicate names would
+            collide in the artifact cache and produce indistinguishable ids.
+        TypeError: An entry is neither a Case nor a ``pytest.param``.
     """
-    if not case_objs:
+    if not entries:
         raise ValueError("st.cases() needs at least one case")
-    names = [c.name for c in case_objs]
+    unwrapped = [_unwrap_entry(e) for e in entries]
+    names = [c.name for c, _ in unwrapped]
     duplicates = sorted({n for n in names if names.count(n) > 1})
     if duplicates:
         raise ValueError(
@@ -153,9 +195,9 @@ def cases(*case_objs: Case) -> Any:
     # ``_st_case``, not ``case``: several suites already parametrize their own
     # ``case`` argument (test_expand_ops, the all_to_all_v skew tests), and a
     # harness-owned param must not collide with a test's own. Mirrors the
-    # existing ``_st_platform``. The pytest id still comes from ids=names, so
-    # the underscore never shows up in a node id.
-    return pytest.mark.parametrize("_st_case", list(case_objs), ids=names)
+    # existing ``_st_platform``. The pytest id still comes from ids, so the
+    # underscore never shows up in a node id.
+    return pytest.mark.parametrize("_st_case", list(entries), ids=[i for _, i in unwrapped])
 
 
 class CaseRun:

--- a/tests/st/harness/st.py
+++ b/tests/st/harness/st.py
@@ -64,6 +64,7 @@ def case(  # noqa: PLR0913 — every knob mirrors one Case field; grouping them 
     enable_pypto_l0c_double_buffer: bool | None = None,
     rtol: float = 1e-5,
     atol: float = 1e-5,
+    compare: Any | None = None,
 ) -> Case:
     """Build one :class:`~harness.core.case.Case`.
 
@@ -91,8 +92,23 @@ def case(  # noqa: PLR0913 — every knob mirrors one Case field; grouping them 
         strategy: Pass-pipeline optimization strategy.
         memory_planner: On-chip memory planner.
         enable_pypto_l0c_double_buffer: Opt in to dbC=2 under the PyPTO planner.
-        rtol: Relative tolerance for output comparison.
-        atol: Absolute tolerance for output comparison.
+        rtol: Relative tolerance for the default elementwise comparison.
+        atol: Absolute tolerance for the default elementwise comparison.
+        compare: Replace the elementwise comparison. Called in the parent as
+            ``compare(actual, expected)`` with dicts of output name to tensor,
+            and raises ``AssertionError`` to fail — the same ``assert`` the
+            test wrote before it became a case. For an assertion that is not
+            per-element, such as a Frobenius relative error::
+
+                def rel_err_under(limit):
+                    def compare(actual, expected):
+                        for name, got in actual.items():
+                            ref = expected[name].float()
+                            rel = (got.float() - ref).norm() / ref.norm()
+                            assert rel < limit, f"{name}: rel_err {rel:.3e} > {limit}"
+                    return compare
+
+            ``rtol`` / ``atol`` are ignored when this is set.
 
     Returns:
         The case, ready to hand to :func:`cases`.
@@ -124,6 +140,7 @@ def case(  # noqa: PLR0913 — every knob mirrors one Case field; grouping them 
         enable_pypto_l0c_double_buffer=enable_pypto_l0c_double_buffer,
         rtol=rtol,
         atol=atol,
+        compare=compare,
     )
 
 
@@ -200,6 +217,31 @@ def cases(*entries: Any) -> Any:
     return pytest.mark.parametrize("_st_case", list(entries), ids=[i for _, i in unwrapped])
 
 
+def rel_err_under(limit: float) -> Any:
+    """A :func:`case` ``compare=`` that bounds the Frobenius relative error.
+
+    ``‖actual - expected‖_F / ‖expected‖_F < limit``, per output. This is the
+    assertion a matmul-shaped test wants: accumulation order across cores and
+    tiles moves individual elements far more than it moves the tensor as a
+    whole, so an elementwise tolerance loose enough to pass would stop catching
+    anything.
+
+    Args:
+        limit: The exclusive upper bound on the relative error.
+
+    Returns:
+        A comparator for ``st.case(..., compare=...)``.
+    """
+
+    def compare(actual: "dict[str, Any]", expected: "dict[str, Any]") -> None:
+        for name, got in actual.items():
+            reference = expected[name].float()
+            rel_err = ((got.float() - reference).norm() / reference.norm()).item()
+            assert rel_err < limit, f"{name}: Frobenius rel_err {rel_err:.3e} exceeds {limit}"
+
+    return compare
+
+
 class CaseRun:
     """What a test asserts on after its case has run.
 
@@ -253,4 +295,4 @@ def case_run(_st_case: Case, test_runner: Any) -> CaseRun:
     return CaseRun(_st_case, test_runner.run(_st_case))
 
 
-__all__ = ["Case", "CaseRun", "case", "case_run", "cases", "from_legacy"]
+__all__ = ["Case", "CaseRun", "case", "case_run", "cases", "from_legacy", "rel_err_under"]

--- a/tests/st/harness/st.py
+++ b/tests/st/harness/st.py
@@ -1,0 +1,214 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""How a system test declares its cases.
+
+A case must be a **collection-time value**, not a statement inside the test
+body.  The pre-compile pool has to know every case before any test body runs,
+and the only way to hand pytest a value that early is to parametrize with it::
+
+    from harness import st
+    from examples.beginner.abs import tile_abs   # @pl.jit.incore
+
+    @st.cases(
+        st.case(tile_abs, a, out, golden=lambda t: torch.abs(t["a"])),
+    )
+    def test_tile_abs(case_run):
+        case_run.assert_passed()
+
+``st.cases`` is a thin wrapper over ``pytest.mark.parametrize``, so the case
+object lands in ``item.callspec.params["_st_case"]`` and the harness reads it
+directly.  It replaces the previous discovery route, which parsed the test
+function's source and re-evaluated its constructor call with a miniature AST
+interpreter — a route that could not see a ``@pl.jit`` test at all, and that
+fell back silently to per-case inline compilation whenever an argument would
+not resolve.
+
+Usage note: declare the case at module level or inside the decorator call.
+Building it inside the test body puts it back out of reach of collection.
+"""
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from pypto.ir.pass_manager import OptimizationStrategy
+from pypto.jit import JITFunction
+from pypto.pypto_core import ir as _ir
+from pypto.pypto_core.passes import MemoryPlanner
+from pypto.runtime.runner import RunResult
+from pypto.runtime.tensor_spec import ScalarSpec
+
+from harness.core.case import Case, from_legacy
+from harness.core.harness import TensorSpec
+from harness.core.kernel_source import IRKernel, JitKernel, ProgramKernel
+
+
+def case(  # noqa: PLR0913 — every knob mirrors one Case field; grouping them would only hide them
+    kernel: Any,
+    *sample_args: Any,
+    name: str | None = None,
+    inputs: dict[str, Any] | None = None,
+    golden: Any | None = None,
+    tensors: list[TensorSpec] | None = None,
+    scalars: list[ScalarSpec] | None = None,
+    platform: str | None = None,
+    strategy: OptimizationStrategy = OptimizationStrategy.Default,
+    memory_planner: MemoryPlanner | None = None,
+    enable_pypto_l0c_double_buffer: bool | None = None,
+    rtol: float = 1e-5,
+    atol: float = 1e-5,
+) -> Case:
+    """Build one :class:`~harness.core.case.Case`.
+
+    The kernel source is chosen from what *kernel* is, so the test does not
+    name it: a ``@pl.jit`` function becomes a ``JitKernel``, an ``ir.Program``
+    an ``IRKernel``, anything else (a ``@pl.program`` class, or a factory
+    returning one) a ``ProgramKernel``.
+
+    Args:
+        kernel: The kernel under test.
+        *sample_args: Sample tensors, positionally, for a ``@pl.jit`` kernel.
+            They carry the shape/dtype contract and are the case's real inputs,
+            so the tensor list is derived from them.
+        name: Case identity — the artifact cache key and the parametrize id.
+            Defaults to a name derived from the kernel and its specialization.
+        inputs: Sample tensors by parameter name, for a ``@pl.jit`` kernel that
+            reads better bound by keyword. Combines with *sample_args*.
+        golden: Called once in the parent with every tensor by name; returns
+            the output tensor, a dict of output name to tensor, or ``None``
+            after mutating in place.
+        tensors: Declare the tensor list explicitly. Required for a
+            ``@pl.program`` / ``ir.Program`` kernel, which cannot derive it.
+        scalars: Scalar TaskArg slots, after all tensor slots.
+        platform: Pin one platform; ``None`` follows the session matrix.
+        strategy: Pass-pipeline optimization strategy.
+        memory_planner: On-chip memory planner.
+        enable_pypto_l0c_double_buffer: Opt in to dbC=2 under the PyPTO planner.
+        rtol: Relative tolerance for output comparison.
+        atol: Absolute tolerance for output comparison.
+
+    Returns:
+        The case, ready to hand to :func:`cases`.
+    """
+    if isinstance(kernel, JITFunction):
+        source = JitKernel(kernel, *sample_args, **(inputs or {}))
+    elif isinstance(kernel, _ir.Program):
+        if name is None:
+            raise ValueError("st.case(ir.Program) needs an explicit name= — a Program carries none")
+        source = IRKernel(kernel, name=name)
+    else:
+        if sample_args or inputs:
+            raise ValueError(
+                f"st.case({kernel!r}): sample arguments only apply to a @pl.jit kernel. "
+                "A @pl.program declares its shapes in its annotations; pass tensors=[...] "
+                "to say how they are filled."
+            )
+        source = ProgramKernel(kernel, name=name)
+
+    return Case(
+        kernel=source,
+        name=name or source.cache_id(),
+        tensors=tensors,
+        golden=golden,
+        scalars=scalars or [],
+        platform=platform,
+        strategy=strategy,
+        memory_planner=memory_planner,
+        enable_pypto_l0c_double_buffer=enable_pypto_l0c_double_buffer,
+        rtol=rtol,
+        atol=atol,
+    )
+
+
+def cases(*case_objs: Case) -> Any:
+    """Parametrize a test over *case_objs*, one item per case.
+
+    Args:
+        *case_objs: The cases, each built by :func:`case`.
+
+    Returns:
+        A ``pytest.mark.parametrize`` decorator binding the harness-owned
+        ``_st_case`` argument; tests reach the case through ``case_run``.
+
+    Raises:
+        ValueError: No cases were given, or two share a name — duplicate names
+            would collide in the artifact cache and produce indistinguishable
+            pytest ids.
+    """
+    if not case_objs:
+        raise ValueError("st.cases() needs at least one case")
+    names = [c.name for c in case_objs]
+    duplicates = sorted({n for n in names if names.count(n) > 1})
+    if duplicates:
+        raise ValueError(
+            f"st.cases(): duplicate case name(s) {duplicates}; names must be unique within a run"
+        )
+    # ``_st_case``, not ``case``: several suites already parametrize their own
+    # ``case`` argument (test_expand_ops, the all_to_all_v skew tests), and a
+    # harness-owned param must not collide with a test's own. Mirrors the
+    # existing ``_st_platform``. The pytest id still comes from ids=names, so
+    # the underscore never shows up in a node id.
+    return pytest.mark.parametrize("_st_case", list(case_objs), ids=names)
+
+
+class CaseRun:
+    """What a test asserts on after its case has run.
+
+    Attributes:
+        case: The case that produced this run.
+        result: The raw ``RunResult`` from the harness.
+    """
+
+    __test__ = False  # not a pytest test class
+
+    def __init__(self, case_obj: Case, result: RunResult):
+        self.case = case_obj
+        self.result = result
+
+    @property
+    def passed(self) -> bool:
+        return self.result.passed
+
+    @property
+    def error(self) -> str | None:
+        return self.result.error
+
+    @property
+    def work_dir(self) -> Path | None:
+        """The compiled artifact directory, or ``None`` if it was not cached.
+
+        Where the generated kernels, ``golden.py`` and any ``dfx_outputs/``
+        live — for a test that asserts on artifacts rather than only on the
+        numeric result.
+        """
+        from harness.core.test_runner import artifact_work_dir  # noqa: PLC0415
+
+        return artifact_work_dir(self.case)
+
+    def assert_passed(self) -> None:
+        """Fail the test with the harness's own error when the case did not pass."""
+        assert self.passed, f"{self.case.name} failed: {self.error}"
+
+    def __repr__(self) -> str:
+        return f"CaseRun({self.case.name!r}, passed={self.passed})"
+
+
+@pytest.fixture
+def case_run(_st_case: Case, test_runner: Any) -> CaseRun:
+    """Run the item's case and return its result.
+
+    Requesting ``test_runner`` is what routes the case through the pre-compile
+    and batched-execute pipeline: ``pytest_itemcollected`` marks any item whose
+    fixture closure reaches ``test_runner`` as ``device_batch``.
+    """
+    return CaseRun(_st_case, test_runner.run(_st_case))
+
+
+__all__ = ["Case", "CaseRun", "case", "case_run", "cases", "from_legacy"]

--- a/tests/st/harness/test_case_declaration.py
+++ b/tests/st/harness/test_case_declaration.py
@@ -439,6 +439,119 @@ class TestDeclaration:
         assert (bound.config.rtol, bound.config.atol) == (1e-3, 1e-2)
 
 
+class TestPlatformMatrixCollection:
+    """A declared case against the multi-platform CLI, through the real hooks.
+
+    Both halves are driven here because they fail independently: the collection
+    hook decides what gets compiled and under which key, and the deselect hook
+    decides which items exist at all. A pin that is honoured by one and ignored
+    by the other still reports coverage it does not have.
+    """
+
+    PLATFORMS = ("a2a3", "a2a3sim", "a5", "a5sim")
+
+    @staticmethod
+    def _conftest() -> Any:
+        """Load ``tests/st/conftest.py`` as a module; it is not importable by name."""
+        import importlib.util  # noqa: PLC0415
+
+        path = Path(__file__).resolve().parents[1] / "conftest.py"
+        spec = importlib.util.spec_from_file_location("_st_conftest_under_test", path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+    @classmethod
+    def _items(cls, case_obj: Case) -> "list[Any]":
+        """One stub item per matrix variant, shaped like the pytest items."""
+
+        class _CallSpec:
+            def __init__(self, params: dict) -> None:
+                self.params = params
+
+        class _Item:
+            module = None
+
+            def __init__(self, params: dict, name: str) -> None:
+                self.callspec = _CallSpec(params)
+                self.name = name
+
+            def iter_markers(self, name: str | None = None) -> Any:
+                return iter(())
+
+        return [_Item({"_st_case": case_obj, "_st_platform": p}, f"test_it[{p}]") for p in cls.PLATFORMS]
+
+    @staticmethod
+    def _config(platform_opt: str) -> Any:
+        class _Hook:
+            def __init__(self) -> None:
+                self.deselected: list[Any] = []
+
+            def pytest_deselected(self, items: "list[Any]") -> None:
+                self.deselected.extend(items)
+
+        class _Config:
+            def __init__(self) -> None:
+                self.hook = _Hook()
+
+            def getoption(self, name: str) -> Any:
+                assert name == "--platform", name
+                return platform_opt
+
+        return _Config()
+
+    def test_a_pinned_case_keeps_only_its_own_matrix_variant(self):
+        """The other three variants would run A5 while claiming to be themselves."""
+        conf = self._conftest()
+        items = self._items(_jit_case(name="abs_pin_deselect", platform="a5"))
+        config = self._config(",".join(self.PLATFORMS))
+
+        kept = list(items)
+        conf.pytest_collection_modifyitems(config, kept)
+
+        assert [i.name for i in kept] == ["test_it[a5]"]
+        assert [i.name for i in config.hook.deselected] == [
+            "test_it[a2a3]",
+            "test_it[a2a3sim]",
+            "test_it[a5sim]",
+        ]
+
+    def test_a_pinned_case_is_collected_once_under_its_pin(self):
+        """Keyed by the pin, not by the item — even with no deselect in front.
+
+        Keying by the item's platform filed one object under a key per variant.
+        The pipeline resolves each of them back to the pin, so it compiled the
+        same artifact directory once per variant, concurrently.
+        """
+        conf = self._conftest()
+        pinned = _jit_case(name="abs_pin_key", platform="a5")
+
+        seen: dict[str, Any] = {}
+        for item in self._items(pinned):
+            conf._collect_test_case_from_item(item, seen, None, "a2a3")
+
+        assert list(seen) == ["abs_pin_key@a5@default"]
+        assert all(c is pinned for c in seen.values()), "a pinned case is never copied"
+
+    def test_an_unpinned_case_still_spans_the_matrix(self):
+        """The pin path must not narrow a case that never asked for one."""
+        conf = self._conftest()
+        declared = _jit_case(name="abs_free_key")
+
+        seen: dict[str, Any] = {}
+        items = self._items(declared)
+        for item in items:
+            conf._collect_test_case_from_item(item, seen, None, "a2a3")
+
+        assert sorted(seen) == [f"abs_free_key@{p}@default" for p in sorted(self.PLATFORMS)]
+        assert len({id(c) for c in seen.values()}) == 4
+        assert declared.get_platform() is None, "the declaration itself stays unbound"
+
+        kept = list(items)
+        conf.pytest_collection_modifyitems(self._config(",".join(self.PLATFORMS)), kept)
+        assert len(kept) == 4, "an unpinned case keeps every variant"
+
+
 class TestCustomCompare:
     """``compare=`` replaces the elementwise check the harness performs."""
 

--- a/tests/st/harness/test_case_declaration.py
+++ b/tests/st/harness/test_case_declaration.py
@@ -112,6 +112,19 @@ class AbsLegacyCase(PTOTestCase):
         tensors["out"][:] = torch.abs(tensors["a"])
 
 
+@jit.incore
+def scaled_kernel(a: pl.Tensor, out: pl.Out[pl.Tensor], scale: float):
+    """Abs then scale — gives the declaration surface a scalar to specialize on."""
+    return pl.store(pl.tile.abs(pl.load(a, [0, 0], [M, N])) * scale, [0, 0], out)
+
+
+@jit
+def scaled_entry(a: pl.Tensor, out: pl.Out[pl.Tensor], scale: float):
+    """Entry over :func:`scaled_kernel`."""
+    out = scaled_kernel(a, out, scale)
+    return out
+
+
 def _jit_case(**kwargs: Any) -> Case:
     """A JIT-authored case over the shared ``a`` / ``out`` signature."""
     kwargs.setdefault("name", "abs_jit")
@@ -387,6 +400,33 @@ class TestDeclaration:
         pinned = _jit_case(name="abs_pinned_matrix", platform="a5")
         assert pinned.for_platform("a2a3") is pinned
         assert pinned.get_platform() == "a5"
+
+    def test_cache_id_separates_positional_scalars(self):
+        """A scalar passed positionally must change the identity.
+
+        It reaches the specializer exactly as a keyword scalar does, and the
+        id is the default case name -- which is the artifact cache key, so a
+        collision makes the second declaration reuse the first one's artifact.
+        """
+        a, out = torch.randn(M, N), torch.zeros(M, N)
+        one = JitKernel(scaled_entry, a, out, 1.0)
+        two = JitKernel(scaled_entry, a, out, 2.0)
+        assert one.cache_id() != two.cache_id(), f"positional scalar dropped from the id: {one.cache_id()}"
+
+    def test_cache_id_separates_scalar_types(self):
+        """``1`` and ``1.0`` specialize differently and must not collide."""
+        a, out = torch.randn(M, N), torch.zeros(M, N)
+        assert JitKernel(scaled_entry, a, out, 1).cache_id() != (
+            JitKernel(scaled_entry, a, out, 1.0).cache_id()
+        )
+
+    def test_cache_id_agrees_across_binding_styles(self):
+        """The same scalar gives the same id positionally or by keyword."""
+        a, out = torch.randn(M, N), torch.zeros(M, N)
+        assert (
+            JitKernel(scaled_entry, a, out, 2.0).cache_id()
+            == JitKernel(scaled_entry, a, out, scale=2.0).cache_id()
+        )
 
     def test_for_platform_carries_the_declaration_over(self):
         """The copy differs in platform alone — every other field is the case's."""

--- a/tests/st/harness/test_case_declaration.py
+++ b/tests/st/harness/test_case_declaration.py
@@ -1,0 +1,322 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Device-free tests for the ``st.case`` declaration surface.
+
+Covers the three things a case has to get right before any card is involved:
+
+1. a ``@pl.jit`` kernel and a ``@pl.program`` class produce the *same* compiled
+   artifact — the claim that lets one execution path serve both;
+2. the tensor list a JIT case derives from its sample arguments matches what a
+   hand-written ``define_tensors()`` would have declared;
+3. the golden callable is adapted to the pipeline's in-place contract, in every
+   return shape it accepts.
+
+Nothing here touches a device, and the compile check is skipped when ``ptoas``
+is unavailable.
+"""
+
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import pypto.language as pl
+import pytest
+import torch
+from pypto.ir.pass_manager import OptimizationStrategy, PassManager
+from pypto.jit.decorator import _ptoas_available, jit
+from pypto.pypto_core import ir as _ir
+
+from harness import st
+from harness.core.case import Case, from_legacy
+from harness.core.harness import DataType, PTOTestCase, TensorSpec
+from harness.core.kernel_source import JitKernel, ProgramKernel, datatype_from_torch
+from harness.core.test_runner import _compile_for_cache
+
+M = 16
+N = 16
+
+
+# ---------------------------------------------------------------------------
+# The same kernel, authored both ways. Function names match on purpose: they
+# are part of the IR, so a naming difference would mask a structural one.
+# ---------------------------------------------------------------------------
+
+
+@jit.incore
+def kernel(a: pl.Tensor, out: pl.Out[pl.Tensor]):
+    tile_a = pl.load(a, [0, 0], [M, N])
+    return pl.store(pl.tile.abs(tile_a), [0, 0], out)
+
+
+@jit
+def orchestrator(a: pl.Tensor, out: pl.Out[pl.Tensor]):
+    out = kernel(a, out)
+    return out
+
+
+@pl.program
+class AbsProgram:
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(
+        self,
+        a: pl.Tensor[[M, N], pl.FP32],
+        out: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+    ) -> pl.Tensor[[M, N], pl.FP32]:
+        tile_a = pl.load(a, [0, 0], [M, N])
+        out = pl.store(pl.tile.abs(tile_a), [0, 0], out)
+        return out
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        a: pl.Tensor[[M, N], pl.FP32],
+        out: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+    ) -> pl.Tensor[[M, N], pl.FP32]:
+        out = self.kernel(a, out)
+        return out
+
+
+class AbsLegacyCase(PTOTestCase):
+    """The pre-``Case`` way of declaring the very same test."""
+
+    __test__ = False
+
+    def get_name(self) -> str:
+        return "abs_legacy"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("a", [M, N], DataType.FP32, init_value=torch.randn(M, N)),
+            TensorSpec("out", [M, N], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return AbsProgram
+
+    def compute_expected(self, tensors: dict[str, torch.Tensor], params=None) -> None:
+        tensors["out"][:] = torch.abs(tensors["a"])
+
+
+def _jit_case(**kwargs: Any) -> Case:
+    """A JIT-authored case over the shared ``a`` / ``out`` signature."""
+    kwargs.setdefault("name", "abs_jit")
+    kwargs.setdefault("golden", lambda t: torch.abs(t["a"]))
+    return st.case(orchestrator, torch.randn(M, N), torch.zeros(M, N), **kwargs)
+
+
+# ---------------------------------------------------------------------------
+
+
+class TestKernelSourceEquivalence:
+    """A JIT kernel and a @pl.program class compile to the same thing."""
+
+    def test_same_ir_after_passes(self):
+        """The two sources' programs are structurally equal once lowered."""
+        pm = PassManager.get_strategy(OptimizationStrategy.Default)
+        jit_program = JitKernel(orchestrator, torch.randn(M, N), torch.zeros(M, N)).build_program()
+        _ir.assert_structural_equal(pm.run_passes(jit_program), pm.run_passes(AbsProgram))
+
+    @pytest.mark.skipif(not _ptoas_available(), reason="ptoas is required to generate kernel sources")
+    def test_same_generated_artifacts(self):
+        """Both sources satisfy ``_compile_for_cache`` and emit the same files.
+
+        This is the integration claim: the existing compile task, unchanged,
+        accepts a ``Case`` whichever surface authored its kernel.
+        """
+        produced: dict[str, tuple[list[str], list[str], bool]] = {}
+        for label, case_obj in (
+            ("jit", _jit_case(platform="a2a3")),
+            (
+                "program",
+                st.case(
+                    AbsProgram,
+                    name="abs_program",
+                    platform="a2a3",
+                    tensors=AbsLegacyCase().define_tensors(),
+                    golden=lambda t: torch.abs(t["a"]),
+                ),
+            ),
+        ):
+            work_dir = Path(tempfile.mkdtemp(prefix=f"case_decl_{label}_"))
+            try:
+                _compile_for_cache(case_obj, work_dir, "a2a3", False, False, None)
+                produced[label] = (
+                    sorted(p.name for p in (work_dir / "kernels").rglob("*.cpp")),
+                    sorted(p.name for p in (work_dir / "orchestration").glob("*.cpp")),
+                    (work_dir / "golden.py").exists(),
+                )
+                # The golden ran in this process and was persisted for the child.
+                assert (work_dir / "data" / "out" / "out.pt").exists(), (
+                    f"{label}: golden outputs were not persisted to data/out/"
+                )
+            finally:
+                shutil.rmtree(work_dir, ignore_errors=True)
+
+        assert produced["jit"][0] == produced["program"][0], "kernel sources differ"
+        assert produced["jit"][1] == produced["program"][1], "orchestration sources differ"
+        assert produced["jit"][2] and produced["program"][2], "golden.py was not written"
+
+    def test_program_kernel_accepts_a_factory(self):
+        """``ProgramKernel`` invokes a plain callable, and passes a class through."""
+        assert ProgramKernel(AbsProgram).build_program() is AbsProgram
+        assert ProgramKernel(lambda: AbsProgram, name="factory").build_program() is AbsProgram
+
+    def test_jit_kernel_rejects_a_program_class(self):
+        """The natural mistake fails with a message naming the right source."""
+        with pytest.raises(TypeError, match="Use ProgramKernel"):
+            JitKernel(AbsProgram)
+
+
+class TestDerivedTensorSpecs:
+    """A JIT case derives the tensor list its author would have written."""
+
+    def test_matches_the_hand_written_declaration(self):
+        derived = _jit_case().tensor_specs
+        expected = AbsLegacyCase().define_tensors()
+        assert [s.name for s in derived] == [s.name for s in expected]
+        assert [s.shape for s in derived] == [s.shape for s in expected]
+        assert [s.dtype for s in derived] == [s.dtype for s in expected]
+        assert [s.is_output for s in derived] == [s.is_output for s in expected]
+
+    def test_out_param_is_not_seeded_but_inout_is(self):
+        """``pl.Out`` is scratch; ``pl.InOut`` carries live input."""
+
+        @jit.incore
+        def accumulate_k(x: pl.Tensor, acc: pl.InOut[pl.Tensor]):
+            total = pl.tile.add(pl.load(x, [0, 0], [M, N]), pl.load(acc, [0, 0], [M, N]))
+            return pl.store(total, [0, 0], acc)
+
+        @jit
+        def accumulate(x: pl.Tensor, acc: pl.InOut[pl.Tensor]):
+            acc = accumulate_k(x, acc)
+            return acc
+
+        specs = {
+            s.name: s
+            for s in st.case(
+                accumulate,
+                torch.randn(M, N),
+                torch.randn(M, N),
+                name="acc_inout",
+                golden=lambda t: t["x"] + t["acc"],
+            ).tensor_specs
+        }
+        assert specs["acc"].is_output and specs["acc"].init_value is not None, "InOut keeps its input"
+        assert specs["x"].init_value is not None
+        out_spec = _jit_case().tensor_specs[-1]
+        assert out_spec.name == "out" and out_spec.is_output and out_spec.init_value is None
+
+    def test_dtype_round_trips(self):
+        """Every harness dtype this torch build supports maps back to itself."""
+        for member in DataType:
+            try:
+                torch_dtype = member.torch_dtype
+            except ValueError:
+                continue  # optional MX dtype this build lacks
+            assert datatype_from_torch(torch_dtype).torch_dtype is torch_dtype
+
+    def test_unknown_dtype_names_what_is_available(self):
+        with pytest.raises(ValueError, match="No harness DataType for torch dtype"):
+            datatype_from_torch(torch.complex64)
+
+    def test_program_case_without_tensors_is_rejected(self):
+        """A @pl.program cannot derive its tensors, and the error says so."""
+        with pytest.raises(ValueError, match="pass tensors="):
+            st.case(AbsProgram, name="no_tensors", golden=lambda t: t["a"])
+
+
+class TestGoldenAdaptation:
+    """The golden callable reaches the pipeline's in-place contract."""
+
+    def _tensors(self) -> dict[str, torch.Tensor]:
+        return {"a": torch.randn(M, N), "out": torch.zeros(M, N)}
+
+    def test_returned_tensor_is_written_to_the_single_output(self):
+        case_obj = _jit_case()
+        tensors = self._tensors()
+        case_obj.compute_expected(tensors)
+        assert torch.equal(tensors["out"], torch.abs(tensors["a"]))
+
+    def test_closure_over_test_locals_is_allowed(self):
+        """The golden runs in this process, so it may capture anything."""
+        scale = 3.0
+        case_obj = _jit_case(name="abs_closure", golden=lambda t: torch.abs(t["a"]) * scale)
+        tensors = self._tensors()
+        case_obj.compute_expected(tensors)
+        assert torch.equal(tensors["out"], torch.abs(tensors["a"]) * scale)
+
+    def test_in_place_golden_is_left_alone(self):
+        def golden(t):
+            t["out"][:] = torch.abs(t["a"])
+
+        tensors = self._tensors()
+        _jit_case(name="abs_inplace", golden=golden).compute_expected(tensors)
+        assert torch.equal(tensors["out"], torch.abs(tensors["a"]))
+
+    def test_dict_return_must_name_the_outputs(self):
+        tensors = self._tensors()
+        _jit_case(name="abs_dict", golden=lambda t: {"out": torch.abs(t["a"])}).compute_expected(tensors)
+        assert torch.equal(tensors["out"], torch.abs(tensors["a"]))
+
+        with pytest.raises(ValueError, match="unknown output"):
+            bad = _jit_case(name="abs_bad_key", golden=lambda t: {"wrong": t["a"]})
+            bad.compute_expected(self._tensors())
+
+    def test_wrong_return_type_is_reported(self):
+        with pytest.raises(TypeError, match="expected a torch.Tensor"):
+            _jit_case(name="abs_bad_type", golden=lambda t: "nope").compute_expected(self._tensors())
+
+    def test_missing_golden_is_reported(self):
+        with pytest.raises(ValueError, match="has no golden"):
+            st.case(
+                orchestrator, torch.randn(M, N), torch.zeros(M, N), name="abs_no_golden"
+            ).compute_expected(self._tensors())
+
+
+class TestDeclaration:
+    """``st.cases`` and the legacy adapter."""
+
+    def test_duplicate_names_are_rejected(self):
+        with pytest.raises(ValueError, match="duplicate case name"):
+            st.cases(_jit_case(name="dup"), _jit_case(name="dup"))
+
+    def test_empty_declaration_is_rejected(self):
+        with pytest.raises(ValueError, match="at least one case"):
+            st.cases()
+
+    def test_from_legacy_preserves_the_case(self):
+        """A wrapped ``PTOTestCase`` keeps its program, tensors and golden."""
+        legacy = AbsLegacyCase()
+        wrapped = from_legacy(legacy)
+        assert wrapped.get_name() == legacy.get_name()
+        assert wrapped.get_program() is AbsProgram
+        assert [s.name for s in wrapped.tensor_specs] == [s.name for s in legacy.tensor_specs]
+
+        tensors = {"a": torch.randn(M, N), "out": torch.zeros(M, N)}
+        wrapped.compute_expected(tensors)
+        assert torch.equal(tensors["out"], torch.abs(tensors["a"]))
+
+    def test_platform_binding_respects_a_pin(self):
+        pinned = _jit_case(name="abs_pinned", platform="a5")
+        pinned.bind_platform("a2a3")
+        assert pinned.get_platform() == "a5", "an explicit pin wins over the item's platform"
+
+        floating = _jit_case(name="abs_floating")
+        floating.bind_platform("a2a3")
+        assert floating.get_platform() == "a2a3"
+
+    def test_unknown_platform_is_rejected(self):
+        with pytest.raises(ValueError, match="unknown platform"):
+            _jit_case(name="abs_bad_platform", platform="a9")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/st/harness/test_case_declaration.py
+++ b/tests/st/harness/test_case_declaration.py
@@ -26,6 +26,7 @@ import shutil
 import tempfile
 from pathlib import Path
 from typing import Any
+from unittest.mock import Mock
 
 import pypto.language as pl
 import pytest
@@ -350,12 +351,18 @@ class TestCustomCompare:
         with pytest.raises(TypeError, match="compare must be callable"):
             _jit_case(name="abs_bad_compare", compare="nope")
 
-    def test_a_legacy_case_has_no_comparator(self):
-        """``PTOTestCase`` carries none, so it always takes the default path."""
+    def test_only_a_case_carries_a_comparator(self):
+        """Matched by type, so nothing else can look like it carries one.
+
+        ``PTOTestCase`` has no such attribute, and a ``Mock`` answers truthily
+        to *any* attribute — an attribute check would send it down the
+        persist-then-compare path with no artifacts to read, which is how this
+        was found.
+        """
         assert _case_comparator(AbsLegacyCase()) is None
+        assert _case_comparator(Mock()) is None, "a Mock must not look like it has a comparator"
         assert _case_comparator(_jit_case(name="abs_no_compare")) is None
-        marker = object()
-        assert _case_comparator(_jit_case(name="abs_has_compare", compare=lambda a, e: marker)) is not None
+        assert _case_comparator(_jit_case(name="abs_has_compare", compare=lambda a, e: None)) is not None
 
     @pytest.mark.skipif(not _ptoas_available(), reason="ptoas is required to generate kernel sources")
     def test_comparator_sees_the_persisted_outputs(self):

--- a/tests/st/harness/test_case_declaration.py
+++ b/tests/st/harness/test_case_declaration.py
@@ -186,8 +186,30 @@ class TestDerivedTensorSpecs:
         assert [s.dtype for s in derived] == [s.dtype for s in expected]
         assert [s.is_output for s in derived] == [s.is_output for s in expected]
 
-    def test_out_param_is_not_seeded_but_inout_is(self):
-        """``pl.Out`` is scratch; ``pl.InOut`` carries live input."""
+    def test_every_tensor_is_seeded_from_its_sample_argument(self):
+        """Outputs included — the sample argument is the buffer the test prepared.
+
+        A kernel that accumulates onto its destination (atomic-add, and any
+        ``pl.InOut``) reads what it is handed, so the baseline a test fills in
+        must reach the device. Deciding from the annotation alone that a
+        ``pl.Out`` buffer is scratch would silently zero that baseline and
+        compare against a golden that assumed it.
+        """
+        baseline = torch.full((M, N), 7.0)
+        case_obj = st.case(
+            orchestrator,
+            torch.randn(M, N),
+            baseline,
+            name="abs_seeded_out",
+            golden=lambda t: torch.abs(t["a"]),
+        )
+        specs = {s.name: s for s in case_obj.tensor_specs}
+        assert specs["out"].is_output
+        assert specs["out"].init_value is baseline, "an Out buffer's contents are the test's statement"
+        assert specs["a"].init_value is not None
+
+    def test_inout_param_is_an_output_and_keeps_its_input(self):
+        """``pl.InOut`` is reported as an output and seeded."""
 
         @jit.incore
         def accumulate_k(x: pl.Tensor, acc: pl.InOut[pl.Tensor]):
@@ -211,8 +233,6 @@ class TestDerivedTensorSpecs:
         }
         assert specs["acc"].is_output and specs["acc"].init_value is not None, "InOut keeps its input"
         assert specs["x"].init_value is not None
-        out_spec = _jit_case().tensor_specs[-1]
-        assert out_spec.name == "out" and out_spec.is_output and out_spec.init_value is None
 
     def test_dtype_round_trips(self):
         """Every harness dtype this torch build supports maps back to itself."""

--- a/tests/st/harness/test_case_declaration.py
+++ b/tests/st/harness/test_case_declaration.py
@@ -34,7 +34,8 @@ import torch
 from pypto.ir.pass_manager import OptimizationStrategy, PassManager
 from pypto.jit.decorator import _ptoas_available, jit
 from pypto.pypto_core import ir as _ir
-from pypto.runtime.runner import validate_persisted_outputs
+from pypto.pypto_core.passes import MemoryPlanner
+from pypto.runtime.runner import RunConfig, validate_persisted_outputs
 
 from harness import st
 from harness.core.case import Case, from_legacy
@@ -329,6 +330,26 @@ class TestDeclaration:
         tensors = {"a": torch.randn(M, N), "out": torch.zeros(M, N)}
         wrapped.compute_expected(tensors)
         assert torch.equal(tensors["out"], torch.abs(tensors["a"]))
+
+    def test_from_legacy_preserves_a_run_config_memory_planner(self):
+        """A planner carried only by the legacy ``RunConfig`` survives the wrap.
+
+        ``_resolve_case_memory_planner`` reads ``get_memory_planner()`` first
+        and the case's own ``RunConfig`` second. A ``Case`` rebuilds that
+        ``RunConfig`` from the tolerances alone, so without folding the second
+        channel into the first the wrapped case would silently fall through to
+        the session planner.
+        """
+        legacy = AbsLegacyCase(RunConfig(memory_planner=MemoryPlanner.DSA_RP))
+        assert legacy.get_memory_planner() is None, "the planner rides on the config only"
+        assert from_legacy(legacy).get_memory_planner() == MemoryPlanner.DSA_RP
+
+    def test_from_legacy_prefers_the_explicit_planner(self):
+        """``get_memory_planner()`` still outranks the config's planner."""
+        legacy = AbsLegacyCase(
+            RunConfig(memory_planner=MemoryPlanner.DSA_RP), memory_planner=MemoryPlanner.PYPTO
+        )
+        assert from_legacy(legacy).get_memory_planner() == MemoryPlanner.PYPTO
 
     def test_platform_binding_respects_a_pin(self):
         pinned = _jit_case(name="abs_pinned", platform="a5")

--- a/tests/st/harness/test_case_declaration.py
+++ b/tests/st/harness/test_case_declaration.py
@@ -33,12 +33,17 @@ import torch
 from pypto.ir.pass_manager import OptimizationStrategy, PassManager
 from pypto.jit.decorator import _ptoas_available, jit
 from pypto.pypto_core import ir as _ir
+from pypto.runtime.runner import validate_persisted_outputs
 
 from harness import st
 from harness.core.case import Case, from_legacy
 from harness.core.harness import DataType, PTOTestCase, TensorSpec
 from harness.core.kernel_source import JitKernel, ProgramKernel, datatype_from_torch
-from harness.core.test_runner import _compile_for_cache
+from harness.core.test_runner import (
+    _case_comparator,
+    _compare_persisted_outputs,
+    _compile_for_cache,
+)
 
 M = 16
 N = 16
@@ -336,6 +341,81 @@ class TestDeclaration:
     def test_unknown_platform_is_rejected(self):
         with pytest.raises(ValueError, match="unknown platform"):
             _jit_case(name="abs_bad_platform", platform="a9")
+
+
+class TestCustomCompare:
+    """``compare=`` replaces the elementwise check the harness performs."""
+
+    def test_non_callable_is_rejected(self):
+        with pytest.raises(TypeError, match="compare must be callable"):
+            _jit_case(name="abs_bad_compare", compare="nope")
+
+    def test_a_legacy_case_has_no_comparator(self):
+        """``PTOTestCase`` carries none, so it always takes the default path."""
+        assert _case_comparator(AbsLegacyCase()) is None
+        assert _case_comparator(_jit_case(name="abs_no_compare")) is None
+        marker = object()
+        assert _case_comparator(_jit_case(name="abs_has_compare", compare=lambda a, e: marker)) is not None
+
+    @pytest.mark.skipif(not _ptoas_available(), reason="ptoas is required to generate kernel sources")
+    def test_comparator_sees_the_persisted_outputs(self):
+        """It receives ``data/actual`` and ``data/out``, keyed by output name.
+
+        Compiled for real so the golden and ``golden.py``'s ``__outputs__`` are
+        the genuine artefacts; only the device run is stood in for, by writing
+        the actuals the run would have persisted.
+        """
+        case_obj = _jit_case(platform="a2a3")
+        work_dir = Path(tempfile.mkdtemp(prefix="case_compare_"))
+        try:
+            _compile_for_cache(case_obj, work_dir, "a2a3", False, False, None)
+            expected = torch.load(work_dir / "data" / "out" / "out.pt")
+
+            # Stand in for the device run: persist an output that is close but
+            # not elementwise-equal, so a comparator that looks at the whole
+            # tensor can accept what the default check would reject.
+            actual = expected + 1e-2
+            (work_dir / "data" / "actual").mkdir(parents=True, exist_ok=True)
+            torch.save(actual, work_dir / "data" / "actual" / "out.pt")
+
+            seen: dict[str, Any] = {}
+
+            def record(actual_map, expected_map):
+                seen["names"] = sorted(actual_map)
+                seen["match"] = torch.equal(actual_map["out"], actual) and torch.equal(
+                    expected_map["out"], expected
+                )
+
+            _compare_persisted_outputs(work_dir, record)
+            assert seen["names"] == ["out"], "keyed by the output names golden.py declares"
+            assert seen["match"], "the comparator receives the persisted tensors verbatim"
+
+            # The default check rejects this pair; a whole-tensor comparator accepts it.
+            with pytest.raises(AssertionError):
+                validate_persisted_outputs(work_dir, rtol=1e-5, atol=1e-5)
+
+            def rel_err_under(limit):
+                def compare(actual_map, expected_map):
+                    for name, got in actual_map.items():
+                        ref = expected_map[name].float()
+                        rel = (got.float() - ref).norm() / ref.norm()
+                        assert rel < limit, f"{name}: rel_err {rel:.3e} exceeds {limit}"
+
+                return compare
+
+            _compare_persisted_outputs(work_dir, rel_err_under(2e-2))
+            with pytest.raises(AssertionError, match="rel_err"):
+                _compare_persisted_outputs(work_dir, rel_err_under(1e-9))
+        finally:
+            shutil.rmtree(work_dir, ignore_errors=True)
+
+    def test_missing_persisted_outputs_are_reported(self):
+        empty = Path(tempfile.mkdtemp(prefix="case_compare_empty_"))
+        try:
+            with pytest.raises((AssertionError, FileNotFoundError)):
+                _compare_persisted_outputs(empty, lambda a, e: None)
+        finally:
+            shutil.rmtree(empty, ignore_errors=True)
 
 
 if __name__ == "__main__":

--- a/tests/st/harness/test_case_declaration.py
+++ b/tests/st/harness/test_case_declaration.py
@@ -343,6 +343,40 @@ class TestDeclaration:
         with pytest.raises(ValueError, match="unknown platform"):
             _jit_case(name="abs_bad_platform", platform="a9")
 
+    def test_for_platform_binds_each_variant_independently(self):
+        """One declared case serves N platform variants without cross-talk.
+
+        ``st.cases`` hands the *same* object to every variant of a
+        multi-platform item, so binding in place would pin the first variant's
+        platform for all of them — and a case's own platform outranks the
+        item's, so every variant would go on to compile and run that first
+        platform's artifact.
+        """
+        declared = _jit_case(name="abs_matrix")
+        variants = {p: declared.for_platform(p) for p in ("a2a3", "a2a3sim", "a5", "a5sim")}
+
+        assert declared.get_platform() is None, "the declaration itself stays unbound"
+        for platform, bound in variants.items():
+            assert bound is not declared
+            assert bound.get_platform() == platform
+        assert len({id(v) for v in variants.values()}) == 4, "one case object per variant"
+
+    def test_for_platform_keeps_a_pin_and_its_identity(self):
+        """A pinned case is returned as-is: the pin must keep outranking the item."""
+        pinned = _jit_case(name="abs_pinned_matrix", platform="a5")
+        assert pinned.for_platform("a2a3") is pinned
+        assert pinned.get_platform() == "a5"
+
+    def test_for_platform_carries_the_declaration_over(self):
+        """The copy differs in platform alone — every other field is the case's."""
+        declared = _jit_case(name="abs_carry", rtol=1e-3, atol=1e-2)
+        bound = declared.for_platform("a5")
+        assert bound.name == declared.name
+        assert bound.kernel is declared.kernel
+        assert bound.golden is declared.golden
+        assert bound.tensor_specs == declared.tensor_specs
+        assert (bound.config.rtol, bound.config.atol) == (1e-3, 1e-2)
+
 
 class TestCustomCompare:
     """``compare=`` replaces the elementwise check the harness performs."""

--- a/tests/st/harness/test_case_pipeline.py
+++ b/tests/st/harness/test_case_pipeline.py
@@ -1,0 +1,79 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""End-to-end guard for the ``st.cases`` declaration path.
+
+A case declared with ``@st.cases(...)`` has to survive the whole route:
+collection reads it out of ``callspec.params``, the pre-compile pool builds its
+IR from the ``@pl.jit`` entry, the golden runs in this process, and the device
+step is batched like any other case.
+
+The discovery half is what this file actually guards, and it is guarded by
+assertion rather than by inspection: a case the pipeline picked up has a
+published artifact directory, and one that fell through to the per-case inline
+path does not.  Before ``st.cases`` existed, a ``@pl.jit`` test could not be
+discovered at all — it silently took the inline path — so a regression here
+would otherwise show up only as CI getting slower.
+
+Runs card-free under ``--codegen-only``; on a device it is one small kernel in
+the batched pool.
+"""
+
+import pypto.language as pl
+import pytest
+import torch
+
+from harness import st
+
+M = 16
+N = 16
+
+
+@pl.jit.incore
+def _abs_kernel(a: pl.Tensor, out: pl.Out[pl.Tensor]):
+    tile_a = pl.load(a, [0, 0], [M, N])
+    return pl.store(pl.tile.abs(tile_a), [0, 0], out)
+
+
+@pl.jit
+def _abs_entry(a: pl.Tensor, out: pl.Out[pl.Tensor]):
+    out = _abs_kernel(a, out)
+    return out
+
+
+torch.manual_seed(0)
+_A = torch.randn(M, N, dtype=torch.float32)
+
+
+@st.cases(
+    st.case(
+        _abs_entry,
+        _A,
+        torch.zeros(M, N, dtype=torch.float32),
+        name="harness_pipeline_abs",
+        golden=lambda tensors: torch.abs(tensors["a"]),
+    ),
+)
+def test_declared_case_runs(case_run, request):
+    """The declared case compiles, runs, and matches its golden."""
+    case_run.assert_passed()
+
+    # Discovery check: with the pre-compile pool active, a discovered case owns
+    # a published artifact directory. ``None`` here means collection did not see
+    # the declaration and the case fell back to inline compilation.
+    if request.config.getoption("--precompile-workers") is not None:
+        assert case_run.work_dir is not None, (
+            "case was not picked up by the pre-compile pipeline — "
+            "pytest_collection_finish did not read it from callspec.params"
+        )
+        assert (case_run.work_dir / "golden.py").exists()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/st/runtime/control_flow/test_dag.py
+++ b/tests/st/runtime/control_flow/test_dag.py
@@ -20,30 +20,27 @@ source of truth and ensure examples are guarded by tests.
 import pytest
 import torch
 from examples.models.vector_dag import golden, vector_dag
+from harness import st
 
 
-class TestDAGOperations:
-    """Test suite for DAG operations."""
+def _vector_dag_case():
+    """Vector DAG computation with 128x128 shape: f = (a + b + 1)(a + b + 2) + (a + b).
 
-    def test_vector_dag(self, test_config):
-        """Test vector DAG computation with 128x128 shape.
+    The example's own ``golden(tensors)`` is handed over unchanged: it already
+    writes the outputs in place and keys them by parameter name, which is the
+    contract a case golden may use. That keeps one source of truth for the
+    reference — the example — rather than a copy of it here.
+    """
+    a = torch.full((128, 128), 2.0, dtype=torch.float32)
+    b = torch.full((128, 128), 3.0, dtype=torch.float32)
+    f = torch.zeros((128, 128), dtype=torch.float32)
+    return st.case(vector_dag, a, b, f, name="vector_dag_128", golden=golden)
 
-        Implements: f = (a + b + 1)(a + b + 2) + (a + b)
-        """
-        vector_dag._cache.clear()
-        a = torch.full((128, 128), 2.0, dtype=torch.float32)
-        b = torch.full((128, 128), 3.0, dtype=torch.float32)
-        f = torch.zeros((128, 128), dtype=torch.float32)
 
-        vector_dag(a, b, f, config=test_config)
-
-        # Reference via the example's golden() function (single source of truth).
-        ref_tensors = {"a": a, "b": b, "f": torch.zeros_like(f)}
-        golden(ref_tensors)
-        expected = ref_tensors["f"]
-        assert torch.allclose(f, expected, rtol=1e-5, atol=1e-5), (
-            f"vector_dag failed: max diff = {(f - expected).abs().max().item()}"
-        )
+@st.cases(_vector_dag_case())
+def test_vector_dag(case_run):
+    """The DAG kernel matches the example's reference computation."""
+    case_run.assert_passed()
 
 
 if __name__ == "__main__":

--- a/tests/st/runtime/cross_core/test_split_reduce_parity.py
+++ b/tests/st/runtime/cross_core/test_split_reduce_parity.py
@@ -49,6 +49,7 @@ import sys
 import pypto.language as pl
 import pytest
 import torch
+from harness import st
 
 T_TILE = 16
 C = 512
@@ -150,38 +151,50 @@ def _golden_y(x: torch.Tensor) -> torch.Tensor:
     return (xf * inv).to(torch.bfloat16)
 
 
-def _run(kernel, test_config) -> tuple[torch.Tensor, torch.Tensor]:
-    """Run a repro kernel on device; return (actual_y, golden_y)."""
-    kernel._cache.clear()
+def _parity_case(key: str):
+    """One repro kernel: per-token row-normalize, compared against the torch golden.
+
+    ``dummy_out`` is an output of the kernel but nothing checks it — the dummy
+    matmul exists only to engage the UP_DOWN split — so its golden is all-NaN,
+    which ``validate_golden`` treats as don't-care. That states the contract
+    rather than leaving the buffer silently compared against zeros.
+    """
     torch.manual_seed(0)
     x = (torch.randn(T, C) * 0.5 + 2.0).to(torch.bfloat16)  # strictly positive -> stable recip
     y = torch.zeros(T, C, dtype=torch.bfloat16)
     dummy_out = torch.zeros(NTASK * MM_M, MM_N, dtype=torch.bfloat16)
-    kernel(x, y, dummy_out, config=test_config)
-    return y, _golden_y(x)
+    return st.case(
+        _KERNELS[key],
+        x,
+        y,
+        dummy_out,
+        name=f"split_reduce_parity_{key}",
+        golden=lambda _: {
+            "y": _golden_y(x),
+            "dummy_out": torch.full_like(dummy_out, float("nan")),
+        },
+        rtol=1.0 / 128,
+        atol=1e-2,
+    )
 
 
-class TestSplitReduceParity:
-    """gh#1864: a row reduction inside an UP_DOWN split scope must not miscompile."""
+@pytest.mark.platforms("a2a3")
+@st.cases(_parity_case("none_reshape"), _parity_case("none_direct"))
+def test_none_split_row_sum_is_correct(case_run):
+    """Baseline: under SplitMode.NONE both reduce forms match the golden."""
+    case_run.assert_passed()
 
-    @pytest.mark.platforms("a2a3")
-    @pytest.mark.parametrize("form", ["reshape", "direct"])
-    def test_none_split_row_sum_is_correct(self, test_config, form):
-        """Baseline: under SplitMode.NONE both reduce forms match the golden."""
-        actual, golden = _run(_KERNELS[f"none_{form}"], test_config)
-        torch.testing.assert_close(actual.float(), golden.float(), rtol=1.0 / 128, atol=1e-2)
 
-    @pytest.mark.platforms("a2a3")
-    @pytest.mark.parametrize("form", ["reshape", "direct"])
-    def test_updown_split_row_sum_matches_none(self, test_config, form):
-        """UP_DOWN must equal the golden (gh#1864 regression).
+@pytest.mark.platforms("a2a3")
+@st.cases(_parity_case("updown_reshape"), _parity_case("updown_direct"))
+def test_updown_split_row_sum_matches_none(case_run):
+    """UP_DOWN must equal the golden (gh#1864 regression).
 
-        Pre-fix, the column reshape that feeds the reciprocal kept its stale
-        full width after the split, so each lane read garbage columns and emitted
-        inf. SplitVectorKernel now migrates the split axis through the reshape.
-        """
-        actual, golden = _run(_KERNELS[f"updown_{form}"], test_config)
-        torch.testing.assert_close(actual.float(), golden.float(), rtol=1.0 / 128, atol=1e-2)
+    Pre-fix, the column reshape that feeds the reciprocal kept its stale
+    full width after the split, so each lane read garbage columns and emitted
+    inf. SplitVectorKernel now migrates the split axis through the reshape.
+    """
+    case_run.assert_passed()
 
 
 if __name__ == "__main__":

--- a/tests/st/runtime/cross_core/test_spmd_dynamic_core_num.py
+++ b/tests/st/runtime/cross_core/test_spmd_dynamic_core_num.py
@@ -31,6 +31,7 @@ import pytest
 torch = pytest.importorskip("torch")
 
 import pypto.language as pl  # noqa: E402
+from harness import st  # noqa: E402
 
 B_DYN = pl.dynamic("B_DYN")
 B = 8  # concrete batch size used by the tests
@@ -68,33 +69,49 @@ def spmd_core_num_floordiv(
     return out
 
 
-class TestSpmdDynamicCoreNum:
+def _dyn_mul_case():
+    """``pl.spmd(b_dim * 3 // 4)`` compiles and casts the dispatched rows.
+
+    Only rows ``[0, cores)`` are dispatched and written; the tail is undefined by
+    contract, so the golden marks it NaN — ``validate_golden`` treats a NaN
+    golden element as don't-care, which is the same region the original
+    ``out[:cores]`` slice compared.
+    """
+    torch.manual_seed(0)
+    x = torch.randn(B, 64, 64, dtype=torch.bfloat16)
+    out = torch.zeros(B, 64, 64, dtype=torch.float32)
+    cores = B * 3 // 4
+
+    def golden(_):
+        expected = torch.full((B, 64, 64), float("nan"), dtype=torch.float32)
+        expected[:cores] = x.float()[:cores]
+        return expected
+
+    return st.case(
+        spmd_core_num_mul, x, out, name="spmd_core_num_dyn_mul", golden=golden, rtol=1e-3, atol=1e-3
+    )
+
+
+def _dyn_floordiv_case():
+    """``pl.spmd(b_dim // 2)`` compiles and casts every element."""
+    torch.manual_seed(0)
+    x = torch.randn(B, 64, 64, dtype=torch.bfloat16)
+    out = torch.zeros(B, 64, 64, dtype=torch.float32)
+    return st.case(
+        spmd_core_num_floordiv,
+        x,
+        out,
+        name="spmd_core_num_dyn_floordiv",
+        golden=lambda _: x.float(),
+        rtol=1e-3,
+        atol=1e-3,
+    )
+
+
+@st.cases(_dyn_mul_case(), _dyn_floordiv_case())
+def test_spmd_dynamic_core_num(case_run):
     """``pl.spmd`` dispatched with a composite dynamic ``core_num`` (issue #1579)."""
-
-    def test_core_num_dyn_mul(self, test_config):
-        """``pl.spmd(b_dim * 3 // 4)`` compiles and casts the dispatched rows."""
-        spmd_core_num_mul._cache.clear()
-        torch.manual_seed(0)
-        x = torch.randn(B, 64, 64, dtype=torch.bfloat16)
-        out = torch.zeros(B, 64, 64, dtype=torch.float32)
-        spmd_core_num_mul(x, out, config=test_config)
-        cores = B * 3 // 4  # only rows [0, cores) are dispatched/written
-        expected = x.float()[:cores]
-        assert torch.allclose(out[:cores], expected, rtol=1e-3, atol=1e-3), (
-            f"dyn*static core_num: max diff = {(out[:cores] - expected).abs().max().item()}"
-        )
-
-    def test_core_num_dyn_floordiv(self, test_config):
-        """``pl.spmd(b_dim // 2)`` compiles and casts every element."""
-        spmd_core_num_floordiv._cache.clear()
-        torch.manual_seed(0)
-        x = torch.randn(B, 64, 64, dtype=torch.bfloat16)
-        out = torch.zeros(B, 64, 64, dtype=torch.float32)
-        spmd_core_num_floordiv(x, out, config=test_config)
-        expected = x.float()
-        assert torch.allclose(out, expected, rtol=1e-3, atol=1e-3), (
-            f"dyn//static core_num: max diff = {(out - expected).abs().max().item()}"
-        )
+    case_run.assert_passed()
 
 
 if __name__ == "__main__":

--- a/tests/st/runtime/cross_core/test_spmd_dynamic_gm_pipe.py
+++ b/tests/st/runtime/cross_core/test_spmd_dynamic_gm_pipe.py
@@ -33,6 +33,7 @@ import pytest
 torch = pytest.importorskip("torch")
 
 import pypto.language as pl  # noqa: E402
+from harness import st  # noqa: E402
 
 M_DYN = pl.dynamic("M_DYN")
 K = 64
@@ -67,25 +68,35 @@ def fused_matmul_epilogue_dyn(
     return out
 
 
-class TestSpmdDynamicGMPipe:
-    """Single-scope cube→vec fusion dispatched over a dynamic dim (issue #1768)."""
+def _fused_case():
+    """``pl.spmd(m // ROW_TILE)`` over a fused matmul+epilogue compiles and runs."""
+    torch.manual_seed(0)
+    a = torch.randn(M, K, dtype=torch.float32)
+    b = torch.randn(K, N, dtype=torch.float32)
+    out = torch.zeros(M, N, dtype=torch.float32)
 
-    def test_dynamic_token_dim_compiles_and_runs(self, test_config):
-        """``pl.spmd(m // ROW_TILE)`` over a fused matmul+epilogue compiles and runs."""
-        fused_matmul_epilogue_dyn._cache.clear()
-        torch.manual_seed(0)
-        a = torch.randn(M, K, dtype=torch.float32)
-        b = torch.randn(K, N, dtype=torch.float32)
-        out = torch.zeros(M, N, dtype=torch.float32)
-
-        fused_matmul_epilogue_dyn(a, b, out, config=test_config)
-
+    def golden(_):
         expected = torch.empty(M, N, dtype=torch.float32)
         for m0 in range(0, M, ROW_TILE):
             expected[m0 : m0 + ROW_TILE] = torch.matmul(a[m0 : m0 + ROW_TILE] + 1.0, b) + 1.0
-        assert torch.allclose(out, expected, rtol=1e-3, atol=1e-3), (
-            f"dynamic-dim cube→vec fusion: max diff = {(out - expected).abs().max().item()}"
-        )
+        return expected
+
+    return st.case(
+        fused_matmul_epilogue_dyn,
+        a,
+        b,
+        out,
+        name="spmd_dynamic_gm_pipe",
+        golden=golden,
+        rtol=1e-3,
+        atol=1e-3,
+    )
+
+
+@st.cases(_fused_case())
+def test_dynamic_token_dim_compiles_and_runs(case_run):
+    """Single-scope cube→vec fusion dispatched over a dynamic dim (issue #1768)."""
+    case_run.assert_passed()
 
 
 if __name__ == "__main__":

--- a/tests/st/runtime/cross_core/test_subview_tmov_valid_shape.py
+++ b/tests/st/runtime/cross_core/test_subview_tmov_valid_shape.py
@@ -26,6 +26,7 @@ this case. This test guards that the matmul -> vec-epilogue -> sub-column-slice
 import pypto.language as pl
 import pytest
 import torch
+from harness import st
 
 M, K, N, SUB = 16, 128, 32, 8
 
@@ -46,25 +47,33 @@ def cube_slice(
     return out
 
 
-class TestSubviewTmovValidShape:
-    """End-to-end @pl.jit compile + execute for the gh#1649 repro."""
+def _cube_slice_case():
+    """End-to-end @pl.jit compile + execute for the gh#1649 repro.
 
-    def test_cube_slice_subcolumn(self, test_config):
-        cube_slice._cache.clear()
+    Compiling alone reproduces the ptoas non-mat tmov rejection if present;
+    running proves the sliced sub-column result as well.
+    """
+    torch.manual_seed(0)
+    x = torch.randn((M, K), dtype=torch.bfloat16)
+    w = torch.randn((N, K), dtype=torch.float32)
+    out = torch.zeros((M, SUB), dtype=torch.float32)
+    # out = 2 * (x_f @ w^T)[:, :SUB]; columns 0..SUB-1 are within w_s valid 24 rows.
+    return st.case(
+        cube_slice,
+        x,
+        w,
+        out,
+        name="cube_slice_subcolumn",
+        golden=lambda _: 2.0 * (x.float() @ w.t())[:, :SUB],
+        rtol=2e-2,
+        atol=2e-2,
+    )
 
-        torch.manual_seed(0)
-        x = torch.randn((M, K), dtype=torch.bfloat16)
-        w = torch.randn((N, K), dtype=torch.float32)
-        out = torch.zeros((M, SUB), dtype=torch.float32)
 
-        # Compiling alone reproduces the ptoas non-mat tmov rejection if present.
-        cube_slice(x, w, out, config=test_config)
-
-        # out = 2 * (x_f @ w^T)[:, :SUB]; columns 0..SUB-1 are within w_s valid 24 rows.
-        expected = 2.0 * (x.float() @ w.t())[:, :SUB]
-        assert torch.allclose(out, expected, rtol=2e-2, atol=2e-2), (
-            f"max diff = {(out - expected).abs().max().item()}"
-        )
+@st.cases(_cube_slice_case())
+def test_cube_slice_subcolumn(case_run):
+    """The sliced cube sub-column matches the torch reference."""
+    case_run.assert_passed()
 
 
 if __name__ == "__main__":

--- a/tests/st/runtime/cross_core/test_sync_set_wait.py
+++ b/tests/st/runtime/cross_core/test_sync_set_wait.py
@@ -30,6 +30,7 @@ signal the event, AIC consumes all 255 logical columns in a matrix multiply.
 import pypto.language as pl
 import pytest
 import torch
+from harness import st
 
 ROWS = 5
 LANE0_ROWS = 2
@@ -203,55 +204,83 @@ def sync_set_wait_odd_last_axis(
     return output
 
 
-class TestSyncSetWait:
-    """Explicit cross-core sync event system test."""
+def _odd_shape_case():
+    """Synchronize one 2/3-row two-AIV GM write with one AIC wait.
 
-    @pytest.mark.platforms("a2a3")
-    def test_static_event_id_on_board(self, test_config):
-        """Synchronize one 2/3-row two-AIV GM write with one AIC wait."""
-        sync_set_wait_odd_shape._cache.clear()
-        torch.manual_seed(0)
-        a = torch.randn(ROWS, K, dtype=torch.float32)
-        b = torch.randn(ROWS, K, dtype=torch.float32)
-        weight = torch.randn(K, N, dtype=torch.float32)
-        transfer = torch.zeros(CUBE_PHYSICAL_ROWS, K, dtype=torch.float32)
-        ffts_workspace = torch.zeros(FFTS_WORKSPACE_ELEMENTS, dtype=torch.int64)
-        output = torch.zeros(CUBE_PHYSICAL_ROWS, N, dtype=torch.float32)
+    ``output`` is ``InOut``, so the whole 16-row tensor is compared: the kernel
+    fills the first ``ROWS`` and the rest must still hold the zeros the caller
+    staged. ``transfer`` is the GM staging buffer — an output of the kernel that
+    nothing checks — so its golden is all-NaN, which ``validate_golden`` treats
+    as don't-care.
+    """
+    torch.manual_seed(0)
+    a = torch.randn(ROWS, K, dtype=torch.float32)
+    b = torch.randn(ROWS, K, dtype=torch.float32)
+    weight = torch.randn(K, N, dtype=torch.float32)
+    transfer = torch.zeros(CUBE_PHYSICAL_ROWS, K, dtype=torch.float32)
+    ffts_workspace = torch.zeros(FFTS_WORKSPACE_ELEMENTS, dtype=torch.int64)
+    output = torch.zeros(CUBE_PHYSICAL_ROWS, N, dtype=torch.float32)
 
-        sync_set_wait_odd_shape(a, b, weight, transfer, ffts_workspace, output, config=test_config)
-
+    def golden(_):
         expected = torch.zeros_like(output)
         expected[:ROWS] = torch.matmul(a + b, weight)
-        assert torch.allclose(output, expected, rtol=1e-3, atol=1e-3), (
-            f"odd-shape sync_set/sync_wait max diff = {(output - expected).abs().max().item()}"
-        )
+        return {"output": expected, "transfer": torch.full_like(transfer, float("nan"))}
 
-    @pytest.mark.platforms("a2a3")
-    def test_odd_last_axis_left_right_on_board(self, test_config):
-        """Synchronize explicit 127/128-column AIV shards before AIC consumes them."""
-        sync_set_wait_odd_last_axis._cache.clear()
-        torch.manual_seed(1)
-        input_tensor = torch.randn(LR_ROWS, LR_COLS, dtype=torch.float16)
-        weight = torch.randn(LR_CUBE_COLS, LR_OUTPUT_COLS, dtype=torch.float16)
-        # Keep padding non-zero so the golden catches accidental inclusion of
-        # transfer column 255 in the logical K=255 contraction.
-        transfer = torch.ones(LR_CUBE_ROWS, LR_CUBE_COLS, dtype=torch.float16)
-        ffts_workspace = torch.zeros(FFTS_WORKSPACE_ELEMENTS, dtype=torch.int64)
-        output = torch.zeros(LR_CUBE_ROWS, LR_OUTPUT_COLS, dtype=torch.float32)
+    return st.case(
+        sync_set_wait_odd_shape,
+        a,
+        b,
+        weight,
+        transfer,
+        ffts_workspace,
+        output,
+        name="sync_set_wait_odd_shape",
+        golden=golden,
+        rtol=1e-3,
+        atol=1e-3,
+    )
 
-        sync_set_wait_odd_last_axis(
-            input_tensor,
-            weight,
-            transfer,
-            ffts_workspace,
-            output,
-            config=test_config,
-        )
 
-        expected = torch.matmul(input_tensor.float(), weight[:LR_COLS].float())
-        assert torch.allclose(output[:LR_ROWS], expected, rtol=1e-3, atol=1e-3), (
-            f"odd-last-axis sync_set/sync_wait max diff = {(output[:LR_ROWS] - expected).abs().max().item()}"
-        )
+def _odd_last_axis_case():
+    """Synchronize explicit 127/128-column AIV shards before AIC consumes them.
+
+    ``output`` is a pure ``Out`` here and only ``output[:LR_ROWS]`` is defined,
+    so the padded tail — and the ``transfer`` staging buffer — are NaN
+    don't-care rather than silently compared against zeros.
+    """
+    torch.manual_seed(1)
+    input_tensor = torch.randn(LR_ROWS, LR_COLS, dtype=torch.float16)
+    weight = torch.randn(LR_CUBE_COLS, LR_OUTPUT_COLS, dtype=torch.float16)
+    # Keep padding non-zero so the golden catches accidental inclusion of
+    # transfer column 255 in the logical K=255 contraction.
+    transfer = torch.ones(LR_CUBE_ROWS, LR_CUBE_COLS, dtype=torch.float16)
+    ffts_workspace = torch.zeros(FFTS_WORKSPACE_ELEMENTS, dtype=torch.int64)
+    output = torch.zeros(LR_CUBE_ROWS, LR_OUTPUT_COLS, dtype=torch.float32)
+
+    def golden(_):
+        expected = torch.full_like(output, float("nan"))
+        expected[:LR_ROWS] = torch.matmul(input_tensor.float(), weight[:LR_COLS].float())
+        return {"output": expected, "transfer": torch.full_like(transfer, float("nan"))}
+
+    return st.case(
+        sync_set_wait_odd_last_axis,
+        input_tensor,
+        weight,
+        transfer,
+        ffts_workspace,
+        output,
+        name="sync_set_wait_odd_last_axis",
+        golden=golden,
+        rtol=1e-3,
+        atol=1e-3,
+    )
+
+
+@pytest.mark.platforms("a2a3")
+@st.cases(_odd_shape_case(), _odd_last_axis_case())
+def test_sync_set_wait_on_board(case_run):
+    """Explicit cross-core sync event system test."""
+    case_run.assert_passed()
 
 
 if __name__ == "__main__":

--- a/tests/st/runtime/ops/test_assemble.py
+++ b/tests/st/runtime/ops/test_assemble.py
@@ -31,113 +31,104 @@ from examples.intermediate.assemble import (
     tile_assemble_row_by_row,
     tile_assemble_vec,
 )
+from harness import st
+
+# Both sim bugs below produce the same wrong output, so they share one reason.
+_SLICE_SIM_BUG = "Sim bug: Vec->Vec assemble with pl.slice produces wrong output (496/1024 mismatch)"
 
 
-# tile.assemble lowers to TINSERT, which is only available on Ascend 950.
-@pytest.mark.platforms("a5", "a5sim")
-class TestAssembleOperations:
-    """Test suite for tile.assemble: one test per distinct pattern."""
+def _left_half_case(kernel, name, **kwargs):
+    """``src`` (32x16) assembled into the left half of a 32x32 ``x``."""
+    torch.manual_seed(0)
+    x = torch.rand(32, 32, dtype=torch.float32)
+    src = torch.rand(32, 16, dtype=torch.float32)
+    y = torch.zeros((32, 32), dtype=torch.float32)
 
-    @pytest.mark.skip(reason="Codegen bug: MemRef not found in mapping for Acc->Mat assemble")
-    def test_tile_assemble_acc_mat(self, test_config):
-        """Acc->Mat (NZ mode): matmul result assembled into right half of Mat target."""
-        tile_assemble_acc_mat._cache.clear()
-        torch.manual_seed(0)
-        x = torch.rand(32, 32, dtype=torch.float32)
-        a = torch.rand(32, 16, dtype=torch.float32)
-        b = torch.rand(16, 16, dtype=torch.float32)
-        y = torch.zeros((32, 32), dtype=torch.float32)
-        tile_assemble_acc_mat(x, a, b, y, config=test_config)
+    def golden(_):
+        expected = x.clone()
+        expected[:, :16] = src
+        return expected
 
+    return st.case(kernel, x, src, y, name=name, golden=golden, **kwargs)
+
+
+def _acc_mat_case():
+    """Acc->Mat (NZ mode): matmul result assembled into the right half of a Mat target."""
+    torch.manual_seed(0)
+    x = torch.rand(32, 32, dtype=torch.float32)
+    a = torch.rand(32, 16, dtype=torch.float32)
+    b = torch.rand(16, 16, dtype=torch.float32)
+    y = torch.zeros((32, 32), dtype=torch.float32)
+
+    def golden(_):
         expected = x.clone()
         expected[:, 16:] = a @ b
-        assert torch.allclose(y, expected, rtol=1e-3, atol=1e-3), (
-            f"acc_mat assemble failed: max diff = {(y - expected).abs().max().item()}"
-        )
+        return expected
 
-    def test_tile_assemble_vec(self, test_config):
-        """Vec->Vec single-shot (ND_VEC mode): src assembled into left half of target."""
-        tile_assemble_vec._cache.clear()
-        torch.manual_seed(0)
-        x = torch.rand(32, 32, dtype=torch.float32)
-        src = torch.rand(32, 16, dtype=torch.float32)
-        y = torch.zeros((32, 32), dtype=torch.float32)
-        tile_assemble_vec(x, src, y, config=test_config)
-
-        expected = x.clone()
-        expected[:, :16] = src
-        assert torch.allclose(y, expected, rtol=1e-5, atol=1e-5), (
-            f"vec assemble failed: max diff = {(y - expected).abs().max().item()}"
-        )
-
-    @pytest.mark.skip(
-        reason="Sim bug: Vec->Vec assemble with pl.slice produces wrong output (496/1024 mismatch)"
+    return st.case(
+        tile_assemble_acc_mat, x, a, b, y, name="assemble_acc_mat", golden=golden, rtol=1e-3, atol=1e-3
     )
-    def test_tile_assemble_row_by_row(self, test_config):
-        """Vec->Vec single loop + pl.slice: dynamic row gather into left half."""
-        tile_assemble_row_by_row._cache.clear()
-        torch.manual_seed(0)
-        x = torch.rand(32, 32, dtype=torch.float32)
-        src = torch.rand(32, 16, dtype=torch.float32)
-        y = torch.zeros((32, 32), dtype=torch.float32)
-        tile_assemble_row_by_row(x, src, y, config=test_config)
 
-        expected = x.clone()
-        expected[:, :16] = src
-        assert torch.allclose(y, expected, rtol=1e-5, atol=1e-5), (
-            f"row_by_row assemble failed: max diff = {(y - expected).abs().max().item()}"
-        )
 
-    @pytest.mark.skip(
-        reason="Sim bug: Vec->Vec assemble with pl.slice produces wrong output (496/1024 mismatch)"
-    )
-    def test_tile_assemble_double_loop(self, test_config):
-        """Vec->Vec nested loops + pl.slice: batch x head two-level index (b*8+i)."""
-        tile_assemble_double_loop._cache.clear()
-        torch.manual_seed(0)
-        x = torch.rand(32, 32, dtype=torch.float32)
-        src = torch.rand(32, 16, dtype=torch.float32)
-        y = torch.zeros((32, 32), dtype=torch.float32)
-        tile_assemble_double_loop(x, src, y, config=test_config)
+def _loop_col_broadcast_case():
+    """Vec->Vec single loop, no pl.slice: the same 32x8 src at each c*8 column offset."""
+    torch.manual_seed(0)
+    x = torch.rand(32, 32, dtype=torch.float32)
+    src = torch.rand(32, 8, dtype=torch.float32)
+    y = torch.zeros((32, 32), dtype=torch.float32)
 
-        expected = x.clone()
-        expected[:, :16] = src
-        assert torch.allclose(y, expected, rtol=1e-5, atol=1e-5), (
-            f"double_loop assemble failed: max diff = {(y - expected).abs().max().item()}"
-        )
-
-    def test_tile_assemble_loop_col_broadcast(self, test_config):
-        """Vec->Vec single loop, no pl.slice: same src column-block at each c*8 offset."""
-        tile_assemble_loop_col_broadcast._cache.clear()
-        torch.manual_seed(0)
-        x = torch.rand(32, 32, dtype=torch.float32)
-        src = torch.rand(32, 8, dtype=torch.float32)
-        y = torch.zeros((32, 32), dtype=torch.float32)
-        tile_assemble_loop_col_broadcast(x, src, y, config=test_config)
-
+    def golden(_):
         expected = x.clone()
         for c in range(4):
             expected[:, c * 8 : (c + 1) * 8] = src
-        assert torch.allclose(y, expected, rtol=1e-5, atol=1e-5), (
-            f"loop_col_broadcast assemble failed: max diff = {(y - expected).abs().max().item()}"
-        )
+        return expected
 
-    def test_tile_assemble_double_loop_broadcast(self, test_config):
-        """Vec->Vec nested loops, no pl.slice: same src[16,16] fills all four quadrants."""
-        tile_assemble_double_loop_broadcast._cache.clear()
-        torch.manual_seed(0)
-        x = torch.rand(32, 32, dtype=torch.float32)
-        src = torch.rand(16, 16, dtype=torch.float32)
-        y = torch.zeros((32, 32), dtype=torch.float32)
-        tile_assemble_double_loop_broadcast(x, src, y, config=test_config)
+    return st.case(
+        tile_assemble_loop_col_broadcast, x, src, y, name="assemble_loop_col_broadcast", golden=golden
+    )
 
+
+def _double_loop_broadcast_case():
+    """Vec->Vec nested loops, no pl.slice: the same 16x16 src fills all four quadrants."""
+    torch.manual_seed(0)
+    x = torch.rand(32, 32, dtype=torch.float32)
+    src = torch.rand(16, 16, dtype=torch.float32)
+    y = torch.zeros((32, 32), dtype=torch.float32)
+
+    def golden(_):
         expected = x.clone()
         for b in range(2):
             for c in range(2):
                 expected[b * 16 : (b + 1) * 16, c * 16 : (c + 1) * 16] = src
-        assert torch.allclose(y, expected, rtol=1e-5, atol=1e-5), (
-            f"double_loop_broadcast assemble failed: max diff = {(y - expected).abs().max().item()}"
-        )
+        return expected
+
+    return st.case(
+        tile_assemble_double_loop_broadcast, x, src, y, name="assemble_double_loop_broadcast", golden=golden
+    )
+
+
+# tile.assemble lowers to TINSERT, which is only available on Ascend 950.
+@pytest.mark.platforms("a5", "a5sim")
+@st.cases(
+    pytest.param(
+        _acc_mat_case(),
+        marks=pytest.mark.skip(reason="Codegen bug: MemRef not found in mapping for Acc->Mat assemble"),
+    ),
+    _left_half_case(tile_assemble_vec, "assemble_vec"),
+    pytest.param(
+        _left_half_case(tile_assemble_row_by_row, "assemble_row_by_row"),
+        marks=pytest.mark.skip(reason=_SLICE_SIM_BUG),
+    ),
+    pytest.param(
+        _left_half_case(tile_assemble_double_loop, "assemble_double_loop"),
+        marks=pytest.mark.skip(reason=_SLICE_SIM_BUG),
+    ),
+    _loop_col_broadcast_case(),
+    _double_loop_broadcast_case(),
+)
+def test_tile_assemble(case_run):
+    """Each tile.assemble pattern matches its torch reference."""
+    case_run.assert_passed()
 
 
 if __name__ == "__main__":

--- a/tests/st/runtime/ops/test_atomic_add.py
+++ b/tests/st/runtime/ops/test_atomic_add.py
@@ -29,6 +29,7 @@ this module exercises the end-to-end execution path on device/simulator.
 import pypto.language as pl
 import pytest
 import torch
+from harness import st
 
 # ---------------------------------------------------------------------------
 # Kernels: pl.store(..., atomic=AtomicType.Add)
@@ -191,179 +192,141 @@ def matmul_split_k_atomic_fp16(a: pl.Tensor, b: pl.Tensor, c: pl.Out[pl.Tensor])
 
 
 # ---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
+#
+# Every tensor a case declares is staged to the device, outputs included, which
+# is what these kernels need: an atomic-add accumulates onto the destination it
+# is handed, so ``out`` arrives holding the test's baseline rather than zeros.
+#
+# The integer cases pass rtol=atol=0 to keep the bit-exact assertion they had
+# before the migration; integer atomic accumulation is exact regardless of the
+# order the cores land in. The bf16/fp16 goldens are stored at the output's own
+# dtype, so a fp32 reference is rounded once (<=0.4% relative) before the
+# comparison — far inside the tolerances these cases already carried.
 
 
-class TestAtomicAddStore:
+def _store_case(kernel, name, x, baseline, **kwargs):
+    """``out`` starts at *baseline* everywhere; the kernel atomic-adds ``x`` onto it."""
+    out = torch.full(tuple(x.shape), baseline, dtype=x.dtype)
+    return st.case(kernel, x, out, name=name, golden=lambda _: baseline + x.float(), **kwargs)
+
+
+def _split_k_case(kernel, name, a, b, out_dtype, **kwargs):
+    """Split-K matmul: SPLIT parallel cores atomic-add their partials into ``c``."""
+    c = torch.zeros((_SPLIT_K_M, _SPLIT_K_N), dtype=out_dtype)
+    return st.case(kernel, a, b, c, name=name, golden=lambda _: a.float() @ b.float(), **kwargs)
+
+
+def _seeded(fn, *args, **kwargs):
+    """Draw *fn* from a freshly seeded generator, as each original test did."""
+    torch.manual_seed(0)
+    return fn(*args, **kwargs)
+
+
+_EXACT = {"rtol": 0.0, "atol": 0.0}
+
+
+@st.cases(
+    _store_case(atomic_add_store_fp32, "atomic_add_store_fp32", _seeded(torch.randn, 16, 16), 1.0),
+    _store_case(
+        atomic_add_store_int32,
+        "atomic_add_store_int32",
+        _seeded(torch.randint, -100, 100, (16, 16), dtype=torch.int32),
+        5,
+        **_EXACT,
+    ),
+    # bf16 atomic-add is A2/A3-only; codegen rejects it on A5.
+    pytest.param(
+        _store_case(
+            atomic_add_store_bf16,
+            "atomic_add_store_bf16",
+            _seeded(torch.randn, 16, 16, dtype=torch.bfloat16),
+            1.0,
+            rtol=2e-2,
+            atol=2e-2,
+        ),
+        marks=pytest.mark.platforms("a2a3", "a2a3sim", reason="bf16 atomic-add is A2/A3-only"),
+    ),
+    _store_case(
+        atomic_add_store_fp16,
+        "atomic_add_store_fp16",
+        _seeded(torch.randn, 16, 16, dtype=torch.float16),
+        1.0,
+        rtol=5e-3,
+        atol=5e-3,
+    ),
+    _store_case(
+        atomic_add_store_int16,
+        "atomic_add_store_int16",
+        _seeded(torch.randint, -100, 100, (16, 16), dtype=torch.int16),
+        5,
+        **_EXACT,
+    ),
+    # int8 needs a 32-col tile: the row byte size (cols * 1) must be 32-byte
+    # aligned, so 16 cols is rejected by ptoas. Values stay small so the int8
+    # accumulation cannot overflow.
+    _store_case(
+        atomic_add_store_int8,
+        "atomic_add_store_int8",
+        _seeded(torch.randint, -20, 20, (16, 32), dtype=torch.int8),
+        1,
+        **_EXACT,
+    ),
+)
+def test_atomic_add_store(case_run):
     """``pl.store(..., atomic=AtomicType.Add)`` accumulates a tile onto a baseline."""
-
-    def test_atomic_add_store_fp32(self, test_config):
-        """FP32: ``out`` starts at 1.0 everywhere; kernel atomic-adds ``x`` onto it."""
-        atomic_add_store_fp32._cache.clear()
-        torch.manual_seed(0)
-        x = torch.randn(16, 16, dtype=torch.float32)
-        baseline = 1.0
-        out = torch.full((16, 16), baseline, dtype=torch.float32)
-        atomic_add_store_fp32(x, out, config=test_config)
-        expected = baseline + x
-        assert torch.allclose(out, expected, rtol=1e-5, atol=1e-5), (
-            f"FP32 atomic-add store mismatch: max diff = {(out - expected).abs().max().item()}"
-        )
-
-    def test_atomic_add_store_int32(self, test_config):
-        """INT32: ``out`` starts at 5 everywhere; kernel atomic-adds ``x`` onto it."""
-        atomic_add_store_int32._cache.clear()
-        torch.manual_seed(0)
-        x = torch.randint(-100, 100, (16, 16), dtype=torch.int32)
-        baseline = 5
-        out = torch.full((16, 16), baseline, dtype=torch.int32)
-        atomic_add_store_int32(x, out, config=test_config)
-        expected = baseline + x
-        assert torch.equal(out, expected), (
-            f"INT32 atomic-add store mismatch: max abs diff = {(out - expected).abs().max().item()}"
-        )
-
-    @pytest.mark.platforms("a2a3", "a2a3sim")
-    def test_atomic_add_store_bf16(self, test_config):
-        """BF16 (A2/A3, VECTOR path): ``out`` starts at 1.0; kernel atomic-adds ``x``.
-
-        bf16 atomic-add is A2/A3-only; on A5 it is rejected in codegen, so this
-        test is restricted to the a2a3 platforms.
-
-        Uses a loose tolerance because bf16 has ~8 mantissa bits — the single
-        accumulation ``1.0 + x`` is exact up to bf16 rounding of the operands.
-        """
-        atomic_add_store_bf16._cache.clear()
-        torch.manual_seed(0)
-        x = torch.randn(16, 16, dtype=torch.bfloat16)
-        baseline = 1.0
-        out = torch.full((16, 16), baseline, dtype=torch.bfloat16)
-        atomic_add_store_bf16(x, out, config=test_config)
-        expected = (baseline + x.float()).bfloat16()
-        diff = (out.float() - expected.float()).abs().max().item()
-        assert torch.allclose(out.float(), expected.float(), rtol=2e-2, atol=2e-2), (
-            f"BF16 atomic-add store mismatch: max diff = {diff}"
-        )
-
-    def test_atomic_add_store_fp16(self, test_config):
-        """FP16 (VECTOR path): ``out`` starts at 1.0; kernel atomic-adds ``x`` (set_atomic_f16)."""
-        atomic_add_store_fp16._cache.clear()
-        torch.manual_seed(0)
-        x = torch.randn(16, 16, dtype=torch.float16)
-        baseline = 1.0
-        out = torch.full((16, 16), baseline, dtype=torch.float16)
-        atomic_add_store_fp16(x, out, config=test_config)
-        expected = (baseline + x.float()).half()
-        diff = (out.float() - expected.float()).abs().max().item()
-        assert torch.allclose(out.float(), expected.float(), rtol=5e-3, atol=5e-3), (
-            f"FP16 atomic-add store mismatch: max diff = {diff}"
-        )
-
-    def test_atomic_add_store_int16(self, test_config):
-        """INT16 (VECTOR path): ``out`` starts at 5; kernel atomic-adds ``x`` (set_atomic_s16); exact."""
-        atomic_add_store_int16._cache.clear()
-        torch.manual_seed(0)
-        x = torch.randint(-100, 100, (16, 16), dtype=torch.int16)
-        baseline = 5
-        out = torch.full((16, 16), baseline, dtype=torch.int16)
-        atomic_add_store_int16(x, out, config=test_config)
-        expected = baseline + x
-        assert torch.equal(out, expected), (
-            f"INT16 atomic-add store mismatch: max abs diff = {(out - expected).abs().max().item()}"
-        )
-
-    def test_atomic_add_store_int8(self, test_config):
-        """INT8 (VECTOR path): ``out`` starts at 1; kernel atomic-adds ``x`` (set_atomic_s8); exact.
-
-        Values are kept small so the int8 accumulation cannot overflow.
-        """
-        atomic_add_store_int8._cache.clear()
-        torch.manual_seed(0)
-        x = torch.randint(-20, 20, (16, 32), dtype=torch.int8)
-        baseline = 1
-        out = torch.full((16, 32), baseline, dtype=torch.int8)
-        atomic_add_store_int8(x, out, config=test_config)
-        expected = baseline + x
-        assert torch.equal(out, expected), (
-            f"INT8 atomic-add store mismatch: max abs diff = {(out - expected).abs().max().item()}"
-        )
+    case_run.assert_passed()
 
 
-class TestAtomicAddAssemble:
-    """``pl.assemble(..., atomic=AtomicType.Add)`` atomically accumulates into a shared tensor."""
-
-    def test_split_k_matmul_atomic_add_fp32(self, test_config):
-        """Split-K matmul: ``SPLIT`` parallel cores atomic-add their partials into ``c``."""
-        matmul_split_k_atomic._cache.clear()
-        torch.manual_seed(0)
-        a = torch.randn(_SPLIT_K_M, _SPLIT_K_K, dtype=torch.float32)
-        b = torch.randn(_SPLIT_K_K, _SPLIT_K_N, dtype=torch.float32)
-        c = torch.zeros((_SPLIT_K_M, _SPLIT_K_N), dtype=torch.float32)
-        matmul_split_k_atomic(a, b, c, config=test_config)
-        expected = a @ b
-        # Atomic-add accumulation order across cores is non-deterministic at
-        # ULP level for floating-point, so allow a small tolerance.
-        assert torch.allclose(c, expected, rtol=1e-3, atol=1e-3), (
-            f"Split-K atomic-add mismatch: max diff = {(c - expected).abs().max().item()}"
-        )
-
-    @pytest.mark.platforms("a2a3", "a2a3sim")
-    def test_split_k_matmul_atomic_add_bf16(self, test_config):
-        """BF16 (A2/A3, CUBE path): parallel cores atomic-add bf16 partials into ``c``.
-
-        bf16 atomic-add is A2/A3-only (rejected in codegen on A5), so this test is
-        restricted to the a2a3 platforms.
-
-        Each core's fp32 accumulator is cast to bf16 and atomic-added directly into
-        the shared bf16 output (set_atomic_bf16). Inputs are scaled down so the
-        accumulated magnitude stays O(1), keeping bf16 rounding within tolerance.
-        """
-        matmul_split_k_atomic_bf16._cache.clear()
-        torch.manual_seed(0)
-        # Scale so partial/accumulated magnitudes are small — bf16 has ~2-3
-        # decimal digits, so large sums would exceed a sane tolerance.
-        a = (torch.randn(_SPLIT_K_M, _SPLIT_K_K) * 0.05).bfloat16()
-        b = (torch.randn(_SPLIT_K_K, _SPLIT_K_N) * 0.05).bfloat16()
-        c = torch.zeros((_SPLIT_K_M, _SPLIT_K_N), dtype=torch.bfloat16)
-        matmul_split_k_atomic_bf16(a, b, c, config=test_config)
-        expected = a.float() @ b.float()
-        assert torch.allclose(c.float(), expected, rtol=5e-2, atol=5e-2), (
-            f"BF16 split-K atomic-add mismatch: max diff = {(c.float() - expected).abs().max().item()}"
-        )
-
-    def test_split_k_matmul_atomic_add_int32(self, test_config):
-        """INT32 (CUBE): int8 x int8 -> int32 partials atomic-added into ``c``; exact.
-
-        Integer atomic accumulation is exact regardless of core-ordering, so this
-        asserts bit-exact equality against the reference int32 matmul.
-        """
-        matmul_split_k_atomic_int32._cache.clear()
-        torch.manual_seed(0)
-        a = torch.randint(-4, 4, (_SPLIT_K_M, _SPLIT_K_K), dtype=torch.int8)
-        b = torch.randint(-4, 4, (_SPLIT_K_K, _SPLIT_K_N), dtype=torch.int8)
-        c = torch.zeros((_SPLIT_K_M, _SPLIT_K_N), dtype=torch.int32)
-        matmul_split_k_atomic_int32(a, b, c, config=test_config)
-        expected = a.to(torch.int32) @ b.to(torch.int32)
-        assert torch.equal(c, expected), (
-            f"INT32 split-K atomic-add mismatch: max abs diff = {(c - expected).abs().max().item()}"
-        )
-
-    def test_split_k_matmul_atomic_add_fp16(self, test_config):
-        """FP16 (CUBE path): fp32 partials atomic-added directly into fp16 ``c`` (set_atomic_f16).
-
-        Inputs are scaled down so the fp16 accumulated magnitude stays O(1).
-        """
-        matmul_split_k_atomic_fp16._cache.clear()
-        torch.manual_seed(0)
-        a = (torch.randn(_SPLIT_K_M, _SPLIT_K_K) * 0.1).half()
-        b = (torch.randn(_SPLIT_K_K, _SPLIT_K_N) * 0.1).half()
-        c = torch.zeros((_SPLIT_K_M, _SPLIT_K_N), dtype=torch.float16)
-        matmul_split_k_atomic_fp16(a, b, c, config=test_config)
-        expected = a.float() @ b.float()
-        assert torch.allclose(c.float(), expected, rtol=2e-2, atol=2e-2), (
-            f"FP16 split-K atomic-add mismatch: max diff = {(c.float() - expected).abs().max().item()}"
-        )
+@st.cases(
+    # Atomic-add accumulation order across cores is non-deterministic at ULP
+    # level for floating point, hence the loosened tolerance.
+    _split_k_case(
+        matmul_split_k_atomic,
+        "split_k_atomic_fp32",
+        _seeded(torch.randn, _SPLIT_K_M, _SPLIT_K_K),
+        torch.randn(_SPLIT_K_K, _SPLIT_K_N),
+        torch.float32,
+        rtol=1e-3,
+        atol=1e-3,
+    ),
+    # Inputs are scaled down so the accumulated magnitude stays O(1) — bf16 has
+    # ~2-3 decimal digits, so large sums would exceed a sane tolerance.
+    pytest.param(
+        _split_k_case(
+            matmul_split_k_atomic_bf16,
+            "split_k_atomic_bf16",
+            (_seeded(torch.randn, _SPLIT_K_M, _SPLIT_K_K) * 0.05).bfloat16(),
+            (torch.randn(_SPLIT_K_K, _SPLIT_K_N) * 0.05).bfloat16(),
+            torch.bfloat16,
+            rtol=5e-2,
+            atol=5e-2,
+        ),
+        marks=pytest.mark.platforms("a2a3", "a2a3sim", reason="bf16 atomic-add is A2/A3-only"),
+    ),
+    _split_k_case(
+        matmul_split_k_atomic_int32,
+        "split_k_atomic_int32",
+        _seeded(torch.randint, -4, 4, (_SPLIT_K_M, _SPLIT_K_K), dtype=torch.int8),
+        torch.randint(-4, 4, (_SPLIT_K_K, _SPLIT_K_N), dtype=torch.int8),
+        torch.int32,
+        **_EXACT,
+    ),
+    _split_k_case(
+        matmul_split_k_atomic_fp16,
+        "split_k_atomic_fp16",
+        (_seeded(torch.randn, _SPLIT_K_M, _SPLIT_K_K) * 0.1).half(),
+        (torch.randn(_SPLIT_K_K, _SPLIT_K_N) * 0.1).half(),
+        torch.float16,
+        rtol=2e-2,
+        atol=2e-2,
+    ),
+)
+def test_split_k_matmul_atomic_add(case_run):
+    """``pl.assemble(..., atomic=AtomicType.Add)`` accumulates into a shared tensor."""
+    case_run.assert_passed()
 
 
 if __name__ == "__main__":

--- a/tests/st/runtime/ops/test_auto_tile_matmul.py
+++ b/tests/st/runtime/ops/test_auto_tile_matmul.py
@@ -34,8 +34,6 @@ the 910B bf16 ``pto.tinsert`` FIXPIPE path (the f32 accumulator is downcast into
 scratch); the a5 f32 converting-``pto.tmov`` assemble is a separate lowering.
 """
 
-import dataclasses
-
 import pypto.language as pl
 import pytest
 import torch
@@ -47,6 +45,7 @@ from examples.advanced.auto_tile_matmul import (
     mat_full_k,
     mat_split_k,
 )
+from harness import st
 from pypto.pypto_core.passes import MemoryPlanner
 
 # AutoTileMatmulL0 predates memory_planner=PTOAS and was initially validated under
@@ -279,265 +278,436 @@ def matmul_bias_a2a3_int_direct(
     return out
 
 
-def _cfg(test_config, planner):
-    """Return the session config with the requested planner selected explicitly."""
-    return dataclasses.replace(test_config, memory_planner=planner)
+# ---------------------------------------------------------------------------
+# Cases
+# ---------------------------------------------------------------------------
+#
+# Each original test crossed its kernel with the planner matrix and re-seeded
+# per item, so every planner saw identical inputs; the builders below keep that
+# by seeding inside each builder. A planner that was skipped by a run-time
+# ``pytest.skip`` in the body is now a collection-time mark, so the case is not
+# pre-compiled either.
+#
+# Three kinds of comparison, all preserved:
+#   * ``rtol``/``atol``          — the elementwise default (DDR direct-store)
+#   * ``rtol=atol=0``            — the exact integer checks (``torch.equal``)
+#   * ``st.rel_err_under(x)``    — the Frobenius bound the bf16 matmul chains use,
+#                                  where near-zero cancellation elements make a
+#                                  per-element tolerance meaningless
+
+
+def _expand(build, planners=_PLANNERS):
+    """Expand *build(planner, planner_id)* over a planner matrix.
+
+    Each entry of the matrix is a ``pytest.param``; its id becomes part of the
+    case name and its marks (e.g. the PTOAS skip in
+    ``_N_BOUNDARY_RETILES_K_PLANNERS``) carry over to the case.
+    """
+    expanded = []
+    for entry in planners:
+        planner = entry.values[0]
+        case_obj = build(planner, entry.id)
+        expanded.append(pytest.param(case_obj, marks=entry.marks) if entry.marks else case_obj)
+    return expanded
+
+
+_PTOAS_ONLY_SKIPS = {
+    "mat_scratch_bias": "PTOAS planner path currently fails this Mat-scratch kernel on device",
+    "mn_boundaries": "PTOAS currently fails this partial M/N boundary kernel on device",
+}
+
+
+def _without_ptoas(planners, reason_key):
+    """The planner matrix with PTOAS marked skip rather than skipped in the body."""
+    kept = []
+    for entry in planners:
+        if entry.values[0] is MemoryPlanner.PTOAS:
+            kept.append(
+                pytest.param(
+                    entry.values[0],
+                    id=entry.id,
+                    marks=pytest.mark.skip(reason=_PTOAS_ONLY_SKIPS[reason_key]),
+                )
+            )
+        else:
+            kept.append(entry)
+    return kept
+
+
+def _bias_case(kernel, name, planner, pid, m, k, n, seed):
+    """``a @ b + bias`` with bf16 operands and an fp32 row bias."""
+    torch.manual_seed(seed)
+    a = torch.randn(m, k, dtype=torch.bfloat16)
+    b = torch.randn(k, n, dtype=torch.bfloat16)
+    bias = torch.randn((1, n), dtype=torch.float32)
+    out = torch.zeros((m, n), dtype=torch.float32)
+    return st.case(
+        kernel,
+        a,
+        b,
+        bias,
+        out,
+        name=f"{name}_{pid}",
+        memory_planner=planner,
+        golden=lambda _: a.float() @ b.float() + bias,
+        compare=st.rel_err_under(2e-2),
+    )
+
+
+def _int_acc_case(kernel, name, planner, pid, m, k, n, seed):
+    """INT8 x INT8 -> INT32 split-K. Integer accumulation is exact, so rtol=atol=0."""
+    torch.manual_seed(seed)
+    a = torch.randint(-3, 4, (m, k), dtype=torch.int8)
+    b = torch.randint(-3, 4, (k, n), dtype=torch.int8)
+    out = torch.zeros((m, n), dtype=torch.int32)
+    return st.case(
+        kernel,
+        a,
+        b,
+        out,
+        name=f"{name}_{pid}",
+        memory_planner=planner,
+        golden=lambda _: a.int() @ b.int(),
+        rtol=0.0,
+        atol=0.0,
+    )
+
+
+def _chained_case(kernel, name, planner, pid, m, k, n, out_n, limit):
+    """``(a @ b) @ e`` with a bf16 on-chip intermediate (FIXPIPE downcast)."""
+    torch.manual_seed(0)
+    a = torch.randn(m, k, dtype=torch.bfloat16)
+    b = torch.randn(k, n, dtype=torch.bfloat16)
+    e = torch.randn(n, out_n, dtype=torch.bfloat16)
+    out = torch.zeros((m, out_n), dtype=torch.float32)
+
+    def golden(_):
+        c_bf16 = (a.float() @ b.float()).to(torch.bfloat16).float()  # FIXPIPE downcast
+        return c_bf16 @ e.float()
+
+    return st.case(
+        kernel,
+        a,
+        b,
+        e,
+        out,
+        name=f"{name}_{pid}",
+        memory_planner=planner,
+        golden=golden,
+        compare=st.rel_err_under(limit),
+    )
+
+
+def _ddr_case(kernel, planner, pid, k):
+    """``a @ b`` -> ``[256, 256]`` fp32 stored straight to DDR."""
+    torch.manual_seed(0)
+    a = torch.randn(256, k, dtype=torch.float32)
+    b = torch.randn(k, 256, dtype=torch.float32)
+    out = torch.zeros((256, 256), dtype=torch.float32)
+    return st.case(
+        kernel,
+        a,
+        b,
+        out,
+        name=f"{kernel.__name__}_ddr_{pid}",
+        memory_planner=planner,
+        golden=lambda _: a @ b,
+        rtol=1e-3,
+        atol=1e-3,
+    )
+
+
+def _int_bias_case(planner, pid):
+    """A2/A3 applies INT32 bias once across an INT8 M/N+K tiled GEMM. Exact."""
+    torch.manual_seed(10)
+    a = torch.randint(-3, 4, (_BIAS_INT_M, _BIAS_INT_K), dtype=torch.int8)
+    b = torch.randint(-3, 4, (_BIAS_INT_K, _BIAS_INT_N), dtype=torch.int8)
+    bias = torch.randint(-20, 21, (1, _BIAS_INT_N), dtype=torch.int32)
+    out = torch.zeros((_BIAS_INT_M, _BIAS_INT_N), dtype=torch.int32)
+    return st.case(
+        matmul_bias_a2a3_int_direct,
+        a,
+        b,
+        bias,
+        out,
+        name=f"matmul_bias_a2a3_int_direct_{pid}",
+        memory_planner=planner,
+        golden=lambda _: a.int() @ b.int() + bias,
+        rtol=0.0,
+        atol=0.0,
+    )
+
+
+def _bias_scratch_case(planner, pid):
+    """A biased producer tiled into Mat scratch for its sole matmul consumer."""
+    torch.manual_seed(12)
+    a = torch.randn(_BIAS_SCRATCH_M, _BIAS_SCRATCH_K, dtype=torch.bfloat16)
+    b = torch.randn(_BIAS_SCRATCH_K, _BIAS_SCRATCH_N, dtype=torch.bfloat16)
+    bias = torch.randn((1, _BIAS_SCRATCH_N), dtype=torch.float32)
+    e = torch.randn(_BIAS_SCRATCH_N, _BIAS_SCRATCH_OUT_N, dtype=torch.bfloat16)
+    out = torch.zeros((_BIAS_SCRATCH_M, _BIAS_SCRATCH_OUT_N), dtype=torch.float32)
+
+    def golden(_):
+        intermediate = (a.float() @ b.float() + bias).to(torch.bfloat16).float()
+        return intermediate @ e.float()
+
+    return st.case(
+        matmul_bias_mn_k_scratch,
+        a,
+        b,
+        bias,
+        e,
+        out,
+        name=f"matmul_bias_mn_k_scratch_{pid}",
+        memory_planner=planner,
+        golden=golden,
+        compare=st.rel_err_under(2e-2),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests — one per original test function, so the platform markers stay attached
+# to exactly the cases they governed.
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.platforms("a2a3", "a2a3sim")
-class TestAutoTileMatmulL0:
-    """End-to-end device checks for the placement x K-strategy x planner matrix."""
+@st.cases(
+    *_expand(lambda planner, pid: _ddr_case(ddr_split_k, planner, pid, 128)),
+    *_expand(lambda planner, pid: _ddr_case(ddr_full_k, planner, pid, 32)),
+)
+def test_ddr_direct_store(case_run):
+    """``a @ b`` -> ``[256, 256]`` stored to DDR (direct-store); split-K (K=128) and
+    full-K (K=32).  Run under all three planners: the oversized grid reuses the L0C
+    accumulator across output tiles, but the Acc->GM ``tile.store`` drain WAR is synced
+    correctly by ptoas, so oversized direct-store works under PTOAS too."""
+    case_run.assert_passed()
 
-    @pytest.mark.parametrize("planner", _PLANNERS)
-    @pytest.mark.parametrize("kernel, K", [(ddr_split_k, 128), (ddr_full_k, 32)])
-    def test_ddr_direct_store(self, test_config, kernel, K, planner):
-        """``a @ b`` -> ``[256, 256]`` stored to DDR (direct-store); split-K (K=128) and
-        full-K (K=32).  Run under all three planners: the oversized grid reuses the L0C
-        accumulator across output tiles, but the Acc->GM ``tile.store`` drain WAR is synced
-        correctly by ptoas, so oversized direct-store works under PTOAS too."""
-        kernel._cache.clear()
-        torch.manual_seed(0)
-        a = torch.randn(256, K, dtype=torch.float32)
-        b = torch.randn(K, 256, dtype=torch.float32)
-        out = torch.zeros((256, 256), dtype=torch.float32)
 
-        kernel(a, b, out, config=_cfg(test_config, planner))
+@pytest.mark.platforms("a2a3", "a2a3sim")
+@st.cases(*_expand(_int_bias_case))
+def test_matmul_bias_a2a3_int_direct_store(case_run):
+    """A2/A3 applies INT32 bias once across an INT8 M/N+K tiled GEMM."""
+    case_run.assert_passed()
 
-        expected = a @ b
-        assert torch.allclose(out, expected, rtol=1e-3, atol=1e-3), (
-            f"{kernel.__name__} (DDR direct-store) max abs diff = {(out - expected).abs().max().item():.3e}"
+
+@pytest.mark.platforms("a2a3", "a2a3sim", "a5", "a5sim")
+@st.cases(
+    *_expand(
+        lambda planner, pid: _bias_case(
+            matmul_bias_mn_k_direct, "matmul_bias_mn_k_direct", planner, pid, _BIAS_M, _BIAS_K, _BIAS_N, 11
         )
+    )
+)
+def test_matmul_bias_mn_k_direct_store(case_run):
+    """Bias is applied once while M/N sub-tiles complete a split-K reduction."""
+    case_run.assert_passed()
 
-    @pytest.mark.parametrize("planner", _PLANNERS)
-    def test_matmul_bias_a2a3_int_direct_store(self, test_config, planner):
-        """A2/A3 applies INT32 bias once across an INT8 M/N+K tiled GEMM."""
-        matmul_bias_a2a3_int_direct._cache.clear()
-        torch.manual_seed(10)
-        a = torch.randint(-3, 4, (_BIAS_INT_M, _BIAS_INT_K), dtype=torch.int8)
-        b = torch.randint(-3, 4, (_BIAS_INT_K, _BIAS_INT_N), dtype=torch.int8)
-        bias = torch.randint(-20, 21, (1, _BIAS_INT_N), dtype=torch.int32)
-        out = torch.zeros((_BIAS_INT_M, _BIAS_INT_N), dtype=torch.int32)
 
-        matmul_bias_a2a3_int_direct(a, b, bias, out, config=_cfg(test_config, planner))
+@pytest.mark.platforms("a2a3", "a2a3sim", "a5", "a5sim")
+@st.cases(*_expand(_bias_scratch_case, _without_ptoas(_PLANNERS, "mat_scratch_bias")))
+def test_matmul_bias_mn_k_mat_scratch(case_run):
+    """A biased producer is tiled into Mat scratch for its sole matmul consumer."""
+    case_run.assert_passed()
 
-        assert torch.equal(out, a.int() @ b.int() + bias)
 
-    @pytest.mark.platforms("a2a3", "a2a3sim", "a5", "a5sim")
-    @pytest.mark.parametrize("planner", _PLANNERS)
-    def test_matmul_bias_mn_k_direct_store(self, test_config, planner):
-        """Bias is applied once while M/N sub-tiles complete a split-K reduction."""
-        matmul_bias_mn_k_direct._cache.clear()
-        torch.manual_seed(11)
-        a = torch.randn(_BIAS_M, _BIAS_K, dtype=torch.bfloat16)
-        b = torch.randn(_BIAS_K, _BIAS_N, dtype=torch.bfloat16)
-        bias = torch.randn((1, _BIAS_N), dtype=torch.float32)
-        out = torch.zeros((_BIAS_M, _BIAS_N), dtype=torch.float32)
+@pytest.mark.platforms("a2a3", "a2a3sim", "a5", "a5sim")
+@st.cases(
+    *_expand(
+        lambda planner, pid: _bias_case(
+            matmul_bias_mn_boundary_direct,
+            "matmul_bias_mn_boundary_direct",
+            planner,
+            pid,
+            _BIAS_BOUNDARY_M,
+            _BIAS_BOUNDARY_K,
+            _BIAS_BOUNDARY_N,
+            13,
+        ),
+        _without_ptoas(_PLANNERS, "mn_boundaries"),
+    )
+)
+def test_matmul_bias_mn_boundaries(case_run):
+    """Partial M/N tiles preserve the logical Bias and output regions."""
+    case_run.assert_passed()
 
-        matmul_bias_mn_k_direct(a, b, bias, out, config=_cfg(test_config, planner))
 
-        expected = a.float() @ b.float() + bias
-        rel_err = ((out - expected).norm() / expected.norm()).item()
-        assert rel_err < 2e-2, f"direct matmul_bias rel_err {rel_err:.3e} exceeds 2e-2"
-
-    @pytest.mark.platforms("a2a3", "a2a3sim", "a5", "a5sim")
-    @pytest.mark.parametrize("planner", _PLANNERS)
-    def test_matmul_bias_mn_k_mat_scratch(self, test_config, planner):
-        """A biased producer is tiled into Mat scratch for its sole matmul consumer."""
-        if planner == MemoryPlanner.PTOAS:
-            pytest.skip("PTOAS planner path currently fails this Mat-scratch kernel on device")
-        matmul_bias_mn_k_scratch._cache.clear()
-        torch.manual_seed(12)
-        a = torch.randn(_BIAS_SCRATCH_M, _BIAS_SCRATCH_K, dtype=torch.bfloat16)
-        b = torch.randn(_BIAS_SCRATCH_K, _BIAS_SCRATCH_N, dtype=torch.bfloat16)
-        bias = torch.randn((1, _BIAS_SCRATCH_N), dtype=torch.float32)
-        e = torch.randn(_BIAS_SCRATCH_N, _BIAS_SCRATCH_OUT_N, dtype=torch.bfloat16)
-        out = torch.zeros((_BIAS_SCRATCH_M, _BIAS_SCRATCH_OUT_N), dtype=torch.float32)
-
-        matmul_bias_mn_k_scratch(a, b, bias, e, out, config=_cfg(test_config, planner))
-
-        intermediate = (a.float() @ b.float() + bias).to(torch.bfloat16).float()
-        expected = intermediate @ e.float()
-        rel_err = ((out - expected).norm() / expected.norm()).item()
-        assert rel_err < 2e-2, f"Mat-scratch matmul_bias rel_err {rel_err:.3e} exceeds 2e-2"
-
-    @pytest.mark.platforms("a2a3", "a2a3sim", "a5", "a5sim")
-    @pytest.mark.parametrize("planner", _PLANNERS)
-    def test_matmul_bias_mn_boundaries(self, test_config, planner):
-        """Partial M/N tiles preserve the logical Bias and output regions."""
-        if planner == MemoryPlanner.PTOAS:
-            pytest.skip("PTOAS currently fails this partial M/N boundary kernel on device")
-        matmul_bias_mn_boundary_direct._cache.clear()
-        torch.manual_seed(13)
-        a = torch.randn(_BIAS_BOUNDARY_M, _BIAS_BOUNDARY_K, dtype=torch.bfloat16)
-        b = torch.randn(_BIAS_BOUNDARY_K, _BIAS_BOUNDARY_N, dtype=torch.bfloat16)
-        bias = torch.randn((1, _BIAS_BOUNDARY_N), dtype=torch.float32)
-        out = torch.zeros((_BIAS_BOUNDARY_M, _BIAS_BOUNDARY_N), dtype=torch.float32)
-
-        matmul_bias_mn_boundary_direct(a, b, bias, out, config=_cfg(test_config, planner))
-
-        expected = a.float() @ b.float() + bias
-        rel_err = ((out - expected).norm() / expected.norm()).item()
-        assert rel_err < 2e-2, f"boundary matmul_bias rel_err {rel_err:.3e} exceeds 2e-2"
-
-    @pytest.mark.platforms("a2a3", "a2a3sim", "a5", "a5sim")
-    @pytest.mark.parametrize("planner", _PLANNERS)
-    def test_matmul_bias_nondivisor_k_tail(self, test_config, planner):
-        """The peeled final K block accumulates without applying bias twice."""
-        matmul_bias_nondivisor_k_tail._cache.clear()
-        torch.manual_seed(14)
-        a = torch.randn(_BIAS_PEEL_M, _BIAS_PEEL_K, dtype=torch.bfloat16)
-        b = torch.randn(_BIAS_PEEL_K, _BIAS_PEEL_N, dtype=torch.bfloat16)
-        bias = torch.randn((1, _BIAS_PEEL_N), dtype=torch.float32)
-        out = torch.zeros((_BIAS_PEEL_M, _BIAS_PEEL_N), dtype=torch.float32)
-
-        matmul_bias_nondivisor_k_tail(a, b, bias, out, config=_cfg(test_config, planner))
-
-        expected = a.float() @ b.float() + bias
-        rel_err = ((out - expected).norm() / expected.norm()).item()
-        assert rel_err < 2e-2, f"peeled-K matmul_bias rel_err {rel_err:.3e} exceeds 2e-2"
-
-    @pytest.mark.platforms("a2a3", "a2a3sim", "a5", "a5sim")
-    @pytest.mark.parametrize("planner", _PLANNERS)
-    def test_matmul_bias_m_only_bias_resident(self, test_config, planner):
-        """M-only tiling reuses a full Bias-resident source without subwindowing."""
-        matmul_bias_m_only_bias_resident._cache.clear()
-        torch.manual_seed(15)
-        a = torch.randn(_BIAS_M_ONLY_M, _BIAS_M_ONLY_K, dtype=torch.bfloat16)
-        b = torch.randn(_BIAS_M_ONLY_K, _BIAS_M_ONLY_N, dtype=torch.bfloat16)
-        bias = torch.randn((1, _BIAS_M_ONLY_N), dtype=torch.float32)
-        out = torch.zeros((_BIAS_M_ONLY_M, _BIAS_M_ONLY_N), dtype=torch.float32)
-
-        matmul_bias_m_only_bias_resident(a, b, bias, out, config=_cfg(test_config, planner))
-
-        expected = a.float() @ b.float() + bias
-        rel_err = ((out - expected).norm() / expected.norm()).item()
-        assert rel_err < 2e-2, f"M-only matmul_bias rel_err {rel_err:.3e} exceeds 2e-2"
-
-    @pytest.mark.parametrize("planner", _PLANNERS)
-    def test_loop_carried_matmul_acc_mn_tiling(self, test_config, planner):
-        """Issue #2232: each output tile must finish all eight source K blocks.
-
-        The logical ``[16, 1152]`` INT32 result is only 72 KiB, but its physical
-        32-row L0C footprint is 144 KiB. Run both planners and compare exactly:
-        integer accumulation has no numerical tolerance.
-        """
-        matmul_acc_mn_issue_2232._cache.clear()
-        torch.manual_seed(0)
-        a = torch.randint(-3, 4, (_ACC_M, _ACC_K), dtype=torch.int8)
-        b = torch.randint(-3, 4, (_ACC_K, _ACC_N_TOTAL), dtype=torch.int8)
-        out = torch.zeros((_ACC_M, _ACC_N_TOTAL), dtype=torch.int32)
-
-        matmul_acc_mn_issue_2232(a, b, out, config=_cfg(test_config, planner))
-
-        expected = a.int() @ b.int()
-        assert torch.equal(out, expected), (
-            f"matmul_acc M/N tiling mismatch: max abs diff = {(out - expected).abs().max().item()}"
+@pytest.mark.platforms("a2a3", "a2a3sim", "a5", "a5sim")
+@st.cases(
+    *_expand(
+        lambda planner, pid: _bias_case(
+            matmul_bias_nondivisor_k_tail,
+            "matmul_bias_nondivisor_k_tail",
+            planner,
+            pid,
+            _BIAS_PEEL_M,
+            _BIAS_PEEL_K,
+            _BIAS_PEEL_N,
+            14,
         )
+    )
+)
+def test_matmul_bias_nondivisor_k_tail(case_run):
+    """The peeled final K block accumulates without applying bias twice."""
+    case_run.assert_passed()
 
-    @pytest.mark.parametrize("planner", _PLANNERS)
-    def test_loop_carried_matmul_acc_both_mn_boundaries(self, test_config, planner):
-        """General #2232 rewrite: exact INT8→INT32 split-K with partial tiles
-        on both output axes, under both memory planners."""
-        matmul_acc_mn_boundaries._cache.clear()
-        torch.manual_seed(1)
-        a = torch.randint(-3, 4, (_BOUNDARY_M, _BOUNDARY_K), dtype=torch.int8)
-        b = torch.randint(-3, 4, (_BOUNDARY_K, _BOUNDARY_N), dtype=torch.int8)
-        out = torch.zeros((_BOUNDARY_M, _BOUNDARY_N), dtype=torch.int32)
 
-        matmul_acc_mn_boundaries(a, b, out, config=_cfg(test_config, planner))
-
-        expected = a.int() @ b.int()
-        assert torch.equal(out, expected), (
-            f"matmul_acc both-boundary tiling mismatch: max abs diff = {(out - expected).abs().max().item()}"
+@pytest.mark.platforms("a2a3", "a2a3sim", "a5", "a5sim")
+@st.cases(
+    *_expand(
+        lambda planner, pid: _bias_case(
+            matmul_bias_m_only_bias_resident,
+            "matmul_bias_m_only_bias_resident",
+            planner,
+            pid,
+            _BIAS_M_ONLY_M,
+            _BIAS_M_ONLY_K,
+            _BIAS_M_ONLY_N,
+            15,
         )
+    )
+)
+def test_matmul_bias_m_only_bias_resident(case_run):
+    """M-only tiling reuses a full Bias-resident source without subwindowing."""
+    case_run.assert_passed()
 
-    @pytest.mark.parametrize("planner", _N_BOUNDARY_RETILES_K_PLANNERS)
-    def test_loop_carried_matmul_acc_n_boundary_retiles_k(self, test_config, planner):
-        """A padded N tail remains valid through secondary inner-K tiling."""
-        matmul_acc_n_boundary_retiles_k._cache.clear()
-        torch.manual_seed(2)
-        a = torch.randint(-3, 4, (_BOUNDARY_M, _COMPOSE_K), dtype=torch.int8)
-        b = torch.randint(-3, 4, (_COMPOSE_K, _BOUNDARY_N), dtype=torch.int8)
-        out = torch.zeros((_BOUNDARY_M, _BOUNDARY_N), dtype=torch.int32)
 
-        matmul_acc_n_boundary_retiles_k(a, b, out, config=_cfg(test_config, planner))
-
-        expected = a.int() @ b.int()
-        assert torch.equal(out, expected), (
-            f"matmul_acc padded-N + K-tiling mismatch: max abs diff = {(out - expected).abs().max().item()}"
+@pytest.mark.platforms("a2a3", "a2a3sim")
+@st.cases(
+    *_expand(
+        lambda planner, pid: _int_acc_case(
+            matmul_acc_mn_issue_2232,
+            "matmul_acc_mn_issue_2232",
+            planner,
+            pid,
+            _ACC_M,
+            _ACC_K,
+            _ACC_N_TOTAL,
+            0,
         )
+    )
+)
+def test_loop_carried_matmul_acc_mn_tiling(case_run):
+    """Issue #2232: each output tile must finish all eight source K blocks.
 
-    @pytest.mark.parametrize("planner", _PLANNERS)
-    @pytest.mark.parametrize("kernel, K", [(mat_split_k, 192), (mat_full_k, 32)])
-    def test_mat_scratch(self, test_config, kernel, K, planner):
-        """``(a @ b) @ e`` with a bf16 ``[256, 256]`` intermediate kept on-chip in an
-        L1/Mat scratch (Acc->Mat ``pto.tinsert``); split-K K=192 and full-K K=32.
+    The logical ``[16, 1152]`` INT32 result is only 72 KiB, but its physical
+    32-row L0C footprint is 144 KiB. Run all planners and compare exactly:
+    integer accumulation has no numerical tolerance."""
+    case_run.assert_passed()
 
-        Run under all three planners.  The PTOAS variants provide regression coverage
-        for #1995: the chained consumer's K-reduction accumulator if-phi must reuse
-        the dominating accumulator handle so all partial sums land in one L0C buffer.
 
-        K=192 is the common cross-planner split point: all planners choose an
-        output-stationary producer with k=64, so its L0 buffers pack against the
-        consumer's. K=128 is planner-dependent (PyPTO splits while PTOAS can keep full K)
-        and can select a monolithic A/B-stationary buffer that the legacy PYPTO
-        allocator cannot pack against the consumer's pipelined buffers. This case
-        remains output-stationary under every planner: PYPTO enforces the issue-1908
-        guard, while DSA_RP/PTOAS reach the same chooser result without the guard.
-
-        Operands are bf16 and the on-chip intermediate is bf16 — the cube's FIXPIPE
-        writeback to L1 downcasts the f32 accumulator, which is also the cube's native
-        operand precision. The golden models that downcast; compare by global relative
-        norm because cancellation-near-zero elements make per-element ``allclose``
-        unstable for this chained reduction."""
-        kernel._cache.clear()
-        torch.manual_seed(0)
-        a = torch.randn(256, K, dtype=torch.bfloat16)
-        b = torch.randn(K, 256, dtype=torch.bfloat16)
-        e = torch.randn(256, 64, dtype=torch.bfloat16)
-        out = torch.zeros((256, 64), dtype=torch.float32)
-
-        kernel(a, b, e, out, config=_cfg(test_config, planner))
-
-        c_bf16 = (a.float() @ b.float()).to(torch.bfloat16).float()  # FIXPIPE downcast
-        expected = c_bf16 @ e.float()
-        rel_err = ((out - expected).norm() / expected.norm()).item()
-        assert rel_err < 2e-2, (
-            f"{kernel.__name__} (Mat-scratch) Frobenius rel_err = {rel_err:.3e} exceeds 2e-2"
+@pytest.mark.platforms("a2a3", "a2a3sim")
+@st.cases(
+    *_expand(
+        lambda planner, pid: _int_acc_case(
+            matmul_acc_mn_boundaries,
+            "matmul_acc_mn_boundaries",
+            planner,
+            pid,
+            _BOUNDARY_M,
+            _BOUNDARY_K,
+            _BOUNDARY_N,
+            1,
         )
+    )
+)
+def test_loop_carried_matmul_acc_both_mn_boundaries(case_run):
+    """General #2232 rewrite: exact INT8->INT32 split-K with partial tiles on both
+    output axes, under every memory planner."""
+    case_run.assert_passed()
 
-    @pytest.mark.parametrize("planner", _PLANNERS)
-    @pytest.mark.parametrize("kernel, K", [(fits_l0c_full_k, 64), (fits_l0c_split_k, 512)])
-    def test_fits_l0c_cast_fold(self, test_config, kernel, K, planner):
-        """``(a @ b) @ e`` with a ``[128, 128]`` intermediate that *fits* L0c (no M/N
-        tiling): the autotiler folds ``pl.cast`` into a single full-window Acc->Mat
-        ``pto.tinsert`` (cube downcast) rather than a Vector ``pto.tcvt``. full-K (K=64,
-        no K-loop) and split-K (K=512, K-loop). Same bf16 FIXPIPE golden as Mat-scratch.
 
-        Run under all three planners: because the intermediate fits L0c there is exactly ONE
-        Acc->Mat assemble (no cross-tile L0C reuse and no drain/MAD WAR fence).
+@pytest.mark.platforms("a2a3", "a2a3sim")
+@st.cases(
+    *_expand(
+        lambda planner, pid: _int_acc_case(
+            matmul_acc_n_boundary_retiles_k,
+            "matmul_acc_n_boundary_retiles_k",
+            planner,
+            pid,
+            _BOUNDARY_M,
+            _COMPOSE_K,
+            _BOUNDARY_N,
+            2,
+        ),
+        _N_BOUNDARY_RETILES_K_PLANNERS,
+    )
+)
+def test_loop_carried_matmul_acc_n_boundary_retiles_k(case_run):
+    """A padded N tail remains valid through secondary inner-K tiling."""
+    case_run.assert_passed()
 
-        On-device proof that the fold is numerically correct (the FIXPIPE bf16 rounding
-        matches the reference) AND that it compiles — the un-folded Vector cast overflows
-        the Vec buffer at this ``[128, 128]`` shape."""
-        kernel._cache.clear()
-        torch.manual_seed(0)
-        a = torch.randn(128, K, dtype=torch.bfloat16)
-        b = torch.randn(K, 128, dtype=torch.bfloat16)
-        e = torch.randn(128, 64, dtype=torch.bfloat16)
-        out = torch.zeros((128, 64), dtype=torch.float32)
 
-        kernel(a, b, e, out, config=_cfg(test_config, planner))
-
-        c_bf16 = (a.float() @ b.float()).to(torch.bfloat16).float()  # FIXPIPE downcast
-        expected = c_bf16 @ e.float()
-        # Frobenius relative error, not allclose: a bf16 ``(a @ b) @ e`` chain has
-        # near-zero cancellation elements where the absolute bf16 rounding error (~0.7 on
-        # operand magnitudes of ~500) dwarfs the small true value, so a per-element atol
-        # fails on a numerically-correct result. The global relative norm is the robust
-        # metric (the unit tests use the same). K=512 makes the intermediate magnitudes
-        # large enough to bite; K=64 happens to pass allclose, but both use one metric.
-        rel_err = ((out - expected).norm() / expected.norm()).item()
-        assert rel_err < 5e-2, (
-            f"{kernel.__name__} (fits-L0c cast-fold) Frobenius rel_err = {rel_err:.3e} exceeds 5e-2"
+@pytest.mark.platforms("a2a3", "a2a3sim")
+@st.cases(
+    *_expand(
+        lambda planner, pid: _chained_case(
+            mat_split_k, "mat_split_k_scratch", planner, pid, 256, 192, 256, 64, 2e-2
         )
+    ),
+    *_expand(
+        lambda planner, pid: _chained_case(
+            mat_full_k, "mat_full_k_scratch", planner, pid, 256, 32, 256, 64, 2e-2
+        )
+    ),
+)
+def test_mat_scratch(case_run):
+    """``(a @ b) @ e`` with a bf16 ``[256, 256]`` intermediate kept on-chip in an
+    L1/Mat scratch (Acc->Mat ``pto.tinsert``); split-K K=192 and full-K K=32.
+
+    Run under all three planners.  The PTOAS variants provide regression coverage
+    for #1995: the chained consumer's K-reduction accumulator if-phi must reuse
+    the dominating accumulator handle so all partial sums land in one L0C buffer.
+
+    K=192 is the common cross-planner split point: all planners choose an
+    output-stationary producer with k=64, so its L0 buffers pack against the
+    consumer's. K=128 is planner-dependent (PyPTO splits while PTOAS can keep full K)
+    and can select a monolithic A/B-stationary buffer that the legacy PYPTO
+    allocator cannot pack against the consumer's pipelined buffers. This case
+    remains output-stationary under every planner: PYPTO enforces the issue-1908
+    guard, while DSA_RP/PTOAS reach the same chooser result without the guard.
+
+    Operands are bf16 and the on-chip intermediate is bf16 — the cube's FIXPIPE
+    writeback to L1 downcasts the f32 accumulator, which is also the cube's native
+    operand precision. The golden models that downcast; the comparison is a global
+    relative norm because cancellation-near-zero elements make per-element
+    ``allclose`` unstable for this chained reduction."""
+    case_run.assert_passed()
+
+
+@pytest.mark.platforms("a2a3", "a2a3sim")
+@st.cases(
+    *_expand(
+        lambda planner, pid: _chained_case(
+            fits_l0c_full_k, "fits_l0c_full_k", planner, pid, 128, 64, 128, 64, 5e-2
+        )
+    ),
+    *_expand(
+        lambda planner, pid: _chained_case(
+            fits_l0c_split_k, "fits_l0c_split_k", planner, pid, 128, 512, 128, 64, 5e-2
+        )
+    ),
+)
+def test_fits_l0c_cast_fold(case_run):
+    """``(a @ b) @ e`` with a ``[128, 128]`` intermediate that *fits* L0c (no M/N
+    tiling): the autotiler folds ``pl.cast`` into a single full-window Acc->Mat
+    ``pto.tinsert`` (cube downcast) rather than a Vector ``pto.tcvt``. full-K (K=64,
+    no K-loop) and split-K (K=512, K-loop). Same bf16 FIXPIPE golden as Mat-scratch.
+
+    Run under all three planners: because the intermediate fits L0c there is exactly ONE
+    Acc->Mat assemble (no cross-tile L0C reuse and no drain/MAD WAR fence).
+
+    On-device proof that the fold is numerically correct (the FIXPIPE bf16 rounding
+    matches the reference) AND that it compiles — the un-folded Vector cast overflows
+    the Vec buffer at this ``[128, 128]`` shape.
+
+    The bound is looser (5e-2) than Mat-scratch: a bf16 ``(a @ b) @ e`` chain has
+    near-zero cancellation elements where the absolute bf16 rounding error (~0.7 on
+    operand magnitudes of ~500) dwarfs the small true value, so a per-element atol
+    fails on a numerically-correct result. K=512 makes the intermediate magnitudes
+    large enough to bite; K=64 happens to pass allclose, but both use one metric."""
+    case_run.assert_passed()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/st/runtime/ops/test_concat.py
+++ b/tests/st/runtime/ops/test_concat.py
@@ -12,29 +12,35 @@
 import pytest
 import torch
 from examples.beginner.concat import tile_concat_32x32
+from harness import st
 
 
-class TestConcatOperations:
-    """Test suite for tile.concat operations."""
+def _concat_case():
+    """Tile concatenation: 32x16 + 32x16 -> 32x32.
 
-    def test_tile_concat_32x32(self, test_config):
-        """Test tile concatenation: 32x16 + 32x16 -> 32x32.
+    Uses random data on purpose: with a constant-filled ``a``, a concat that
+    overwrites rows of its own source before reading them still produces the
+    expected output (every row holds the same value), so the corruption is
+    invisible. Distinct per-row values are what make such a defect fail here.
+    """
+    torch.manual_seed(0)
+    a = torch.randn(32, 16, dtype=torch.float32)
+    b = torch.randn(32, 16, dtype=torch.float32)
+    c = torch.zeros((32, 32), dtype=torch.float32)
+    return st.case(
+        tile_concat_32x32,
+        a,
+        b,
+        c,
+        name="tile_concat_32x32",
+        golden=lambda _: torch.cat([a, b], dim=1),
+    )
 
-        Uses random data on purpose: with a constant-filled ``a``, a concat that
-        overwrites rows of its own source before reading them still produces the
-        expected output (every row holds the same value), so the corruption is
-        invisible. Distinct per-row values are what make such a defect fail here.
-        """
-        tile_concat_32x32._cache.clear()
-        torch.manual_seed(0)
-        a = torch.randn(32, 16, dtype=torch.float32)
-        b = torch.randn(32, 16, dtype=torch.float32)
-        c = torch.zeros((32, 32), dtype=torch.float32)
-        tile_concat_32x32(a, b, c, config=test_config)
-        expected = torch.cat([a, b], dim=1)
-        assert torch.allclose(c, expected, rtol=1e-5, atol=1e-5), (
-            f"tile_concat_32x32 failed: max diff = {(c - expected).abs().max().item()}"
-        )
+
+@st.cases(_concat_case())
+def test_tile_concat_32x32(case_run):
+    """Column-wise concat matches the torch reference."""
+    case_run.assert_passed()
 
 
 if __name__ == "__main__":

--- a/tests/st/runtime/ops/test_elementwise.py
+++ b/tests/st/runtime/ops/test_elementwise.py
@@ -11,8 +11,7 @@
 Runtime tests for tile-based elementwise operations using the @pl.jit frontend.
 
 Verifies that the migrated tile_add_64/tile_add_128/tile_mul_64/tile_mul_128 kernels
-from ``examples.beginner.elementwise`` produce results matching torch references on
-the platform configured via ``test_config``.
+from ``examples.beginner.elementwise`` produce results matching torch references.
 """
 
 import pytest
@@ -23,42 +22,39 @@ from examples.beginner.elementwise import (
     tile_mul_64,
     tile_mul_128,
 )
+from harness import st
 
 _ADD_KERNELS = {64: tile_add_64, 128: tile_add_128}
 _MUL_KERNELS = {64: tile_mul_64, 128: tile_mul_128}
 
 
-class TestElementwiseOperations:
-    """Test suite for elementwise operations on the configured platform."""
+def _add_case(size):
+    """Tile addition: c = a + b at the given square size."""
+    a = torch.full((size, size), 2.0, dtype=torch.float32)
+    b = torch.full((size, size), 3.0, dtype=torch.float32)
+    c = torch.zeros((size, size), dtype=torch.float32)
+    return st.case(_ADD_KERNELS[size], a, b, c, name=f"tile_add_{size}", golden=lambda _: a + b)
 
-    @pytest.mark.parametrize("size", [64, 128])
-    def test_tile_add(self, test_config, size):
-        """Test tile addition: c = a + b at the given square size."""
-        kernel = _ADD_KERNELS[size]
-        kernel._cache.clear()
-        a = torch.full((size, size), 2.0, dtype=torch.float32)
-        b = torch.full((size, size), 3.0, dtype=torch.float32)
-        c = torch.zeros((size, size), dtype=torch.float32)
-        kernel(a, b, c, config=test_config)
-        expected = a + b
-        assert torch.allclose(c, expected, rtol=1e-5, atol=1e-5), (
-            f"tile_add_{size} failed: max diff = {(c - expected).abs().max().item()}"
-        )
 
-    @pytest.mark.parametrize("size", [64, 128])
-    def test_tile_mul(self, test_config, size):
-        """Test tile multiplication: c = a * b at the given square size."""
-        kernel = _MUL_KERNELS[size]
-        kernel._cache.clear()
-        torch.manual_seed(0)
-        a = torch.randn(size, size, dtype=torch.float32)
-        b = torch.full((size, size), 3.0, dtype=torch.float32)
-        c = torch.zeros((size, size), dtype=torch.float32)
-        kernel(a, b, c, config=test_config)
-        expected = a * b
-        assert torch.allclose(c, expected, rtol=1e-5, atol=1e-5), (
-            f"tile_mul_{size} failed: max diff = {(c - expected).abs().max().item()}"
-        )
+def _mul_case(size):
+    """Tile multiplication: c = a * b at the given square size."""
+    torch.manual_seed(0)
+    a = torch.randn(size, size, dtype=torch.float32)
+    b = torch.full((size, size), 3.0, dtype=torch.float32)
+    c = torch.zeros((size, size), dtype=torch.float32)
+    return st.case(_MUL_KERNELS[size], a, b, c, name=f"tile_mul_{size}", golden=lambda _: a * b)
+
+
+@st.cases(_add_case(64), _add_case(128))
+def test_tile_add(case_run):
+    """Elementwise add matches the torch reference at both sizes."""
+    case_run.assert_passed()
+
+
+@st.cases(_mul_case(64), _mul_case(128))
+def test_tile_mul(case_run):
+    """Elementwise multiply matches the torch reference at both sizes."""
+    case_run.assert_passed()
 
 
 if __name__ == "__main__":

--- a/tests/st/runtime/ops/test_memory_reuse_acc_coalesce.py
+++ b/tests/st/runtime/ops/test_memory_reuse_acc_coalesce.py
@@ -31,6 +31,7 @@ import pytest
 torch = pytest.importorskip("torch")
 
 import pypto.language as pl  # noqa: E402
+from harness import st  # noqa: E402
 
 M, N, K = 512, 512, 192
 
@@ -46,26 +47,36 @@ def matmul_512x512x192_bf16(a: pl.Tensor, b: pl.Tensor, out: pl.Out[pl.Tensor]):
     return out
 
 
+def _acc_coalesce_case():
+    """The peeled ``176 x 176`` fp32 accumulator coalesces to one L0C buffer.
+
+    So this shape compiles (no L0C overflow), ptoas accepts it (no Acc->Acc
+    ``tmov``), and the result matches the reference. bf16 operands with cube f32
+    accumulation, so the reference is f32 over the same bf16 inputs, and the
+    assertion is on the tensor's Frobenius relative error rather than per
+    element — accumulation order moves individual elements much further than it
+    moves the whole tensor.
+    """
+    torch.manual_seed(0)
+    a = torch.randn(M, K, dtype=torch.bfloat16)
+    b = torch.randn(K, N, dtype=torch.bfloat16)
+    out = torch.zeros((M, N), dtype=torch.float32)
+    return st.case(
+        matmul_512x512x192_bf16,
+        a,
+        b,
+        out,
+        name="matmul_512x512x192_bf16_acc_coalesce",
+        golden=lambda _: a.float() @ b.float(),
+        compare=st.rel_err_under(2e-2),
+    )
+
+
 @pytest.mark.platforms("a2a3", "a2a3sim")
-class TestMemoryReuseAccumulatorCoalesce:
+@st.cases(_acc_coalesce_case())
+def test_512x512x192_bf16_compiles_and_runs(case_run):
     """End-to-end device check for the peeled-accumulator coalescing fix."""
-
-    def test_512x512x192_bf16_compiles_and_runs(self, test_config):
-        """The peeled ``176 x 176`` fp32 accumulator coalesces to one L0C buffer,
-        so this shape compiles (no L0C overflow), ptoas accepts it (no Acc->Acc
-        ``tmov``), and the result matches the reference."""
-        matmul_512x512x192_bf16._cache.clear()
-        torch.manual_seed(0)
-        a = torch.randn(M, K, dtype=torch.bfloat16)
-        b = torch.randn(K, N, dtype=torch.bfloat16)
-        out = torch.zeros((M, N), dtype=torch.float32)
-
-        matmul_512x512x192_bf16(a, b, out, config=test_config)
-
-        # bf16 operands, cube f32 accumulation -> f32 reference on the same bf16 inputs.
-        expected = a.float() @ b.float()
-        rel_err = ((out - expected).norm() / expected.norm()).item()
-        assert rel_err < 2e-2, f"512x512x192 bf16 matmul Frobenius rel_err = {rel_err:.3e} exceeds 2e-2"
+    case_run.assert_passed()
 
 
 if __name__ == "__main__":

--- a/tests/st/runtime/ops/test_memref_slots.py
+++ b/tests/st/runtime/ops/test_memref_slots.py
@@ -43,6 +43,7 @@ import pytest
 torch = pytest.importorskip("torch")
 
 import pypto.language as pl  # noqa: E402
+from harness import st  # noqa: E402
 
 # Acc case: [M, K] @ [K, N] in NT column tiles. One fp32 slot is M * TN * 4 = 16 KB,
 # so the pair fits L0C with room to spare.
@@ -104,36 +105,56 @@ def vector_slot_pingpong(
             pl.store(s, [i * TR, 0], out)
 
 
+def _acc_pingpong_case():
+    """L0C ping-pong: each slot keeps its own matmul, so the two outputs differ.
+
+    The golden returns a dict because the kernel has two outputs, each with its
+    own reference — the whole point of the test is that ``out2`` is ``a2 @ b``
+    and not a second copy of ``a @ b``.
+    """
+    torch.manual_seed(0)
+    a = torch.randn(M, K, dtype=torch.float32)
+    a2 = torch.randn(M, K, dtype=torch.float32)
+    b = torch.randn(K, N, dtype=torch.float32)
+    out1 = torch.zeros((M, N), dtype=torch.float32)
+    out2 = torch.zeros((M, N), dtype=torch.float32)
+    return st.case(
+        matmul_slot_pingpong,
+        a,
+        a2,
+        b,
+        out1,
+        out2,
+        name="matmul_acc_slot_pingpong",
+        golden=lambda _: {"out1": a @ b, "out2": a2 @ b},
+        rtol=1e-3,
+        atol=1e-3,
+    )
+
+
+def _vec_pingpong_case():
+    """UB ping-pong: the sum is ``a + b``, not ``b + b``."""
+    torch.manual_seed(0)
+    a = torch.randn(ROWS, TC, dtype=torch.float32)
+    b = torch.randn(ROWS, TC, dtype=torch.float32)
+    out = torch.zeros((ROWS, TC), dtype=torch.float32)
+    return st.case(
+        vector_slot_pingpong,
+        a,
+        b,
+        out,
+        name="vector_slot_pingpong",
+        golden=lambda _: a + b,
+        rtol=1e-3,
+        atol=1e-3,
+    )
+
+
 @pytest.mark.platforms("a2a3", "a2a3sim")
-class TestMemRefSlots:
+@st.cases(_acc_pingpong_case(), _vec_pingpong_case())
+def test_slots_rotate_at_runtime(case_run):
     """Runtime-indexed slots of one declared allocation, on device."""
-
-    def test_acc_slots_rotate_at_runtime(self, test_config):
-        """L0C ping-pong: each slot keeps its own matmul, so the two outputs differ."""
-        matmul_slot_pingpong._cache.clear()
-        torch.manual_seed(0)
-        a = torch.randn(M, K, dtype=torch.float32)
-        a2 = torch.randn(M, K, dtype=torch.float32)
-        b = torch.randn(K, N, dtype=torch.float32)
-        out1 = torch.zeros((M, N), dtype=torch.float32)
-        out2 = torch.zeros((M, N), dtype=torch.float32)
-
-        matmul_slot_pingpong(a, a2, b, out1, out2, config=test_config)
-
-        torch.testing.assert_close(out1, a @ b, rtol=1e-3, atol=1e-3)
-        torch.testing.assert_close(out2, a2 @ b, rtol=1e-3, atol=1e-3)
-
-    def test_vec_slots_rotate_at_runtime(self, test_config):
-        """UB ping-pong: the sum is `a + b`, not `b + b`."""
-        vector_slot_pingpong._cache.clear()
-        torch.manual_seed(0)
-        a = torch.randn(ROWS, TC, dtype=torch.float32)
-        b = torch.randn(ROWS, TC, dtype=torch.float32)
-        out = torch.zeros((ROWS, TC), dtype=torch.float32)
-
-        vector_slot_pingpong(a, b, out, config=test_config)
-
-        torch.testing.assert_close(out, a + b, rtol=1e-3, atol=1e-3)
+    case_run.assert_passed()
 
 
 if __name__ == "__main__":

--- a/tests/ut/jit/test_specialize.py
+++ b/tests/ut/jit/test_specialize.py
@@ -1,0 +1,167 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""``JITFunction.specialize`` and the parameter-direction accessors.
+
+``specialize()`` is the pre-pass half of ``lower()``: it returns the parsed
+program before any pass has run, which is what a consumer driving the pass
+pipeline itself needs — ``ir.compile(program, output_dir=...)`` runs passes and
+code generation together, so handing it ``lower()``'s output would run the
+pipeline twice.
+
+The system-test harness is that consumer: it builds every case's IR through
+this method, whichever surface authored the kernel.
+"""
+
+import pypto.language as pl
+import pytest
+import torch
+from pypto.ir.pass_manager import OptimizationStrategy, PassManager
+from pypto.jit.decorator import jit
+from pypto.pypto_core import ir
+
+M = 16
+N = 16
+
+
+@jit.incore
+def _abs_kernel(a: pl.Tensor, out: pl.Out[pl.Tensor]):
+    tile_a = pl.load(a, [0, 0], [M, N])
+    return pl.store(pl.tile.abs(tile_a), [0, 0], out)
+
+
+@jit
+def _abs_entry(a: pl.Tensor, out: pl.Out[pl.Tensor]):
+    out = _abs_kernel(a, out)
+    return out
+
+
+@jit.incore
+def _shaped_kernel(a: pl.Tensor[[M, N], pl.FP32], out: pl.Out[pl.Tensor[[M, N], pl.FP32]]):
+    tile_a = pl.load(a, [0, 0], [M, N])
+    return pl.store(pl.tile.abs(tile_a), [0, 0], out)
+
+
+@jit
+def _shaped_entry(a: pl.Tensor[[M, N], pl.FP32], out: pl.Out[pl.Tensor[[M, N], pl.FP32]]):
+    out = _shaped_kernel(a, out)
+    return out
+
+
+@jit
+def _mixed_directions(
+    x: pl.Tensor, acc: pl.InOut[pl.Tensor], y: pl.Tensor, z: pl.Out[pl.Tensor]
+):  # pragma: no cover - never specialized, only its signature is read
+    return acc
+
+
+@pl.program
+class _AbsRef:
+    """Hand-written equivalent of ``_abs_entry``."""
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(
+        self,
+        a: pl.Tensor[[M, N], pl.FP32],
+        out: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+    ) -> pl.Tensor[[M, N], pl.FP32]:
+        tile_a = pl.load(a, [0, 0], [M, N])
+        out = pl.store(pl.tile.abs(tile_a), [0, 0], out)
+        return out
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        a: pl.Tensor[[M, N], pl.FP32],
+        out: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+    ) -> pl.Tensor[[M, N], pl.FP32]:
+        out = self.kernel(a, out)
+        return out
+
+
+class TestSpecialize:
+    """``specialize()`` returns a usable pre-pass program."""
+
+    def test_returns_pre_pass_program(self):
+        """The entry and its dep are both present, untransformed."""
+        program = _abs_entry.specialize(torch.randn(M, N), torch.zeros(M, N))
+        assert isinstance(program, ir.Program)
+        assert len(list(program.functions)) == 2, "entry + its @pl.jit.incore dep"
+
+    def test_matches_hand_written_program_after_passes(self):
+        """The specialized program lowers to the same IR as the reference.
+
+        Asserted after the pass pipeline, not before: the specializer renames
+        SSA-rebound locals (``out`` becomes ``out_v1``), so the two programs are
+        only textually different beforehand. Running both through the same
+        strategy is the equivalence that matters — it is what the harness
+        compiles.
+
+        The JIT functions are declared here, rather than at module level,
+        because function names are part of the IR: they must match the
+        reference's ``kernel`` / ``orchestrator`` for the comparison to be
+        about structure rather than about naming.
+        """
+
+        @jit.incore
+        def kernel(a: pl.Tensor, out: pl.Out[pl.Tensor]):
+            tile_a = pl.load(a, [0, 0], [M, N])
+            return pl.store(pl.tile.abs(tile_a), [0, 0], out)
+
+        @jit
+        def orchestrator(a: pl.Tensor, out: pl.Out[pl.Tensor]):
+            out = kernel(a, out)
+            return out
+
+        pm = PassManager.get_strategy(OptimizationStrategy.Default)
+        got = pm.run_passes(orchestrator.specialize(torch.randn(M, N), torch.zeros(M, N)))
+        ir.assert_structural_equal(got, pm.run_passes(_AbsRef))
+
+    def test_agrees_with_lower(self):
+        """Running passes over ``specialize()`` reproduces ``lower()`` exactly."""
+        a, out = torch.randn(M, N), torch.zeros(M, N)
+        pm = PassManager.get_strategy(OptimizationStrategy.Default)
+        ir.assert_structural_equal(pm.run_passes(_abs_entry.specialize(a, out)), _abs_entry.lower(a, out))
+
+    def test_does_not_populate_the_compiled_cache(self):
+        """No compilation happens, so the L1 cache stays empty."""
+        _abs_entry._cache.clear()
+        _abs_entry.specialize(torch.randn(M, N), torch.zeros(M, N))
+        assert len(_abs_entry._cache) == 0
+
+    def test_signature_mode_needs_full_shapes(self):
+        """A bare ``pl.Tensor`` cannot be specialized without a sample."""
+        with pytest.raises(TypeError, match="bare 'pl.Tensor' annotation with no shape"):
+            _abs_entry.specialize()
+
+    def test_signature_mode_works_with_shaped_annotations(self):
+        """Fully-shaped annotations specialize with no sample tensors at all."""
+        program = _shaped_entry.specialize()
+        assert isinstance(program, ir.Program)
+        assert len(list(program.functions)) == 2
+
+
+class TestParamAccessors:
+    """``param_names`` / ``output_param_names`` describe the signature."""
+
+    def test_param_names_in_declaration_order(self):
+        assert _abs_entry.param_names == ("a", "out")
+        assert _mixed_directions.param_names == ("x", "acc", "y", "z")
+
+    def test_output_param_names_covers_out_and_inout(self):
+        """Both directions are outputs, reported in declaration order."""
+        assert _mixed_directions.output_param_names == ("acc", "z")
+
+    def test_output_param_names_excludes_pure_inputs(self):
+        assert _abs_entry.output_param_names == ("out",)
+        assert _abs_kernel.output_param_names == ("out",)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/jit/test_specialize.py
+++ b/tests/ut/jit/test_specialize.py
@@ -25,6 +25,7 @@ import torch
 from pypto.ir.pass_manager import OptimizationStrategy, PassManager
 from pypto.jit.decorator import jit
 from pypto.pypto_core import ir
+from pypto.runtime.runner import RunConfig
 
 M = 16
 N = 16
@@ -145,6 +146,21 @@ class TestSpecialize:
         program = _shaped_entry.specialize()
         assert isinstance(program, ir.Program)
         assert len(list(program.functions)) == 2
+
+    def test_rejects_config(self):
+        """``config=`` is refused rather than silently discarded.
+
+        No pass runs here, so nothing would read a ``RunConfig``. Consuming it
+        quietly would let a caller believe a strategy or diagnostics setting
+        shaped the returned IR.
+        """
+        with pytest.raises(TypeError, match="specialize\\(\\) does not accept config="):
+            _abs_entry.specialize(torch.randn(M, N), torch.zeros(M, N), config=RunConfig())
+
+    def test_rejects_config_in_signature_mode(self):
+        """The same refusal applies with no sample arguments at all."""
+        with pytest.raises(TypeError, match="specialize\\(\\) does not accept config="):
+            _shaped_entry.specialize(config=RunConfig(strategy=OptimizationStrategy.Default))
 
 
 class TestParamAccessors:


### PR DESCRIPTION
## Summary

System tests split into two execution paths that share nothing. A case written as a `PTOTestCase` is pre-compiled card-free and its device run is batched. A case written the way the project's own rules require — `testing-and-examples.md`: "Every kernel written to be *run* ... must use the `@pl.jit` family" — can only run in-process, one card, serially.

So the more a new test obeys the rules, the slower it runs. This PR closes that gap by making a case a collection-time **value**, and adds the one JIT accessor the compile pipeline needs to consume it.

## Why the paths forked

Not a missing capability — **discovery** is what forked.

The pre-compile pipeline needs every case before any test body runs. But cases were built *inside* the body, so `_collect_test_case_from_item` parsed the test's source and re-evaluated its constructor call through a miniature AST interpreter. Two consequences:

- a `@pl.jit` test has **no constructor call to find**, so it was invisible to the pipeline — every such test fell to the inline path by construction;
- an argument the interpreter could not resolve (built in a loop, arithmetic on params) **silently** degraded that case to per-case inline compilation, with no diagnostic.

Batching never constrained the golden, which is what made the fix possible: the golden runs in the parent during pre-compilation and is persisted to `data/out/*.pt`; the task-submit child only compares against those files, and validation happens back in the parent with the test's real tolerance. A golden can therefore be any callable, closures included.

## What this adds

| Layer | Surface |
| --- | --- |
| `JITFunction.specialize(*args)` | entry and every transitive dep specialized into `@pl.program` source and parsed — the **pre-pass** `ir.Program` |
| `JITFunction.param_names` / `.output_param_names` | declared order; the latter is `pl.Out` + `pl.InOut` |
| `KernelSource` | `build_program() -> pre-pass ir.Program`; one implementation each for `@pl.jit` (`JitKernel`), `@pl.program` (`ProgramKernel`), a built `ir.Program` (`IRKernel`) |
| `Case` | a dataclass composing a `KernelSource`, a tensor list and a golden callable — it says nothing about execution |
| `st.case(...)` / `st.cases(...)` | `pytest.mark.parametrize` over `_st_case`, read straight out of `callspec.params` — no source parsing, no re-construction, no silent fallback |

`specialize()` is the pre-pass half of `lower()`. It exists because `ir.compile(program, output_dir=...)` runs passes **and** code generation together, so handing it `lower()`'s output would run the pipeline twice.

## What a test looks like now

`tests/st/examples/00_hello_world/test_hello_world.py`, before and after:

```python
# before -- a statement inside the body, so the pipeline cannot see it
class TestHelloWorld:
    def test_hello_world_add(self, test_config):
        tile_add._cache.clear()
        a = torch.full((128, 128), 2.0, dtype=torch.float32)
        b = torch.full((128, 128), 3.0, dtype=torch.float32)
        c = torch.zeros((128, 128), dtype=torch.float32)
        tile_add(a, b, c, config=test_config)          # in-process, one card, serial
        expected = a + b
        assert torch.allclose(c, expected, rtol=1e-5, atol=1e-5), ...
```

```python
# after -- a value at collection time
def _add_case():
    a = torch.full((128, 128), 2.0, dtype=torch.float32)
    b = torch.full((128, 128), 3.0, dtype=torch.float32)
    c = torch.zeros((128, 128), dtype=torch.float32)
    return st.case(tile_add, a, b, c, name="hello_world_add", golden=lambda _: a + b)

@st.cases(_add_case())
def test_hello_world_add(case_run):
    case_run.assert_passed()
```

A JIT case derives its whole tensor list from the sample arguments plus the parameter directions, so **shapes are never declared a second time**. Every tensor is seeded from its sample argument, outputs included: an atomic-add kernel accumulates onto the buffer it is handed, so zeroing a `pl.Out` because the annotation says "output" would discard the baseline the test compares against.

## Custom comparison

`compare=` replaces the elementwise check entirely, for assertions that are not per-element. `st.rel_err_under(limit)` bounds the Frobenius relative error, which is what a matmul-shaped test actually wants — accumulation order across cores and tiles moves individual elements far more than it moves the tensor as a whole, so an elementwise tolerance loose enough to pass stops catching anything.

## Migration

20 test files move onto declared cases — 51 `st.case(...)` declarations across 40 `@st.cases`-parametrized tests:

| Area | Files |
| --- | --- |
| `tests/st/examples/` | hello_world, basic_ops, activation, ffn_activations, layer_norm, rms_norm, softmax |
| `tests/st/runtime/ops/` | assemble, atomic_add, auto_tile_matmul, concat, elementwise, memory_reuse_acc_coalesce, memref_slots |
| `tests/st/runtime/cross_core/` | split_reduce_parity, spmd_dynamic_core_num, spmd_dynamic_gm_pipe, subview_tmov_valid_shape, sync_set_wait |
| `tests/st/runtime/control_flow/` | dag |

**Nothing existing changes behaviour.** `from_legacy()` wraps a `PTOTestCase` unchanged, and the AST discovery route still runs for every case that has not moved.

## Notes for review

- `program_build_lock` becomes an `RLock`: `_compile_for_cache` holds it around `get_program()`, which for a `Case` re-enters `KernelSource.build_program()`.
- `_st_case`, not `case` — `test_expand_ops` and the all_to_all_v skew tests already own a `case` parameter.
- The platform-matrix gate now also admits `case_run`, which otherwise would have run on one platform only.

## Fixes from review

| Finding | Commit |
| --- | --- |
| Every platform variant of a declared case resolved to the first platform, so a four-platform matrix compiled and ran one artifact | `198171b4` |
| `specialize()` accepted `config=` and silently discarded it, against its own documented contract | `acbcdf15` |
| `from_legacy` dropped a planner carried on the legacy `RunConfig`, losing the second tier of `_resolve_case_memory_planner`'s precedence | `d9317233` |

A fourth finding — that `Case.get_program()` needed `program_build_lock` — was declined and withdrawn by the reviewer: the contract sits on `KernelSource` implementations, and all three honour it.

## Verification

- A JIT case and a `@pl.program` case emit the same kernel and orchestration sources and the same `func_id` manifest through the unchanged `_compile_for_cache`.
- The specialized program is structurally equal to a hand-written `@pl.program` after passes, and running passes over `specialize()` reproduces `lower()` exactly.
- The don't-care (NaN) golden contract is verified rather than assumed: a garbage value in a don't-care output passes while a wrong value in a real output still fails.
- Data fidelity checked per migrated case against the originals' seeded draws — inputs bit-identical, goldens exactly equal.
