### PR TITLE
refactor(ir): resolve result-aliases-input through the op registry

### DIFF
--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -439,7 +439,11 @@ bool ShareOneMemRefWindow(const std::shared_ptr<const TileType>& lhs,
 //   * `IsInPlaceInput0DpsOp` — ops whose in-place-ness is a codegen-lowering fact.
 //     Gated on a shared base memref only, which is the long-standing behaviour.
 //
-//   * the registry (`set_output_reuses_input`) — the declared, op-level truth.
+//   * `BuiltinWritebackArgIndex` — the declared, op-level truth: the registry's
+//     `set_output_reuses_input` slot. Deliberately not `ResultAliasedArgIndex`,
+//     which answers the *lineage* question (which argument does the result
+//     name) and additionally covers host-level ops whose result is a window,
+//     not a buffer this emitter may alias.
 //     This is what lets `tile.matmul_acc` accumulate directly into its
 //     accumulator operand: when that operand is a `tile.slice` of a larger Acc
 //     tile its SSA is a `pto.subview`, so the MAD writes straight into the
@@ -474,9 +478,7 @@ bool ShouldAliasResultToInPlaceInput(const AssignStmtPtr& stmt) {
     return result_memref && input_memref && result_memref->base_.get() == input_memref->base_.get();
   }
 
-  auto& registry = ir::OpRegistry::GetInstance();
-  if (!registry.IsRegistered(call->op_->name_)) return false;
-  auto declared = registry.GetEntry(call->op_->name_).GetOutputReusesInputArg();
+  auto declared = ir::op_predicates::BuiltinWritebackArgIndex(call->op_, call->args_.size());
   if (!declared.has_value()) return false;
   auto input_tile_type = input_tile_type_at(*declared);
   if (!input_tile_type) return false;

--- a/src/ir/transforms/canonicalize_tile_slice_pass.cpp
+++ b/src/ir/transforms/canonicalize_tile_slice_pass.cpp
@@ -347,19 +347,16 @@ bool NamesSameWindowExtent(const TileTypePtr& lhs, const TileTypePtr& rhs) {
   return true;
 }
 
-/// The accumulator operand of `call` — the argument the op registry declares as
-/// the in-place destination via `set_output_reuses_input`.  Null when the call
-/// is not an accumulator op (or carries no Var there).
+/// The accumulator operand of `call` — the argument whose buffer the result
+/// names.  Null when the call is not an accumulator op (or carries no Var there).
 ///
-/// Reading the relation from the registry — rather than naming
-/// `tile.matmul_acc` / `tile.gemv_acc` / `tile.matmul_mx_acc` — is what lets the
-/// guard below cover any future accumulator op for free.
+/// Asking `BuiltinWritebackArgIndex` — rather than naming `tile.matmul_acc` /
+/// `tile.gemv_acc` / `tile.matmul_mx_acc` — is what lets the guard below cover
+/// any future accumulator op for free.
 VarPtr AccumulatorOperand(const CallPtr& call) {
   if (!call || !call->op_) return nullptr;
-  auto& reg = OpRegistry::GetInstance();
-  if (!reg.IsRegistered(call->op_->name_)) return nullptr;
-  auto declared = reg.GetEntry(call->op_->name_).GetOutputReusesInputArg();
-  if (!declared.has_value() || *declared >= call->args_.size()) return nullptr;
+  auto declared = op_predicates::BuiltinWritebackArgIndex(call->op_, call->args_.size());
+  if (!declared.has_value()) return nullptr;
   return AsVarLike(call->args_[*declared]);
 }
 

--- a/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
+++ b/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
@@ -625,6 +625,11 @@ class ConsumerSpaceCollector : public IRVisitor {
         propagation_edges_.emplace_back(op->var_.get(), src_var.get());
       } else if (auto call = As<Call>(op->value_);
                  call && !std::dynamic_pointer_cast<const GlobalVar>(call->op_)) {
+        // Deliberately the raw `OutputMemoryInheritsInput()` flag, NOT
+        // `op_predicates::IsBufferAliasingViewOp`: the edge recorded here carries
+        // the memory *space* relation, which is what the flag declares. Buffer
+        // identity is the stricter `inherit && IsInplaceSafe()` and is answered
+        // by `ResultAliasedArgIndex` elsewhere in this pass.
         auto& op_reg = OpRegistry::GetInstance();
         if (op_reg.IsRegistered(call->op_->name_) &&
             op_reg.GetEntry(call->op_->name_).OutputMemoryInheritsInput()) {

--- a/src/ir/transforms/infer_tile_memory_space_pass.cpp
+++ b/src/ir/transforms/infer_tile_memory_space_pass.cpp
@@ -181,6 +181,12 @@ class DemandCollector : public IRVisitor {
 
   void RecordInheritInputEdge(const VarPtr& dst, const CallPtr& call) {
     if (!dst) return;
+    // Deliberately the raw `OutputMemoryInheritsInput()` flag, NOT
+    // `op_predicates::IsBufferAliasingViewOp`. This pass propagates the memory
+    // *space*, which is exactly what the flag declares; aliasing the input's
+    // *buffer* is the stricter `inherit && IsInplaceSafe()`. `tile.transpose` is
+    // the case that separates them: it lands in its input's space (so it needs
+    // this edge) while permuting into a fresh buffer (so it is not a view).
     auto& reg = OpRegistry::GetInstance();
     if (!reg.IsRegistered(call->op_->name_)) return;
     if (!reg.GetEntry(call->op_->name_).OutputMemoryInheritsInput()) return;

--- a/src/ir/transforms/init_memref.cpp
+++ b/src/ir/transforms/init_memref.cpp
@@ -63,23 +63,6 @@ namespace ir {
 
 namespace {
 
-// Check if operation is a view operation (zero-copy metadata transform).
-// A view op is one registered with set_output_memory_inherit_input() — its
-// output reuses the input's MemRef view. Delegates to the shared registry
-// predicate so InferTileMemorySpace and InitMemRef agree on the set.
-bool IsViewOperation(const std::string& op_name) {
-  auto& registry = OpRegistry::GetInstance();
-  if (!registry.IsRegistered(op_name)) return false;
-  return registry.GetEntry(op_name).OutputMemoryInheritsInput();
-}
-
-// Whether an inherit-input op *permutes* data rather than just reinterpreting
-// it (tile.transpose).  A pure metadata view (slice/reshape/extract/...) aliases
-// its input's buffer, but a permuting op's output must never alias the input:
-// pto.ttrans is not in-place safe (the unaligned scalar path writes dst directly
-// from src), so InitMemRef gives the transpose output a fresh buffer.
-bool IsDataPermutingInheritOp(const OpPtr& op) { return IsOp(op, "tile.transpose"); }
-
 // A tile owns no general-pool buffer ("buffer-less by design") when its defining
 // value is a cross-core tpop result, or a non-permuting zero-copy view / plain
 // alias chained off a buffer-less source. `source_buffer_less` reports whether a
@@ -101,14 +84,6 @@ bool ProducesBufferLessTile(const ExprPtr& value, const SourceBufferLess& source
   }
   auto v = AsVarLike(value);
   return v && source_buffer_less(v.get());
-}
-
-// Check if an operation's output should reuse the MemRef of a specific input argument.
-// Returns the input arg index whose MemRef to share, or nullopt.
-std::optional<size_t> GetOutputReusesInputArg(const std::string& op_name) {
-  auto& registry = OpRegistry::GetInstance();
-  if (!registry.IsRegistered(op_name)) return std::nullopt;
-  return registry.GetEntry(op_name).GetOutputReusesInputArg();
 }
 
 /// Byte envelope of a static slice of an NZ-boxed accumulator (L0C) parent.
@@ -835,26 +810,39 @@ class InitMemRefMutator : public IRMutator {
       // A pure metadata view (slice/reshape/...) inherits its input's buffer.  A
       // permuting inherit-input op — tile.transpose — must NOT: pto.ttrans is
       // not in-place safe (the unaligned scalar path writes dst directly from
-      // src), so the transpose output always gets a fresh buffer.
-      if (IsViewOperation(call->op_->name_) && call->args_.size() > 0) {
+      // src), so the transpose output always gets a fresh buffer.  Both halves
+      // of that statement are `IsBufferAliasingViewOp`, which is
+      // `OutputMemoryInheritsInput() && IsInplaceSafe()` — it excludes transpose
+      // without naming it, and will exclude any future inherit-input op
+      // registered `not_inplace_safe()`.
+      if (op_predicates::IsBufferAliasingViewOp(call->op_->name_) && !call->args_.empty()) {
         LOG_DEBUG << "Detected view operation: " << call->op_->name_;
         // Get the input tile (first argument) after mutation
         auto new_call = std::dynamic_pointer_cast<const Call>(new_value);
         if (new_call && !new_call->args_.empty()) {
-          const bool may_inherit = !IsDataPermutingInheritOp(call->op_);
-          if (may_inherit) {
-            auto result = ShareMemRefFrom(new_call->args_[0], op, new_value);
-            if (result) {
-              LOG_DEBUG << "Sharing MemRef from input tile to " << op->var_->name_hint_;
-              return result;
-            }
-            LOG_DEBUG << "Input tile has no MemRef yet";
+          auto result = ShareMemRefFrom(new_call->args_[0], op, new_value);
+          if (result) {
+            LOG_DEBUG << "Sharing MemRef from input tile to " << op->var_->name_hint_;
+            return result;
           }
+          LOG_DEBUG << "Input tile has no MemRef yet";
         }
       }
 
-      // Handle ops whose output reuses a specific input arg's MemRef (registry-based)
-      auto reuse_arg_idx = GetOutputReusesInputArg(call->op_->name_);
+      // Handle ops whose output lands in a specific input arg's MemRef.
+      //
+      // The registry's `set_output_reuses_input` slot, NOT the broader
+      // `ResultAliasedArgIndex`. The two answer different questions.  This pass
+      // asks a *physical* one — which argument's buffer does this result
+      // occupy, so the LHS can be bound to it — and only the registry
+      // declaration states that.  `ResultAliasedArgIndex` additionally covers
+      // host-level ops whose result names an argument for *lineage* purposes
+      // (`tensor.write`, and the `pld.tensor.*` collectives, whose result is
+      // the window they reduced or gathered into).  A window's storage belongs
+      // to the distributed runtime and is materialized later by
+      // LowerHostTensorCollectives, so binding the SSA result to it here
+      // rewrites a buffer this pass does not own.
+      auto reuse_arg_idx = op_predicates::BuiltinWritebackArgIndex(call->op_, call->args_.size());
       if (reuse_arg_idx.has_value()) {
         auto new_call = std::dynamic_pointer_cast<const Call>(new_value);
         if (new_call && *reuse_arg_idx < new_call->args_.size()) {

--- a/src/ir/transforms/loop_invariant_mat_residency.cpp
+++ b/src/ir/transforms/loop_invariant_mat_residency.cpp
@@ -359,10 +359,10 @@ class LoopResidencyInventory : public IRVisitor {
     if (AsVarLike(value)) return false;
     auto call = As<Call>(value);
     if (!call || !call->op_) return true;
-    if (op_predicates::IsBufferAliasingViewOp(call->op_->name_)) return false;
-    auto& registry = OpRegistry::GetInstance();
-    if (!registry.IsRegistered(call->op_->name_)) return true;
-    return !registry.GetEntry(call->op_->name_).GetOutputReusesInputArg().has_value();
+    // "Does this result get to choose its own buffer" is exactly the question
+    // OutputInheritsSourceBuffer answers (zero-copy view OR declared in-place
+    // reuse); an unregistered op name is a user function, which owns its result.
+    return !op_predicates::OutputInheritsSourceBuffer(call->op_->name_);
   }
 
   void RecordOwnedTileFootprint(const VarPtr& var, const ExprPtr& value) {

--- a/src/ir/transforms/memory_reuse_pass.cpp
+++ b/src/ir/transforms/memory_reuse_pass.cpp
@@ -737,9 +737,7 @@ class TopDownRetargeter {
       auto call = As<Call>(assign->value_);
       if (!call || !call->op_ || !registry.IsRegistered(call->op_->name_)) continue;
       if (!op_predicates::OutputInheritsSourceBuffer(call->op_->name_)) continue;
-      const auto& entry = registry.GetEntry(call->op_->name_);
-      if (auto reuse_idx = entry.GetOutputReusesInputArg();
-          reuse_idx.has_value() && *reuse_idx < call->args_.size()) {
+      if (auto reuse_idx = op_predicates::BuiltinWritebackArgIndex(call->op_, call->args_.size())) {
         if (auto source = AsVarLike(call->args_[*reuse_idx])) {
           alias_source_[var] = source;
           inplace_source_[var] = source;
@@ -910,10 +908,8 @@ class TopDownRetargeter {
       }
       auto call = As<Call>(assign->value_);
       if (!call || !call->op_) break;
-      const auto& registry = OpRegistry::GetInstance();
-      if (!registry.IsRegistered(call->op_->name_)) break;
-      auto reuse_idx = registry.GetEntry(call->op_->name_).GetOutputReusesInputArg();
-      if (!reuse_idx.has_value() || *reuse_idx >= call->args_.size()) break;
+      auto reuse_idx = op_predicates::BuiltinWritebackArgIndex(call->op_, call->args_.size());
+      if (!reuse_idx.has_value()) break;
       result = AsVarLike(call->args_[*reuse_idx]);
       break;
     }
@@ -1155,10 +1151,9 @@ class TopDownRetargeter {
     if (!reg.IsRegistered(call->op_->name_)) return false;
     const auto& entry = reg.GetEntry(call->op_->name_);
 
-    auto reuse_idx = entry.GetOutputReusesInputArg();
+    auto reuse_idx = op_predicates::BuiltinWritebackArgIndex(call->op_, call->args_.size());
     if (reuse_idx.has_value()) {
       // Pinned output: can't change this stmt's LHS MemRef; recurse onto pinned input.
-      if (*reuse_idx >= call->args_.size()) return false;
       auto input_var = AsVarLike(call->args_[*reuse_idx]);
       if (!input_var) return false;
       if (!TryRetargetVar(input_var, target, target_memory)) return false;
@@ -1169,9 +1164,17 @@ class TopDownRetargeter {
 
     // Decline retargeting for ops whose output memory is not fully captured
     // by the LHS type alone:
-    //   1. View ops (set_output_memory_inherit_input) — output MemRef
-    //      inherits the input's view byte_offset_ / size_, which rewriting
-    //      with target's full MemRef would silently drop.
+    //   1. Buffer-aliasing view ops — output MemRef inherits the input's view
+    //      byte_offset_ / size_, which rewriting with target's full MemRef
+    //      would silently drop.  `tile.transpose` is declined here too, even
+    //      though it permutes into a fresh buffer and so has no inherited view
+    //      offset to lose: `set_output_memory_inherit_input()` also pins its
+    //      output's memory SPACE to its input's, and nothing below enforces
+    //      that — case 4 reads a null `deduce_output_memory` for an
+    //      inherit-input op and never fires, and case 3 compares MemRef bases,
+    //      not spaces.  Retyping its LHS onto a different-space target would
+    //      contradict the relation InferTileMemorySpace established.  Making
+    //      transpose retargetable needs that space guard first.
     //   2. Ops that encode output memory in a `target_memory` kwarg (e.g.
     //      tile.create / tile.move / tile.load) — retyping the LHS to a
     //      different memory_space would require rewriting the kwarg too.
@@ -1190,7 +1193,7 @@ class TopDownRetargeter {
     //      different buffer than its init, which YieldFixupMutator reconciles
     //      with a real move (see AlignLoopCarriesToInitMutator's contract).
     //      Same-space targets are unaffected: only the MemRef base moves.
-    if (IsOutputMemoryInheritInput(entry)) {
+    if (entry.OutputMemoryInheritsInput()) {
       // Most view ops can carry a sub-region offset, so retargeting their LHS
       // directly would lose view-relative addressing. tile.set_validshape is
       // the narrow exception: it is a zero-offset, shape-preserving alias of
@@ -1236,13 +1239,6 @@ class TopDownRetargeter {
       c.VisitExpr(call.args_[i]);
     }
     return c.bases.count(target_base) > 0;
-  }
-
-  /// True when the op is registered with set_output_memory_inherit_input.
-  /// Delegates to the shared OpRegistryEntry predicate so passes that reason
-  /// about pass-through ops (here and InferTileMemorySpace) agree on the set.
-  static bool IsOutputMemoryInheritInput(const OpRegistryEntry& entry) {
-    return entry.OutputMemoryInheritsInput();
   }
 
   static bool HasKwarg(const Call& call, const std::string& key) {
@@ -1516,12 +1512,8 @@ class RetypeApplier : public IRMutator {
   /// view whose input was retargeted (caller then falls back to the default visit).
   StmtPtr FollowRetargetedViewInput(const AssignStmtPtr& op) {
     auto orig_call = As<Call>(op->value_);
-    if (!orig_call || orig_call->args_.empty()) return nullptr;
-    const auto& reg = OpRegistry::GetInstance();
-    if (!reg.IsRegistered(orig_call->op_->name_) ||
-        !reg.GetEntry(orig_call->op_->name_).OutputMemoryInheritsInput()) {
-      return nullptr;
-    }
+    if (!orig_call || !orig_call->op_ || orig_call->args_.empty()) return nullptr;
+    if (!op_predicates::IsBufferAliasingViewOp(orig_call->op_->name_)) return nullptr;
     auto in_var = AsVarLike(orig_call->args_[0]);
     if (!in_var) return nullptr;
     auto sub = var_substitution_.find(in_var);
@@ -1534,11 +1526,10 @@ class RetypeApplier : public IRMutator {
     const auto& in_old = *in_old_opt;
     const auto& in_new = *in_new_opt;
     // Use the ORIGINAL (pre-mutation) types: a view inherited its input's buffer
-    // iff its output base equalled the input base in the input IR.  This naturally
-    // excludes the one inherit-input op that does NOT always inherit — a
-    // data-permuting tile.transpose over a sub-region input gets a fresh buffer
-    // (output base != input base from the start), so it is left untouched.  Fire
-    // only when the view inherited AND the input actually moved to another buffer.
+    // iff its output base equalled the input base in the input IR.  Fire only
+    // when the view inherited AND the input actually moved to another buffer.
+    // (tile.transpose is already excluded by IsBufferAliasingViewOp above — it
+    // inherits the memory space but permutes into a fresh buffer.)
     if (out_mr->base_.get() != in_old->base_.get() || in_new->base_.get() == in_old->base_.get()) {
       return nullptr;
     }
@@ -2140,8 +2131,28 @@ static const Var* TileMemRefBase(const VarPtr& v) {
   return nullptr;
 }
 
-/// Op names whose output aliases the input MemRef and lowers to a PTO view
-/// instruction — kept in sync with the PTO buffer-reuse view allowlist.
+/// Ops through which a `tile.load` result's taint reaches the writer below.
+///
+/// This is deliberately NOT one of the registry alias predicates, and the
+/// distinction is the whole point.  Those answer a *semantic* question — does
+/// this operator declare that its result names an argument's buffer.  The taint
+/// closure needs a *physical* one — can this result end up occupying the load's
+/// buffer — and after opportunistic reuse the two differ.  `tile.fillpad`
+/// declares no aliasing at all, yet it is in-place safe, so `RetargetAssign`
+/// may coalesce its output straight onto its input's buffer; that is asserted
+/// by `test_fillpad_output_can_reuse_input`.  Deriving this set from the
+/// registry drops `tile.fillpad` and reopens
+/// `load -> fillpad -> writer(result, tpop_from_aic)`.
+///
+/// The list is therefore kept as-is, and it is an approximation with two known
+/// gaps, both pre-existing:
+///   * it omits `tile.assemble` / `tile.set_validshape` / `tile.tget_scale_addr`,
+///     which do declare aliasing, so a load reaching the writer through one of
+///     them is not tainted; and
+///   * it omits every other in-place-safe op (`tile.add`, ...) whose output
+///     `RetargetAssign` may likewise coalesce onto a load buffer.
+/// Closing either needs the taint to follow post-reuse physical bases rather
+/// than op names, which is a change to the reuse decision itself.
 static bool IsLegalTileViewOp(const OpPtr& op) {
   return IsOp(op, "tile.reshape") || IsOp(op, "tile.extract") || IsOp(op, "tile.slice") ||
          IsOp(op, "tile.fillpad") || IsOp(op, "tile.fillpad_inplace") || IsOp(op, "tile.transpose_view") ||
@@ -4273,11 +4284,9 @@ class NormalizeIdentityCopyBuffersMutator : public IRMutator {
   /// traversal. Returns nullptr when the allocation already agrees.
   StmtPtr ReanchorInplaceOutput(const AssignStmtPtr& op) {
     auto call = As<Call>(op->value_);
-    if (!call) return nullptr;
-    const auto& reg = OpRegistry::GetInstance();
-    if (!reg.IsRegistered(call->op_->name_)) return nullptr;
-    auto reuse_idx = reg.GetEntry(call->op_->name_).GetOutputReusesInputArg();
-    if (!reuse_idx.has_value() || *reuse_idx >= call->args_.size()) return nullptr;
+    if (!call || !call->op_) return nullptr;
+    auto reuse_idx = op_predicates::BuiltinWritebackArgIndex(call->op_, call->args_.size());
+    if (!reuse_idx.has_value()) return nullptr;
     auto in_var = AsVarLike(call->args_[*reuse_idx]);
     if (!in_var) return nullptr;
     auto new_in = AsVarLike(VisitExpr(in_var));  // follow prior subst_ renames


### PR DESCRIPTION
## What

"Does this call's result occupy one of its arguments' buffers?" was answered by hand in several places. This routes every one through the shared predicates that already exist.

| Deleted | Replaced by |
| ------- | ----------- |
| `init_memref.cpp` `IsViewOperation` + `IsDataPermutingInheritOp` — the inherit flag, then `tile.transpose` named to take it back out | `op_predicates::IsBufferAliasingViewOp` (= `inherit && IsInplaceSafe()`) |
| `memory_reuse_pass.cpp` `IsOutputMemoryInheritInput` — a private wrapper | the flag directly, at its one remaining caller |
| `loop_invariant_mat_residency.cpp` `OwnsAllocation`'s three-line reassembly | `op_predicates::OutputInheritsSourceBuffer` |
| Six raw `GetOutputReusesInputArg()` reads in `MemoryReuse` / `InitMemRef` / `CanonicalizeTileSlice` / PTO codegen | `op_predicates::BuiltinWritebackArgIndex` |

Raw registry-flag reads: **20 → 6**. Each survivor answers a *different* question and now says so in a comment:

- `InferTileMemorySpace`, `ConvertTensorToTileOps` — propagate the memory **space**, which is exactly what `OutputMemoryInheritsInput()` declares.
- PTO control-flow codegen — asks whether a producer writes anything at its own handle.
- `MemoryReuse`'s retarget gate — keeps the inherit flag because it must *also* decline `tile.transpose`: that op's output space is pinned to its input's, and nothing on the retarget path enforces spaces (`FixedOutputMemoryConflicts` reads a null `deduce_output_memory` for an inherit-input op; `CallReadsBase` compares bases).
- Two sites ask `IsInplaceSafe()` — in-place safety, not buffer identity.

## Semantic aliasing is not physical placement

The split-AIV `load` + `tpop_from_aic` hazard taint needs the **physical** question, and its op list looks like a stale semantic-alias set but is not.

`tile.fillpad` declares no aliasing at all — yet it is in-place safe, so `RetargetAssign` may coalesce its output straight onto its input's buffer. `test_fillpad_output_can_reuse_input` asserts exactly that. So a load reaching a writer through `fillpad` must stay tainted, and deriving the set from the registry silently reopens `load → fillpad → writer(result, tpop_from_aic)` on Ascend910B.

The list is therefore **left alone**. A comment now records why, plus the two gaps it has always had: ops that *do* declare aliasing but are absent (`tile.assemble`, `tile.set_validshape`, `tile.tget_scale_addr`), and every other in-place-safe op whose output may likewise be coalesced onto a load buffer (`tile.add`, …). Closing either needs the taint to follow post-reuse **physical bases** rather than op names — a change to the reuse decision itself, not to a predicate.

## `BuiltinWritebackArgIndex`, not `ResultAliasedArgIndex`

Every site here asks the physical question, so all of them use `BuiltinWritebackArgIndex`.

`ResultAliasedArgIndex` answers the **lineage** question — which argument does the result *name* — and additionally covers host-level ops whose result is a window (`tensor.write`, the `pld.tensor.*` collectives). A window's storage belongs to the distributed runtime and is materialized later by `LowerHostTensorCollectives`, so binding a buffer to it in these passes rewrites storage they do not own. Its three existing consumers (`ConvertTensorToTileOps`, `ScopeOutliner`, the `In`-param-written verifier) are untouched.

## Behaviour

**None.** 353 generated artifacts (`.pto` plus orchestration `.cpp`) across the split-AIV DSL, tile-op, matmul, transpose, intermediate-example and distributed-collective (allgather / reduce_scatter / all_to_all / barrier) suites are byte-identical to the base commit. Diffs normalize the worktree path in `loc()` and the timestamped output directory.

## Verification

- Build clean; `ctest` 1/1; `clang-tidy` (`--diff-base`) and `clang-format` clean; repo lints pass.
- `tests/ut` — **11135 passed**. Two failures, both reproduced on clean `upstream/main` at the same base: `test_signature_memref_base_prints_as_a_string` (pre-existing) and `test_symlinked_import_path_still_names_the_caller` (local editable-install artifact).

## Revision history

Three behaviour riders were tried and backed out, each once it turned out to need validation a refactor PR cannot carry. Recorded so the analysis is not lost:

1. **`pto_control_flow_codegen.cpp` phi-handle re-pointing.** Swapping the inherit read for `IsBufferAliasingViewOp || !IsInplaceSafe()` is *not* equivalent — the delta is 32 ops (`tile.recip`, `row_sum`, `concat`, the gather family, …) that lose re-pointing and gain an `alloc_tile` + full-tile `tmov` per branch. That block is gated on `!emit_tile_addr_`, i.e. PTOAS only, so a PYPTO-mode codegen A/B cannot see it.
2. **Making `tile.transpose` retargetable.** Needs the memory-space guard described above; showed no benefit across the compared outputs.
3. **Deriving the hazard taint set from the registry.** The `tile.fillpad` hole above; caught in review.

An earlier revision also routed `InitMemRef` through `ResultAliasedArgIndex`, which turned `dist-system-tests` red on `test_all_to_all_v_skewed_counts[2-over_capacity]`. Fixed, and the lineage/physical distinction is now written down at the call site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
