### PR TITLE
refactor(ir)!: keyword-only ir.compile, one compile mapping, RunConfig split three ways, and the ir/runtime cycle

### DIFF
--- a/docs/en/dev/03-runtime-dfx.md
+++ b/docs/en/dev/03-runtime-dfx.md
@@ -332,7 +332,7 @@ this hint at the end of every scope-stats-enabled run.
 | ------- | ---- | ----------------- |
 | `RunConfig` field declarations | [runner.py](../../../python/pypto/runtime/runner.py) | `RunConfig` dataclass + `any_dfx_enabled()` |
 | `CallConfig` plumbing | [device_runner.py](../../../python/pypto/runtime/device_runner.py) | `_execute_on_device(..., enable_*, output_prefix)` |
-| Pipeline bundle | [runner.py](../../../python/pypto/runtime/runner.py) | `_DfxOpts` dataclass + `_DfxOpts.from_run_config` |
+| Pipeline bundle | [runner.py](../../../python/pypto/runtime/runner.py) | `DfxOptions` dataclass + `RunConfig.dfx_options()` |
 | Per-flag post-run dispatch | [runner.py](../../../python/pypto/runtime/runner.py) | `_collect_dfx_artifacts` |
 | Kernel-name map synthesis | [runner.py](../../../python/pypto/runtime/runner.py) | `_write_name_map` |
 | L3 per-dispatch program marker | [distributed_runner.py](../../../python/pypto/runtime/distributed_runner.py) | `_record_dispatch_program` / `_read_dispatch_program` |

--- a/docs/en/dev/08-entry-points.md
+++ b/docs/en/dev/08-entry-points.md
@@ -178,6 +178,40 @@ Moving those five out to the harness is the step this does not take: they reach
 silently missing from the other. `lower()` still has its own narrower mapping —
 it stops before codegen and targets the pass pipeline, not `ir.compile`.
 
+## Which way the layers point
+
+`ir` produces the artifact; `runtime` dispatches it. The arrow between them
+should point one way, and mostly does — but `CompiledProgram` is both the
+compilation artifact *and* the execution handle, so `pypto.ir.compiled_program`
+reaches forward into `pypto.runtime` through ten function-local imports.
+
+Those deferrals are usually described as breaking an import cycle. Measured, one
+at a time, that was true of exactly one of them:
+
+| Deferred import | Hoists cleanly? | Actual reason |
+| --------------- | --------------- | ------------- |
+| `runtime.runner` (6 sites) | Yes | Layering choice — keeps the dispatch layer out of `pypto.ir`'s import graph |
+| `runtime.distributed_runner` (2 sites) | Yes | Same |
+| `runtime.debug.run_script_writer` | Yes, *now* | Was a real cycle: it read `ParamInfo` back out of `compiled_program` |
+| `runtime.device_runner` | No | Needs the optional `simpler` package at import time |
+
+The one real cycle is gone. The parameter metadata moved to
+[`ir/param_info.py`](../../../python/pypto/ir/param_info.py), a leaf that imports
+nothing from `pypto.runtime`, and the replay-script writer reads it there;
+`compiled_program` re-exports the names, so nothing else moved. A unit test pins
+the leaf, because pulling one runtime import into it restores the cycle.
+
+`pypto.runtime` importing `pypto.ir.distributed_compiled_program` directly — the
+one place the arrow points back — *is* cycle-avoidance, and stays.
+
+Fully inverting the dependency is a larger question than the import statements.
+It means `CompiledProgram` stops being callable and `ir.compile` returns a
+descriptor that `runtime` wraps, which changes the return type of the API every
+example and both downstream repositories use. The import list is a symptom of
+that double role, not the cause, and hoisting the eight that hoist cleanly would
+make the coupling *stronger*, not weaker — it would put `pypto.runtime.runner`
+on `import pypto.ir`'s critical path.
+
 ## What is internal
 
 These have no stability guarantee. They are not in any `__all__`, and code

--- a/docs/en/dev/08-entry-points.md
+++ b/docs/en/dev/08-entry-points.md
@@ -151,15 +151,18 @@ Its fields split three ways, and each way is a type:
 | Dispatch | `RunOptions` | `platform`, `device_id`, `aicpu_thread_num`, the `ring_*` overrides ([Ring sizing](05-runtime-ring-sizing.md)), and a nested `DfxOptions` |
 | A dispatch's diagnostics | `DfxOptions` | `enable_chip_swimlane`, `enable_dump_args`, `enable_pmu`, `enable_dep_gen`, `enable_scope_stats` ([DFX](03-runtime-dfx.md)) |
 | The system-test harness only | — | `rtol`, `atol`, `golden_data_dir`, `save_kernels`, `codegen_only` |
-| Nobody — derived | — | `backend_type`, set from `platform` during construction |
+| Nobody — derived | — | `backend_type`, a read-only property over `platform`, not a field |
 
 **`platform` names the target once.** `RunConfig` derives `backend_type` from it
 during construction, and `ir.compile` lets `platform` win whenever one is given,
 so a `backend_type` that disagrees has never taken effect — passing one to
 `RunConfig` now warns and is discarded. `CompileOptions` therefore does not carry
 it at all: the object always passes a platform, so a second spelling of the same
-decision could only ever be redundant or wrong. `ir.compile` keeps its
-`backend_type` parameter for the lower-level callers that pass no platform.
+decision could only ever be redundant or wrong. On `RunConfig` it is a read-only
+property rather than a field, so `dataclasses.replace(cfg, platform=...)` cannot
+re-supply the previous platform's backend and trip its own warning.
+`ir.compile` keeps its `backend_type` parameter for the lower-level callers that
+pass no platform.
 
 `RunConfig.compile_options()` / `run_options()` / `dfx_options()` are views onto
 the aggregate, and `compile_kwargs()` is `compile_options().as_compile_kwargs()`.

--- a/docs/en/dev/08-entry-points.md
+++ b/docs/en/dev/08-entry-points.md
@@ -164,6 +164,18 @@ from pypto.runtime import CompileOptions
 compiled = ir.compile(program, **CompileOptions(platform="a2a3").as_compile_kwargs())
 ```
 
+**Only two of the three are exported**, because only two are things a caller can
+hand somewhere. `CompileOptions` unpacks into `ir.compile`, above.
+`DfxOptions` is the `dfx=` parameter of `execute_compiled`, `execute_artifact_dir`
+and `execute_batch_manifest`. `RunOptions` is neither: every dispatch entry point
+— `CompiledProgram.__call__`, `ChipWorker.run`, and the distributed pair — takes
+a `RunConfig` and reaches the dispatch half through `run_options()` itself.
+Handing one in raises `AttributeError`, so it stays internal
+(`pypto.runtime.runner.RunOptions`) until those signatures widen. Widening them
+is a migration of its own: it means a union type on the `config=` parameter of
+the primary dispatch API, and doing it to some entry points and not others would
+be worse than not doing it.
+
 `RunConfig` keeps every field and every caller; the three types are the
 vocabulary underneath it. A unit test pins the split as *total* — every
 `RunConfig` field is claimed by one of the views or is one of the five
@@ -221,7 +233,7 @@ outside PyPTO should not import them:
 - `pypto.ir.compiled_program` — `CompiledProgram._build_orch_args`,
   `CompiledProgram._build_call_config`
 - `pypto.runtime.runner` — `_execute_compiled`, `_execute_golden_case`,
-  `_build_call_config`, `_coerced_to_orch_args`, `_DfxOpts`
+  `_build_call_config`, `_coerced_to_orch_args`, `RunOptions`
 - `pypto.runtime.distributed_runner` — `_execute_distributed`
 - `pypto.runtime.device_runner` — the whole assembly layer:
   `_compile_and_assemble`, `_compile_single_kernel`,

--- a/docs/en/dev/08-entry-points.md
+++ b/docs/en/dev/08-entry-points.md
@@ -143,13 +143,33 @@ compiled = ir.compile(program, **config.compile_kwargs())
 compiled(*tensors, config=config)
 ```
 
-Its fields split three ways:
+Its fields split three ways, and each way is a type:
 
-| Read by | Fields |
-| ------- | ------ |
-| `ir.compile`, via `compile_kwargs()` | `strategy`, `backend_type`, `platform`, `memory_planner`, `dump_passes`, `dump_ptoas_passes`, `compile_profiling`, `diagnostic_phase`, `disabled_diagnostics`, `analyze_auto_scopes_for_deps`, `save_kernels_dir` (as `output_dir`), `distributed_config` |
-| Dispatch | `device_id`, `aicpu_thread_num`, the `ring_*` overrides ([Ring sizing](05-runtime-ring-sizing.md)), the DFX toggles ([DFX](03-runtime-dfx.md)) |
-| The system-test harness only | `rtol`, `atol`, `golden_data_dir`, `save_kernels`, `codegen_only` |
+| Read by | Type | Fields |
+| ------- | ---- | ------ |
+| `ir.compile` | `CompileOptions` | `platform`, `backend_type`, `strategy`, `dump_passes`, `dump_ptoas_passes`, `profiling` (`compile_profiling`), `diagnostic_phase`, `disabled_diagnostics`, `analyze_auto_scopes_for_deps`, `output_dir` (`save_kernels_dir`), `memory_planner`, `distributed_config` |
+| Dispatch | `RunOptions` | `platform`, `device_id`, `aicpu_thread_num`, the `ring_*` overrides ([Ring sizing](05-runtime-ring-sizing.md)), and a nested `DfxOptions` |
+| A dispatch's diagnostics | `DfxOptions` | `enable_chip_swimlane`, `enable_dump_args`, `enable_pmu`, `enable_dep_gen`, `enable_scope_stats` ([DFX](03-runtime-dfx.md)) |
+| The system-test harness only | — | `rtol`, `atol`, `golden_data_dir`, `save_kernels`, `codegen_only` |
+
+`RunConfig.compile_options()` / `run_options()` / `dfx_options()` are views onto
+the aggregate, and `compile_kwargs()` is `compile_options().as_compile_kwargs()`.
+`CompileOptions` names its fields the way `ir.compile` does — `output_dir`, not
+`save_kernels_dir` — because it exists to say the compile side in the compiler's
+own vocabulary, and it stands alone:
+
+```python
+from pypto.runtime import CompileOptions
+
+compiled = ir.compile(program, **CompileOptions(platform="a2a3").as_compile_kwargs())
+```
+
+`RunConfig` keeps every field and every caller; the three types are the
+vocabulary underneath it. A unit test pins the split as *total* — every
+`RunConfig` field is claimed by one of the views or is one of the five
+harness-only fields — so a field added later cannot quietly belong to neither.
+Moving those five out to the harness is the step this does not take: they reach
+`pypto-lib`'s constructor calls too.
 
 `compile_kwargs()` is the only mapping onto `ir.compile`'s parameters. The
 `@pl.jit` path used to carry a second copy that omitted `platform` and

--- a/docs/en/dev/08-entry-points.md
+++ b/docs/en/dev/08-entry-points.md
@@ -147,10 +147,19 @@ Its fields split three ways, and each way is a type:
 
 | Read by | Type | Fields |
 | ------- | ---- | ------ |
-| `ir.compile` | `CompileOptions` | `platform`, `backend_type`, `strategy`, `dump_passes`, `dump_ptoas_passes`, `profiling` (`compile_profiling`), `diagnostic_phase`, `disabled_diagnostics`, `analyze_auto_scopes_for_deps`, `output_dir` (`save_kernels_dir`), `memory_planner`, `distributed_config` |
+| `ir.compile` | `CompileOptions` | `platform`, `strategy`, `dump_passes`, `dump_ptoas_passes`, `profiling` (`compile_profiling`), `diagnostic_phase`, `disabled_diagnostics`, `analyze_auto_scopes_for_deps`, `output_dir` (`save_kernels_dir`), `memory_planner`, `distributed_config` |
 | Dispatch | `RunOptions` | `platform`, `device_id`, `aicpu_thread_num`, the `ring_*` overrides ([Ring sizing](05-runtime-ring-sizing.md)), and a nested `DfxOptions` |
 | A dispatch's diagnostics | `DfxOptions` | `enable_chip_swimlane`, `enable_dump_args`, `enable_pmu`, `enable_dep_gen`, `enable_scope_stats` ([DFX](03-runtime-dfx.md)) |
 | The system-test harness only | — | `rtol`, `atol`, `golden_data_dir`, `save_kernels`, `codegen_only` |
+| Nobody — derived | — | `backend_type`, set from `platform` during construction |
+
+**`platform` names the target once.** `RunConfig` derives `backend_type` from it
+during construction, and `ir.compile` lets `platform` win whenever one is given,
+so a `backend_type` that disagrees has never taken effect — passing one to
+`RunConfig` now warns and is discarded. `CompileOptions` therefore does not carry
+it at all: the object always passes a platform, so a second spelling of the same
+decision could only ever be redundant or wrong. `ir.compile` keeps its
+`backend_type` parameter for the lower-level callers that pass no platform.
 
 `RunConfig.compile_options()` / `run_options()` / `dfx_options()` are views onto
 the aggregate, and `compile_kwargs()` is `compile_options().as_compile_kwargs()`.

--- a/docs/en/dev/08-entry-points.md
+++ b/docs/en/dev/08-entry-points.md
@@ -53,7 +53,8 @@ into loadable binaries. It is internal and has no supported entry point.
 `ir.compile` is the only supported one; the rest of the table is here so a name
 that turns up in a traceback can be placed on a layer. It also shadows the
 Python builtin `compile`, so prefer `from pypto import ir` and call
-`ir.compile` over importing the name directly.
+`ir.compile` over importing the name directly. Every option it takes is
+keyword-only; `program` is the one positional parameter.
 
 Its parameters are documented in [Compiling](../user/execution/00-compile.md).
 
@@ -150,9 +151,12 @@ Its fields split three ways:
 | Dispatch | `device_id`, `aicpu_thread_num`, the `ring_*` overrides ([Ring sizing](05-runtime-ring-sizing.md)), the DFX toggles ([DFX](03-runtime-dfx.md)) |
 | The system-test harness only | `rtol`, `atol`, `golden_data_dir`, `save_kernels`, `codegen_only` |
 
-The `@pl.jit` path keeps its own mapping in
-`jit.decorator._run_config_compile_kwargs`, which omits `platform` and
-`backend_type` because that path forwards them separately.
+`compile_kwargs()` is the only mapping onto `ir.compile`'s parameters. The
+`@pl.jit` path used to carry a second copy that omitted `platform` and
+`backend_type` and forwarded the platform separately; it now calls
+`compile_kwargs()` like every other caller, so a knob added to one is not
+silently missing from the other. `lower()` still has its own narrower mapping —
+it stops before codegen and targets the pass pipeline, not `ir.compile`.
 
 ## What is internal
 

--- a/docs/en/user/execution/00-compile.md
+++ b/docs/en/user/execution/00-compile.md
@@ -54,7 +54,8 @@ assert compiled.param_names == ["a", "b", "out"]
 
 ### `ir.compile` parameters
 
-Seventeen, of which four carry most decisions. The rest have defaults you rarely move.
+Eighteen, of which four carry most decisions. The rest have defaults you rarely
+move. All are keyword-only — only `program` is positional.
 
 | Parameter | Default | What it decides |
 | --------- | ------- | --------------- |
@@ -75,6 +76,7 @@ Seventeen, of which four carry most decisions. The rest have defaults you rarely
 | `enable_pypto_l0c_double_buffer` | `None` | L0C double buffering |
 | `emit_source_loc` | `None` | Carry DSL source locations into the emitted `.pto` |
 | `dump_ptoas_passes` | `False` | Also dump ptoas's own pass IR |
+| `runtime` | `None` | Simpler runtime ABI to target — `TENSORMAP_AND_RINGBUFFER` or `HOST_BUILD_GRAPH` (what `@pl.jit.graph` needs — [Functions](../language/01-functions.md)); `None` inherits the active `PassContext`. The worker must match it |
 
 ### Pass dumps
 

--- a/docs/zh/dev/03-runtime-dfx.md
+++ b/docs/zh/dev/03-runtime-dfx.md
@@ -295,7 +295,7 @@ python runtime/tools/scope_stats_plot.py \
 | ------ | ---- | ----------- |
 | `RunConfig` 字段定义 | [runner.py](../../../python/pypto/runtime/runner.py) | `RunConfig` dataclass + `any_dfx_enabled()` |
 | `CallConfig` 透传 | [device_runner.py](../../../python/pypto/runtime/device_runner.py) | `_execute_on_device(..., enable_*, output_prefix)` |
-| 流水线打包 | [runner.py](../../../python/pypto/runtime/runner.py) | `_DfxOpts` dataclass + `_DfxOpts.from_run_config` |
+| 流水线打包 | [runner.py](../../../python/pypto/runtime/runner.py) | `DfxOptions` dataclass + `RunConfig.dfx_options()` |
 | 按 flag 后处理分发 | [runner.py](../../../python/pypto/runtime/runner.py) | `_collect_dfx_artifacts` |
 | kernel 名称映射合成 | [runner.py](../../../python/pypto/runtime/runner.py) | `_write_name_map` |
 | L3 每次 dispatch 的 program 标记 | [distributed_runner.py](../../../python/pypto/runtime/distributed_runner.py) | `_record_dispatch_program` / `_read_dispatch_program` |

