### PR TITLE
fix(ir): give the column arg reductions the row forms' exact tmp check

### DIFF
--- a/python/pypto/ir/op/tile_ops.py
+++ b/python/pypto/ir/op/tile_ops.py
@@ -2690,7 +2690,8 @@ def col_sum(tile: Expr, tmp_tile: Expr | None = None, span: Span | None = None) 
     Args:
         tile: Input tile (TileType [M, N])
         tmp_tile: Optional scratch tile (TileType, same shape/dtype as input) that
-            activates binary-tree reduction.
+            activates binary-tree reduction. Unlike the arg reductions, this is
+            not enforced by type deduction -- pass the input's shape and dtype.
         span: Optional source span for debugging (auto-captured if not provided)
 
     Returns:
@@ -2791,7 +2792,8 @@ def col_argmax(tile: Expr, tmp_tile: Expr, span: Span | None = None) -> Call:
 
     Args:
         tile: Input tile (TileType [M, N])
-        tmp_tile: Temporary tile (TileType)
+        tmp_tile: Scratch tile (TileType) with exactly the same shape and dtype as
+            ``tile`` -- the kernel reads the column count from the tmp/src extent
         span: Optional source span for debugging (auto-captured if not provided)
 
     Returns:
@@ -2809,7 +2811,8 @@ def col_argmin(tile: Expr, tmp_tile: Expr, span: Span | None = None) -> Call:
 
     Args:
         tile: Input tile (TileType [M, N])
-        tmp_tile: Temporary tile (TileType)
+        tmp_tile: Scratch tile (TileType) with exactly the same shape and dtype as
+            ``tile`` -- the kernel reads the column count from the tmp/src extent
         span: Optional source span for debugging (auto-captured if not provided)
 
     Returns:

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -1766,7 +1766,8 @@ def col_sum(tile: Tile, tmp_tile: Tile | None = None) -> Tile:
     Args:
         tile: Input tile
         tmp_tile: Optional scratch tile (same shape/dtype as input) that selects
-            the binary-tree reduction path.
+            the binary-tree reduction path. Unlike the arg reductions, this is not
+            enforced by type deduction -- pass the input's shape and dtype.
 
     Returns:
         Tile wrapping the col_sum operation
@@ -1861,7 +1862,7 @@ def col_argmax(tile: Tile, tmp_tile: Tile) -> Tile:
 
     Args:
         tile: Input tile
-        tmp_tile: Temporary tile
+        tmp_tile: Scratch tile with exactly the same shape and dtype as ``tile``
 
     Returns:
         Tile wrapping the col_argmax operation
@@ -1878,7 +1879,7 @@ def col_argmin(tile: Tile, tmp_tile: Tile) -> Tile:
 
     Args:
         tile: Input tile
-        tmp_tile: Temporary tile
+        tmp_tile: Scratch tile with exactly the same shape and dtype as ``tile``
 
     Returns:
         Tile wrapping the col_argmin operation

--- a/python/pypto/language/op/unified_ops.py
+++ b/python/pypto/language/op/unified_ops.py
@@ -220,7 +220,8 @@ _TMP_ROW_REDUCTION_REQUIREMENT = (
 )
 _TMP_ROW_ARG_REDUCTION_REQUIREMENT = "tmp_tile with exactly the same shape and dtype as the input"
 _TMP_COL_ARG_REDUCTION_REQUIREMENT = (
-    "tmp_tile — the tile form takes caller-owned scratch, unlike pl.col_max / pl.col_min"
+    "tmp_tile with exactly the same shape and dtype as the input — the tile form takes "
+    "caller-owned scratch, unlike pl.col_max / pl.col_min"
 )
 
 
