### PR TITLE
fix(ir): validate a loop's backedge against its halved carry

### DIFF
--- a/docs/en/dev/passes/21-lower_auto_vector_split.md
+++ b/docs/en/dev/passes/21-lower_auto_vector_split.md
@@ -774,13 +774,24 @@ Such a position stays unclassified and a full-width one is rejected.
 Three places rewrite state *around* the halving rather than in it, and each must
 follow the same axis and tracking rules or the conditions above misfire:
 
-- **Loop carries.** An `iter_arg` inherits its init value's tracking, so a halved
-  init makes the carry lane-local; the loop-exit `return_var` inherits it in turn
-  so a later `tile.store` gets the per-lane offset. Both the explicit and the
-  AUTO affinity-gated arms share `RepairIterArgs` / `RepairReturnVars` — the AUTO
-  arm recurses through its own walk and cannot reach the explicit path's `ForStmt`
+- **Loop carries.** A carry has three edges, and all three must agree. An
+  `iter_arg` inherits its init value's tracking, so a halved init makes the carry
+  lane-local; the loop-exit `return_var` inherits it in turn so a later
+  `tile.store` gets the per-lane offset. Both the explicit and the AUTO
+  affinity-gated arms share `RepairIterArgs` / `RepairReturnVars` — the AUTO arm
+  recurses through its own walk and cannot reach the explicit path's `ForStmt`
   branch, so without this a legal tile accumulator has its carry reported as a
   full-width operand.
+- **The loop backedge.** The third edge is the value the body yields back into
+  the carry, and `ValidateCarryBackedge` is what checks it: the yielded value
+  must be lane-local exactly when the carry is. A halved carry fed a full-width
+  value declares a per-lane type that contradicts the value flowing into it on
+  every iteration after the first — the same defect as an un-sharded operand,
+  which no operand check sees because those inspect a `Call`'s arguments and this
+  is a `Yield`. The check is symmetric, so a lane-local value yielded into a
+  full-width carry is rejected too. It validates rather than repairs: when the
+  yielded value is tracked the trailing `Substitute` already swaps in its halved
+  replacement, and when it is not there is no halved version to substitute.
 - **Branch merges.** An `IfStmt`'s merge variable (`return_vars_`, a `DefField`)
   is lane-local exactly when the values its branches yield are. Left at its
   declared full width it contradicts both `Yield` values *and* stays untracked,

--- a/docs/zh/dev/passes/21-lower_auto_vector_split.md
+++ b/docs/zh/dev/passes/21-lower_auto_vector_split.md
@@ -653,11 +653,18 @@ picked = pl.tile.gather(src, indices, tmp)   # 被拒绝：表被折半了
 有三处是在折半**周围**改写状态而非折半本身，它们必须遵循同样的轴映射与跟踪规则，
 否则上面的条件会误判：
 
-- **循环携带值。** `iter_arg` 继承其 init 的跟踪信息，因此 init 被折半时携带值也变为
-  lane 局部；循环出口的 `return_var` 再继承之，使后续 `tile.store` 拿到 per-lane 偏移。
-  显式路径与 AUTO 亲和性门控路径共用 `RepairIterArgs` / `RepairReturnVars`——AUTO 走的是
-  自己的遍历，够不到显式路径的 `ForStmt` 分支，缺了这一步就会把合法的 tile 累加器的携带值
-  当成全宽操作数报错。
+- **循环携带值。** 一个携带值有三条边，三者必须一致。`iter_arg` 继承其 init 的跟踪信息，
+  因此 init 被折半时携带值也变为 lane 局部；循环出口的 `return_var` 再继承之，使后续
+  `tile.store` 拿到 per-lane 偏移。显式路径与 AUTO 亲和性门控路径共用 `RepairIterArgs` /
+  `RepairReturnVars`——AUTO 走的是自己的遍历，够不到显式路径的 `ForStmt` 分支，缺了这一步
+  就会把合法的 tile 累加器的携带值当成全宽操作数报错。
+- **循环回边。** 第三条边是循环体 yield 回携带值的那个值，由 `ValidateCarryBackedge` 负责
+  校验：yield 的值当且仅当携带值是 lane 局部时才可以是 lane 局部。被折半的携带值收到一个
+  全宽值，就会声明一个与第二轮起流入它的值相矛盾的 per-lane 类型——和未分片操作数是同一个
+  缺陷，但所有操作数检查都看不见它，因为那些检查读的是 `Call` 的实参，而这里是 `Yield`。
+  该校验是对称的，因此把 lane 局部的值 yield 进全宽携带值同样会被拒绝。它只校验、不修复：
+  yield 的值若已被跟踪，尾部的 `Substitute` 本就会换上折半替身；若未被跟踪，则根本不存在
+  可替换的折半版本。
 - **分支归并值。** `IfStmt` 的归并变量（`return_vars_`，一个 `DefField`）是否 lane 局部，
   取决于两个分支 yield 的值是否 lane 局部。保持声明的全宽会同时与两个 `Yield` 矛盾，
   而且因为它从不被登记进 `tile_vars`，后续 `tile.store` 拿不到 lane 偏移——**两条 AIV