--- a/docs/zh/dev/08-entry-points.md
+++ b/docs/zh/dev/08-entry-points.md
@@ -152,6 +152,14 @@ from pypto.runtime import CompileOptions
 compiled = ir.compile(program, **CompileOptions(platform="a2a3").as_compile_kwargs())
 ```
 
+**三个里只导出两个**，因为只有两个是调用方真能交出去的东西。`CompileOptions` 如上，
+解包进 `ir.compile`；`DfxOptions` 是 `execute_compiled`、`execute_artifact_dir`、
+`execute_batch_manifest` 的 `dfx=` 参数。`RunOptions` 两者都不是：每个派发入口 ——
+`CompiledProgram.__call__`、`ChipWorker.run` 以及分布式那一对 —— 收的都是 `RunConfig`，
+再自己经 `run_options()` 取派发侧那一半。直接把它交进去会抛 `AttributeError`，
+所以在那些签名放宽之前，它保持内部（`pypto.runtime.runner.RunOptions`）。放宽本身是另一件
+迁移：那意味着主派发 API 的 `config=` 参数要变成联合类型，而只改一部分入口比不改更糟。
+
 `RunConfig` 保留全部字段与全部调用方；这三个类型是它底下的词汇。有一个单测把这个划分钉成
 **完备**的 —— 每个 `RunConfig` 字段要么被某个视图认领，要么属于那五个 harness 专用字段 ——
 于是以后新加的字段不会悄悄两边都不属于。把那五个挪去 harness 是本次**没有**做的一步：
@@ -199,7 +207,7 @@ compiled = ir.compile(program, **CompileOptions(platform="a2a3").as_compile_kwar
 - `pypto.ir.compiled_program` —— `CompiledProgram._build_orch_args`、
   `CompiledProgram._build_call_config`
 - `pypto.runtime.runner` —— `_execute_compiled`、`_execute_golden_case`、
-  `_build_call_config`、`_coerced_to_orch_args`、`_DfxOpts`
+  `_build_call_config`、`_coerced_to_orch_args`、`RunOptions`
 - `pypto.runtime.distributed_runner` —— `_execute_distributed`
 - `pypto.runtime.device_runner` —— 整个装配层：`_compile_and_assemble`、
   `_compile_single_kernel`、`_compile_single_orchestration`、`_execute_on_device`

--- a/docs/zh/dev/08-entry-points.md
+++ b/docs/zh/dev/08-entry-points.md
@@ -140,13 +140,15 @@ compiled(*tensors, config=config)
 | 派发 | `RunOptions` | `platform`、`device_id`、`aicpu_thread_num`、`ring_*` 覆写项（[Ring 尺寸](05-runtime-ring-sizing.md)），以及内嵌的 `DfxOptions` |
 | 一次派发采集哪些诊断 | `DfxOptions` | `enable_chip_swimlane`、`enable_dump_args`、`enable_pmu`、`enable_dep_gen`、`enable_scope_stats`（[DFX](03-runtime-dfx.md)） |
 | 仅系统测试 harness | —— | `rtol`、`atol`、`golden_data_dir`、`save_kernels`、`codegen_only` |
-| 无人读取 —— 派生 | —— | `backend_type`，构造时由 `platform` 推导 |
+| 无人读取 —— 派生 | —— | `backend_type`，是 `platform` 上的只读属性，不是字段 |
 
 **目标只由 `platform` 说一次。** `RunConfig` 在构造时由它推导出 `backend_type`，而
 `ir.compile` 只要拿到 platform 就让 platform 胜出 —— 所以一个与之矛盾的 `backend_type`
 从来就没有生效过；现在把它传给 `RunConfig` 会告警并被丢弃。`CompileOptions` 因此干脆
-不带这个字段：它总是会传 platform，同一个决策的第二种写法只可能是冗余或错误。
-`ir.compile` 保留 `backend_type` 参数，供那些完全不传 platform 的底层调用方使用。
+不带这个字段：它总是会传 platform，同一个决策的第二种写法只可能是冗余或错误。在 `RunConfig`
+上它是只读属性而非字段，这样 `dataclasses.replace(cfg, platform=...)` 就不会把上一个
+platform 的 backend 重新塞回来、触发它自己的告警。`ir.compile` 保留 `backend_type`
+参数，供那些完全不传 platform 的底层调用方使用。
 
 `RunConfig.compile_options()` / `run_options()` / `dfx_options()` 是这个聚合体上的视图，
 而 `compile_kwargs()` 就是 `compile_options().as_compile_kwargs()`。`CompileOptions`

--- a/docs/zh/dev/08-entry-points.md
+++ b/docs/zh/dev/08-entry-points.md
@@ -136,10 +136,17 @@ compiled(*tensors, config=config)
 
 | 由谁读取 | 类型 | 字段 |
 | -------- | ---- | ---- |
-| `ir.compile` | `CompileOptions` | `platform`、`backend_type`、`strategy`、`dump_passes`、`dump_ptoas_passes`、`profiling`（`compile_profiling`）、`diagnostic_phase`、`disabled_diagnostics`、`analyze_auto_scopes_for_deps`、`output_dir`（`save_kernels_dir`）、`memory_planner`、`distributed_config` |
+| `ir.compile` | `CompileOptions` | `platform`、`strategy`、`dump_passes`、`dump_ptoas_passes`、`profiling`（`compile_profiling`）、`diagnostic_phase`、`disabled_diagnostics`、`analyze_auto_scopes_for_deps`、`output_dir`（`save_kernels_dir`）、`memory_planner`、`distributed_config` |
 | 派发 | `RunOptions` | `platform`、`device_id`、`aicpu_thread_num`、`ring_*` 覆写项（[Ring 尺寸](05-runtime-ring-sizing.md)），以及内嵌的 `DfxOptions` |
 | 一次派发采集哪些诊断 | `DfxOptions` | `enable_chip_swimlane`、`enable_dump_args`、`enable_pmu`、`enable_dep_gen`、`enable_scope_stats`（[DFX](03-runtime-dfx.md)） |
 | 仅系统测试 harness | —— | `rtol`、`atol`、`golden_data_dir`、`save_kernels`、`codegen_only` |
+| 无人读取 —— 派生 | —— | `backend_type`，构造时由 `platform` 推导 |
+
+**目标只由 `platform` 说一次。** `RunConfig` 在构造时由它推导出 `backend_type`，而
+`ir.compile` 只要拿到 platform 就让 platform 胜出 —— 所以一个与之矛盾的 `backend_type`
+从来就没有生效过；现在把它传给 `RunConfig` 会告警并被丢弃。`CompileOptions` 因此干脆
+不带这个字段：它总是会传 platform，同一个决策的第二种写法只可能是冗余或错误。
+`ir.compile` 保留 `backend_type` 参数，供那些完全不传 platform 的底层调用方使用。
 
 `RunConfig.compile_options()` / `run_options()` / `dfx_options()` 是这个聚合体上的视图，
 而 `compile_kwargs()` 就是 `compile_options().as_compile_kwargs()`。`CompileOptions`

--- a/docs/zh/dev/08-entry-points.md
+++ b/docs/zh/dev/08-entry-points.md
@@ -132,13 +132,30 @@ compiled = ir.compile(program, **config.compile_kwargs())
 compiled(*tensors, config=config)
 ```
 
-它的字段分三类：
+它的字段分三类，而每一类都是一个类型：
 
-| 由谁读取 | 字段 |
-| -------- | ---- |
-| `ir.compile`，经 `compile_kwargs()` | `strategy`、`backend_type`、`platform`、`memory_planner`、`dump_passes`、`dump_ptoas_passes`、`compile_profiling`、`diagnostic_phase`、`disabled_diagnostics`、`analyze_auto_scopes_for_deps`、`save_kernels_dir`（作为 `output_dir`）、`distributed_config` |
-| 派发 | `device_id`、`aicpu_thread_num`、`ring_*` 覆写项（[Ring 尺寸](05-runtime-ring-sizing.md)）、DFX 开关（[DFX](03-runtime-dfx.md)） |
-| 仅系统测试 harness | `rtol`、`atol`、`golden_data_dir`、`save_kernels`、`codegen_only` |
+| 由谁读取 | 类型 | 字段 |
+| -------- | ---- | ---- |
+| `ir.compile` | `CompileOptions` | `platform`、`backend_type`、`strategy`、`dump_passes`、`dump_ptoas_passes`、`profiling`（`compile_profiling`）、`diagnostic_phase`、`disabled_diagnostics`、`analyze_auto_scopes_for_deps`、`output_dir`（`save_kernels_dir`）、`memory_planner`、`distributed_config` |
+| 派发 | `RunOptions` | `platform`、`device_id`、`aicpu_thread_num`、`ring_*` 覆写项（[Ring 尺寸](05-runtime-ring-sizing.md)），以及内嵌的 `DfxOptions` |
+| 一次派发采集哪些诊断 | `DfxOptions` | `enable_chip_swimlane`、`enable_dump_args`、`enable_pmu`、`enable_dep_gen`、`enable_scope_stats`（[DFX](03-runtime-dfx.md)） |
+| 仅系统测试 harness | —— | `rtol`、`atol`、`golden_data_dir`、`save_kernels`、`codegen_only` |
+
+`RunConfig.compile_options()` / `run_options()` / `dfx_options()` 是这个聚合体上的视图，
+而 `compile_kwargs()` 就是 `compile_options().as_compile_kwargs()`。`CompileOptions`
+按 `ir.compile` 的叫法命名字段 —— 是 `output_dir` 而不是 `save_kernels_dir` ——
+因为它存在的意义就是用编译器自己的词汇说出编译侧；它也可以独立使用：
+
+```python
+from pypto.runtime import CompileOptions
+
+compiled = ir.compile(program, **CompileOptions(platform="a2a3").as_compile_kwargs())
+```
+
+`RunConfig` 保留全部字段与全部调用方；这三个类型是它底下的词汇。有一个单测把这个划分钉成
+**完备**的 —— 每个 `RunConfig` 字段要么被某个视图认领，要么属于那五个 harness 专用字段 ——
+于是以后新加的字段不会悄悄两边都不属于。把那五个挪去 harness 是本次**没有**做的一步：
+它们也出现在 `pypto-lib` 的构造调用里。
 
 `compile_kwargs()` 是通往 `ir.compile` 参数的唯一映射。`@pl.jit` 路径过去另有一份
 副本，省略 `platform` 与 `backend_type` 并单独转发 platform；现在它和其他调用方一样

--- a/docs/zh/dev/08-entry-points.md
+++ b/docs/zh/dev/08-entry-points.md
@@ -49,7 +49,8 @@ PyPTO 的编译与执行入口比它拥有的概念要多，而且好几个名�
 
 只有 `ir.compile` 是受支持的入口；表中其余项列在这里，是为了让 traceback 里出现的
 名字能被定位到某一层。它还遮蔽了 Python 内置的 `compile`，因此更推荐
-`from pypto import ir` 后调用 `ir.compile`，而不是直接导入这个名字。
+`from pypto import ir` 后调用 `ir.compile`，而不是直接导入这个名字。它接受的每个
+选项都是关键字参数；`program` 是唯一的位置参数。
 
 它的参数在[编译](../user/execution/00-compile.md)中有说明。
 
@@ -139,8 +140,10 @@ compiled(*tensors, config=config)
 | 派发 | `device_id`、`aicpu_thread_num`、`ring_*` 覆写项（[Ring 尺寸](05-runtime-ring-sizing.md)）、DFX 开关（[DFX](03-runtime-dfx.md)） |
 | 仅系统测试 harness | `rtol`、`atol`、`golden_data_dir`、`save_kernels`、`codegen_only` |
 
-`@pl.jit` 路径保留了自己的映射 `jit.decorator._run_config_compile_kwargs`，
-它省略了 `platform` 与 `backend_type`，因为该路径会单独转发这两项。
+`compile_kwargs()` 是通往 `ir.compile` 参数的唯一映射。`@pl.jit` 路径过去另有一份
+副本，省略 `platform` 与 `backend_type` 并单独转发 platform；现在它和其他调用方一样
+调用 `compile_kwargs()`，于是给一边加的开关不会在另一边悄悄缺席。`lower()` 仍有自己
+那份更窄的映射 —— 它止步于 codegen 之前，对准的是 pass 流水线而不是 `ir.compile`。
 
 ## 哪些是内部实现
 

--- a/docs/zh/dev/08-entry-points.md
+++ b/docs/zh/dev/08-entry-points.md
@@ -162,6 +162,35 @@ compiled = ir.compile(program, **CompileOptions(platform="a2a3").as_compile_kwar
 调用 `compile_kwargs()`，于是给一边加的开关不会在另一边悄悄缺席。`lower()` 仍有自己
 那份更窄的映射 —— 它止步于 codegen 之前，对准的是 pass 流水线而不是 `ir.compile`。
 
+## 层与层之间的箭头朝哪
+
+`ir` 产出产物，`runtime` 派发它。两者之间的箭头本该单向，而且大体上是单向的 ——
+但 `CompiledProgram` 既是编译**产物**又是执行**句柄**，于是
+`pypto.ir.compiled_program` 通过十处函数内 import 反向伸向 `pypto.runtime`。
+
+这些延迟导入通常被说成是为了打破导入环。逐个实测下来，真正如此的只有一处：
+
+| 延迟导入 | 能提到模块级吗？ | 真实原因 |
+| -------- | ---------------- | -------- |
+| `runtime.runner`（6 处） | 能 | 分层选择 —— 不让派发层进入 `pypto.ir` 的导入图 |
+| `runtime.distributed_runner`（2 处） | 能 | 同上 |
+| `runtime.debug.run_script_writer` | **现在**能了 | 曾是真环：它把 `ParamInfo` 从 `compiled_program` 读回去 |
+| `runtime.device_runner` | 不能 | 它在导入期就需要可选的 `simpler` 包 |
+
+那唯一的真环已经消除。参数元数据移到了
+[`ir/param_info.py`](../../../python/pypto/ir/param_info.py) —— 一个不从
+`pypto.runtime` 导入任何东西的叶子模块 —— 重放脚本生成器改从那里读；
+`compiled_program` 重新导出这些名字，所以别处什么都不用动。有一个单测把这个叶子性质
+钉住，因为往里拉进任何一个 runtime 导入都会让环回来。
+
+`pypto.runtime` 直接导入 `pypto.ir.distributed_compiled_program` —— 箭头唯一反向的
+那一处 —— **确实**是为了避开导入环，保持原样。
+
+彻底反转这个依赖，是比这些 import 语句大得多的问题。它意味着 `CompiledProgram` 不再可调用、
+`ir.compile` 改为返回一个由 `runtime` 包装的描述符 —— 那会改掉每个 example 和两个下游仓库
+都在用的 API 返回类型。这份 import 清单是那个双重身份的症状而非成因；而把那八处能提的都提到
+模块级，只会让耦合**更强** —— 那等于把 `pypto.runtime.runner` 放上 `import pypto.ir` 的关键路径。
+
 ## 哪些是内部实现
 
 以下没有稳定性保证。它们不在任何 `__all__` 中，PyPTO 之外的代码不应导入：

--- a/docs/zh/user/execution/00-compile.md
+++ b/docs/zh/user/execution/00-compile.md
@@ -45,7 +45,8 @@ assert compiled.param_names == ["a", "b", "out"]
 
 ### `ir.compile` 的参数
 
-十七个，其中四个承担了大部分决策，其余的默认值你很少会动。
+十八个，其中四个承担了大部分决策，其余的默认值你很少会动。它们全部是关键字参数 ——
+只有 `program` 是位置参数。
 
 | 参数 | 默认 | 决定什么 |
 | ---- | ---- | -------- |
@@ -66,6 +67,7 @@ assert compiled.param_names == ["a", "b", "out"]
 | `enable_pypto_l0c_double_buffer` | `None` | L0C double buffer |
 | `emit_source_loc` | `None` | 把 DSL 源位置带进发出的 `.pto` |
 | `dump_ptoas_passes` | `False` | 同时 dump ptoas 自己的 pass IR |
+| `runtime` | `None` | 面向哪个 Simpler 运行时 ABI —— `TENSORMAP_AND_RINGBUFFER` 或 `HOST_BUILD_GRAPH`（`@pl.jit.graph` 需要它 —— [函数](../language/01-functions.md)）；`None` 继承当前 `PassContext`。派发它的 worker 必须与之匹配 |
 
 ### Pass dump
 

--- a/examples/models/04_paged_attention.py
+++ b/examples/models/04_paged_attention.py
@@ -39,7 +39,6 @@ import struct
 import pypto.language as pl
 import torch
 from pypto import ir
-from pypto.backend import BackendType
 from pypto.ir.pass_manager import OptimizationStrategy
 from pypto.runtime import RunConfig
 
@@ -619,7 +618,6 @@ def main():
         device_id=11,
         strategy=OptimizationStrategy.Default,
         dump_passes=True,
-        backend_type=BackendType.Ascend910B,
         enable_chip_swimlane=args.enable_chip_swimlane,
     )
     compiled = ir.compile(program, **run_config.compile_kwargs())

--- a/examples/models/06_paged_attention_dynamic.py
+++ b/examples/models/06_paged_attention_dynamic.py
@@ -24,7 +24,6 @@ import argparse
 import pypto.language as pl
 import torch
 from pypto import ir
-from pypto.backend import BackendType
 from pypto.ir.pass_manager import OptimizationStrategy
 from pypto.runtime import RunConfig
 
@@ -548,7 +547,6 @@ def main():
         device_id=11,
         strategy=OptimizationStrategy.Default,
         dump_passes=True,
-        backend_type=BackendType.Ascend910B,
         enable_chip_swimlane=args.enable_chip_swimlane,
     )
     compiled = ir.compile(program, **run_config.compile_kwargs())

--- a/examples/models/07_paged_attention_multi_config.py
+++ b/examples/models/07_paged_attention_multi_config.py
@@ -52,7 +52,6 @@ import argparse
 import pypto.language as pl
 import torch
 from pypto import ir
-from pypto.backend import BackendType
 from pypto.ir.pass_manager import OptimizationStrategy
 from pypto.runtime import RunConfig
 
@@ -807,7 +806,6 @@ def main():
         device_id=11,
         strategy=OptimizationStrategy.Default,
         dump_passes=True,
-        backend_type=BackendType.Ascend910B,
         compile_profiling=True,
         enable_chip_swimlane=args.enable_chip_swimlane,
     )

--- a/examples/models/09_paged_attention_spmd.py
+++ b/examples/models/09_paged_attention_spmd.py
@@ -52,7 +52,6 @@ from collections.abc import Sequence
 import pypto.language as pl
 import torch
 from pypto import ir
-from pypto.backend import BackendType
 from pypto.ir.pass_manager import OptimizationStrategy
 from pypto.runtime import RunConfig
 
@@ -797,7 +796,6 @@ def main():
         device_id=args.device,
         strategy=OptimizationStrategy.Default,
         dump_passes=True,
