### PR TITLE
fix(codegen): keep an alloc below the control-flow value that sizes it

### DIFF
--- a/docs/en/dev/codegen/01-orchestration_codegen.md
+++ b/docs/en/dev/codegen/01-orchestration_codegen.md
@@ -140,6 +140,8 @@ SIMPLER_SCOPE() {
 
 External tensors borrow chip-resident descriptors passed through `ChipTaskArgs`. Internal tensors are pre-allocated at scope entry via `alloc_tensors()` — all `tensor.create` calls within the same scope (function body, for body, if body) are batched into a single `alloc_tensors` invocation. Pre-allocated tensors are then passed to kernels via `add_output(const ChipTensor&)` (OUTPUT_EXISTING overload).
 
+A create is only hoisted to scope entry when its size is *entry-valid*. A size that reads a value the body itself defines — a plain local, or an `if` / `for` / `while` return_var, whose C++ declaration is emitted where that statement sits — keeps the create in body order instead, so the emitted C++ never uses a name before its declaration. The same rule covers the `__gm_pipe_buffer` placeholder, whose real size is `slot_bytes * core_num` rather than its IR shape.
+
 ### Parameter Direction
 
 The `ParamDirection` of each function parameter determines how it appears in task submission:

--- a/docs/zh/dev/codegen/01-orchestration_codegen.md
+++ b/docs/zh/dev/codegen/01-orchestration_codegen.md
@@ -139,6 +139,8 @@ SIMPLER_SCOPE() {
 
 外部张量借用通过 `ChipTaskArgs` 传入的设备侧描述符。内部张量在 scope 入口处通过 `alloc_tensors()` 预分配——同一 scope（函数体、for 循环体、if 分支体）中的所有 `tensor.create` 被批量合并为一条 `alloc_tensors` 调用。预分配的张量随后通过 `add_output(const ChipTensor&)`（OUTPUT_EXISTING 重载）传递给核函数。
 
+只有尺寸在 scope 入口处已经可见（entry-valid）的 create 才会被提升到入口。若尺寸读取了函数体自身定义的值——普通局部变量，或 `if` / `for` / `while` 的 return_var（其 C++ 声明在对应语句处才emit）——该 create 会保留在语句顺序上，从而保证生成的 C++ 不会在声明之前使用某个名字。`__gm_pipe_buffer` 占位符同样适用此规则：它的真实尺寸是 `slot_bytes * core_num`，而非其 IR shape。
+
 ### 参数方向
 
 每个函数参数的 `ParamDirection` 决定其在任务提交中的表现：

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -3273,12 +3273,15 @@ class OrchestrationStmtCodegen : public CodegenBase {
     for (size_t stmt_idx = 0; stmt_idx < stmts.size(); ++stmt_idx) {
       const auto& stmt = stmts[stmt_idx];
       auto assign = As<AssignStmt>(stmt);
-      if (!assign) {
-        continue;
-      }
-      auto call = As<Call>(assign->value_);
+      auto call = assign ? As<Call>(assign->value_) : nullptr;
       if (!call || !IsOp(call, "tensor.create")) {
-        locally_defined.insert(assign->var_.get());
+        // Track every name this level defines, not just AssignStmt targets: an
+        // IfStmt / ForStmt / WhileStmt return_var is a phi whose C++ declaration
+        // is emitted where the statement sits, so a create sized from one is
+        // hoist-ineligible exactly like a create sized from a plain local.
+        for (const auto* def : var_collectors::CollectStmtDefinedVars(stmt)) {
+          locally_defined.insert(def);
+        }
         continue;
       }
       if (declared_var_ptrs_.count(assign->var_.get()) || param_name_set_.count(GetVarName(assign->var_))) {

--- a/tests/ut/codegen/test_orchestration_codegen_more.py
+++ b/tests/ut/codegen/test_orchestration_codegen_more.py
@@ -254,6 +254,114 @@ class TestOrchestrationMore:
         assert m_name in size_decl.group(1), (m_name, size_decl.group(1))
         assert code.index(f"int64_t {m_name} =") < code.index("gm_pipe_buffer"), code
 
+    def test_clamped_gm_pipe_buffer_alloc_follows_its_phi(self):
+        """A GM pipe buffer sized from an ``if``-clamped scalar must follow the phi decl.
+
+        Same shape as the branch-free case above, except the ``pl.spmd`` extent is
+        clamped, so the value sizing the buffer is an ``IfStmt`` return_var rather
+        than a plain assignment. Its C++ declaration is emitted where the ``if``
+        sits, so hoisting the alloc to the scope top emits a use before the
+        declaration (``'m_clamped' was not declared in this scope``).
+        """
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        K = 64
+        SPMD_N = 16
+        ROW_TILE = 16
+        CAP = 128
+        M_DYN = pl.dynamic("M_DYN")
+
+        @pl.program
+        class ClampedDynPipeProgram:
+            @pl.function(type=pl.FunctionType.Opaque)
+            def main(
+                self,
+                a: pl.Tensor[[M_DYN, K], pl.FP32],
+                b: pl.Tensor[[K, SPMD_N], pl.FP32],
+                out: pl.Tensor[[M_DYN, SPMD_N], pl.FP32],
+            ) -> pl.Tensor[[M_DYN, SPMD_N], pl.FP32]:
+                m = pl.tensor.dim(a, 0)
+                if m > CAP:
+                    m_clamped: pl.Scalar[pl.INDEX] = pl.yield_(CAP)
+                else:
+                    m_clamped: pl.Scalar[pl.INDEX] = pl.yield_(m)
+                for ob in pl.spmd(m_clamped // ROW_TILE, name_hint="hc"):
+                    m0 = ob * ROW_TILE
+                    a_slice = pl.slice(a, [ROW_TILE, K], [m0, 0])
+                    a_add = pl.add(a_slice, 1.0)  # vector produces matmul operand (V->C)
+                    c_tile = pl.matmul(a_add, b)  # cube
+                    c_vec = pl.add(c_tile, 1.0)  # vector consumes matmul result (C->V)
+                    out = pl.assemble(out, c_vec, [m0, 0])
+                return out
+
+        program = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(ClampedDynPipeProgram)
+        orch_func = next(
+            f for f in program.functions.values() if f.func_type == ir.FunctionType.Orchestration
+        )
+        code = codegen.generate_orchestration(program, orch_func).code
+
+        # The size must genuinely reference the phi, or the test passes vacuously.
+        size_decl = re.search(r"gm_pipe_buffer_\w+_ci_shapes\[1\] = \{(.+?)\};", code)
+        assert size_decl is not None, code
+        phi_decl = re.search(r"int64_t (\w*m_clamped\w*);", code)
+        assert phi_decl is not None, code
+        phi_name = phi_decl.group(1)
+        assert phi_name in size_decl.group(1), (phi_name, size_decl.group(1))
+        assert code.index(f"int64_t {phi_name};") < code.index("gm_pipe_buffer"), code
+
+    def test_clamped_tensor_create_alloc_follows_its_phi(self):
+        """A ``tensor.create`` whose shape reads an ``if`` phi must not be hoisted above it.
+
+        The generic hoist guard (``ShapeDependsOnLocalVars``) shares the
+        body-local set with the GM-pipe guard, so an ordinary dynamically-shaped
+        allocation sized from a clamped scalar breaks the same way.
+        """
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        N = 16
+        CAP = 128
+        M_DYN = pl.dynamic("M_DYN")
+
+        @pl.program
+        class ClampedCreateProgram:
+            @pl.function(type=pl.FunctionType.AIV)
+            def kernel(
+                self,
+                a: pl.Tensor[[16, N], pl.FP32],
+                out: pl.Out[pl.Tensor[[16, N], pl.FP32]],
+            ) -> pl.Tensor[[16, N], pl.FP32]:
+                t = pl.load(a, [0, 0], [16, N])
+                out = pl.store(t, [0, 0], out)
+                return out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[M_DYN, N], pl.FP32],
+            ) -> pl.Tensor[[16, N], pl.FP32]:
+                m = pl.tensor.dim(a, 0)
+                if m > CAP:
+                    m_clamped: pl.Scalar[pl.INDEX] = pl.yield_(CAP)
+                else:
+                    m_clamped: pl.Scalar[pl.INDEX] = pl.yield_(m)
+                scratch: pl.Tensor[[M_DYN, N], pl.FP32] = pl.create_tensor([m_clamped, N], dtype=pl.FP32)
+                a_slice = pl.slice(a, [16, N], [0, 0])
+                s_slice = pl.slice(scratch, [16, N], [0, 0])
+                s_slice = self.kernel(a_slice, s_slice)
+                return s_slice
+
+        code = _generate_orch_code(ClampedCreateProgram)
+
+        shape_decl = re.search(r"uint32_t scratch_ci_shapes\[2\] = \{(.+?)\};", code)
+        assert shape_decl is not None, code
+        phi_decl = re.search(r"int64_t (\w*m_clamped\w*);", code)
+        assert phi_decl is not None, code
+        phi_name = phi_decl.group(1)
+        assert phi_name in shape_decl.group(1), (phi_name, shape_decl.group(1))
+        assert code.index(f"int64_t {phi_name};") < code.index("scratch_ci_shapes"), code
+
     def test_for_loop_with_slice(self):
         """Test for loop + tensor.slice: simplified paged attention pattern.
 


### PR DESCRIPTION
## What

Orchestration codegen no longer hoists a `tensor.create` above the `if` / `for` / `while` phi that sizes it.

## Why

A `pl.spmd` extent derived from an `if`-clamped runtime scalar produced C++ that does not compile:

```cpp
uint32_t gm_pipe_buffer_0_ci_shapes[1] = {static_cast<uint32_t>((4096) * ((m_clamped / 16)))};
TaskOutputTensors alloc_0 = alloc_tensors(gm_pipe_buffer_0_ci);   // use
const Tensor& gm_pipe_buffer_0 = alloc_0.get_ref(0);
int64_t m_clamped;                                                // def
if ((128 < M_DYN)) { ... m_clamped = static_cast<int64_t>(128); }
```

```
error: 'm_clamped' was not declared in this scope
```

`EmitBatchedAllocTensors` hoists eligible `tensor.create`s to scope entry and guards that with a `locally_defined` set — a create sized from a body-local stays in body order instead. The set was built **only** from `AssignStmt` targets; the loop `continue`d on every other statement kind without recording anything.

An `IfStmt::return_vars_` phi is declared in C++ where the `if` sits (`VisitStmt_(const IfStmtPtr&)`), so a create sized from one is exactly as hoist-ineligible as one sized from a plain local — but it never entered the set. Both guards that read it, the `__gm_pipe_buffer` `core_num` guard and the generic `ShapeDependsOnLocalVars`, therefore saw no dependency.

The branch-free form of the same arithmetic works only because it *is* an `AssignStmt`. That is the entire difference between the two spellings, which is why the failure looked arbitrary from the DSL.

## How

Populate `locally_defined` from `var_collectors::CollectStmtDefinedVars(stmt)` — `AssignStmt` targets plus `If` / `For` / `While` `return_vars_` — instead of `AssignStmt` targets alone. The create then falls to the per-op path and is emitted after the statement that defines its size.

## Notes for the reviewer

- Not specific to `pl.spmd` or to `gm_pipe_buffer`: an ordinary `pl.create_tensor([m_clamped, N])` after an `if` broke identically, since both guards share the set. Both cases have a regression test.
- Both new tests were confirmed to fail on a pre-fix build (rebuilt without the patch) and pass with it.
- `tests/ut` + `tests/lint`: 11083 passed, 3 skipped, 1 xfailed. `ctest` green.
- Docs (en + zh) now state the entry-valid condition rather than a flat "at scope entry".