--- a/include/pypto/ir/transforms/utils/split_axis_utils.h
+++ b/include/pypto/ir/transforms/utils/split_axis_utils.h
@@ -367,6 +367,23 @@ std::vector<VarPtr> RepairReturnVars(const std::vector<VarPtr>& return_vars,
 /// value while the other yields a full-width one has no single merge type, and
 /// picking either silently gives one AIV lane the wrong extent -- so that is
 /// rejected rather than merged.
+/// Check a loop's BACKEDGE against its carry: the value the body yields back
+/// into slot ``i`` must be lane-local exactly when that carry is. Call AFTER
+/// lowering the body, with the LOWERED body and the repaired iter_args.
+///
+/// RepairIterArgs and RepairReturnVars cover the carry's entry and exit only, so
+/// without this a body yielding a full-width value into a halved carry emits a
+/// Yield whose declared type contradicts its value -- the gh#2203 defect on the
+/// carry path, which no operand check sees because those inspect a Call's
+/// arguments and this is a Yield.
+///
+/// Validate rather than repair: when the yielded value IS tracked the trailing
+/// Substitute already swaps in its halved replacement, and when it is not there
+/// is no halved version to substitute, so a diagnostic naming the carry is the
+/// only correct answer.
+void ValidateCarryBackedge(const StmtPtr& new_body, const std::vector<IterArgPtr>& new_iter_args,
+                           const std::unordered_map<const Var*, TileInfo>& tile_vars, const Span& span);
+
 std::vector<VarPtr> RepairIfReturnVars(const std::vector<VarPtr>& return_vars, const StmtPtr& new_then_body,
                                        const std::optional<StmtPtr>& new_else_body,
                                        std::unordered_map<const Var*, TileInfo>& tile_vars,

--- a/src/ir/transforms/lower_auto_vector_split_pass.cpp
+++ b/src/ir/transforms/lower_auto_vector_split_pass.cpp
@@ -565,6 +565,8 @@ std::vector<StmtPtr> LowerStmts(const std::vector<StmtPtr>& stmts, SplitMode mod
       auto body = transform_utils::FlattenToStmts(for_stmt->body_);
       auto new_body = LowerStmts(body, mode, split_dim, tile_vars, subblock_idx, var_replacements, used_names,
                                  lane_stride);
+      split_axis::ValidateCarryBackedge(loop_repair::MakeBody(new_body, for_stmt->span_), new_iter_args,
+                                        tile_vars, for_stmt->span_);
       auto new_return_vars = split_axis::RepairReturnVars(for_stmt->return_vars_, new_iter_args, tile_vars,
                                                           var_replacements, subblock_idx, lane_stride);
       result.push_back(loop_repair::RebuildForStmt(
@@ -604,6 +606,8 @@ std::vector<StmtPtr> LowerStmts(const std::vector<StmtPtr>& stmts, SplitMode mod
       auto body = transform_utils::FlattenToStmts(while_stmt->body_);
       auto new_body = LowerStmts(body, mode, split_dim, tile_vars, subblock_idx, var_replacements, used_names,
                                  lane_stride);
+      split_axis::ValidateCarryBackedge(loop_repair::MakeBody(new_body, while_stmt->span_), new_iter_args,
+                                        tile_vars, while_stmt->span_);
       auto new_return_vars = split_axis::RepairReturnVars(while_stmt->return_vars_, new_iter_args, tile_vars,
                                                           var_replacements, subblock_idx, lane_stride);
       result.push_back(loop_repair::RebuildWhileStmt(

--- a/src/ir/transforms/utils/split_axis_utils.cpp
+++ b/src/ir/transforms/utils/split_axis_utils.cpp
@@ -1372,6 +1372,9 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_dim,
     INTERNAL_CHECK_SPAN(for_stmt->iter_args_.size() == for_stmt->return_vars_.size(), for_stmt->span_)
         << "Internal error: ForStmt iter_args and return_vars sizes must match, got "
         << for_stmt->iter_args_.size() << " vs " << for_stmt->return_vars_.size();
+    // The backedge is the third edge of the carry, and the only one the two
+    // Repair* helpers do not touch.
+    ValidateCarryBackedge(new_body, new_iter_args, tile_vars, for_stmt->span_);
     new_return_vars = RepairReturnVars(for_stmt->return_vars_, new_iter_args, tile_vars, var_replacements,
                                        subblock_idx, lane_stride);
     return loop_repair::RebuildForStmt(for_stmt, new_iter_args, new_body, new_return_vars);
@@ -1531,6 +1534,41 @@ bool SameTileInfo(const TileInfo& a, const TileInfo& b) {
 }
 
 }  // namespace
+
+void ValidateCarryBackedge(const StmtPtr& new_body, const std::vector<IterArgPtr>& new_iter_args,
+                           const std::unordered_map<const Var*, TileInfo>& tile_vars, const Span& span) {
+  if (new_iter_args.empty()) return;
+  auto yield = transform_utils::GetLastYieldStmt(new_body);
+  // A loop that carries state ends in a Yield feeding every slot; anything else
+  // is malformed IR the SSA verifier rejects, so there is nothing to compare.
+  if (!yield || yield->value_.size() != new_iter_args.size()) return;
+
+  for (size_t i = 0; i < new_iter_args.size(); ++i) {
+    auto carry_it = tile_vars.find(new_iter_args[i].get());
+    const bool carry_is_lane_local = carry_it != tile_vars.end();
+    auto yielded = YieldedTileInfo(yield, i, tile_vars);
+
+    if (!carry_is_lane_local && !yielded.has_value()) continue;
+    if (carry_is_lane_local && yielded.has_value() && SameTileInfo(carry_it->second, *yielded)) continue;
+
+    auto yielded_var = AsVarLike(yield->value_[i]);
+    const std::string yielded_name =
+        yielded_var ? " '" + yielded_var->name_hint_ + "'" : std::string(" the yielded value");
+    CHECK_SPAN(false, span)
+        << "LowerAutoVectorSplit: the loop carry '" << new_iter_args[i]->name_hint_
+        << "' inside the automatically split vector region "
+        << (carry_is_lane_local
+                ? "is lane-local (the split halved its init value), but the body yields" + yielded_name +
+                      " back into it, which no lane owns a half of. The carry's declared per-lane type "
+                      "would contradict the value flowing into it on every iteration after the first."
+                : "is full width, but the body yields" + yielded_name +
+                      " back into it, which the split made lane-local. The carry cannot hold a per-lane "
+                      "value under a full-width declared type.")
+        << " Derive both the same way -- load or slice the value inside the split region on both the "
+           "init and the backedge, or keep both shared by the two lanes -- or move the loop outside the "
+           "automatically split region.";
+  }
+}
 
 std::vector<VarPtr> RepairIfReturnVars(const std::vector<VarPtr>& return_vars, const StmtPtr& new_then_body,
                                        const std::optional<StmtPtr>& new_else_body,

--- a/tests/ut/ir/transforms/test_lower_auto_vector_split.py
+++ b/tests/ut/ir/transforms/test_lower_auto_vector_split.py
@@ -2064,8 +2064,11 @@ def test_loop_carried_tile_accumulator_is_tracked():
     # The carry and everything derived from it are lane-local.
     assert "pl.tile.add(acc_it, acc_it)" in printed
     assert printed.count("[64, 128]") >= 3
-    # The store on the loop-exit var picks up the per-lane offset.
-    assert "subblock_idx * 64" in printed
+    # The store on the loop-exit var picks up the per-lane offset. Assert it on the
+    # store LINE: a bare `"subblock_idx * 64" in printed` also matches the tile.load
+    # above, so it passed whether or not the store was offset at all.
+    store_line = next(line for line in printed.splitlines() if "pl.tile.store(" in line)
+    assert "pl.tile.store(acc_loop, [0 + subblock_idx * 64, 0]" in store_line
 
 
 def test_slice_drop_dims_maps_the_result_axis_back_to_the_source_axis():
@@ -4325,6 +4328,69 @@ def test_source_level_no_else_phi_still_merges_after_ssa_conversion():
     assert f"{merge_name}: pl.Tile[[64, 128], pl.FP32, pl.Mem.Vec]" in printed
     store_line = next(line for line in printed.splitlines() if "pl.tile.store(" in line)
     assert f"pl.tile.store({merge_name}, [0 + subblock_idx * 64, 0]" in store_line
+
+
+def test_loop_backedge_yielding_a_full_width_value_is_rejected():
+    """The backedge must agree with the carry it feeds.
+
+    ``RepairIterArgs`` / ``RepairReturnVars`` repair the carry's entry and exit,
+    but nothing looked at the value the body yields back into it. With a halved
+    init and a body that yields a full-width parameter, the carry is retyped to
+    ``[64, 128]`` while the yielded value stays ``[128, 128]`` — the gh#2203
+    "declared type contradicts the value" defect on the carry path, which no
+    operand check sees because it inspects a ``Call``'s arguments and this is a
+    ``Yield``.
+    """
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def split_auto(
+            cube_seed: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat],
+            data: pl.Tensor[[128, 128], pl.FP32],
+            full: pl.Tile[[128, 128], pl.FP32, pl.Mem.Vec],
+            out_0: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+        ) -> pl.Tensor[[128, 128], pl.FP32]:
+            seed_vec = pl.tile.move(cube_seed, target_memory=pl.Mem.Vec)  # noqa: F841
+            accum = pl.tile.load(data, [0, 0], [128, 128], target_memory=pl.Mem.Vec)
+            for i, (acc_it,) in pl.range(2, init_values=(accum,)):  # noqa: B007
+                acc_loop = pl.yield_(full)
+            out_store = pl.tile.store(acc_loop, [0, 0], out_0)
+            return out_store
+
+    with pytest.raises(ValueError, match="yields") as exc_info:
+        _lower(Before)
+    assert "acc" in str(exc_info.value)
+
+
+def test_loop_backedge_yielding_a_lane_local_value_into_a_shared_carry_is_rejected():
+    """The mismatch is rejected in both directions.
+
+    Here the carry's init is a full-width parameter, so nothing halved it, while
+    the body yields a value the split made lane-local. A per-lane value cannot
+    live in a full-width carry any more than the converse, and the check is
+    symmetric so neither direction silently survives.
+    """
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def split_auto(
+            cube_seed: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat],
+            data: pl.Tensor[[128, 128], pl.FP32],
+            full: pl.Tile[[128, 128], pl.FP32, pl.Mem.Vec],
+            out_0: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+        ) -> pl.Tensor[[128, 128], pl.FP32]:
+            seed_vec = pl.tile.move(cube_seed, target_memory=pl.Mem.Vec)  # noqa: F841
+            for i, (acc_it,) in pl.range(2, init_values=(full,)):  # noqa: B007
+                halved = pl.tile.load(data, [0, 0], [128, 128], target_memory=pl.Mem.Vec)
+                acc_loop = pl.yield_(halved)
+            out_store = pl.tile.store(acc_loop, [0, 0], out_0)
+            return out_store
+
+    with pytest.raises(ValueError, match="is full width, but the body yields") as exc_info:
+        _lower(Before)
+    assert "'halved'" in str(exc_info.value)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

`LowerAutoVectorSplit` repairs a loop's carried state in two steps — init value → `iter_arg`, then `iter_arg` → `return_var` (`RepairIterArgs` / `RepairReturnVars`). Neither looks at the **third edge**: the value the body yields back into the carry.

With a halved init and a body that yields a full-width value, the carry was retyped to the per-lane extent while the yielded value stayed whole, and the result was **accepted**:

```text
accum:    pl.Tile[[64, 128], ...] = pl.tile.load(data, [0 + subblock_idx * 64, 0], ...)
for i, (acc_it,) in pl.range(2, init_values=(accum,)):
    acc_loop: pl.Tile[[64, 128], ...] = pl.yield_(full)   # `full` is [128, 128]
```

That is the #2203 defect — a declared type contradicting the value it describes — on the carry path. No operand check sees it: those inspect a `Call`'s arguments, and this is a `Yield`. It also survives print→parse, because the parser does not type-check a yield binding against its value, so nothing downstream flagged it either.

Behavior change: such a loop is now rejected at compile time with a `ValueError` naming the carry and the yielded value. No in-contract program changes behavior. No interface or migration step.

## Changes

- `src/ir/transforms/utils/split_axis_utils.{h,cpp}`: add `ValidateCarryBackedge` — the yielded value must be lane-local exactly when the carry is. The check is **symmetric**: a lane-local value yielded into a full-width carry is rejected too, since a per-lane value cannot live under a whole-tile declared type either.
- Called from all three sites that repair a carry: `ProcessStmt`'s `ForStmt` arm, and the AUTO affinity-gated arm's `ForStmt` and `WhileStmt` arms.
- `docs/{en,zh}/dev/passes/21-lower_auto_vector_split.md`: the carry now documents all three edges.
- `tests/ut/ir/transforms/test_lower_auto_vector_split.py`: two rejection cases (below), plus one strengthened assertion.

### Why validate rather than repair

It is the only available answer in both directions. When the yielded value **is** tracked, the trailing `Substitute` already swaps in its halved replacement and there is nothing to fix. When it is **not**, no halved version of it exists to substitute — so a diagnostic naming the carry and the yielded value is what the author can act on.

### One test strengthened

`test_loop_carried_tile_accumulator_is_tracked` asserted `"subblock_idx * 64" in printed` for the loop-exit store. The `tile.load` line above already satisfies that, so it passed whether or not the store was offset at all. It now asserts the offset on the store line itself. (Behavior was already correct — this only closes the hole in the assertion.)

## Verification

Run at the pushed commit, in a worktree-local build. Each check run into a log file with its exit code asserted, not judged by its tail:

- `pytest tests/ut/ -q -n 16 -p no:randomly` → `EXIT=1`: 11140 passed, 8 skipped, 1 xfailed, 1 failed. The single failure is `test_symlinked_import_path_still_names_the_caller`, which fails identically on an unmodified checkout of this machine (the editable install's meta-path finder hijacks the subprocess's symlinked `import pypto`).
- `pytest tests/ut/ir/transforms/test_lower_auto_vector_split.py` → 106 passed.
- `clang_tidy.py -B build --strict-version --diff-base=upstream/main` → `EXIT=0` (clang-tidy 21.1.0, files actually linted).
- `clang-format --dry-run --Werror` → `EXIT=0`; `ruff check` / `ruff format --check` (0.14.8) → `EXIT=0`; `pyright` → `EXIT=0`; `markdownlint-cli2` on both docs → `EXIT=0`; all `tests/lint/*.py` → pass.

Both new tests were mutation-checked: stubbing `ValidateCarryBackedge` to return immediately makes exactly those two fail and nothing else, so neither is vacuous.

`tests/ut/codegen/test_orchestration_codegen_graph.py::test_generated_orchestration_compiles_against_the_pinned_runtime` is deselected locally: this checkout's `runtime` submodule sits at `dbdd041e` while the branch pins `15f5cbd9`, so the generated file is type-checked against the wrong headers. The submodule is deliberately left unstaged; CI is green on it.

No system tests were run locally; CI covers them.

Closes #2613