-        backend_type=BackendType.Ascend950 if args.platform.startswith("a5") else BackendType.Ascend910B,
         enable_chip_swimlane=args.enable_chip_swimlane,
     )
     compiled = ir.compile(program, **run_config.compile_kwargs())

--- a/python/pypto/ir/compile.py
+++ b/python/pypto/ir/compile.py
@@ -254,6 +254,7 @@ def _run_pass_pipeline(  # noqa: PLR0913
 
 def compile(  # noqa: PLR0913
     program: _ir_core.Program,
+    *,
     output_dir: str | None = None,
     strategy: OptimizationStrategy = OptimizationStrategy.Default,
     dump_passes: bool | PassDumpLevel = True,
@@ -270,8 +271,6 @@ def compile(  # noqa: PLR0913
     analyze_auto_scopes_for_deps: bool = False,
     emit_source_loc: bool | None = None,
     dump_ptoas_passes: bool = False,
-    # Appended, not inserted: every parameter above is positional, so slotting a
-    # new one in the middle would silently rebind existing positional callers.
     runtime: _passes.RuntimeKind | None = None,
 ) -> "CompiledProgram | DistributedCompiledProgram":
     """Compile a Program through passes and codegen.
@@ -281,6 +280,12 @@ def compile(  # noqa: PLR0913
     2. Optionally dumps IR before and after each pass (if dump_passes=True)
     3. Generates code via selected backend
     4. Saves all artifacts to a unified output directory
+
+    Every option is keyword-only. The list has grown to eighteen and reads as a
+    flat bag rather than an ordered signature, so binding one by position was
+    never how a call site stayed readable — and it made the order load-bearing:
+    a new option could only be appended, never slotted in beside the one it
+    belongs with, or it would silently rebind an existing positional caller.
 
     Args:
         program: Input Program to compile

--- a/python/pypto/ir/compiled_program.py
+++ b/python/pypto/ir/compiled_program.py
@@ -683,7 +683,7 @@ def _invoke_compiled(
         args, param_infos, output_indices, return_types, caller_name=caller_name
     )
 
-    from pypto.runtime.runner import RunConfig, _DfxOpts, _execute_compiled  # noqa: PLC0415
+    from pypto.runtime.runner import RunConfig, _execute_compiled  # noqa: PLC0415
 
     execution_platform = platform if config is None else config.platform
     if config is None:
@@ -694,7 +694,7 @@ def _invoke_compiled(
         coerced,
         platform=execution_platform,
         device_id=config.device_id,
-        dfx=_DfxOpts.from_run_config(config),
+        dfx=config.dfx_options(),
         aicpu_thread_num=config.aicpu_thread_num,
         config=config,
     )

--- a/python/pypto/ir/compiled_program.py
+++ b/python/pypto/ir/compiled_program.py
@@ -16,13 +16,27 @@ torch tensors::
     compiled(a, b, c)                    # in-place on default sim, device 0
     c = compiled(a, b)                   # return style
     compiled(a, b, c, device=1)          # specify device at call time
+
+**Why the ``pypto.runtime`` imports are function-local.** This module is both
+the compilation artifact and the execution handle, so it reaches forward into
+the layer below it. Each deferral has its own reason, and they are not the same:
+
+- ``device_runner`` needs the optional ``simpler`` package at import time.
+  Hoisting it would make ``simpler`` a hard requirement of ``import pypto.ir``,
+  which the unit-test runners do not have.
+- ``runner``, ``debug.run_script_writer`` and (in the L3 sibling)
+  ``distributed_runner`` import cleanly at module scope; they stay deferred to
+  keep ``pypto.ir``'s own import graph free of the dispatch layer, not because
+  hoisting them fails.
+
+The one import that genuinely could not be hoisted was the metadata the replay
+writer reads back — that cycle is gone: it lives in the ``param_info`` leaf now.
 """
 
 import ctypes
 import json
 import os
 from collections.abc import Callable, Sequence
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -41,6 +55,15 @@ from pypto.pypto_core.ir import (
     ShapedType,
 )
 from pypto.runtime.device_tensor import DeviceTensor, StackedDeviceTensor
+
+# Re-exported: these moved to a leaf module so a consumer of the metadata can
+# depend on it without depending on this module. See ``param_info``.
+from .param_info import (  # noqa: F401  -- re-export
+    _DATATYPE_TO_TORCH,
+    ParamInfo,
+    _ParamInfo,
+    _to_torch_dtype,
+)
 
 # Type alias for arguments accepted by CompiledProgram.__call__().
 # Tensor params accept ``torch.Tensor`` (host), :class:`DeviceTensor`
@@ -86,42 +109,6 @@ _BUILD_KIND_MARKERS = (
     "orchestration/host_orch.py",
 )
 
-# IR DataType -> torch.dtype mapping.
-# Keyed by string because nanobind DataType instances are not singletons,
-# so dict lookup by object identity / hash may fail even for equal values.
-_DATATYPE_TO_TORCH: dict[str, torch.dtype] = {
-    "fp16": torch.float16,
-    "fp32": torch.float32,
-    "fp64": torch.float64,
-    "bfloat16": torch.bfloat16,
-    "int8": torch.int8,
-    "int16": torch.int16,
-    "int32": torch.int32,
-    "int64": torch.int64,
-    "uint8": torch.uint8,
-    "bool": torch.bool,
-    "index": torch.int64,
-}
-# uint16/32/64 were added in PyTorch 2.3; register only if available
-for _name in ("uint16", "uint32", "uint64"):
-    _torch_dtype = getattr(torch, _name, None)
-    if _torch_dtype is not None:
-        _DATATYPE_TO_TORCH[_name] = _torch_dtype
-del _name, _torch_dtype
-# Float8 / MX scale dtypes (PyTorch 2.1+ / 2.3+ / 2.7+); map IR string → torch.dtype.
-# Packed MXFP4 (fp4 ↔ float4_e2m1fn_x2) must be here so return-style execution
-# can allocate FP4 outputs after JIT specialization accepts the torch dtype.
-for _ir_name, _torch_name in (
-    ("fp8e4m3fn", "float8_e4m3fn"),
-    ("fp8e5m2", "float8_e5m2"),
-    ("fp8e8m0", "float8_e8m0fnu"),
-    ("fp4", "float4_e2m1fn_x2"),
-):
-    _torch_dtype = getattr(torch, _torch_name, None)
-    if _torch_dtype is not None:
-        _DATATYPE_TO_TORCH[_ir_name] = _torch_dtype
-del _ir_name, _torch_name, _torch_dtype
-
 # IR DataType -> ctypes scalar constructor mapping.
 # Used to wrap Python int/float/bool values into the correct ctypes scalar
 # when calling a compiled program with scalar parameters.
@@ -141,11 +128,6 @@ _DATATYPE_TO_CTYPE: dict[str, type[ctypes._SimpleCData]] = {
     "bool": ctypes.c_bool,
     "index": ctypes.c_int64,
 }
-
-
-def _to_torch_dtype(dtype: DataType) -> torch.dtype | None:
-    """Convert an IR DataType to the corresponding torch.dtype."""
-    return _DATATYPE_TO_TORCH.get(str(dtype))
 
 
 def _to_runtime_shape(shape: list[int], dtype: DataType) -> list[int]:
@@ -173,16 +155,6 @@ def _validate_fp4_carrier_shape(shape: Sequence[int], info: "_ParamInfo") -> Non
             f"Packed FP4 parameter {info.name!r} requires a positive runtime x2 carrier last dimension; "
             f"got shape {tuple(shape)}"
         )
-
-
-@dataclass
-class _ParamInfo:
-    """Metadata for a single orchestration function parameter."""
-
-    name: str
-    direction: ParamDirection
-    shape: list[int] | None  # None for scalar params
-    dtype: DataType
 
 
 # Reverse map ``str(DataType) -> DataType`` for JSON round-tripping (e.g. the L3
@@ -1518,5 +1490,5 @@ class _SubChipCallable(_RuntimeFacade):
 
 # Public re-exports for callers (e.g. ir.compile()) that need orchestration
 # parameter metadata without instantiating a full CompiledProgram.
-ParamInfo = _ParamInfo
+
 extract_param_infos = _extract_param_infos

--- a/python/pypto/ir/param_info.py
+++ b/python/pypto/ir/param_info.py
@@ -1,0 +1,86 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Orchestration parameter metadata, and the IR-dtype to torch-dtype map.
+
+A leaf: it imports nothing from ``pypto.runtime`` and nothing from the rest of
+``pypto.ir`` beyond the core bindings, so anything may depend on it.
+
+That is the point. This metadata used to live in ``compiled_program``, which
+made a consumer of it — ``pypto.runtime.debug.run_script_writer``, which
+renders a replay script from a program's parameters — import back into the
+module that reaches forward into ``pypto.runtime``. That is a genuine cycle:
+hoisting ``run_script_writer``'s import to module scope fails with
+``cannot import name 'ParamInfo' from partially initialized module``. Splitting
+the metadata out removes the back edge; ``compiled_program`` re-exports these
+names, so nothing else has to know they moved.
+"""
+
+from dataclasses import dataclass
+
+import torch
+
+from pypto.pypto_core import DataType
+from pypto.pypto_core.ir import ParamDirection
+
+# IR DataType -> torch.dtype mapping.
+# Keyed by string because nanobind DataType instances are not singletons,
+# so dict lookup by object identity / hash may fail even for equal values.
+_DATATYPE_TO_TORCH: dict[str, torch.dtype] = {
+    "fp16": torch.float16,
+    "fp32": torch.float32,
+    "fp64": torch.float64,
+    "bfloat16": torch.bfloat16,
+    "int8": torch.int8,
+    "int16": torch.int16,
+    "int32": torch.int32,
+    "int64": torch.int64,
+    "uint8": torch.uint8,
+    "bool": torch.bool,
+    "index": torch.int64,
+}
+# uint16/32/64 were added in PyTorch 2.3; register only if available
+for _name in ("uint16", "uint32", "uint64"):
+    _torch_dtype = getattr(torch, _name, None)
+    if _torch_dtype is not None:
+        _DATATYPE_TO_TORCH[_name] = _torch_dtype
+del _name, _torch_dtype
+# Float8 / MX scale dtypes (PyTorch 2.1+ / 2.3+ / 2.7+); map IR string → torch.dtype.
+# Packed MXFP4 (fp4 ↔ float4_e2m1fn_x2) must be here so return-style execution
+# can allocate FP4 outputs after JIT specialization accepts the torch dtype.
+for _ir_name, _torch_name in (
+    ("fp8e4m3fn", "float8_e4m3fn"),
+    ("fp8e5m2", "float8_e5m2"),
+    ("fp8e8m0", "float8_e8m0fnu"),
+    ("fp4", "float4_e2m1fn_x2"),
+):
+    _torch_dtype = getattr(torch, _torch_name, None)
+    if _torch_dtype is not None:
+        _DATATYPE_TO_TORCH[_ir_name] = _torch_dtype
+del _ir_name, _torch_name, _torch_dtype
+
+
+def _to_torch_dtype(dtype: DataType) -> torch.dtype | None:
+    """Convert an IR DataType to the corresponding torch.dtype."""
+    return _DATATYPE_TO_TORCH.get(str(dtype))
+
+
+@dataclass
+class _ParamInfo:
+    """Metadata for a single orchestration function parameter."""
+
+    name: str
+    direction: ParamDirection
+    shape: list[int] | None  # None for scalar params
+    dtype: DataType
+
+
+# Public spelling for code outside ``pypto.ir`` (the replay-script writer, and
+# harnesses that bind arguments themselves).
+ParamInfo = _ParamInfo

--- a/python/pypto/jit/decorator.py
+++ b/python/pypto/jit/decorator.py
@@ -1513,57 +1513,13 @@ def _overlay_dep_declared_layouts(dep: JITFunction, dep_tensor_meta: dict[str, T
 
 
 # ---------------------------------------------------------------------------
-# RunConfig -> ir.compile() keyword forwarding
+# RunConfig -> pass-pipeline keyword forwarding
+#
+# The compile-side half has no counterpart here: ``RunConfig.compile_kwargs()``
+# is the single mapping onto ``ir.compile()``'s parameters, and the JIT path
+# calls it directly. ``lower()`` stops before codegen, so it needs its own
+# narrower mapping onto ``_run_pass_pipeline``.
 # ---------------------------------------------------------------------------
-
-
-def _run_config_compile_kwargs(run_config: Any) -> dict[str, Any]:
-    """Extract ``ir.compile()`` keyword arguments from a ``pypto.runtime.RunConfig``.
-
-    Maps the compile-side fields of ``RunConfig`` onto the parameters
-    ``ir.compile()`` accepts, so a ``@pl.jit`` kernel invoked with
-    ``config=RunConfig(...)`` honours the same compile knobs that
-    ``ir.compile(program, ...)`` does. Runtime-only fields (``device_id``,
-    ``rtol`` / ``atol``, DFX toggles, ...) are not compile inputs and are
-    consumed by ``CompiledProgram.__call__`` instead.
-
-    ``backend_type`` is intentionally omitted: ``ir.compile()`` derives the
-    codegen backend from ``platform``, which the JIT path already forwards;
-    passing ``backend_type`` as well would be redundant and could conflict.
-
-    ``output_dir`` is forwarded only when set, so an unset value defers to
-    ``ir.compile()``'s own default.
-
-    ``distributed_config`` is likewise forwarded only when set. When supplied it
-    makes ``ir.compile()`` emit a ``DistributedCompiledProgram`` (HOST-level
-    ``@pl.jit.host`` kernels), which ``__call__`` then dispatches per-rank. An
-    unset value defers to ``ir.compile()``'s default (a single-chip
-    ``CompiledProgram``) and keeps it out of the cache key for non-distributed
-    callers.
-
-    ``analyze_auto_scopes_for_deps`` is forwarded because it changes the pass
-    pipeline's dependency derivation and therefore the generated orchestration.
-
-    ``memory_planner`` is forwarded only when set: ``ir.compile()`` rejects an
-    explicit planner while a ``PassContext`` is active, and an unset value must
-    defer to that context (or to the ``PYPTO`` default when there is none).
-    """
-    kwargs: dict[str, Any] = {
-        "strategy": run_config.strategy,
-        "dump_passes": run_config.dump_passes,
-        "dump_ptoas_passes": run_config.dump_ptoas_passes,
-        "profiling": run_config.compile_profiling,
-        "diagnostic_phase": run_config.diagnostic_phase,
-        "disabled_diagnostics": run_config.disabled_diagnostics,
-        "analyze_auto_scopes_for_deps": run_config.analyze_auto_scopes_for_deps,
-    }
-    if run_config.save_kernels_dir is not None:
-        kwargs["output_dir"] = run_config.save_kernels_dir
-    if run_config.distributed_config is not None:
-        kwargs["distributed_config"] = run_config.distributed_config
-    if run_config.memory_planner is not None:
-        kwargs["memory_planner"] = run_config.memory_planner
-    return kwargs
 
 
 def _run_config_lower_kwargs(run_config: Any) -> dict[str, Any]:
@@ -1641,7 +1597,7 @@ class JITFunction:
             ``device=`` dispatch loop. End-to-end runtime dispatch works when
             the caller supplies ``config=RunConfig(distributed_config=...)``:
             the config is forwarded through ``_compile`` → ``ir.compile()``
-            (see ``_run_config_compile_kwargs``), which yields a
+            (see ``RunConfig.compile_kwargs``), which yields a
             ``DistributedCompiledProgram`` that ``__call__`` dispatches
             per-rank.
         _level: pl.Level or None.
@@ -2205,10 +2161,12 @@ class JITFunction:
             allow_signature_mode=allow_signature_mode,
         )
 
-        # Compile-side knobs (strategy, dump_passes, ...) come from the
-        # RunConfig. Forwarding them lets a @pl.jit kernel honour the same
-        # compile options as a direct ir.compile(program, ...) call.
-        compile_kwargs = _run_config_compile_kwargs(run_config) if run_config is not None else {}
+        # Compile-side knobs (platform, strategy, dump_passes, ...) come from
+        # the RunConfig, through the same mapping a direct
+        # ``ir.compile(program, **config.compile_kwargs())`` call uses. With no
+        # config there is nothing to forward and ir.compile()'s own defaults
+        # apply, platform included.
+        compile_kwargs = run_config.compile_kwargs() if run_config is not None else {}
 
         # Build cache key. Platform and strategy are included so artifacts
         # compiled for different targets or optimization strategies never
@@ -2261,7 +2219,6 @@ class JITFunction:
                 specialization.scalar_dtypes,
                 specialization.per_func_dyn,
                 pl,
-                platform=platform,
                 **compile_kwargs,
             )
 
@@ -2289,7 +2246,7 @@ class JITFunction:
         A ``config=RunConfig(...)`` keyword argument is consumed here rather
         than passed to the decorated function: its compile-side fields
         (``strategy``, ``dump_passes``, diagnostics, ...) are forwarded to
-        ``ir.compile()`` via ``_run_config_compile_kwargs``, and its
+        ``ir.compile()`` via ``RunConfig.compile_kwargs``, and its
         runtime fields drive on-device execution.  ``strategy`` also takes
         part in the cache key so artifacts compiled under different strategy
         values never share a cache entry.
@@ -2463,7 +2420,6 @@ class JITFunction:
         scalar_dtypes: dict[str, DataType],
         per_func_dyn: dict[int, dict[str, dict[int, DynDim]]],
         pl: Any,
-        platform: str | None = None,
         **ir_compile_kwargs: Any,
     ) -> Any:
         """Specialize entry + deps into @pl.program source, parse, and compile.
@@ -2478,9 +2434,9 @@ class JITFunction:
         doesn't re-walk the dep graph on every cache miss.
 
         ``ir_compile_kwargs`` are forwarded verbatim to ``ir.compile()`` —