@@ -1319,8 +1320,11 @@ def col_argmax(input: Tile, tmp_tile: Tile) -> Tile: ...
 def col_argmax(input, tmp_tile: Tile | None = None):
     """Column-wise argmax (per-column max index, int32), dispatched by input type.
 
-    For Tile inputs, tmp_tile is required (unlike col_max). Tensor inputs must
-    omit it — the conversion injects the tmp tile — and passing one raises.
+    For Tile inputs, tmp_tile is required (unlike col_max) and must have exactly
+    the same shape and dtype as the input: the pto-isa kernel reads the column
+    count from the tmp/src extent, so an oversized scratch walks past the valid
+    columns. Tensor inputs must omit it — the conversion injects the tmp tile —
+    and passing one raises.
     """
     if isinstance(input, Tensor):
         _reject_tmp_for_tensor("col_argmax", tmp_tile, "tmp_tile")
@@ -1338,8 +1342,11 @@ def col_argmin(input: Tile, tmp_tile: Tile) -> Tile: ...
 def col_argmin(input, tmp_tile: Tile | None = None):
     """Column-wise argmin (per-column min index, int32), dispatched by input type.
 
-    For Tile inputs, tmp_tile is required (unlike col_min). Tensor inputs must
-    omit it — the conversion injects the tmp tile — and passing one raises.
+    For Tile inputs, tmp_tile is required (unlike col_min) and must have exactly
+    the same shape and dtype as the input: the pto-isa kernel reads the column
+    count from the tmp/src extent, so an oversized scratch walks past the valid
+    columns. Tensor inputs must omit it — the conversion injects the tmp tile —
+    and passing one raises.
     """
     if isinstance(input, Tensor):
         _reject_tmp_for_tensor("col_argmin", tmp_tile, "tmp_tile")