-        compile-side knobs (``strategy``, ``dump_passes``, ``output_dir``,
-        ``profiling``, diagnostics, ...) that the JIT caller derives from a
-        ``RunConfig`` via ``_run_config_compile_kwargs``.
+        compile-side knobs (``platform``, ``strategy``, ``dump_passes``,
+        ``output_dir``, ``profiling``, diagnostics, ...) that the JIT caller
+        derives from a ``RunConfig`` via ``RunConfig.compile_kwargs``.
         """
         from pypto.ir.compile import compile as ir_compile  # noqa: PLC0415
 
@@ -2492,7 +2448,7 @@ class JITFunction:
         try:
             parsed = pl.parse(source, filename=self._diagnostic_filename, source_map=specializer.source_map)
             skip_ptoas = not _ptoas_available()
-            return ir_compile(parsed, skip_ptoas=skip_ptoas, platform=platform, **ir_compile_kwargs)
+            return ir_compile(parsed, skip_ptoas=skip_ptoas, **ir_compile_kwargs)
         except Exception as exc:
             rewritten = _rewrite_jit_error(exc, rename_map)
             if rewritten is exc:

--- a/python/pypto/pypto_core/backend.pyi
+++ b/python/pypto/pypto_core/backend.pyi
@@ -168,7 +168,7 @@ def get_backend_instance(backend_type: BackendType) -> Backend:
     :class:`BackendType` regardless of the global configuration.
 
     This is useful for callers that already know which backend they want
-    (for example, :class:`RunOptions.backend_type` may differ from the
+    (for example, :attr:`CompileOptions.backend_type` may differ from the
     globally-configured type when running multiple backends in sequence).
     """
     ...

--- a/python/pypto/runtime/__init__.py
+++ b/python/pypto/runtime/__init__.py
@@ -40,6 +40,14 @@ work, and forward to the same implementation, but each emits a
 ``dfx`` / ``aicpu_thread_num`` onto the :class:`RunConfig` first — see its
 docstring for why a plain rename changes where the run lands.
 
+``RunConfig`` aggregates three concerns, each also available on its own:
+:class:`CompileOptions` (what compilation reads, in ``ir.compile``'s
+vocabulary), :class:`RunOptions` (what a dispatch reads) and :class:`DfxOptions`
+(which diagnostics it collects, nested inside ``RunOptions``). ``RunConfig``
+keeps every field and every caller — ``compile_options()`` / ``run_options()`` /
+``dfx_options()`` are views onto it, and code that needs only one half should
+take that half.
+
 ``docs/en/dev/08-entry-points.md`` maps every compile and execution entry point
 to the layer it belongs to.
 """
@@ -56,7 +64,7 @@ from .log_config import _ensure_configured as _ensure_log_configured
 from .log_config import configure_log
 from .log_config import current_level as log_level
 from .pto_isa import ensure_pto_isa_root, pto_isa_include_dir
-from .runner import RunConfig, RunResult, execute_compiled
+from .runner import CompileOptions, DfxOptions, RunConfig, RunOptions, RunResult, execute_compiled
 from .runtime_base import Worker
 from .tensor_spec import ScalarSpec, TensorSpec
 from .worker import ChipWorker, RegistrationHandle
@@ -82,7 +90,10 @@ __all__ = [
     "DistributedRunHandle",
     "ReadOnlyHostTensor",
     "RegistrationHandle",
+    "CompileOptions",
+    "DfxOptions",
     "RunConfig",
+    "RunOptions",
     "RunResult",
     "ScalarSpec",
     "TensorSpec",

--- a/python/pypto/runtime/__init__.py
+++ b/python/pypto/runtime/__init__.py
@@ -40,13 +40,19 @@ work, and forward to the same implementation, but each emits a
 ``dfx`` / ``aicpu_thread_num`` onto the :class:`RunConfig` first — see its
 docstring for why a plain rename changes where the run lands.
 
-``RunConfig`` aggregates three concerns, each also available on its own:
-:class:`CompileOptions` (what compilation reads, in ``ir.compile``'s
-vocabulary), :class:`RunOptions` (what a dispatch reads) and :class:`DfxOptions`
-(which diagnostics it collects, nested inside ``RunOptions``). ``RunConfig``
-keeps every field and every caller — ``compile_options()`` / ``run_options()`` /
-``dfx_options()`` are views onto it, and code that needs only one half should
-take that half.
+``RunConfig`` aggregates three concerns, and ``compile_options()`` /
+``run_options()`` / ``dfx_options()`` return each on its own. It keeps every
+field and every caller; the parts are the vocabulary underneath it.
+
+Two of the three are exported because something takes them:
+:class:`CompileOptions` unpacks straight into ``ir.compile``
+(``ir.compile(program, **options.as_compile_kwargs())``), so a caller that only
+compiles needs no ``RunConfig``; :class:`DfxOptions` is the ``dfx=`` parameter
+of ``execute_compiled`` and the artifact-directory CLI entry points.
+``RunOptions`` is **not** exported: no dispatch entry point accepts one yet —
+they all take a ``RunConfig`` — so it is currently the internal shape the
+dispatch plumbing reads, reachable as ``pypto.runtime.runner.RunOptions``.
+Exporting it is for the change that migrates those signatures.
 
 ``docs/en/dev/08-entry-points.md`` maps every compile and execution entry point
 to the layer it belongs to.
@@ -64,7 +70,7 @@ from .log_config import _ensure_configured as _ensure_log_configured
 from .log_config import configure_log
 from .log_config import current_level as log_level
 from .pto_isa import ensure_pto_isa_root, pto_isa_include_dir
-from .runner import CompileOptions, DfxOptions, RunConfig, RunOptions, RunResult, execute_compiled
+from .runner import CompileOptions, DfxOptions, RunConfig, RunResult, execute_compiled
 from .runtime_base import Worker
 from .tensor_spec import ScalarSpec, TensorSpec
 from .worker import ChipWorker, RegistrationHandle
@@ -93,7 +99,6 @@ __all__ = [
     "CompileOptions",
     "DfxOptions",
     "RunConfig",
-    "RunOptions",
     "RunResult",
     "ScalarSpec",
     "TensorSpec",

--- a/python/pypto/runtime/debug/replay.py
+++ b/python/pypto/runtime/debug/replay.py
@@ -60,7 +60,6 @@ from pypto.runtime.runner import (
     _SWIMLANE_FULL_LEVEL,
     _SWIMLANE_MAX_LEVEL,
     RunConfig,
-    _DfxOpts,
     _execute_compiled,
 )
 
@@ -217,7 +216,7 @@ def replay(
             list(tensors),
             platform=config.platform,
             device_id=config.device_id,
-            dfx=_DfxOpts.from_run_config(config),
+            dfx=config.dfx_options(),
             config=config,
         )
 

--- a/python/pypto/runtime/debug/run_script_writer.py
+++ b/python/pypto/runtime/debug/run_script_writer.py
@@ -28,7 +28,7 @@ from pathlib import Path
 
 import torch
 
-from pypto.ir.compiled_program import ParamInfo, _to_torch_dtype
+from pypto.ir.param_info import ParamInfo, _to_torch_dtype
 from pypto.pypto_core.ir import ParamDirection
 
 _TORCH_DTYPE_NAMES: dict[torch.dtype, str] = {

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -707,11 +707,11 @@ def _make_call_config(
     call_config = CallConfig()
     call_config.aicpu_thread_num = dc.aicpu_thread_num
     if run_config is not None:
-        from .runner import _apply_ring_overrides, _DfxOpts  # noqa: PLC0415
+        from .runner import _apply_ring_overrides  # noqa: PLC0415
 
         _apply_ring_overrides(call_config, run_config)
 
-        dfx = _DfxOpts.from_run_config(run_config)
+        dfx = run_config.dfx_options()
         if dfx.any():
             if dfx_base is None:
                 raise ValueError("_make_call_config: dfx_base is required when a DFX flag is enabled on L3")
@@ -1367,9 +1367,7 @@ def _execute_distributed(
     # Scope DFX artifacts to this run: drop any stale ``rank*/d{k}`` dirs from an
     # earlier (possibly larger) run before the first dispatch writes new ones.
     if config is not None:
-        from .runner import _DfxOpts  # noqa: PLC0415
-
-        if _DfxOpts.from_run_config(config).any():
+        if config.dfx_options().any():
             _clear_dfx_dispatch_dirs(dfx_base)
 
     if config is not None and config.enable_chip_swimlane > 0 and not compiled.platform.endswith("sim"):
@@ -2918,9 +2916,7 @@ class DistributedWorker(Worker):
         # This worker reuses one output_dir across dispatches, so stale
         # ``rank*/d{k}`` dirs from an earlier, larger run must be cleared before
         # this run rewrites ``d0, d1, ...``.
-        from .runner import _DfxOpts  # noqa: PLC0415
-
-        if _DfxOpts.from_run_config(config).any():
+        if config.dfx_options().any():
             # Every dispatch writes below the same output directory. Finish
             # earlier work before clearing or repopulating those paths.
             self._drain_dispatch_handles()

--- a/python/pypto/runtime/execute_artifact.py
+++ b/python/pypto/runtime/execute_artifact.py
@@ -51,7 +51,7 @@ from pypto.runtime.runner import (
     _SWIMLANE_CLI_HELP,
     _SWIMLANE_FULL_LEVEL,
     _SWIMLANE_MAX_LEVEL,
-    _DfxOpts,
+    DfxOptions,
     _execute_golden_case,
 )
 
@@ -79,7 +79,7 @@ def execute_artifact_dir(
     platform: str,
     device_id: int,
     *,
-    dfx: _DfxOpts = _DfxOpts(),
+    dfx: DfxOptions = DfxOptions(),
     validate: bool = True,
 ) -> None:
     """Rebuild the compiled artifact in *work_dir* and run it on *device_id*.
@@ -148,7 +148,7 @@ def _run_on_device(
     runtime_name: str,
     enable_sdma: bool,
     *,
-    dfx: _DfxOpts,
+    dfx: DfxOptions,
     validate: bool,
 ) -> None:
     """Device-run half shared by the single (:func:`execute_artifact_dir`) and
@@ -176,7 +176,7 @@ def execute_batch_manifest(
     manifest_path: Path,
     device_id: int,
     *,
-    dfx: _DfxOpts = _DfxOpts(),
+    dfx: DfxOptions = DfxOptions(),
     validate: bool = False,
 ) -> bool:
     """Run a batch of artifacts in ONE process, reusing the device session.
@@ -441,7 +441,7 @@ def main(argv: list[str] | None = None) -> int:
     """
     parser = _build_parser()
     args = parser.parse_args(argv)
-    dfx = _DfxOpts(
+    dfx = DfxOptions(
         enable_chip_swimlane=_resolve_swimlane_args(parser, args),
         enable_dump_args=args.dump_args,
         enable_pmu=args.enable_pmu,

--- a/python/pypto/runtime/runner.py
+++ b/python/pypto/runtime/runner.py
@@ -114,6 +114,18 @@ _SWIMLANE_CLI_HELP = (
 )
 
 
+def _backend_type_for_platform(platform: str) -> BackendType:
+    """Return the codegen backend a runtime platform string selects."""
+    return BackendType.Ascend950 if platform.startswith("a5") else BackendType.Ascend910B
+
+
+_BACKEND_TYPE_DEPRECATION = (
+    "RunConfig(backend_type=...) is deprecated and has never taken effect: the backend is "
+    "derived from platform, which wins. Drop the argument, or pass the platform that implies "
+    "the backend you want. Reading RunConfig.backend_type still reports what platform selected."
+)
+
+
 _SWIMLANE_ALIAS_DEPRECATION = (
     "RunConfig.enable_l2_swimlane is deprecated; use enable_chip_swimlane instead. "
     "Same values and semantics — Simpler renamed the L2 layer to 'chip', and the "
@@ -178,9 +190,9 @@ class RunConfig:
         platform: Target execution platform — ``"a2a3sim"`` / ``"a2a3"``
             (Ascend 910B) or ``"a5sim"`` / ``"a5"`` (Ascend 950).
         device_id: Hardware device index (ignored for simulator).
-        backend_type: **Derived, not an input.** Set from ``platform`` during
-            construction; supplying one that disagrees warns and is discarded.
-            Read it to learn which backend a platform selected.
+        backend_type: **Not a field** — a read-only property derived from
+            ``platform``. Accepted as a deprecated constructor keyword, which
+            warns and is discarded when it contradicts the platform.
         rtol: Relative tolerance for result comparison.
         atol: Absolute tolerance for result comparison.
         strategy: PyPTO optimisation strategy applied during compilation.
@@ -343,9 +355,6 @@ class RunConfig:
     rtol: float = 1e-5
     atol: float = 1e-5
     strategy: OptimizationStrategy = field(default_factory=lambda: OptimizationStrategy.Default)
-    # Derived from ``platform`` in ``__post_init__``; ``None`` means "not supplied".
-    # Typed as the concrete enum because every reader sees it after that runs.
-    backend_type: BackendType = None  # type: ignore[assignment]
     dump_passes: bool | PassDumpLevel = False
     save_kernels: bool = False
     save_kernels_dir: str | None = None
@@ -381,21 +390,6 @@ class RunConfig:
             raise ValueError(
                 f"Invalid platform {self.platform!r}. Expected 'a2a3sim', 'a2a3', 'a5sim', or 'a5'."
             )
-        # ``platform`` is the single source of truth for the target: it selects
-        # both the codegen backend and the runtime toolchain, and they must
-        # agree. ``backend_type`` is therefore derived, never an input -- a
-        # supplied one has always been discarded here, silently. Say so instead.
-        derived = BackendType.Ascend950 if self.platform.startswith("a5") else BackendType.Ascend910B
-        if self.backend_type is not None and self.backend_type != derived:
-            warnings.warn(
-                f"RunConfig(backend_type={self.backend_type!r}) is ignored: the backend is derived "
-                f"from platform={self.platform!r}, which selects {derived!r}. Drop the argument, or "
-                f"pass the platform that implies the backend you want.",
-                DeprecationWarning,
-                stacklevel=3,
-            )
-        self.backend_type = derived
-
         backend = _backend_core.get_backend_instance(self.backend_type)
         expected_arch = backend.get_handler().get_pto_target_arch()
         if not self.platform.startswith(expected_arch):
@@ -563,6 +557,16 @@ class RunConfig:
         )
 
     @property
+    def backend_type(self) -> BackendType:
+        """The codegen backend :attr:`platform` selects. Derived, never stored.
+
+        ``platform`` is the single source of truth for the target, so there is
+        nothing to keep in sync: ``a5`` / ``a5sim`` are Ascend950 and the rest
+        are Ascend910B. Read it to learn which backend a platform chose.
+        """
+        return _backend_type_for_platform(self.platform)
+
+    @property
     def enable_l2_swimlane(self) -> int:
         """Deprecated alias for :attr:`enable_chip_swimlane`.
 
@@ -580,7 +584,7 @@ class RunConfig:
 
 
 # ---------------------------------------------------------------------------
-# Deprecated ``enable_l2_swimlane`` spelling
+# Deprecated constructor keywords: ``enable_l2_swimlane`` and ``backend_type``
 # ---------------------------------------------------------------------------
 # Simpler's Worker/Chip/Core naming migration renamed the L2 layer to "chip"
 # (``L2Swimlane*`` -> ``ChipSwimlane*``, ``l2_swimlane_records.json`` ->
@@ -596,13 +600,27 @@ class RunConfig:
 # silently overridden by the stale alias. Keeping the alias off the field list
 # leaves ``replace``, ``fields()``, ``asdict()`` and ``repr()`` clean, and routes
 # the old name through an ``__init__`` wrapper plus a property instead.
+#
+# ``backend_type`` is off the field list for the same reason, plus one of its
+# own. It is derived from ``platform``, so a caller-supplied value has never
+# taken effect. As a field it would come back through ``replace()``:
+# ``replace(cfg, platform="a5")`` re-supplies the *old* platform's backend, and
+# nothing can tell that echo from a caller who typed a contradicting value —
+# so a plain platform switch would warn, and fail outright under
+# warnings-as-errors.
 
 _RUN_CONFIG_INIT = RunConfig.__init__
 
 
 @functools.wraps(_RUN_CONFIG_INIT)
 def _run_config_init(self: RunConfig, *args: Any, **kwargs: Any) -> None:
-    """``RunConfig.__init__`` that also accepts the deprecated alias."""
+    """``RunConfig.__init__`` that also accepts the deprecated keywords."""
+    if "backend_type" in kwargs:
+        supplied = kwargs.pop("backend_type")
+        platform = kwargs.get("platform", "a2a3sim")
+        if supplied is not None and supplied != _backend_type_for_platform(platform):
+            warnings.warn(_BACKEND_TYPE_DEPRECATION, DeprecationWarning, stacklevel=2)
+
     alias = kwargs.pop("enable_l2_swimlane", None)
     if alias is not None:
         warnings.warn(_SWIMLANE_ALIAS_DEPRECATION, DeprecationWarning, stacklevel=2)

--- a/python/pypto/runtime/runner.py
+++ b/python/pypto/runtime/runner.py
@@ -310,7 +310,7 @@ class RunConfig:
             to the runtime's compile-time default.
         distributed_config: Optional L3 distributed-execution config, consumed
             only on the ``@pl.jit`` path. When set, it is forwarded to
-            ``ir.compile()`` (via :func:`~pypto.jit.decorator._run_config_compile_kwargs`)
+            ``ir.compile()`` (via :meth:`RunConfig.compile_kwargs`)
             so a HOST-level ``@pl.jit.host`` kernel compiles to a
             :class:`~pypto.ir.distributed_compiled_program.DistributedCompiledProgram`
             and dispatches per-rank. ``None`` (default) compiles a regular
@@ -708,6 +708,14 @@ class RunOptions:
     ``platform`` appears in both halves because it is genuinely two decisions
     that must agree: the target codegen builds for, and the device the worker
     opens. A worker rejects an artifact whose platform differs from its own.
+
+    **Not exported from** ``pypto.runtime``, and deliberately so: no dispatch
+    entry point accepts one yet. ``CompiledProgram.__call__``,
+    ``ChipWorker.run`` and their distributed counterparts all take a
+    :class:`RunConfig`, and reach it through ``run_options()``. Until those
+    signatures widen, this is the internal shape the dispatch plumbing reads,
+    not a configuration a caller can hand in — exporting it would advertise an
+    entry point that does not exist.
     """
 
     platform: str = "a2a3sim"

--- a/python/pypto/runtime/runner.py
+++ b/python/pypto/runtime/runner.py
@@ -471,13 +471,7 @@ class RunConfig:
         chip swimlane, argument dump, PMU, dep_gen and scope_stats. They are
         independent toggles that share an output directory.
         """
-        return (
-            self.enable_chip_swimlane > 0
-            or self.enable_dump_args > 0
-            or self.enable_pmu > 0
-            or self.enable_dep_gen
-            or self.enable_scope_stats
-        )
+        return self.dfx_options().any()
 
     def compile_kwargs(self) -> dict[str, Any]:
         """Return the compile-side fields as ``ir.compile()`` keyword arguments.
@@ -509,24 +503,55 @@ class RunConfig:
         Returns:
             Keyword arguments accepted by :func:`pypto.ir.compile`.
         """
-        kwargs: dict[str, Any] = {
-            "strategy": self.strategy,
-            "backend_type": self.backend_type,
-            "platform": self.platform,
-            "dump_passes": self.dump_passes,
-            "dump_ptoas_passes": self.dump_ptoas_passes,
-            "profiling": self.compile_profiling,
-            "diagnostic_phase": self.diagnostic_phase,
-            "disabled_diagnostics": self.disabled_diagnostics,
-            "analyze_auto_scopes_for_deps": self.analyze_auto_scopes_for_deps,
-        }
-        if self.save_kernels_dir is not None:
-            kwargs["output_dir"] = self.save_kernels_dir
-        if self.distributed_config is not None:
-            kwargs["distributed_config"] = self.distributed_config
-        if self.memory_planner is not None:
-            kwargs["memory_planner"] = self.memory_planner
-        return kwargs
+        return self.compile_options().as_compile_kwargs()
+
+    def compile_options(self) -> "CompileOptions":
+        """Return the compile-side half as a :class:`CompileOptions`.
+
+        The field renames are the compiler's own vocabulary:
+        ``save_kernels_dir`` is ``ir.compile``'s ``output_dir`` and
+        ``compile_profiling`` is its ``profiling``.
+        """
+        return CompileOptions(
+            platform=self.platform,
+            backend_type=self.backend_type,
+            strategy=self.strategy,
+            dump_passes=self.dump_passes,
+            dump_ptoas_passes=self.dump_ptoas_passes,
+            profiling=self.compile_profiling,
+            diagnostic_phase=self.diagnostic_phase,
+            disabled_diagnostics=self.disabled_diagnostics,
+            analyze_auto_scopes_for_deps=self.analyze_auto_scopes_for_deps,
+            output_dir=self.save_kernels_dir,
+            memory_planner=self.memory_planner,
+            distributed_config=self.distributed_config,
+        )
+
+    def run_options(self) -> "RunOptions":
+        """Return the dispatch-side half as a :class:`RunOptions`."""
+        return RunOptions(
+            platform=self.platform,
+            device_id=self.device_id,
+            aicpu_thread_num=self.aicpu_thread_num,
+            ring_task_window=self.ring_task_window,
+            ring_heap=self.ring_heap,
+            ring_dep_pool=self.ring_dep_pool,
+            dfx=self.dfx_options(),
+        )
+
+    def dfx_options(self) -> "DfxOptions":
+        """Return the diagnostic toggles as a :class:`DfxOptions`.
+
+        Shorthand for ``run_options().dfx`` — the runtime asks for the
+        diagnostics alone far more often than for the whole dispatch half.
+        """
+        return DfxOptions(
+            enable_chip_swimlane=self.enable_chip_swimlane,
+            enable_dump_args=self.enable_dump_args,
+            enable_pmu=self.enable_pmu,
+            enable_dep_gen=self.enable_dep_gen,
+            enable_scope_stats=self.enable_scope_stats,
+        )
 
     @property
     def enable_l2_swimlane(self) -> int:
@@ -626,12 +651,18 @@ class RunResult:
 
 
 # ---------------------------------------------------------------------------
-# Internal helpers
+# Option objects
+#
+# The three concerns :class:`RunConfig` aggregates, each as a value of its own:
+# what compilation reads, what a dispatch reads, and which diagnostics a
+# dispatch collects. ``RunConfig`` keeps every field and every caller — these
+# are the vocabulary underneath it, and what code that only needs one half
+# should take. See ``docs/en/dev/08-entry-points.md``.
 # ---------------------------------------------------------------------------
 
 
 @dataclass(frozen=True)
-class _DfxOpts:
+class DfxOptions:
     """Bundle of runtime DFX toggles passed through the execute pipeline.
 
     Each field maps to a ``CallConfig`` member on the runtime side. The public
@@ -666,21 +697,94 @@ class _DfxOpts:
             or self.enable_scope_stats
         )
 
-    @classmethod
-    def from_run_config(cls, cfg: "RunConfig") -> "_DfxOpts":
-        return cls(
-            enable_chip_swimlane=cfg.enable_chip_swimlane,
-            enable_dump_args=cfg.enable_dump_args,
-            enable_pmu=cfg.enable_pmu,
-            enable_dep_gen=cfg.enable_dep_gen,
-            enable_scope_stats=cfg.enable_scope_stats,
-        )
+
+@dataclass(frozen=True)
+class RunOptions:
+    """What a dispatch reads: where it runs, how big its rings are, what it collects.
+
+    Everything here is per-launch. Nothing here reaches compilation — an
+    artifact compiled once can be dispatched under any number of these.
+
+    ``platform`` appears in both halves because it is genuinely two decisions
+    that must agree: the target codegen builds for, and the device the worker
+    opens. A worker rejects an artifact whose platform differs from its own.
+    """
+
+    platform: str = "a2a3sim"
+    device_id: int = 0
+    aicpu_thread_num: int | None = None
+    # Scalar (broadcast to every scope-depth ring) or a list of ``_RING_DEPTH``
+    # ints sizing rings 0..3; a 0 entry leaves that ring at its default.
+    ring_task_window: int | list[int] | tuple[int, ...] | None = None
+    ring_heap: int | list[int] | tuple[int, ...] | None = None
+    ring_dep_pool: int | list[int] | tuple[int, ...] | None = None
+    dfx: DfxOptions = DfxOptions()
+
+
+@dataclass(frozen=True)
+class CompileOptions:
+    """What compilation reads, in ``ir.compile``'s own vocabulary.
+
+    The typed form of :meth:`RunConfig.compile_kwargs`. A caller that only
+    compiles needs this and not a :class:`RunConfig`::
+
+        from pypto import ir
+        from pypto.runtime import CompileOptions
+
+        compiled = ir.compile(program, **CompileOptions(platform="a2a3").as_compile_kwargs())
+
+    Field names are ``ir.compile``'s, not ``RunConfig``'s: what ``RunConfig``
+    spells ``save_kernels_dir`` and ``compile_profiling`` are ``output_dir`` and
+    ``profiling`` here, because this object exists to name the compile side as
+    the compiler names it.
+    """
+
+    platform: str = "a2a3sim"
+    backend_type: BackendType = field(default_factory=lambda: BackendType.Ascend910B)
+    strategy: OptimizationStrategy = field(default_factory=lambda: OptimizationStrategy.Default)
+    dump_passes: bool | PassDumpLevel = False
+    dump_ptoas_passes: bool = False
+    profiling: bool = False
+    diagnostic_phase: DiagnosticPhase | None = None
+    disabled_diagnostics: DiagnosticCheckSet | None = None
+    analyze_auto_scopes_for_deps: bool = False
+    # Absent rather than ``None`` in ``as_compile_kwargs`` when unset, so
+    # ``ir.compile``'s own default applies. That is load-bearing for
+    # ``memory_planner``: an explicit one is rejected while a ``PassContext`` is
+    # active, so an unset planner has to defer to that context.
+    output_dir: str | None = None
+    memory_planner: MemoryPlanner | None = None
+    distributed_config: "DistributedConfig | None" = None
+
+    def as_compile_kwargs(self) -> dict[str, Any]:
+        """Return these options as :func:`pypto.ir.compile` keyword arguments."""
+        kwargs: dict[str, Any] = {
+            "platform": self.platform,
+            "backend_type": self.backend_type,
+            "strategy": self.strategy,
+            "dump_passes": self.dump_passes,
+            "dump_ptoas_passes": self.dump_ptoas_passes,
+            "profiling": self.profiling,
+            "diagnostic_phase": self.diagnostic_phase,
+            "disabled_diagnostics": self.disabled_diagnostics,
+            "analyze_auto_scopes_for_deps": self.analyze_auto_scopes_for_deps,
+        }
+        for name in ("output_dir", "memory_planner", "distributed_config"):
+            value = getattr(self, name)
+            if value is not None:
+                kwargs[name] = value
+        return kwargs
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
 
 
 def _execute_dfx_passes(
-    run_pass: Callable[["_DfxOpts"], None],
+    run_pass: Callable[["DfxOptions"], None],
     capture_deps: Callable[[], None],
-    dfx: "_DfxOpts",
+    dfx: "DfxOptions",
     platform: str,
 ) -> None:
     """Drive device execution, splitting into two passes when swimlane is on.