--- a/src/ir/op/tile_ops/reduction.cpp
+++ b/src/ir/op/tile_ops/reduction.cpp
@@ -144,7 +144,18 @@ TypePtr DeduceTileRowReductionType(const std::vector<ExprPtr>& args,
 TypePtr DeduceTileColReductionType(const std::vector<ExprPtr>& args,
                                    const std::vector<std::pair<std::string, std::any>>& kwargs,
                                    const std::string& op_name,
-                                   std::optional<DataType> out_dtype = std::nullopt) {
+                                   std::optional<DataType> out_dtype = std::nullopt,
+                                   bool require_exact_tmp_shape = false) {
+  // Guard the operand count BEFORE touching args[0]. Indexing an empty vector is
+  // undefined behaviour, and here it segfaulted the interpreter rather than
+  // raising -- `create_op_call("tile.col_argmax", [])` died with SIGSEGV. Every
+  // other registration using this deducer guards arity in its own lambda; doing
+  // it here covers them all and cannot be forgotten by the next one.
+  CHECK(!args.empty()) << "The operator " << op_name << " requires at least 1 argument, but got 0";
+  if (require_exact_tmp_shape) {
+    CHECK(args.size() == 2) << "The operator " << op_name << " requires 2 arguments, but got " << args.size();
+  }
+
   // First argument must be TileType
   auto tile_type = As<TileType>(args[0]->GetType());
   CHECK(tile_type) << "The operator " << op_name << " requires first argument to be a TileType, but got "
@@ -154,6 +165,37 @@ TypePtr DeduceTileColReductionType(const std::vector<ExprPtr>& args,
   int64_t input_ndim = static_cast<int64_t>(input_shape.size());
   CHECK(input_ndim >= 2) << "The operator " << op_name << " requires at least a 2D tile, but got "
                          << input_ndim << " dimensions";
+
+  // The column ARG reductions need a scratch tile shaped exactly like the source:
+  // pto-isa's TCOLARGMAX / TCOLARGMIN read the column count from the tmp/src
+  // extent, so a wider tmp walks past the valid columns and can return the wrong
+  // index per column -- a silent wrong answer with nothing downstream to catch
+  // it. The row forms enforce this already; this is the column half (gh#2615).
+  //
+  // Only the arg forms opt in. col_sum's optional tmp drives a binary-tree
+  // reduction with different sizing semantics and is deliberately left alone.
+  if (require_exact_tmp_shape) {
+    auto tmp_type = As<TileType>(args[1]->GetType());
+    CHECK_SPAN(tmp_type, args[1]->span_)
+        << "The operator " << op_name << " requires tmp_tile to be a TileType, but got "
+        << args[1]->GetType()->TypeName();
+    CHECK_SPAN(tmp_type->dtype_ == tile_type->dtype_, args[1]->span_)
+        << "The operator " << op_name
+        << " requires tmp_tile dtype to match input dtype, but got tmp_tile dtype "
+        << tmp_type->dtype_.ToString() << " and input dtype " << tile_type->dtype_.ToString();
+    CHECK_SPAN(tmp_type->shape_.size() == input_shape.size(), args[1]->span_)
+        << "The operator " << op_name << " requires tmp_tile to have the same rank as the input, but got "
+        << "tmp_tile shape " << FormatShape(tmp_type->shape_) << " and input shape "
+        << FormatShape(input_shape);
+    for (size_t i = 0; i < input_shape.size(); ++i) {
+      CHECK_SPAN(ProveValidExtentEqual(input_shape[i], tmp_type->shape_[i]) == ProofResult::kTrue,
+                 args[1]->span_)
+          << "The operator " << op_name
+          << " requires tmp_tile shape to exactly match the input shape, but dimension " << i
+          << " differs; got tmp_tile shape " << FormatShape(tmp_type->shape_) << " and input shape "
+          << FormatShape(input_shape);
+    }
+  }
 
   // Output shape: [1, ...remaining] — reduce along first axis with keepdim=True
   std::vector<ExprPtr> output_shape;
@@ -377,7 +419,7 @@ REGISTER_OP("tile.col_argmax")
     .set_op_category("TileOp")
     .set_description("Column-wise argmax: row index of the per-column maximum (maps to TCOLARGMAX)")
     .add_argument("tile", "Input tile (TileType)")
-    .add_argument("tmp_tile", "Temporary tile (TileType)")
+    .add_argument("tmp_tile", "Same-dtype scratch tile shaped EXACTLY like the input (TileType)")
     .set_input_memory(0, MemorySpace::Vec)
     .set_input_memory(1, MemorySpace::Vec)
     .set_output_memory(MemorySpace::Vec)
@@ -385,39 +427,31 @@ REGISTER_OP("tile.col_argmax")
     // output must not alias an input (the tmp-bearing column variants share the
     // row-reduction in-place hazard, unlike the 1-arg col_max/col_min).
     .not_inplace_safe()
-    // NOT declared lane-invariant: argmax/argmin need a tmp shaped EXACTLY like
-    // the source (the TROWARGMAX/TCOLARGMAX kernels read the column count from
-    // the tmp/src extent), so a wider tmp walks past the valid columns and can
-    // return the wrong index per column. Unlike the row forms,
-    // DeduceTileColReductionType never inspects args[1] (gh#2615), so type
-    // deduction is BLIND here -- leaving it undeclared is what makes automatic
-    // AIV splitting treat it as per-lane data and reject a full-width one.
+    // NOT declared lane-invariant, and it must not be: the deducer below runs
+    // with require_exact_tmp_shape, so it already rejects a full-width tmp beside
+    // a halved input. Automatic AIV splitting consults a declaration only where
+    // type deduction is silent, so one here could never be reached.
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
-      CHECK(args.size() == 2) << "The operator tile.col_argmax requires 2 arguments, but got " << args.size();
-      return DeduceTileColReductionType(args, kwargs, "tile.col_argmax", DataType(DataType::INT32));
+      return DeduceTileColReductionType(args, kwargs, "tile.col_argmax", DataType(DataType::INT32), true);
     });
 
 REGISTER_OP("tile.col_argmin")
     .set_op_category("TileOp")
     .set_description("Column-wise argmin: row index of the per-column minimum (maps to TCOLARGMIN)")
     .add_argument("tile", "Input tile (TileType)")
-    .add_argument("tmp_tile", "Temporary tile (TileType)")
+    .add_argument("tmp_tile", "Same-dtype scratch tile shaped EXACTLY like the input (TileType)")
     .set_input_memory(0, MemorySpace::Vec)
     .set_input_memory(1, MemorySpace::Vec)
     .set_output_memory(MemorySpace::Vec)
     .not_inplace_safe()
-    // NOT declared lane-invariant: argmax/argmin need a tmp shaped EXACTLY like
-    // the source (the TROWARGMAX/TCOLARGMAX kernels read the column count from
-    // the tmp/src extent), so a wider tmp walks past the valid columns and can
-    // return the wrong index per column. Unlike the row forms,
-    // DeduceTileColReductionType never inspects args[1] (gh#2615), so type
-    // deduction is BLIND here -- leaving it undeclared is what makes automatic
-    // AIV splitting treat it as per-lane data and reject a full-width one.
+    // NOT declared lane-invariant, and it must not be: the deducer below runs
+    // with require_exact_tmp_shape, so it already rejects a full-width tmp beside
+    // a halved input. Automatic AIV splitting consults a declaration only where
+    // type deduction is silent, so one here could never be reached.
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
-      CHECK(args.size() == 2) << "The operator tile.col_argmin requires 2 arguments, but got " << args.size();
-      return DeduceTileColReductionType(args, kwargs, "tile.col_argmin", DataType(DataType::INT32));
+      return DeduceTileColReductionType(args, kwargs, "tile.col_argmin", DataType(DataType::INT32), true);
     });
 
 }  // namespace ir

--- a/tests/ut/ir/operators/test_lane_invariant_arg_coverage.py
+++ b/tests/ut/ir/operators/test_lane_invariant_arg_coverage.py
@@ -115,8 +115,9 @@ EXPECTED_BLIND_ARGS = {
     ("tile.gather", 0),
     ("tile.gatherb", 0),
     # --- undeclared: per-lane data, so the pass requires it to be sharded ---
-    ("tile.col_argmax", 1),
-    ("tile.col_argmin", 1),
+    # (tile.col_argmax / col_argmin arg 1 used to sit here; gh#2615 gave their
+    # deducer the row forms' exact-shape check, so type consistency decides them
+    # now and no declaration is reachable for either.)
     ("tile.col_expand", 1),
     ("tile.col_expand_add", 1),
     ("tile.col_expand_div", 1),

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -863,6 +863,94 @@ class TestTileReductionOps:
         assert isinstance(call.type, ir.TileType)
         assert call.type.dtype == DataType.INT32
 
+    @pytest.mark.parametrize("op", [tile.col_argmax, tile.col_argmin])
+    @pytest.mark.parametrize("tmp_shape", [[8, 256], [8, 640], [16, 512]])
+    def test_tile_col_arg_reduction_rejects_non_exact_tmp_shape(self, op, tmp_shape):
+        """Column arg reductions need the same exact scratch the row forms need.
+
+        pto-isa's TCOLARGMAX / TCOLARGMIN read the column count from the tmp/src
+        extent, so an oversized tmp walks past the valid columns and can return
+        the wrong index per column — a silent wrong answer with nothing
+        downstream to catch it.
+        """
+        span = ir.Span.unknown()
+        input_tile = ir.Var("input_tile", ir.TileType([8, 512], DataType.FP32), span)
+        tmp_tile = ir.Var("tmp_tile", ir.TileType(tmp_shape, DataType.FP32), span)
+
+        with pytest.raises(ValueError, match="requires tmp_tile shape to exactly match the input shape"):
+            op(input_tile, tmp_tile)
+
+    @pytest.mark.parametrize("op", [tile.col_argmax, tile.col_argmin])
+    def test_tile_col_arg_reduction_rejects_mismatched_tmp_rank(self, op):
+        """Rank is checked before the per-dimension extents, and reports as rank."""
+        span = ir.Span.unknown()
+        input_tile = ir.Var("input_tile", ir.TileType([8, 512], DataType.FP32), span)
+        tmp_tile = ir.Var("tmp_tile", ir.TileType([8, 512, 1], DataType.FP32), span)
+
+        with pytest.raises(ValueError, match="requires tmp_tile to have the same rank as the input"):
+            op(input_tile, tmp_tile)
+
+    @pytest.mark.parametrize("op_name", ["tile.col_argmax", "tile.col_argmin"])
+    def test_tile_col_arg_reduction_rejects_no_arguments(self, op_name):
+        """An empty operand list must raise, not read past the end of the list.
+
+        The deducer reads ``args[0]`` to get the input type; guarding the count
+        only afterwards made ``create_op_call(op, [])`` index an empty vector,
+        which segfaulted the interpreter instead of raising.
+        """
+        with pytest.raises(ValueError, match="requires at least 1 argument"):
+            ir.create_op_call(op_name, [], {}, ir.Span.unknown())
+
+    @pytest.mark.parametrize("op", [tile.col_argmax, tile.col_argmin])
+    def test_tile_col_arg_reduction_rejects_mismatched_tmp_dtype(self, op):
+        """Column arg reductions require scratch storage with the input element type."""
+        span = ir.Span.unknown()
+        input_tile = ir.Var("input_tile", ir.TileType([8, 512], DataType.FP32), span)
+        tmp_tile = ir.Var("tmp_tile", ir.TileType([8, 512], DataType.FP16), span)
+
+        with pytest.raises(ValueError, match="requires tmp_tile dtype to match input dtype"):
+            op(input_tile, tmp_tile)
+
+    @pytest.mark.parametrize("op", [tile.col_argmax, tile.col_argmin])
+    def test_tile_col_arg_reduction_accepts_exact_tmp_shape(self, op):
+        """The exact form every in-tree caller already passes still lowers.
+
+        Both producers build the scratch from the input's own shape: the
+        tensor->tile conversion (``MakeArgReductionConv``) and the tile-level
+        DSL call sites.
+        """
+        span = ir.Span.unknown()
+        input_tile = ir.Var("input_tile", ir.TileType([8, 512], DataType.FP32), span)
+        tmp_tile = ir.Var("tmp_tile", ir.TileType([8, 512], DataType.FP32), span)
+
+        call = op(input_tile, tmp_tile)
+
+        assert isinstance(call.type, ir.TileType)
+        assert call.type.dtype == DataType.INT32
+        assert isinstance(call.type.shape[0], ir.ConstInt)
+        assert isinstance(call.type.shape[1], ir.ConstInt)
+        assert [call.type.shape[0].value, call.type.shape[1].value] == [1, 512]
+
+    def test_tile_col_sum_tmp_is_not_validated_by_the_arg_form_check(self):
+        """gh#2615's exact-shape check does not widen to col_sum.
+
+        This pins the SCOPE of that change, not a contract: col_sum's tmp drives a
+        binary-tree reduction rather than an arg scan, and its docstrings still ask
+        callers for the input's shape and dtype. Type deduction simply does not
+        enforce it, and this test exists so that staying unenforced is a decision
+        rather than an accident — flip it deliberately if col_sum is tightened too.
+        """
+        span = ir.Span.unknown()
+        input_tile = ir.Var("input_tile", ir.TileType([8, 512], DataType.FP32), span)
+        wider_tmp = ir.Var("tmp_tile", ir.TileType([8, 640], DataType.FP32), span)
+
+        call = tile.col_sum(input_tile, wider_tmp)
+
+        assert isinstance(call.type, ir.TileType)
+        assert isinstance(call.type.shape[0], ir.ConstInt)
+        assert isinstance(call.type.shape[1], ir.ConstInt)
+        assert [call.type.shape[0].value, call.type.shape[1].value] == [1, 512]
+
     @pytest.mark.parametrize("dtype", [DataType.INT16, DataType.INT32, DataType.FP16, DataType.FP32])
     def test_tile_row_min_accepts_exact_pto_contract(self, dtype):
         """tile.row_min accepts every PTO dtype and produces a DN column vector."""


### PR DESCRIPTION
## Summary

`tile.row_argmax` / `row_argmin` validate that their `tmp_tile` is shaped exactly like the source; `tile.col_argmax` / `col_argmin` validated it **not at all**. `DeduceTileColReductionType` inspects `args[0]` only — it never reads `args[1]`, so there was no dtype, rank or shape check on the scratch tile.

The contract is stated where the tensor→tile conversion builds that scratch (`op_conversion_registry.cpp:1329`):

> Argmax/argmin require a tmp tile shaped EXACTLY like the source (the pto-isa TROWARGMAX/TCOLARGMAX kernels read the column count from the tmp/src extent).

A wider tmp therefore makes the column argmax iterate past the valid columns and can return the wrong index per column — a silent wrong answer, with nothing on the path to catch it.

Behavior change: a `tile.col_argmax` / `col_argmin` whose `tmp_tile` mismatches the input in dtype, rank or any extent is now rejected at construction with a `ValueError`. Unlike the other fixes in this series this check is **not** scoped to auto-split regions — it applies wherever the op is built — so the blast radius is written up below.

## Blast radius — nothing in tree relied on the looser contract

Both producers already build the scratch from the input's own shape:

| Producer | Scratch it builds |
| -------- | ----------------- |
| `MakeArgReductionConv` (`op_conversion_registry.cpp:1346`) — the only path from `tensor.col_argmax` | `MakeTuple(tile_type->shape_)`, i.e. the input's shape exactly |
| `tests/st/runtime/ops/test_argmax_reduction.py:188,218` — the tile-level DSL call sites | `tmp: pl.Tile[[m, n]]` beside `t: pl.Tile[[m, n]]` |

The tile-level wrapper (`pl.tile.col_argmax(tile, tmp_tile)`) is user-reachable, so a caller *could* have passed a non-exact tmp — none does. The full unit suite passes unchanged (11218 passed).

## Changes

- `src/ir/op/tile_ops/reduction.cpp`: `DeduceTileColReductionType` gains `require_exact_tmp_shape`, mirroring the row form — dtype must match, rank must match, every extent must be provably equal. `col_argmax` / `col_argmin` pass `true`.
- `tests/ut/ir/operators/test_tile_ops.py`: the column siblings of the row form's tmp tests (non-exact shape rejected in three shapes, mismatched dtype rejected, exact shape accepted), plus one pinning that `col_sum` keeps its looser contract.
- `tests/ut/ir/operators/test_lane_invariant_arg_coverage.py`: the two positions leave the deducer-blind inventory.
- Registry comments and the `tmp_tile` argument description, which described the gap this closes.

### Why `col_sum` is deliberately untouched

`col_sum`'s optional tmp drives a binary-tree reduction with different sizing semantics, not an arg scan. The check is therefore opt-in per registration rather than applied to every column reduction, and a test pins that `col_sum` still accepts a wider tmp.

### The coverage test doing its job

`test_lane_invariant_arg_coverage.py` failed on this change before I updated it:

```
no longer blind (the deducer now decides; drop any Scratch declaration):
  [('tile.col_argmax', 1), ('tile.col_argmin', 1)]
```

That is the loop that test was built for in #2585: completing a deducer is what shrinks the set `LowerAutoVectorSplit` needs registry metadata for, and the inventory makes the shrinkage explicit in the diff instead of silent. The registry comments claiming "type deduction is BLIND here" are stale as of this PR and are replaced with the wording the row forms carry.

## Verification

Run at the pushed commit, in a worktree-local build. Every check run into a log file with its exit code asserted:

- `pytest tests/ut/ -q -n 16 -p no:randomly` → 11218 passed, 8 skipped, 1 xfailed, 1 failed. The single failure is `test_symlinked_import_path_still_names_the_caller`, which fails identically on an unmodified checkout of this machine.
- `clang_tidy.py -B build --strict-version --diff-base=upstream/main` → `EXIT=0` at clang-tidy 21.1.0.
- `clang-format --dry-run --Werror`, `ruff check`, `ruff format --check` (0.14.8), `pyright`, and all `tests/lint/*.py` → all `EXIT=0`.

`tests/ut/codegen/test_orchestration_codegen_graph.py::test_generated_orchestration_compiles_against_the_pinned_runtime` is deselected locally: this checkout's `runtime` submodule sits at `dbdd041e` while main now pins `77fa0171`. The submodule is deliberately left unstaged; CI is green on it.

No system tests were run locally; CI covers them — `tests/st/runtime/ops/test_argmax_reduction.py` is the on-device case for this op and is the one to watch.

Closes #2615