@@ -899,26 +1003,27 @@ def _coerced_to_orch_args(
     return orch_args
 
 
-def _apply_ring_overrides(call_config: Any, run_config: "RunConfig") -> None:
-    """Overlay a :class:`RunConfig`'s per-task ring sizing onto a ``CallConfig``.
+def _apply_ring_overrides(call_config: Any, run_config: "RunConfig | RunOptions") -> None:
+    """Overlay per-task ring sizing onto a ``CallConfig``.
 
     Each ``runtime_env`` field is left at its ``0`` default when the matching
-    ``RunConfig`` override is ``None``, so the runtime applies its own
-    compile-time default. Shared by the L2
-    (:func:`_build_call_config`) and L3
+    override is ``None``, so the runtime applies its own compile-time default.
+    Shared by the L2 (:func:`_build_call_config`) and L3
     (:func:`pypto.runtime.distributed_runner._make_call_config`) dispatch paths
     so both transcribe ring sizing identically.
 
     Args:
         call_config: A simpler ``CallConfig`` (mutated in place).
-        run_config: The :class:`RunConfig` whose ``ring_*`` overrides are copied.
+        run_config: A :class:`RunOptions`, or a :class:`RunConfig` to read one
+            from. The three ``ring_*`` fields are spelled the same on both.
     """
-    if run_config.ring_task_window is not None:
-        call_config.runtime_env.ring_task_window = run_config.ring_task_window
-    if run_config.ring_heap is not None:
-        call_config.runtime_env.ring_heap = run_config.ring_heap
-    if run_config.ring_dep_pool is not None:
-        call_config.runtime_env.ring_dep_pool = run_config.ring_dep_pool
+    options = run_config.run_options() if isinstance(run_config, RunConfig) else run_config
+    if options.ring_task_window is not None:
+        call_config.runtime_env.ring_task_window = options.ring_task_window
+    if options.ring_heap is not None:
+        call_config.runtime_env.ring_heap = options.ring_heap
+    if options.ring_dep_pool is not None:
+        call_config.runtime_env.ring_dep_pool = options.ring_dep_pool
 
 
 def _build_call_config(
@@ -945,23 +1050,25 @@ def _build_call_config(
     )
 
     cfg = CallConfig()
+    options = run_config.run_options()
 
-    at = aicpu_thread_num_override if aicpu_thread_num_override is not None else run_config.aicpu_thread_num
+    at = aicpu_thread_num_override if aicpu_thread_num_override is not None else options.aicpu_thread_num
     at = at if at is not None else runtime_config.get("aicpu_thread_num")
     if at is not None:
         cfg.aicpu_thread_num = at
 
     # Already a normalized collection level (0-4), so it lands on the runtime's
     # ``int32_t`` field verbatim rather than through the setter's bool shortcut.
-    cfg.enable_chip_swimlane = run_config.enable_chip_swimlane
-    cfg.enable_dump_args = run_config.enable_dump_args
-    cfg.enable_pmu = run_config.enable_pmu
-    cfg.enable_dep_gen = run_config.enable_dep_gen
-    cfg.enable_scope_stats = run_config.enable_scope_stats
+    dfx = options.dfx
+    cfg.enable_chip_swimlane = dfx.enable_chip_swimlane
+    cfg.enable_dump_args = dfx.enable_dump_args
+    cfg.enable_pmu = dfx.enable_pmu
+    cfg.enable_dep_gen = dfx.enable_dep_gen
+    cfg.enable_scope_stats = dfx.enable_scope_stats
 
     # Per-task ring sizing: leave the runtime_env field at its 0 default when
     # unset so the runtime applies its own compile-time default.
-    _apply_ring_overrides(cfg, run_config)
+    _apply_ring_overrides(cfg, options)
 
     if dfx_dir is not None:
         cfg.output_prefix = str(dfx_dir)
@@ -975,7 +1082,7 @@ def _execute_golden_case(
     runtime_name: str,
     platform: str,
     device_id: int,
-    dfx: _DfxOpts = _DfxOpts(),
+    dfx: DfxOptions = DfxOptions(),
     validate: bool = True,
     actual_out_dir: "Path | None" = None,
     enable_sdma: bool = False,
@@ -1031,7 +1138,7 @@ def _execute_golden_case(
         dfx_dir = work_dir / "dfx_outputs"
         dfx_dir.mkdir(parents=True, exist_ok=True)
 
-    def _run_pass(pass_dfx: "_DfxOpts") -> None:
+    def _run_pass(pass_dfx: "DfxOptions") -> None:
         _execute_on_device(
             chip_callable,
             orch_args,
@@ -1126,7 +1233,7 @@ def validate_persisted_outputs(work_dir: Path, rtol: float, atol: float) -> None
 def _collect_dfx_artifacts(
     dfx_dir: Path,
     platform: str,
-    dfx: "_DfxOpts",
+    dfx: "DfxOptions",
 ) -> None:
     """Dispatch post-run DFX converters per enabled flag.
 
@@ -1335,7 +1442,7 @@ def _execute_compiled(  # noqa: PLR0913
     *,
     platform: str,
     device_id: int,
-    dfx: _DfxOpts = _DfxOpts(),
+    dfx: DfxOptions = DfxOptions(),
     level: int = 2,
     aicpu_thread_num: int | None = None,
     analyze_auto_scopes_for_deps: bool = False,
@@ -1416,7 +1523,7 @@ def _execute_compiled(  # noqa: PLR0913
         dfx_dir = work_dir / "dfx_outputs"
         dfx_dir.mkdir(parents=True, exist_ok=True)
 
-    def _run_pass(pass_dfx: "_DfxOpts") -> None:
+    def _run_pass(pass_dfx: "DfxOptions") -> None:
         _execute_on_device(
             chip_callable,
             args,
@@ -1487,7 +1594,7 @@ def execute_compiled(  # noqa: PLR0913
     *,
     platform: str,
     device_id: int,
-    dfx: _DfxOpts = _DfxOpts(),
+    dfx: DfxOptions = DfxOptions(),
     level: int = 2,
     aicpu_thread_num: int | None = None,
     analyze_auto_scopes_for_deps: bool = False,

--- a/python/pypto/runtime/runner.py
+++ b/python/pypto/runtime/runner.py
@@ -489,6 +489,11 @@ class RunConfig:
             compiled = ir.compile(program, **config.compile_kwargs())
             compiled(*tensors, config=config)
 
+        It is the only mapping onto ``ir.compile``'s parameters: the ``@pl.jit``
+        path calls it too, so a knob added here reaches both. (``lower()`` keeps
+        its own narrower mapping — it stops before codegen and targets the pass
+        pipeline rather than ``ir.compile``.)
+
         Dispatch-only fields (``device_id``, the DFX toggles, the ring-sizing
         overrides) are not compile inputs and are consumed by
         :meth:`~pypto.ir.CompiledProgram.__call__` instead. ``rtol`` / ``atol``

--- a/python/pypto/runtime/runner.py
+++ b/python/pypto/runtime/runner.py
@@ -178,10 +178,12 @@ class RunConfig:
         platform: Target execution platform — ``"a2a3sim"`` / ``"a2a3"``
             (Ascend 910B) or ``"a5sim"`` / ``"a5"`` (Ascend 950).
         device_id: Hardware device index (ignored for simulator).
+        backend_type: **Derived, not an input.** Set from ``platform`` during
+            construction; supplying one that disagrees warns and is discarded.
+            Read it to learn which backend a platform selected.
         rtol: Relative tolerance for result comparison.
         atol: Absolute tolerance for result comparison.
         strategy: PyPTO optimisation strategy applied during compilation.
-        backend_type: Code-generation backend (:attr:`BackendType.Ascend910B` by default).
         dump_passes: Per-pass IR dump control. A :class:`~pypto.ir.PassDumpLevel`
             (``NONE`` / ``CONCISE`` / ``EXPLICIT``) or a ``bool``
             (``True`` -> ``CONCISE``, ``False`` -> ``NONE``). ``EXPLICIT`` resolves
@@ -341,7 +343,9 @@ class RunConfig:
     rtol: float = 1e-5
     atol: float = 1e-5
     strategy: OptimizationStrategy = field(default_factory=lambda: OptimizationStrategy.Default)
-    backend_type: BackendType = field(default_factory=lambda: BackendType.Ascend910B)
+    # Derived from ``platform`` in ``__post_init__``; ``None`` means "not supplied".
+    # Typed as the concrete enum because every reader sees it after that runs.
+    backend_type: BackendType = None  # type: ignore[assignment]
     dump_passes: bool | PassDumpLevel = False
     save_kernels: bool = False
     save_kernels_dir: str | None = None
@@ -377,14 +381,20 @@ class RunConfig:
             raise ValueError(
                 f"Invalid platform {self.platform!r}. Expected 'a2a3sim', 'a2a3', 'a5sim', or 'a5'."
             )
-        # A caller-provided platform is the public source of truth for runtime
-        # toolchain selection. Keep backend_type synchronized with it so codegen
-        # and execution target the same architecture, rather than silently
-        # rewriting the requested platform back to the default backend.
-        if self.platform.startswith("a5"):
-            self.backend_type = BackendType.Ascend950
-        else:
-            self.backend_type = BackendType.Ascend910B
+        # ``platform`` is the single source of truth for the target: it selects
+        # both the codegen backend and the runtime toolchain, and they must
+        # agree. ``backend_type`` is therefore derived, never an input -- a
+        # supplied one has always been discarded here, silently. Say so instead.
+        derived = BackendType.Ascend950 if self.platform.startswith("a5") else BackendType.Ascend910B
+        if self.backend_type is not None and self.backend_type != derived:
+            warnings.warn(
+                f"RunConfig(backend_type={self.backend_type!r}) is ignored: the backend is derived "
+                f"from platform={self.platform!r}, which selects {derived!r}. Drop the argument, or "
+                f"pass the platform that implies the backend you want.",
+                DeprecationWarning,
+                stacklevel=3,
+            )
+        self.backend_type = derived
 
         backend = _backend_core.get_backend_instance(self.backend_type)
         expected_arch = backend.get_handler().get_pto_target_arch()
@@ -514,7 +524,6 @@ class RunConfig:
         """
         return CompileOptions(
             platform=self.platform,
-            backend_type=self.backend_type,
             strategy=self.strategy,
             dump_passes=self.dump_passes,
             dump_ptoas_passes=self.dump_ptoas_passes,
@@ -745,10 +754,16 @@ class CompileOptions:
     spells ``save_kernels_dir`` and ``compile_profiling`` are ``output_dir`` and
     ``profiling`` here, because this object exists to name the compile side as
     the compiler names it.
+
+    ``platform`` is the only way to name the target. ``ir.compile`` also takes a
+    ``backend_type``, but derives it from ``platform`` whenever one is given, so
+    carrying both here would offer a pairing that cannot take effect: set them
+    to disagree and the platform silently wins. ``ir.compile`` keeps its
+    parameter for callers that pass no platform at all; this object always
+    passes one.
     """
 
     platform: str = "a2a3sim"
-    backend_type: BackendType = field(default_factory=lambda: BackendType.Ascend910B)
     strategy: OptimizationStrategy = field(default_factory=lambda: OptimizationStrategy.Default)
     dump_passes: bool | PassDumpLevel = False
     dump_ptoas_passes: bool = False
@@ -768,7 +783,6 @@ class CompileOptions:
         """Return these options as :func:`pypto.ir.compile` keyword arguments."""
         kwargs: dict[str, Any] = {
             "platform": self.platform,
-            "backend_type": self.backend_type,
             "strategy": self.strategy,
             "dump_passes": self.dump_passes,
             "dump_ptoas_passes": self.dump_ptoas_passes,

--- a/python/pypto/runtime/worker.py
+++ b/python/pypto/runtime/worker.py
@@ -590,9 +590,9 @@ class ChipWorker(Worker):
         self._run_chip(compiled.chip_callable, orch_args, cfg)
 
         if dfx_dir is not None:
-            from .runner import _collect_dfx_artifacts, _DfxOpts  # noqa: PLC0415
+            from .runner import _collect_dfx_artifacts  # noqa: PLC0415
 
-            _collect_dfx_artifacts(dfx_dir, self.platform, _DfxOpts.from_run_config(rc))
+            _collect_dfx_artifacts(dfx_dir, self.platform, rc.dfx_options())
 
         if not return_style:
             return None

--- a/tests/st/harness/core/test_runner.py
+++ b/tests/st/harness/core/test_runner.py
@@ -55,9 +55,9 @@ from pypto.runtime.golden_writer import (
     generate_golden_source,
 )
 from pypto.runtime.runner import (
+    DfxOptions,
     RunConfig,
     RunResult,
-    _DfxOpts,
     _execute_golden_case,
     validate_persisted_outputs,
 )
@@ -525,7 +525,7 @@ def _fused_compile_task(
 _RESULT_MARKER_PREFIX = "PYPTO_EXEC_RESULT"
 
 
-def _dfx_to_cli(dfx: "_DfxOpts") -> list[str]:
+def _dfx_to_cli(dfx: "DfxOptions") -> list[str]:
     """Inverse of ``execute_artifact`` DFX arg parsing.
 
     Emits only the flags whose value differs from the off-default, so a plain
@@ -648,7 +648,7 @@ def _shell_quote_run(project_root: Path, inner: "list[str]") -> str:
     )
 
 
-def _build_execute_artifact_cmd(mode_args: "list[str]", dfx: "_DfxOpts") -> list[str]:
+def _build_execute_artifact_cmd(mode_args: "list[str]", dfx: "DfxOptions") -> list[str]:
     """Assemble the ``python -m pypto.runtime.execute_artifact`` child argv.
 
     *mode_args* selects single (``--work-dir`` / ``--platform``) vs batch
@@ -725,7 +725,7 @@ def _exec_task_submit(
 def _run_artifact_via_task_submit(
     work_dir: Path,
     platform: str,
-    dfx: "_DfxOpts",
+    dfx: "DfxOptions",
     max_time: int,
     queue_timeout: int,
     device: str = "auto",
@@ -753,7 +753,7 @@ def _run_batch_via_task_submit(
     entries: "list[tuple[Path, str]]",
     manifest_path: Path,
     device: str,
-    dfx: "_DfxOpts",
+    dfx: "DfxOptions",
     max_time: int,
     queue_timeout: int,
 ) -> "dict[str, tuple[bool, str | None, int | None]]":
@@ -908,7 +908,7 @@ def _fused_execute_task(
             artifact.runtime_name,
             artifact.resolved_platform,
             device_id,
-            dfx=_pipeline_ctx.get("dfx", _DfxOpts()),
+            dfx=_pipeline_ctx.get("dfx", DfxOptions()),
             enable_sdma=artifact.enable_sdma,
         )
         return RunResult(
@@ -986,7 +986,7 @@ def _batch_submitter(batch_size: int, cache_dir: Path) -> None:
     try:
         assert _execute_pool is not None, "execute pool not initialised"
         device = _pipeline_ctx.get("task_submit_device", "auto")
-        dfx = _pipeline_ctx.get("dfx", _DfxOpts())
+        dfx = _pipeline_ctx.get("dfx", DfxOptions())
         max_time = _pipeline_ctx.get("task_max_time", 600)
         queue_timeout = _pipeline_ctx.get("task_queue_timeout", 1800)
         # A 0 / negative batch size would never fill a batch (``len(pending) >= 0``
@@ -1117,7 +1117,7 @@ def start_pipeline(  # noqa: PLR0913
         "codegen_only": codegen_only,
         "analyze_auto_scopes_for_deps": analyze_auto_scopes_for_deps,
         "memory_planner": memory_planner,
-        "dfx": _DfxOpts(
+        "dfx": DfxOptions(
             enable_chip_swimlane=enable_chip_swimlane,
             enable_dump_args=enable_dump_args,
             enable_pmu=enable_pmu,
@@ -1497,7 +1497,7 @@ class TestRunner:
                 passed, error, device = _run_artifact_via_task_submit(
                     work_dir,
                     resolved_platform,
-                    _DfxOpts.from_run_config(self.config),
+                    self.config.dfx_options(),
                     _pipeline_ctx.get("task_max_time", 600),
                     _pipeline_ctx.get("task_queue_timeout", 1800),
                     _pipeline_ctx.get("task_submit_device", "auto"),
@@ -1525,7 +1525,7 @@ class TestRunner:
                 runtime_name,
                 resolved_platform,
                 self.config.device_id,
-                dfx=_DfxOpts.from_run_config(self.config),
+                dfx=self.config.dfx_options(),
                 enable_sdma=enable_sdma,
             )
 

--- a/tests/ut/ir/test_compiled_program.py
+++ b/tests/ut/ir/test_compiled_program.py
@@ -13,6 +13,7 @@ import contextlib
 import ctypes
 import json
 import os
+import pathlib
 import sys
 import types
 import warnings
@@ -677,6 +678,47 @@ class TestCompiledProgramDeviceTensor:
 
         with pytest.raises(TypeError, match="expects dtype"):
             cp(a, bad_b, c)
+
+
+class TestParamInfoIsALeaf:
+    """``pypto.ir.param_info`` must not depend on ``pypto.runtime``.
+
+    The parameter metadata used to live in ``compiled_program``, which reaches
+    forward into ``pypto.runtime``. Its consumer
+    ``pypto.runtime.debug.run_script_writer`` imports the metadata back, so the
+    two modules formed a genuine cycle: hoisting that import to module scope
+    failed with ``cannot import name 'ParamInfo' from partially initialized
+    module``. Splitting the metadata into a leaf removed the back edge. Pulling
+    a runtime import into the leaf would restore it.
+    """
+
+    def _imported_modules(self, path):
+        import ast  # noqa: PLC0415
+
+        tree = ast.parse(path.read_text())
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                yield from (alias.name for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+                yield node.module
+
+    def test_param_info_imports_nothing_from_the_runtime(self):
+        from pypto.ir import param_info  # noqa: PLC0415
+
+        source = pathlib.Path(param_info.__file__)
+        offenders = [m for m in self._imported_modules(source) if m.split(".")[:2] == ["pypto", "runtime"]]
+
+        assert offenders == []
+
+    def test_the_run_script_writer_takes_metadata_from_the_leaf(self):
+        """The consumer that closed the cycle must read the leaf, not the god-module."""
+        from pypto.runtime.debug import run_script_writer  # noqa: PLC0415
+
+        source = pathlib.Path(run_script_writer.__file__)
+        ir_imports = {m for m in self._imported_modules(source) if m.startswith("pypto.ir")}
+
+        assert "pypto.ir.param_info" in ir_imports
+        assert "pypto.ir.compiled_program" not in ir_imports
 
 
 class TestCompiledProgramExtraction:

--- a/tests/ut/jit/test_decorator.py
+++ b/tests/ut/jit/test_decorator.py
@@ -33,7 +33,6 @@ from pypto.jit.decorator import (
     _extract_tensor_meta,
     _resolve_dep_call_metadata,
     _rewrite_jit_error,
-    _run_config_compile_kwargs,
     _scan_dep_io,
     _scan_dynamic_dims,
     _SlicedArg,
@@ -2567,51 +2566,11 @@ class TestCompileKwargForwarding:
     Before this fix, ``_compile`` only forwarded ``skip_ptoas`` and
     ``platform`` — every other compile knob a user set on ``RunConfig``
     (``strategy``, ``dump_passes``, ...) was silently dropped on the JIT path.
+
+    The mapping itself is ``RunConfig.compile_kwargs`` and is tested in
+    ``tests/ut/runtime/test_run_config.py``; what these cases pin is that the
+    JIT path uses it rather than a second copy of it.
     """
-
-    def test_run_config_compile_kwargs_maps_fields(self, tmp_path):
-        """Compile-side RunConfig fields map onto the ir.compile() parameter names."""
-        artifacts_dir = tmp_path / "jit_artifacts"
-        cfg = RunConfig(
-            strategy=OptimizationStrategy.Default,
-            dump_passes=True,
-            dump_ptoas_passes=True,
-            compile_profiling=True,
-            save_kernels_dir=str(artifacts_dir),
-            analyze_auto_scopes_for_deps=True,
-        )
-        kwargs = _run_config_compile_kwargs(cfg)
-        assert kwargs["strategy"] == OptimizationStrategy.Default
-        assert kwargs["dump_passes"] is True
-        assert kwargs["dump_ptoas_passes"] is True
-        assert kwargs["profiling"] is True  # mapped from RunConfig.compile_profiling
-        assert kwargs["output_dir"] == str(artifacts_dir)  # from RunConfig.save_kernels_dir
-        assert kwargs["analyze_auto_scopes_for_deps"] is True
-        assert "diagnostic_phase" in kwargs
-        assert "disabled_diagnostics" in kwargs
-        # backend_type is derived from `platform` by ir.compile(); not forwarded.
-        assert "backend_type" not in kwargs
-
-    def test_run_config_compile_kwargs_omits_unset_output_dir(self):
-        """save_kernels_dir left unset omits output_dir so ir.compile()'s default applies."""
-        kwargs = _run_config_compile_kwargs(RunConfig())
-        assert "output_dir" not in kwargs
-
-    def test_run_config_compile_kwargs_forwards_distributed_config(self):
-        """A RunConfig.distributed_config is forwarded so @pl.jit.host kernels go distributed."""
-        from pypto.ir import DistributedConfig  # noqa: PLC0415
-
-        dc = DistributedConfig(device_ids=[0, 1])
-        kwargs = _run_config_compile_kwargs(RunConfig(distributed_config=dc))
-        # Forwarded verbatim (same object) so ir.compile() emits a
-        # DistributedCompiledProgram for the HOST-level entry.
-        assert kwargs["distributed_config"] is dc
-
-    def test_run_config_compile_kwargs_omits_unset_distributed_config(self):
-        """distributed_config left unset is omitted so ir.compile()'s single-chip default applies."""
-        kwargs = _run_config_compile_kwargs(RunConfig())
-        assert "distributed_config" not in kwargs
-        assert kwargs["analyze_auto_scopes_for_deps"] is False
 
     def test_make_cache_key_splits_on_distributed_config(self):
         """distributed_config participates in the cache key (distinct device_ids ≠ collide)."""
@@ -2815,8 +2774,7 @@ class TestCompileKwargForwarding:
             scalar_dtypes={},
             per_func_dyn={id(fwd_kernel._func): {}},
             pl=pl,
-            platform="a2a3sim",
-            **_run_config_compile_kwargs(cfg),
+            **cfg.compile_kwargs(),
         )
         assert result == "fake-compiled-program"
         assert captured["strategy"] == OptimizationStrategy.Default
@@ -2829,8 +2787,14 @@ class TestCompileKwargForwarding:
         # compile to a DistributedCompiledProgram and dispatch per-rank.
         assert captured["distributed_config"] is dc
 
-    def test_compile_without_kwargs_forwards_only_defaults(self, monkeypatch):
-        """_compile with no extra kwargs forwards only skip_ptoas + platform."""
+    def test_compile_without_kwargs_forwards_only_skip_ptoas(self, monkeypatch):
+        """_compile with no extra kwargs forwards only skip_ptoas.
+
+        ``platform`` rides in the ``RunConfig.compile_kwargs`` mapping, so with
+        no config there is nothing to forward and ``ir.compile``'s own default
+        applies — the same effective platform the old explicit ``platform=None``
+        produced.
+        """
         ir_compile_mod = importlib.import_module("pypto.ir.compile")
 
         @jit
@@ -2858,8 +2822,7 @@ class TestCompileKwargForwarding:
             per_func_dyn={id(plain_kernel._func): {}},
             pl=pl,
         )
-        assert set(captured) == {"skip_ptoas", "platform"}
-        assert captured["platform"] is None
+        assert set(captured) == {"skip_ptoas"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ut/runtime/test_deprecated_entry_points.py
+++ b/tests/ut/runtime/test_deprecated_entry_points.py
@@ -23,7 +23,6 @@ from unittest.mock import MagicMock, patch
 import pytest
 import torch
 from pypto.runtime import DeviceTensor, RunConfig, execute_compiled, execute_distributed_compiled
-from pypto.runtime.runner import _DfxOpts
 
 _L3_FROM_DIR = "pypto.ir.distributed_compiled_program.DistributedCompiledProgram.from_dir"
 
@@ -39,7 +38,7 @@ def test_execute_compiled_warns_and_forwards(tmp_path):
                 args,
                 platform="a2a3sim",
                 device_id=2,
-                dfx=_DfxOpts.from_run_config(config),
+                dfx=config.dfx_options(),
                 config=config,
             )
 

--- a/tests/ut/runtime/test_execute_artifact.py
+++ b/tests/ut/runtime/test_execute_artifact.py
@@ -20,7 +20,7 @@ import json
 from unittest.mock import MagicMock, patch
 
 import pytest
-from pypto.runtime.runner import _DfxOpts
+from pypto.runtime.runner import DfxOptions
 
 execute_artifact = importlib.import_module("pypto.runtime.execute_artifact")
 main = execute_artifact.main
@@ -104,7 +104,7 @@ def test_dfx_flags_parsed_into_dfx_opts(tmp_path):
         )
     assert rc == 0
     _, kwargs = run.call_args
-    assert kwargs["dfx"] == _DfxOpts(
+    assert kwargs["dfx"] == DfxOptions(
         enable_chip_swimlane=True,
         enable_dump_args=2,
         enable_pmu=5,
@@ -117,7 +117,7 @@ def test_plain_run_has_default_dfx(tmp_path):
     with patch.object(execute_artifact, "execute_artifact_dir") as run:
         main(_argv(tmp_path))
     _, kwargs = run.call_args
-    assert kwargs["dfx"] == _DfxOpts()
+    assert kwargs["dfx"] == DfxOptions()
     # Default (manual repro): validate in-process.
     assert kwargs["validate"] is True
 

--- a/tests/ut/runtime/test_run_config.py
+++ b/tests/ut/runtime/test_run_config.py
@@ -774,6 +774,17 @@ class TestRunConfigCompileForwarding:
         assert kwargs["platform"] == "a5sim"
         assert kwargs["backend_type"] == BackendType.Ascend950
 
+    def test_compile_kwargs_forward_distributed_config_by_identity(self):
+        """A set ``distributed_config`` is forwarded as the same object.
+
+        ``ir.compile`` bakes it into the ``DistributedCompiledProgram`` and the
+        per-rank dispatch reads it back, so a copy would let the two disagree.
+        """
+        from pypto.ir import DistributedConfig  # noqa: PLC0415
+
+        dc = DistributedConfig(device_ids=[0, 1])
+        assert RunConfig(distributed_config=dc).compile_kwargs()["distributed_config"] is dc
+
 
 # ``_execute_on_device`` lives in ``device_runner`` which eagerly imports the
 # ``simpler`` package (via ``task_interface``). Unit-tests CI runs without

--- a/tests/ut/runtime/test_run_config.py
+++ b/tests/ut/runtime/test_run_config.py
@@ -767,12 +767,36 @@ class TestRunConfigCompileForwarding:
         kwargs = stub_device_runner._execute_on_device.call_args.kwargs
         assert kwargs["enable_sdma"] is expected_enable_sdma
 
-    def test_compile_kwargs_carry_the_codegen_target(self):
-        """``platform`` and the ``backend_type`` it implies both reach compilation."""
-        kwargs = RunConfig(platform="a5sim").compile_kwargs()
+    def test_compile_kwargs_name_the_target_once(self):
+        """Only ``platform`` is forwarded; ``ir.compile`` derives the backend from it.
+
+        Forwarding both would offer a pairing that cannot take effect —
+        ``ir.compile`` lets ``platform`` win whenever one is given — so the
+        config states the target once and the compiler resolves it.
+        """
+        cfg = RunConfig(platform="a5sim")
+        kwargs = cfg.compile_kwargs()
 
         assert kwargs["platform"] == "a5sim"
-        assert kwargs["backend_type"] == BackendType.Ascend950
+        assert "backend_type" not in kwargs
+        # Still readable on the config, as the backend that platform selected.
+        assert cfg.backend_type == BackendType.Ascend950
+
+    def test_a_backend_type_that_contradicts_the_platform_warns(self):
+        """It was always discarded here; now it says so."""
+        with pytest.warns(DeprecationWarning, match=r"derived from platform='a5sim'"):
+            cfg = RunConfig(platform="a5sim", backend_type=BackendType.Ascend910B)
+
+        assert cfg.backend_type == BackendType.Ascend950
+
+    def test_a_backend_type_that_agrees_with_the_platform_is_silent(self):
+        import warnings  # noqa: PLC0415
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            cfg = RunConfig(platform="a5sim", backend_type=BackendType.Ascend950)
+
+        assert cfg.backend_type == BackendType.Ascend950
 
     def test_compile_kwargs_forward_distributed_config_by_identity(self):
         """A set ``distributed_config`` is forwarded as the same object.
@@ -793,6 +817,8 @@ class TestOptionObjects:
     # are listed; everything else keeps its name.
     _COMPILE_RENAMES = {"save_kernels_dir": "output_dir", "compile_profiling": "profiling"}
     _HARNESS_ONLY = {"rtol", "atol", "golden_data_dir", "save_kernels", "codegen_only"}
+    # Derived from ``platform`` rather than carried: no view claims it.
+    _DERIVED = {"backend_type"}
 
     def test_every_run_config_field_is_claimed_by_exactly_one_concern(self):
         """The split must stay total: a new field lands in a view, or in the harness set.
@@ -812,7 +838,7 @@ class TestOptionObjects:
             if renamed in compile_fields or name in dispatch_fields:
                 claimed.add(name)
 
-        assert run_config_fields - claimed == self._HARNESS_ONLY
+        assert run_config_fields - claimed == self._HARNESS_ONLY | self._DERIVED
 
     def test_compile_kwargs_is_the_compile_options_view(self):
         """``compile_kwargs()`` must be exactly what the typed object produces."""

--- a/tests/ut/runtime/test_run_config.py
+++ b/tests/ut/runtime/test_run_config.py
@@ -12,6 +12,7 @@
 import dataclasses
 import sys
 import types
+import warnings
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -784,10 +785,29 @@ class TestRunConfigCompileForwarding:
 
     def test_a_backend_type_that_contradicts_the_platform_warns(self):
         """It was always discarded here; now it says so."""
-        with pytest.warns(DeprecationWarning, match=r"derived from platform='a5sim'"):
+        with pytest.warns(DeprecationWarning, match=r"backend_type=\.\.\.\) is deprecated"):
             cfg = RunConfig(platform="a5sim", backend_type=BackendType.Ascend910B)
 
         assert cfg.backend_type == BackendType.Ascend950
+
+    def test_replace_can_switch_platform_without_warning(self):
+        """``backend_type`` must not be a field, or ``replace`` re-supplies a stale one.
+
+        ``dataclasses.replace`` passes every field of the existing instance back
+        to ``__init__``. As a field, ``backend_type`` would arrive holding the
+        *old* platform's backend, indistinguishable from a caller who typed a
+        contradicting value — so switching platform would warn, and raise under
+        warnings-as-errors.
+        """
+        assert "backend_type" not in {f.name for f in dataclasses.fields(RunConfig)}
+
+        cfg = RunConfig(platform="a2a3")
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            switched = dataclasses.replace(cfg, platform="a5")
+
+        assert switched.platform == "a5"
+        assert switched.backend_type == BackendType.Ascend950
 
     def test_a_backend_type_that_agrees_with_the_platform_is_silent(self):
         import warnings  # noqa: PLC0415
@@ -817,8 +837,6 @@ class TestOptionObjects:
     # are listed; everything else keeps its name.
     _COMPILE_RENAMES = {"save_kernels_dir": "output_dir", "compile_profiling": "profiling"}
     _HARNESS_ONLY = {"rtol", "atol", "golden_data_dir", "save_kernels", "codegen_only"}
-    # Derived from ``platform`` rather than carried: no view claims it.
-    _DERIVED = {"backend_type"}
 
     def test_every_run_config_field_is_claimed_by_exactly_one_concern(self):
         """The split must stay total: a new field lands in a view, or in the harness set.
@@ -838,7 +856,7 @@ class TestOptionObjects:
             if renamed in compile_fields or name in dispatch_fields:
                 claimed.add(name)
 
-        assert run_config_fields - claimed == self._HARNESS_ONLY | self._DERIVED
+        assert run_config_fields - claimed == self._HARNESS_ONLY
 
     def test_compile_kwargs_is_the_compile_options_view(self):
         """``compile_kwargs()`` must be exactly what the typed object produces."""

--- a/tests/ut/runtime/test_run_config.py
+++ b/tests/ut/runtime/test_run_config.py
@@ -861,6 +861,31 @@ class TestOptionObjects:
         assert options.dfx == cfg.dfx_options()
         assert options.dfx.enable_pmu == 2
 
+    def test_only_the_option_types_something_accepts_are_exported(self):
+        """An exported option type must be one a caller can actually hand somewhere.
+
+        ``CompileOptions`` unpacks into ``ir.compile`` and ``DfxOptions`` is the
+        ``dfx=`` parameter of ``execute_compiled``. ``RunOptions`` is neither:
+        every dispatch entry point takes a ``RunConfig`` and calls
+        ``run_options()`` itself, so handing one in raises ``AttributeError``.
+        Exporting it would advertise an entry point that does not exist.
+        """
+        import inspect  # noqa: PLC0415
+
+        from pypto import runtime  # noqa: PLC0415
+
+        assert "CompileOptions" in runtime.__all__
+        assert "DfxOptions" in runtime.__all__
+        assert isinstance(inspect.signature(runtime.execute_compiled).parameters["dfx"].default, DfxOptions)
+
+        assert "RunOptions" not in runtime.__all__
+        assert not hasattr(runtime, "RunOptions")
+
+    def test_dispatch_still_requires_a_run_config(self):
+        """Records why ``RunOptions`` stays internal: the dispatch path calls back into it."""
+        with pytest.raises(AttributeError, match="dfx_options"):
+            RunOptions(platform="a2a3sim").dfx_options()  # pyright: ignore[reportAttributeAccessIssue]
+
     def test_any_dfx_enabled_agrees_with_the_dfx_view(self):
         """One predicate, not two: the aggregate answers through the view."""
         for cfg in (RunConfig(), RunConfig(enable_scope_stats=True), RunConfig(enable_chip_swimlane=True)):

--- a/tests/ut/runtime/test_run_config.py
+++ b/tests/ut/runtime/test_run_config.py
@@ -17,7 +17,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from pypto.backend import BackendType
 from pypto.pypto_core.passes import MemoryPlanner
-from pypto.runtime.runner import RunConfig, _DfxOpts, _execute_compiled
+from pypto.runtime.runner import CompileOptions, DfxOptions, RunConfig, RunOptions, _execute_compiled
 
 
 class TestRunConfigPlatformResolution:
@@ -136,11 +136,11 @@ class TestRunConfigDfxFlags:
             RunConfig(platform="a5", enable_chip_swimlane="full")  # pyright: ignore[reportArgumentType]
 
     def test_dfx_opts_normalizes_swimlane_bool(self):
-        # _DfxOpts is constructed directly by the harness and by the CLI, so it
+        # DfxOptions is constructed directly by the harness and by the CLI, so it
         # normalizes too — _dfx_to_cli stringifies this field.
-        assert _DfxOpts(enable_chip_swimlane=True).enable_chip_swimlane == 4
-        assert _DfxOpts(enable_chip_swimlane=2).enable_chip_swimlane == 2
-        assert _DfxOpts(enable_chip_swimlane=0).any() is False
+        assert DfxOptions(enable_chip_swimlane=True).enable_chip_swimlane == 4
+        assert DfxOptions(enable_chip_swimlane=2).enable_chip_swimlane == 2
+        assert DfxOptions(enable_chip_swimlane=0).any() is False
 
     def test_dfx_flags_are_independent(self):
         # Enabling one flag must not implicitly enable another.
@@ -163,7 +163,7 @@ class TestRunConfigDfxFlags:
         assert cfg.enable_pmu == 0
         assert cfg.enable_dep_gen is False
 
-    def test_dfx_opts_from_run_config_carries_all_five(self):
+    def test_dfx_options_carry_all_five(self):
         cfg = RunConfig(
             platform="a5",
             enable_chip_swimlane=True,
@@ -172,7 +172,7 @@ class TestRunConfigDfxFlags:
             enable_dep_gen=True,
             enable_scope_stats=True,
         )
-        opts = _DfxOpts.from_run_config(cfg)
+        opts = cfg.dfx_options()
         assert opts.enable_chip_swimlane == 4  # True normalizes to the full level
         assert opts.enable_dump_args == 2
         assert opts.enable_pmu == 2
@@ -181,11 +181,11 @@ class TestRunConfigDfxFlags:
         assert opts.any() is True
 
     def test_dfx_opts_any_true_for_scope_stats_only(self):
-        # _DfxOpts.any() must report True when scope_stats is the sole flag.
-        assert _DfxOpts(enable_scope_stats=True).any() is True
+        # DfxOptions.any() must report True when scope_stats is the sole flag.
+        assert DfxOptions(enable_scope_stats=True).any() is True
 
     def test_dfx_opts_any_false_when_all_off(self):
-        assert _DfxOpts().any() is False
+        assert DfxOptions().any() is False
 
 
 class TestSwimlaneAliasDeprecation:
@@ -730,7 +730,7 @@ class TestRunConfigCompileForwarding:
             [],
             platform="a2a3",
             device_id=0,
-            dfx=_DfxOpts(enable_chip_swimlane=True),
+            dfx=DfxOptions(enable_chip_swimlane=True),
             config=config,
         )
 
@@ -784,6 +784,87 @@ class TestRunConfigCompileForwarding:
 
         dc = DistributedConfig(device_ids=[0, 1])
         assert RunConfig(distributed_config=dc).compile_kwargs()["distributed_config"] is dc
+
+
+class TestOptionObjects:
+    """``RunConfig`` as an aggregate of ``CompileOptions`` / ``RunOptions`` / ``DfxOptions``."""
+
+    # RunConfig field -> the option-object field it becomes. Only the renames
+    # are listed; everything else keeps its name.
+    _COMPILE_RENAMES = {"save_kernels_dir": "output_dir", "compile_profiling": "profiling"}
+    _HARNESS_ONLY = {"rtol", "atol", "golden_data_dir", "save_kernels", "codegen_only"}
+
+    def test_every_run_config_field_is_claimed_by_exactly_one_concern(self):
+        """The split must stay total: a new field lands in a view, or in the harness set.
+
+        Without this, adding a field to ``RunConfig`` silently leaves it out of
+        both views — readable through the aggregate, invisible to any caller
+        that took the half it belongs to.
+        """
+        run_config_fields = {f.name for f in dataclasses.fields(RunConfig)}
+        compile_fields = {f.name for f in dataclasses.fields(CompileOptions)}
+        dispatch_fields = {f.name for f in dataclasses.fields(RunOptions) if f.name != "dfx"}
+        dispatch_fields |= {f.name for f in dataclasses.fields(DfxOptions)}
+
+        claimed = set()
+        for name in run_config_fields:
+            renamed = self._COMPILE_RENAMES.get(name, name)
+            if renamed in compile_fields or name in dispatch_fields:
+                claimed.add(name)
+
+        assert run_config_fields - claimed == self._HARNESS_ONLY
+
+    def test_compile_kwargs_is_the_compile_options_view(self):
+        """``compile_kwargs()`` must be exactly what the typed object produces."""
+        cfg = RunConfig(
+            platform="a5sim",
+            save_kernels_dir="/tmp/pypto-options",
+            compile_profiling=True,
+            memory_planner=MemoryPlanner.DSA_RP,
+        )
+        assert cfg.compile_kwargs() == cfg.compile_options().as_compile_kwargs()
+
+    def test_compile_options_use_the_compilers_field_names(self):
+        """``save_kernels_dir`` / ``compile_profiling`` are ``ir.compile``'s names here."""
+        options = RunConfig(save_kernels_dir="/tmp/pypto-options", compile_profiling=True).compile_options()
+
+        assert options.output_dir == "/tmp/pypto-options"
+        assert options.profiling is True
+
+    def test_compile_options_stand_alone_without_a_run_config(self):
+        """A caller that only compiles needs no ``RunConfig``."""
+        import inspect  # noqa: PLC0415
+
+        from pypto import ir  # noqa: PLC0415
+
+        kwargs = CompileOptions(platform="a5sim").as_compile_kwargs()
+
+        assert set(kwargs) <= set(inspect.signature(ir.compile).parameters)
+        assert kwargs["platform"] == "a5sim"
+        # Unset optionals stay absent so ir.compile's own defaults apply.
+        assert "memory_planner" not in kwargs
+        assert "output_dir" not in kwargs
+        assert "distributed_config" not in kwargs
+
+    def test_run_options_carry_the_dispatch_half_with_dfx_nested(self):
+        cfg = RunConfig(
+            platform="a2a3",
+            device_id=3,
+            aicpu_thread_num=7,
+            ring_heap=1024 * 1024,
+            enable_pmu=2,
+        )
+        options = cfg.run_options()
+
+        assert (options.platform, options.device_id, options.aicpu_thread_num) == ("a2a3", 3, 7)
+        assert options.ring_heap == 1024 * 1024
+        assert options.dfx == cfg.dfx_options()
+        assert options.dfx.enable_pmu == 2
+
+    def test_any_dfx_enabled_agrees_with_the_dfx_view(self):
+        """One predicate, not two: the aggregate answers through the view."""
+        for cfg in (RunConfig(), RunConfig(enable_scope_stats=True), RunConfig(enable_chip_swimlane=True)):
+            assert cfg.any_dfx_enabled() == cfg.dfx_options().any()
 
 
 # ``_execute_on_device`` lives in ``device_runner`` which eagerly imports the

--- a/tests/ut/runtime/test_swimlane_two_pass.py
+++ b/tests/ut/runtime/test_swimlane_two_pass.py
@@ -26,20 +26,20 @@ import pytest
 import torch
 from pypto.runtime import _dep_gen_capture
 from pypto.runtime.device_tensor import DeviceTensor
-from pypto.runtime.runner import _build_args_spec, _DfxOpts, _execute_dfx_passes, _generate_swimlane
+from pypto.runtime.runner import DfxOptions, _build_args_spec, _execute_dfx_passes, _generate_swimlane
 
 
-def _drive(dfx: _DfxOpts, platform: str) -> tuple[list[_DfxOpts], int]:
+def _drive(dfx: DfxOptions, platform: str) -> tuple[list[DfxOptions], int]:
     """Run the helper with stubs that record each in-process pass and capture.
 
     Returns ``(in_process_passes, capture_calls)``. ``_execute_dfx_passes``
     returns ``None`` (per-run timing is no longer a return value — simpler PR
     #1177); the protocol it drives is asserted via the recorded passes/captures.
     """
-    seen: list[_DfxOpts] = []
+    seen: list[DfxOptions] = []
     captures = {"n": 0}
 
-    def run_pass(pass_dfx: _DfxOpts) -> None:
+    def run_pass(pass_dfx: DfxOptions) -> None:
         seen.append(pass_dfx)
 
     def capture_deps() -> None:
@@ -50,7 +50,7 @@ def _drive(dfx: _DfxOpts, platform: str) -> tuple[list[_DfxOpts], int]:
 
 
 def test_onboard_swimlane_captures_deps_then_times_in_process():
-    seen, captures = _drive(_DfxOpts(enable_chip_swimlane=True), "a2a3")
+    seen, captures = _drive(DfxOptions(enable_chip_swimlane=True), "a2a3")
     # deps captured once (subprocess), one in-process timing pass.
     assert captures == 1
     assert len(seen) == 1
@@ -62,7 +62,7 @@ def test_onboard_swimlane_captures_deps_then_times_in_process():
 def test_onboard_swimlane_preserves_requested_level():
     # Regression (issue #2385): the two-pass split must carry the requested
     # collection level through to the timing pass, not re-derive an on/off flag.
-    seen, captures = _drive(_DfxOpts(enable_chip_swimlane=2), "a2a3")
+    seen, captures = _drive(DfxOptions(enable_chip_swimlane=2), "a2a3")
     assert captures == 1
     assert len(seen) == 1
     assert seen[0].enable_chip_swimlane == 2
@@ -72,7 +72,7 @@ def test_onboard_swimlane_preserves_requested_level():
 def test_onboard_swimlane_with_explicit_dep_gen_still_one_capture():
     # An explicit --enable-dep-gen alongside swimlane must NOT add an in-process
     # dep_gen run: the subprocess capture already produced deps.json.
-    seen, captures = _drive(_DfxOpts(enable_chip_swimlane=True, enable_dep_gen=True), "a2a3")
+    seen, captures = _drive(DfxOptions(enable_chip_swimlane=True, enable_dep_gen=True), "a2a3")
     assert captures == 1
     assert len(seen) == 1
     assert seen[0].enable_chip_swimlane == 4 and seen[0].enable_dep_gen is False
@@ -81,7 +81,7 @@ def test_onboard_swimlane_with_explicit_dep_gen_still_one_capture():
 def test_onboard_swimlane_timing_dfx_ride_the_in_process_pass():
     # PMU / args-dump / scope-stats are timing-sensitive: they ride the clean
     # in-process timing pass (the subprocess capture is dep_gen-only).
-    dfx = _DfxOpts(
+    dfx = DfxOptions(
         enable_chip_swimlane=True,
         enable_pmu=2,
         enable_dump_args=1,
@@ -97,7 +97,7 @@ def test_onboard_swimlane_timing_dfx_ride_the_in_process_pass():
 
 
 def test_only_dep_gen_is_single_pass_no_capture():
-    seen, captures = _drive(_DfxOpts(enable_dep_gen=True), "a2a3")
+    seen, captures = _drive(DfxOptions(enable_dep_gen=True), "a2a3")
     assert captures == 0
     assert len(seen) == 1
     assert seen[0].enable_dep_gen is True
@@ -105,15 +105,15 @@ def test_only_dep_gen_is_single_pass_no_capture():
 
 
 def test_no_dfx_is_single_pass_no_capture():
-    seen, captures = _drive(_DfxOpts(), "a2a3")
+    seen, captures = _drive(DfxOptions(), "a2a3")
     assert captures == 0
     assert len(seen) == 1
-    assert seen[0] == _DfxOpts()
+    assert seen[0] == DfxOptions()
 
 
 def test_sim_swimlane_stays_single_pass_no_capture():
     # Simulator skips swimlane conversion anyway, so no capture / second run.
-    seen, captures = _drive(_DfxOpts(enable_chip_swimlane=True), "a2a3sim")
+    seen, captures = _drive(DfxOptions(enable_chip_swimlane=True), "a2a3sim")
     assert captures == 0
     assert len(seen) == 1
     assert seen[0].enable_chip_swimlane == 4

--- a/tests/ut/runtime/test_task_submit_dispatch.py
+++ b/tests/ut/runtime/test_task_submit_dispatch.py
@@ -29,7 +29,7 @@ from unittest.mock import Mock, patch
 import pytest
 from pypto.pypto_core.passes import MemoryPlanner
 from pypto.runtime import execute_artifact
-from pypto.runtime.runner import RunConfig, _DfxOpts
+from pypto.runtime.runner import DfxOptions, RunConfig
 
 _ST_DIR = Path(__file__).resolve().parents[2] / "st"
 if str(_ST_DIR) not in sys.path:
@@ -165,11 +165,11 @@ def test_inline_compile_forwards_session_memory_planner():
 
 
 def test_dfx_to_cli_empty_for_default():
-    assert test_runner._dfx_to_cli(_DfxOpts()) == []
+    assert test_runner._dfx_to_cli(DfxOptions()) == []
 
 
 def test_dfx_to_cli_emits_only_enabled_flags():
-    dfx = _DfxOpts(enable_chip_swimlane=True, enable_dump_args=2, enable_pmu=5, enable_dep_gen=True)
+    dfx = DfxOptions(enable_chip_swimlane=True, enable_dump_args=2, enable_pmu=5, enable_dep_gen=True)
     argv = test_runner._dfx_to_cli(dfx)
     assert argv == [
         "--enable-chip-swimlane",
@@ -256,7 +256,7 @@ def test_dfx_to_cli_round_trips_the_swimlane_level():
     # Regression (issue #2385): a level 1-3 capture must survive the harness ->
     # execute_artifact CLI hop instead of being flattened to the bare flag.
     for level in (1, 2, 3, 4):
-        argv = test_runner._dfx_to_cli(_DfxOpts(enable_chip_swimlane=level))
+        argv = test_runner._dfx_to_cli(DfxOptions(enable_chip_swimlane=level))
         assert argv == ["--enable-chip-swimlane", str(level)]
         # ``--device-id`` is the parser's only required argument.
         parsed = execute_artifact._build_parser().parse_args([*argv, "--device-id", "0"])
@@ -279,7 +279,7 @@ def test_parse_executed_device():
 
 
 def test_task_submit_argv_and_pass(tmp_path):
-    dfx = _DfxOpts(enable_chip_swimlane=True)
+    dfx = DfxOptions(enable_chip_swimlane=True)
     with patch.object(
         test_runner.subprocess,
         "run",
@@ -314,7 +314,7 @@ def test_task_submit_pins_device_when_requested(tmp_path):
         test_runner.subprocess, "run", return_value=_proc(0, "PYPTO_EXEC_RESULT=PASS device=2\n")
     ) as run:
         passed, _, device = test_runner._run_artifact_via_task_submit(
-            tmp_path, "a2a3", _DfxOpts(), 600, 1800, device="2"
+            tmp_path, "a2a3", DfxOptions(), 600, 1800, device="2"
         )
     assert passed is True
     assert device == 2
@@ -327,7 +327,7 @@ def test_task_submit_real_failure(tmp_path):
         test_runner.subprocess, "run", return_value=_proc(1, "PYPTO_EXEC_RESULT=FAIL\n", "Traceback: boom")
     ):
         passed, error, device = test_runner._run_artifact_via_task_submit(
-            tmp_path, "a2a3", _DfxOpts(), 600, 1800
+            tmp_path, "a2a3", DfxOptions(), 600, 1800
         )
     assert passed is False
     assert device is None
@@ -337,14 +337,18 @@ def test_task_submit_real_failure(tmp_path):
 
 def test_task_submit_queue_timeout_is_distinguished(tmp_path):
     with patch.object(test_runner.subprocess, "run", return_value=_proc(1, "", "")):
-        passed, error, _ = test_runner._run_artifact_via_task_submit(tmp_path, "a2a3", _DfxOpts(), 600, 1800)
+        passed, error, _ = test_runner._run_artifact_via_task_submit(
+            tmp_path, "a2a3", DfxOptions(), 600, 1800
+        )
     assert passed is False
     assert "queue wait timed out" in error
 
 
 def test_task_submit_watchdog_kill_is_distinguished(tmp_path):
     with patch.object(test_runner.subprocess, "run", return_value=_proc(137, "", "")):
-        passed, error, _ = test_runner._run_artifact_via_task_submit(tmp_path, "a2a3", _DfxOpts(), 600, 1800)
+        passed, error, _ = test_runner._run_artifact_via_task_submit(
+            tmp_path, "a2a3", DfxOptions(), 600, 1800
+        )
     assert passed is False
     assert "--max-time" in error
 
@@ -355,7 +359,9 @@ def test_task_submit_exec_failure(tmp_path, exc):
     # not a device test failure — with the "do not pass --execute-via-task-submit"
     # hint so the operator knows to drop the flag on this host.
     with patch.object(test_runner.subprocess, "run", side_effect=exc):
-        passed, error, _ = test_runner._run_artifact_via_task_submit(tmp_path, "a2a3", _DfxOpts(), 600, 1800)
+        passed, error, _ = test_runner._run_artifact_via_task_submit(
+            tmp_path, "a2a3", DfxOptions(), 600, 1800
+        )
     assert passed is False
     assert "do not pass --execute-via-task-submit" in error
 
@@ -432,7 +438,7 @@ def test_batch_argv_and_per_artifact_results(tmp_path):
     # wd2 fails, wd3 has no marker (process died before reaching it).
     stdout = f"PYPTO_EXEC_RESULT=PASS work_dir={wd1} device=2\nPYPTO_EXEC_RESULT=FAIL work_dir={wd2}\n"
     with patch.object(test_runner.subprocess, "run", return_value=_proc(1, stdout, "boom")) as run:
-        results = test_runner._run_batch_via_task_submit(entries, manifest, "auto", _DfxOpts(), 600, 1800)
+        results = test_runner._run_batch_via_task_submit(entries, manifest, "auto", DfxOptions(), 600, 1800)
     # manifest written + batch command shape
     assert json.loads(manifest.read_text()) == [
         {"work_dir": str(wd1), "platform": "a2a3"},
@@ -453,7 +459,7 @@ def test_batch_missing_task_submit(tmp_path):
     entries = [(tmp_path / "a@a2a3", "a2a3")]
     with patch.object(test_runner.subprocess, "run", side_effect=FileNotFoundError):
         results = test_runner._run_batch_via_task_submit(
-            entries, tmp_path / "b.json", "auto", _DfxOpts(), 600, 1800
+            entries, tmp_path / "b.json", "auto", DfxOptions(), 600, 1800
         )
     ok, error, _ = results[str(tmp_path / "a@a2a3")]
     assert ok is False


### PR DESCRIPTION
## Summary

Stages C and D from `docs/en/dev/08-entry-points.md`. Stage B landed in #2609
and #2616.

Three commits, each readable on its own.

## 1. `ir.compile` becomes keyword-only

It accepted all eighteen parameters positionally. **Nobody passes them that
way** — an AST scan over this repository's 121 `ir.compile` call sites and
pypto-lib's 4 finds not one that binds a second argument by position — but the
*possibility* was load-bearing. It made parameter order part of the contract, so
a new option could only be appended, never slotted in beside the one it belongs
with. The source said so, in the signature:

```python
    dump_ptoas_passes: bool = False,
    # Appended, not inserted: every parameter above is positional, so slotting a
    # new one in the middle would silently rebind existing positional callers.
    runtime: _passes.RuntimeKind | None = None,
```

Every option is now keyword-only; `program` stays positional. The comment goes
with the constraint it described, and the docstring says why the signature is
shaped this way. **No call site changes** — in this repo or in pypto-lib.

## 2. One `RunConfig` → `ir.compile` mapping, not two

The translation existed twice: `RunConfig.compile_kwargs()` and
`jit.decorator._run_config_compile_kwargs`, byte-identical apart from the JIT
copy omitting `platform` and `backend_type` — it forwarded the platform through
a separate `_compile(platform=...)` parameter instead. Two copies of one mapping
means a knob added to either is silently missing from the other path.

The JIT copy is deleted. `_compile` loses its `platform` parameter and the
platform rides in the mapping like every other compile-side field, which is what
makes the two paths one.

**Behaviour changes in one visible way:** `backend_type` now reaches a JIT
compile explicitly. It cannot conflict — `RunConfig.__post_init__` derives
`backend_type` from `platform`, and `ir.compile`'s `_backend_type_for_platform`
lets `platform` win regardless — so this only stops the JIT path from depending
on that fallback. With no `RunConfig` the mapping is empty and `ir.compile`'s own
defaults apply, exactly as the old explicit `platform=None` did.

`_run_config_lower_kwargs` stays. `lower()` stops before codegen and targets the
pass pipeline, not `ir.compile`, so its narrower mapping is a different thing
rather than a third copy.

## Tests

The four `_run_config_compile_kwargs` unit tests in `tests/ut/jit/test_decorator.py`
are deleted: every assertion they made is already made against `compile_kwargs()`
in `tests/ut/runtime/test_run_config.py`, which is now the mapping's only owner.
The forwarding tests that remain in the JIT file pin what is still JIT-specific —
that the path *uses* the shared mapping rather than a second copy.
`test_run_config.py` gains identity coverage for `distributed_config`, the one
assertion the deleted tests made that it did not.

## 3. `RunConfig` splits into three typed halves

`RunConfig` is 27 fields covering four unrelated concerns, and no field name says
which. `compile_kwargs()` named the compile subset as a dict; this gives all
three subsets a type.

| Type | Holds | Exported? |
| ---- | ----- | --------- |
| `CompileOptions` | What compilation reads, in `ir.compile`'s vocabulary — `output_dir`, not `save_kernels_dir`; `profiling`, not `compile_profiling`. `as_compile_kwargs()` produces the call | Yes — it unpacks into `ir.compile` |

**`platform` names the target once.** `RunConfig` has always derived `backend_type` from `platform` in `__post_init__`, and `ir.compile` lets `platform` win whenever one is given — so `RunConfig(platform="a5sim", backend_type=Ascend910B)` yields `Ascend950`, and always has. `CompileOptions` therefore carries no `backend_type`. On `RunConfig` it is a read-only property rather than a field — as a field, `dataclasses.replace(cfg, platform="a5")` re-supplies the old platform's backend and trips its own warning — with the deprecated constructor keyword handled in the same `__init__` wrapper as `enable_l2_swimlane`, warning only when the value contradicts the platform. `ir.compile` keeps its parameter for callers that pass no platform. The four in-repo `RunConfig(backend_type=...)` call sites were dead configuration and are gone.
| `DfxOptions` | The five diagnostic toggles. **Not new** — the private `_DfxOpts`, already the bundle threaded through `execute_on_device` and `CallConfig`, published under the name the concern deserves | Yes — it is `execute_compiled`'s `dfx=` parameter |
| `RunOptions` | What a dispatch reads — `platform`, `device_id`, `aicpu_thread_num`, the three `ring_*` overrides, and a nested `DfxOptions` | **No** — see below |

**`RunOptions` stays internal.** Every dispatch entry point takes a `RunConfig`
and calls `run_options()` itself, so nothing accepts one: handing it to
`CompiledProgram.__call__` reaches `config.dfx_options()` and `ChipWorker.run`
reaches `config.any_dfx_enabled()`, neither of which it has. Exporting it would
advertise an entry point that does not exist. Widening those signatures is a
migration of its own — a union type on the `config=` parameter of the primary
dispatch API — and doing it to some entry points and not others would be worse
than not doing it. Two tests pin the rule and the reason.

`platform` is in both halves on purpose: two decisions that must agree — the
target codegen builds for, and the device the worker opens.

**`RunConfig` keeps every field and all 310 construction sites** (279 here, 31 in
pypto-lib). It becomes the aggregate: the three accessors are views onto it,
`compile_kwargs()` is `compile_options().as_compile_kwargs()`, and
`any_dfx_enabled()` is `dfx_options().any()` rather than a second copy of that
predicate.

The views have real consumers rather than waiting for a migration:
`_build_call_config` and `_apply_ring_overrides` — the L2 and L3 paths that
transcribe a config onto simpler's `CallConfig` — read `RunOptions` and its
nested `DfxOptions` instead of reaching into `RunConfig` field by field, and the
ten `_DfxOpts.from_run_config(cfg)` call sites become `cfg.dfx_options()`.
`from_run_config` goes with them: with the accessor on the aggregate, a
classmethod on the part was a second way to say the same thing.

A test pins the split as **total** — every `RunConfig` field is claimed by one of
the views, or is one of the five harness-only fields (`rtol`, `atol`,
`golden_data_dir`, `save_kernels`, `codegen_only`). Without it a field added
later would be readable through the aggregate and invisible to any caller that
took the half it belongs to.

### What this deliberately does not do

Move those five fields out to the system-test harness. They reach pypto-lib's
`RunConfig(...)` calls too, so that is the same cross-repo migration
`execute_compiled` is waiting on — not a step that can land here.

## 4. Stage D: the cycle that was real, and the seven that were not

Stage D reads: invert the `ir` → `runtime` dependency, on the grounds that
`ir/compiled_program.py` carries nine function-local imports of `pypto.runtime`
"each present solely to break an import cycle".

I measured it — hoist each import to module scope, then import `pypto.ir` /
`pypto.runtime` / `pypto` / `pypto.language` / `pypto.jit` in a fresh
interpreter with the optional `simpler` package blocked. That claim is true of
**exactly one of the ten**:

| Deferred import | Hoists cleanly? | Actual reason |
| --------------- | --------------- | ------------- |
| `runtime.runner` (6 sites) | Yes | Layering choice, not a necessity |
| `runtime.distributed_runner` (2 sites) | Yes | Same |
| `runtime.debug.run_script_writer` | **No** | A real cycle |
| `runtime.device_runner` | **No** | Needs `simpler` at import time |

The real one is fixed. `run_script_writer` renders a replay script from a
program's parameters, so it imported `ParamInfo` and `_to_torch_dtype` back out
of `compiled_program` — the module that reaches forward into `pypto.runtime`.
Hoisting it failed with `cannot import name 'ParamInfo' from partially
initialized module`.

That metadata is IR-layer data with no runtime dependency, so it moves to
`ir/param_info.py`, a leaf. `run_script_writer` reads it there;
`compiled_program` re-exports all four names, so no other caller moved, and the
`ParamInfo` alias no longer sits alone at the bottom of a 1500-line module.
Hoisting that import now succeeds in all five orders. A test pins the leaf,
because pulling one runtime import back in restores the cycle.

### What this does not do

Invert the dependency. The import list is a symptom of `CompiledProgram` being
both the compilation artifact and the execution handle; the cause is that double
role. Inverting it means `CompiledProgram` stops being callable and `ir.compile`
returns a descriptor `runtime` wraps — a change to the return type of the API
every example, both test suites and pypto-lib use.

And hoisting the eight that hoist cleanly would make the coupling **stronger**:
it would put `pypto.runtime.runner` on `import pypto.ir`'s critical path. So the
module docstring and the dev doc now record what each deferral actually buys, in
place of a cycle claim that was wrong about eight of them.

## Verification

Run in the worktree against its own build, at the pushed commit.

- `pytest tests/ut/ -n 16`: 11085 passed, 8 skipped, 1 xfailed
- `tests/lint/check_*.py` (12 scripts): all pass
- `ruff check` / `ruff format --check` (pinned 0.14.8): clean
- `pyright python/pypto tests examples`: only the two pre-existing
  `torch.float4_e2m1fn_x2` errors, from this machine's older torch rather than
  CI's pinned 2.8.0
- `markdownlint-cli2 v0.20.0` on the changed pages: 0 errors

Two environment failures, both confirmed against unmodified `main` in the same
worktree:

- `test_orchestration_codegen_graph.py::test_generated_orchestration_compiles_against_the_pinned_runtime`
  compiles generated orchestration against `runtime/`'s headers. The checked-out
  submodule here predates the commit `main` pins, and that commit is not
  fetchable from this environment.
- `test_unified_ops.py::…::test_symlinked_import_path_still_names_the_caller`
  (deselected, as in the previous PRs) — the editable install's meta-path finder
  redirects `pypto` inside the subprocess the test spawns.

Device tests were not run; this change touches no kernel or codegen output.
