### PR TITLE
WIP: refactor(runtime): persistent-domain retention off Simpler privates onto public API + artifact-compatible default (Closes #2284)

### DIFF
--- a/docs/en/dev/06-persistent-l3.md
+++ b/docs/en/dev/06-persistent-l3.md
@@ -13,7 +13,12 @@ with decode.prepare(persistent=True) as worker:
         worker(x, weights, output)
 ```
 
-The persistent path is opt-in. The default `prepare()` behavior is unchanged.
+`persistent` defaults to `None`, which defers to pypto's own choice (today,
+non-persistent — unchanged from the prior `False` default). Pass an explicit
+`True` to require persistence: on an artifact that predates the
+`_domain_provider` hook this raises `ValueError` rather than silently
+dispatching non-persistently. Leaving `persistent` unset never raises for that
+reason — see "Artifact compatibility" below.
 
 ## Lifecycle
 
@@ -31,6 +36,24 @@ keyword. Normal dispatch leaves it unset and continues to call
 `orch.allocate_domain`. Persistent dispatch supplies a provider keyed by the
 compiled program and generated domain name. Existing generated artifacts must
 be regenerated before they can use persistent execution.
+
+## Artifact compatibility
+
+`DistributedWorker` detects the `_domain_provider` hook on the loaded
+orchestration entry at `prepare()` time, before any dispatch. What happens on
+a missing hook depends on whether persistence was requested explicitly:
+
+- `persistent=True` (explicit): raises `ValueError` naming the missing hook.
+  Recompile via `ir.compile()` to pick it up.
+- `persistent=None` (the default, or forwarded unset through `benchmark()`):
+  warns with `RuntimeWarning` and falls back to transient dispatch for every
+  program on the worker, instead of raising. A caller who never asked for
+  persistence should not see a hard failure just because pypto's own default
+  happens to want it.
+
+A worker preparing multiple programs (`extra_compiled=[...]`) shares one
+`persistent` flag: if any program's artifact lacks the hook, the whole worker
+falls back (or raises, if requested explicitly) — not just that program.
 
 ## Window contents
 

--- a/docs/en/dev/06-persistent-l3.md
+++ b/docs/en/dev/06-persistent-l3.md
@@ -95,6 +95,30 @@ their windows exactly with named buffers. Reset rejects artifacts with unnamed
 window slack because the Buffer API cannot restore that slack to fresh-window
 state.
 
+## Shape stability
+
+A retained CommDomain's spec — its worker set, `window_size`, and named buffer
+sizes — is an identity, fixed by its first dispatch. A compiled program's
+`window_size` can depend on a runtime scalar (a decode loop's sequence length,
+for example), so two dispatches of the same persistent worker *can* legitimately
+request different sizes for the same generated domain. When that happens,
+persistent dispatch raises `ValueError` instead of silently reallocating.
+
+This is deliberate, not a limitation to work around with a retry: a single
+dispatch can declare more than one CommDomain in sequence, and by the time a
+later domain's mismatch is discovered, an earlier one in the same request may
+already be entered with real device-side effects issued against it. There is
+no safe point to swap out just the mismatched domain, so the failure poisons
+the whole persistent worker — every subsequent call raises the same stored
+error, including one that reverts to the original, previously-matching shape.
+`close()` after such a failure still releases every retained domain cleanly.
+
+A workload whose shape genuinely varies across calls should pass
+`persistent=False` explicitly, or pad requests to one fixed window size so the
+retained spec never changes. Leaving `persistent` unset does not avoid this —
+the fallback in "Artifact compatibility" only covers a missing `_domain_provider`
+hook, not a shape change once persistence is active.
+
 ## Multiple compiled programs
 
 Persistent execution supports the existing multi-program prepared worker:

--- a/docs/zh/dev/06-persistent-l3.md
+++ b/docs/zh/dev/06-persistent-l3.md
@@ -81,6 +81,27 @@ reset copy 会计入每次重复请求的 host 开销。
 会由具名 buffer 完整覆盖 window；如果 artifact 含有未命名的 window 空隙，reset
 会直接拒绝，因为当前 Buffer API 无法将该空隙恢复为 fresh-window 状态。
 
+## Shape 稳定性
+
+一个 retained CommDomain 的 spec（worker 集合、`window_size`、具名 buffer 大小）
+在其首次 dispatch 后即固定为一份身份标识。compiled program 的 `window_size`
+可能依赖某个运行时标量（例如 decode 循环的序列长度），因此同一个持久 worker
+的两次 dispatch **确实可能**为同一个 generated domain 请求不同大小。发生这种
+情况时，持久 dispatch 会抛出 `ValueError`，而不会静默重新分配。
+
+这是刻意设计，而非可以重试规避的限制：一次 dispatch 可能按顺序声明多个
+CommDomain，等到后面某个 domain 的 shape 不匹配被发现时，同一次请求中更早的
+domain 可能已经进入使用状态，并已对其发出真实的设备端操作。因此不存在能够
+安全地只替换那个不匹配 domain 的时机——失败会使整个持久 worker 中毒：此后
+每次调用都会抛出同一个已存储的错误，即便某次调用又恢复到最初匹配的 shape 也
+一样。这种失败之后调用 `close()` 仍会正常释放所有 retained domain。
+
+Shape 确实会变化的工作负载应当显式传入 `persistent=False`，或者把请求填充
+（pad）到同一个固定 window 大小，使 retained spec 永不改变。不传 `persistent`
+（保持默认）并不能规避这个问题——「Artifact 兼容性」一节中的回退逻辑只覆盖
+`_domain_provider` hook 缺失的情形，并不覆盖持久模式已激活后发生的 shape
+变化。
+
 ## 多 compiled program
 
 持久模式支持现有的 multi-program prepared worker：

--- a/docs/zh/dev/06-persistent-l3.md
+++ b/docs/zh/dev/06-persistent-l3.md
@@ -13,7 +13,11 @@ with decode.prepare(persistent=True) as worker:
         worker(x, weights, output)
 ```
 
-持久模式需要显式开启，默认的 `prepare()` 行为保持不变。
+`persistent` 默认为 `None`，表示交由 pypto 自行决定（目前解析为非持久模式，
+与此前默认值 `False` 的行为一致）。显式传入 `True` 则要求必须启用持久模式：
+若 artifact（构建产物）早于 `_domain_provider` hook（钩子）生成，将抛出
+`ValueError`，而不会静默退回非持久 dispatch。不传 `persistent`（保持默认）
+则永远不会因为这个原因抛错——见下文「Artifact 兼容性」。
 
 ## 生命周期
 
@@ -28,6 +32,23 @@ domain 释放错误都会抛给调用方。
 不传该参数，仍然调用 `orch.allocate_domain`；持久 dispatch 则传入一个按 compiled
 program 和 generated domain name 隔离的 provider。已有 generated artifact 必须
 重新生成后才能使用持久模式。
+
+## Artifact 兼容性
+
+`DistributedWorker` 会在 `prepare()` 时（即任何 dispatch 之前）检测已加载
+orchestration entry 上是否存在 `_domain_provider` hook。缺失该 hook 时的处理
+方式取决于持久模式是否被显式请求：
+
+- `persistent=True`（显式）：抛出 `ValueError`，指明缺失的 hook。需通过
+  `ir.compile()` 重新编译以获得该 hook。
+- `persistent=None`（默认值，或经 `benchmark()` 透传的未设置状态）：发出
+  `RuntimeWarning` 警告，并将该 worker 上的所有 program 都退回非持久
+  dispatch，而不是抛错。调用方本就没有请求持久模式，不应仅因为 pypto 自身的
+  默认策略想要持久模式而遭遇硬失败。
+
+若一个 worker 同时准备多个 program（`extra_compiled=[...]`），它们共享同一个
+`persistent` 标志：只要其中任意一个 program 的 artifact 缺失该 hook，整个
+worker 都会退回（或者在显式请求时抛错）——而不仅仅是那一个 program。
 
 ## Window 内容
 

--- a/python/pypto/ir/distributed_compiled_program.py
+++ b/python/pypto/ir/distributed_compiled_program.py
@@ -477,7 +477,7 @@ class DistributedCompiledProgram:
         config: "RunConfig | None" = None,
         *,
         extra_compiled: Sequence["DistributedCompiledProgram"] = (),
-        persistent: bool = False,
+        persistent: bool | None = None,
         reset_persistent_windows: bool | None = None,
         callbacks: dict[str, Callable[..., Any]] | None = None,
         sub_worker_overrides: dict[str, Callable[..., Any]] | None = None,
@@ -521,9 +521,14 @@ class DistributedCompiledProgram:
             persistent: Retain each compiled program's CommDomains across
                 dispatches. Every request still runs through its own
                 ``Worker.run`` completion fence. Retained windows are restored
-                to zero before reuse by default. Requires artifacts generated
-                by a PyPTO version that supports the internal domain-provider
-                hook.
+                to zero before reuse by default. ``None`` (the default) defers
+                to pypto's own choice and, on an artifact predating the internal
+                domain-provider hook, silently falls back to transient dispatch
+                with a ``RuntimeWarning`` instead of raising — a caller who
+                never asked for persistence should not see one. Pass an
+                explicit ``True`` to require it: an incompatible artifact then
+                raises ``ValueError`` instead of falling back, so recompile via
+                ``ir.compile()`` to pick up the hook.
             reset_persistent_windows: Whether to restore retained CommDomain
                 windows to zero before every reuse. ``None`` (the default)
                 enables reset in persistent mode. Set to ``False`` only when

--- a/python/pypto/runtime/bench.py
+++ b/python/pypto/runtime/bench.py
@@ -1273,7 +1273,7 @@ def benchmark(
     platform: str | None = None,
     device_id: int | None = None,
     config: RunConfig | None = None,
-    persistent: bool = False,
+    persistent: bool | None = None,
     reset_persistent_windows: bool | None = None,
 ) -> BenchmarkStats:
     """Register *compiled* once and dispatch *rounds* timed launches.
@@ -1331,6 +1331,10 @@ def benchmark(
             ``ring_dep_pool``); ``None`` reuses the prepared baseline.
         persistent: L3 only. Reuse retained CommDomains across all warmup and
             measured dispatches while fencing each launch with ``Worker.run``.
+            ``None`` (the default) defers to pypto's own choice and falls back
+            to transient dispatch with a warning on an artifact that predates
+            the domain-provider hook; pass ``True`` to require it instead (see
+            ``DistributedCompiledProgram.prepare``).
         reset_persistent_windows: L3 persistent mode only. Restore retained
             windows to zero before reuse. ``None`` (the default) enables reset
             in persistent mode. Set to ``False`` only when the benchmarked

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -1937,16 +1937,10 @@ class DistributedWorker(Worker):
         """Fail before worker initialization when Simpler cannot retain domains."""
         if not self._persistent:
             return
-        live_domains = getattr(self._w, "_live_domains", None)
-        missing = []
-        if not isinstance(live_domains, dict):
-            missing.append("_live_domains")
-        if not hasattr(self._w, "_building_run_resources"):
-            missing.append("_building_run_resources")
-        if missing:
+        if not hasattr(self._w, "detach_persistent_domain"):
             raise RuntimeError(
-                "persistent distributed execution requires Simpler's private retention hooks: "
-                + ", ".join(missing)
+                "persistent distributed execution requires a Simpler version exposing "
+                "Worker.detach_persistent_domain"
             )
 
     def _reset_persistent_domains(
@@ -2020,32 +2014,11 @@ class DistributedWorker(Worker):
     def _detach_persistent_domain(self, handle: Any) -> None:
         """Transfer one CommDomain from the current run to Worker ownership.
 
-        Simpler records a newly allocated domain in both the current
-        ``_RunResources.live_domains`` journal and ``Worker._live_domains``.
-        Remove only the run-local claim: the global entry must remain reachable
-        so ``Worker.close()`` can reclaim it if request finalization is
-        interrupted before the run is retired.
+        Delegates to Simpler's public ``Worker.detach_persistent_domain``, which
+        keeps the domain reachable via ``Worker.live_domains`` so ``close()`` can
+        reclaim it if request finalization is interrupted before the run retires.
         """
-        live_domains = getattr(self._w, "_live_domains", None)
-        resources = getattr(self._w, "_building_run_resources", None)
-        run_live_domains = getattr(resources, "live_domains", None)
-        domain_lock = getattr(resources, "domain_lock", None)
-        if (
-            not isinstance(live_domains, dict)
-            or not isinstance(run_live_domains, dict)
-            or domain_lock is None
-        ):
-            raise RuntimeError(
-                "persistent distributed execution requires Simpler's active per-run CommDomain journal"
-            )
-        with domain_lock:
-            if bool(getattr(resources, "retired", False)):
-                raise RuntimeError("persistent CommDomain cannot be retained from an already-retired run")
-            if live_domains.get(handle.name) is not handle or run_live_domains.get(handle.name) is not handle:
-                raise RuntimeError(
-                    "persistent distributed execution could not transfer the CommDomain's run-local ownership"
-                )
-            del run_live_domains[handle.name]
+        self._w.detach_persistent_domain(handle)
 
     def _release_persistent_domains(
         self,

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -61,6 +61,12 @@ _DTYPE_MAP: dict[str, tuple[type, torch.dtype]] = {
 }
 
 
+# The library's own choice when a caller passes ``persistent=None`` (the default across
+# ``prepare()`` / ``DistributedWorker`` / ``benchmark()``). Kept as one module-level seam so a
+# future default flip touches this single line, not every call site's fallback logic.
+_PERSISTENT_DEFAULT = False
+
+
 def _resolve_persistent_window_reset(persistent: bool, reset_persistent_windows: bool | None) -> bool:
     """Resolve the retained-window reset policy.
 
@@ -1567,7 +1573,7 @@ class DistributedWorker(Worker):
         compiled: DistributedCompiledProgram | Sequence[DistributedCompiledProgram],
         config: RunConfig | None = None,
         *,
-        persistent: bool = False,
+        persistent: bool | None = None,
         reset_persistent_windows: bool | None = None,
         callbacks: dict[str, Callable[..., Any]] | None = None,
         sub_worker_overrides: dict[str, Callable[..., Any]] | None = None,
@@ -1581,7 +1587,14 @@ class DistributedWorker(Worker):
         # attached to DeviceTensor for address-free wire TaskArgs.
         self._device_buffers: dict[tuple[int, int], Any] = {}
         callbacks = _coalesce_callbacks(callbacks, sub_worker_overrides)
-        reset_persistent_windows = _resolve_persistent_window_reset(persistent, reset_persistent_windows)
+        # ``None`` defers to the library default; an explicit bool is a hard requirement that
+        # must raise (not silently fall back) if an artifact cannot honor it — see the
+        # ``persistent_explicit`` branch below, at the ``_domain_provider`` hook check.
+        persistent_explicit = persistent is not None
+        resolved_persistent = _PERSISTENT_DEFAULT if persistent is None else persistent
+        reset_persistent_windows = _resolve_persistent_window_reset(
+            resolved_persistent, reset_persistent_windows
+        )
         inherited, self._inherited_host_spans = self._resolve_inherited_host_tensors(inherited_host_tensors)
         self._inherited_host_tensors = inherited
         # `is_shared()` is kept as a one-way signal: True confirms a torch-managed shared
@@ -1607,7 +1620,7 @@ class DistributedWorker(Worker):
         # Minting and first creation are not atomic while `alloc_stacked_tensor` runs one thread
         # per chip through this path, so the cache, owner, and counter are guarded together.
         self._named_host_buffer_mu = threading.Lock()
-        self._persistent = bool(persistent)
+        self._persistent = resolved_persistent
         self._reset_persistent_windows = reset_persistent_windows
         self._persistent_error: BaseException | None = None
         self._persistent_error_reported = False
@@ -1689,10 +1702,24 @@ class DistributedWorker(Worker):
                     "persistent_id": f"p{program_index}",
                 }
                 if self._persistent and "_domain_provider" not in inspect.signature(entry_fn).parameters:
-                    raise ValueError(
-                        "persistent distributed execution requires regenerated host orchestration "
-                        "with the internal _domain_provider hook"
+                    if persistent_explicit:
+                        raise ValueError(
+                            "persistent distributed execution requires regenerated host orchestration "
+                            "with the internal _domain_provider hook"
+                        )
+                    # persistent=True only because it's the library default, not a caller
+                    # requirement: a caller who never asked for persistence must not see this
+                    # artifact start raising. Fall back to transient dispatch for every program on
+                    # this worker (self._persistent is worker-wide, not per-program) instead.
+                    warnings.warn(
+                        f"DistributedWorker: {prog.output_dir} predates persistent-domain codegen "
+                        "support (_domain_provider hook missing) — falling back to transient "
+                        "dispatch for every program on this worker. Recompile via ir.compile() to "
+                        "enable persistence and its execute_s win.",
+                        RuntimeWarning,
+                        stacklevel=3,
                     )
+                    self._persistent = False
                 loaded.append((prog, chip_callables, sub_worker_fns))
 
             unconsumed = sorted(set(callbacks) - consumed)

--- a/tests/ut/runtime/test_benchmark.py
+++ b/tests/ut/runtime/test_benchmark.py
@@ -1111,8 +1111,10 @@ def test_benchmark_l3_dispatches_via_distributed_worker():
     # prepare() gets the dispatch config, so it prewarms the runtime arena with
     # the ring sizing the loop dispatches with (here: None -> baseline sizing).
     assert compiled.prepare_config is None
+    # persistent=None (not False) forwards unresolved — DistributedWorker.__init__
+    # is where the None -> _PERSISTENT_DEFAULT resolution happens, not prepare().
     assert compiled.prepare_kwargs == {
-        "persistent": False,
+        "persistent": None,
         "reset_persistent_windows": None,
     }
     # The parser is told this is a distributed run.

--- a/tests/ut/runtime/test_distributed_worker.py
+++ b/tests/ut/runtime/test_distributed_worker.py
@@ -2846,6 +2846,7 @@ class _PersistentOrch:
         self.handles: list[_PersistentDomainHandle] = []
         self.resources: list[_PersistentRunResources] = []
         self.worker.close.side_effect = self._close_live_domains
+        self.worker.detach_persistent_domain = self._detach_persistent_domain
 
     def _begin_run(self) -> _PersistentRunResources:
         resources = _PersistentRunResources()
@@ -2906,6 +2907,23 @@ class _PersistentOrch:
     def copy_to(self, dst: _FakeBuffer, src: _FakeBuffer) -> None:
         payload = ctypes.string_at(int(src.base), int(src.nbytes))
         self.copy_calls.append((dst, src, payload))
+
+    def _detach_persistent_domain(self, handle: _PersistentDomainHandle) -> None:
+        """Model Simpler's ``Worker.detach_persistent_domain`` against this fake."""
+        resources = self.worker._building_run_resources
+        if resources is None:
+            raise RuntimeError("detach_persistent_domain: no run resources are being built")
+        with resources.domain_lock:
+            if resources.retired:
+                raise RuntimeError("detach_persistent_domain: run resources are already retired")
+            if (
+                self.worker._live_domains.get(handle.name) is not handle
+                or resources.live_domains.get(handle.name) is not handle
+            ):
+                raise RuntimeError(
+                    "detach_persistent_domain: handle is not this run's live claim on this domain"
+                )
+            del resources.live_domains[handle.name]
 
     def _close_live_domains(self) -> None:
         first_error: BaseException | None = None
@@ -2988,17 +3006,13 @@ class TestPersistentDistributedWorker:
             rt(a)  # falls back to ordinary transient dispatch, does not raise
             rt.close()
 
-    @pytest.mark.parametrize("attribute", ["_live_domains", "_building_run_resources"])
-    def test_rejects_missing_persistent_runtime_hooks_before_init(self, patched_setup, attribute):
+    def test_rejects_missing_persistent_runtime_hooks_before_init(self, patched_setup):
         m = patched_setup
-        if attribute == "_live_domains":
-            m["worker"]._live_domains = None
-        else:
-            del m["worker"]._building_run_resources
+        del m["worker"].detach_persistent_domain
         m["load_entry"].return_value = (_persistent_entry(64, []), None)
         compiled = _fake_compiled([_param("a", [16, 16])], [])
 
-        with pytest.raises(RuntimeError, match=attribute):
+        with pytest.raises(RuntimeError, match="detach_persistent_domain"):
             DistributedWorker(compiled, persistent=True)
 
         m["worker"].init.assert_not_called()

--- a/tests/ut/runtime/test_distributed_worker.py
+++ b/tests/ut/runtime/test_distributed_worker.py
@@ -2973,6 +2973,41 @@ def _persistent_entry(
     return entry
 
 
+def _persistent_entry_variable_size(window_sizes: list[int], seen_handles: list[Any]):
+    """Like ``_persistent_entry``, but requests a different ``window_size`` on
+    each successive call — models a program whose CommDomain size depends on a
+    runtime scalar (e.g. a decode loop's sequence length), which
+    ``distributed_codegen.cpp``'s ``GetCommSlotSizeAsCode`` supports emitting.
+    """
+    calls = {"n": 0}
+
+    def entry(
+        orch,
+        _args,
+        config,
+        *,
+        tensors,
+        callables,
+        sub_ids,
+        _keep,
+        world_size,
+        _domain_provider=None,
+    ):
+        del orch, _args, config, tensors, callables, sub_ids, _keep
+        assert _domain_provider is not None
+        size = window_sizes[calls["n"]]
+        calls["n"] += 1
+        with _domain_provider(
+            name="comm_d0",
+            workers=[*range(world_size)],
+            window_size=size,
+            buffers=[SimpleNamespace(name="buffer_0", dtype="opaque", count=size, nbytes=size)],
+        ) as domain:
+            seen_handles.append(domain)
+
+    return entry
+
+
 class TestPersistentDistributedWorker:
     def test_window_reset_requires_persistent_mode(self):
         compiled = _fake_compiled([_param("a", [16, 16])], [])
@@ -3497,6 +3532,79 @@ class TestPersistentDistributedWorker:
         assert len(errors) == 1
         assert isinstance(errors[0], RuntimeError)
         assert str(errors[0]) == "persistent dispatch failed before cleanup"
+        rt.close()
+
+
+class TestPersistentDomainShapeChangePolicy:
+    """A retained CommDomain's spec (workers, window_size, buffers) is an identity.
+
+    Deliberate policy, not a gap: a compiled program's window_size can depend on
+    a runtime scalar (distributed_codegen.cpp emits dynamic size expressions),
+    so a shape change across dispatches of the same persistent worker is a real
+    scenario, not hypothetical. Silently reallocating mid-request is unsafe —
+    a single dispatch can declare multiple CommDomains in sequence, and an
+    earlier one may already be entered (with real device-side effects issued
+    against it) by the time a later one's mismatch is discovered, so there is
+    no safe point to swap the mismatched domain in isolation. The policy is
+    therefore to raise, and to raise for every subsequent call too (poison the
+    whole worker) rather than leave it in a partially-abandoned state. A caller
+    whose workload legitimately varies shape should pass persistent=False, or
+    pad requests to one fixed window size.
+    """
+
+    def test_shape_change_raises_with_a_clear_message(self, patched_setup):
+        m = patched_setup
+        m["worker"]._live_domains = {}
+        seen_handles: list[Any] = []
+        m["load_entry"].return_value = (_persistent_entry_variable_size([64, 128], seen_handles), None)
+        compiled = _fake_compiled([_param("a", [16, 16])], [])
+
+        rt = DistributedWorker(compiled, persistent=True)
+        try:
+            arg = _resident(rt, (16, 16))
+            rt(arg)  # first call: window_size=64, allocates and detaches cleanly
+            with pytest.raises(ValueError, match="changed specification"):
+                rt(arg)  # second call: window_size=128, mismatches the retained spec
+        finally:
+            rt.close()
+
+    def test_shape_mismatch_poisons_subsequent_calls_including_the_original_shape(self, patched_setup):
+        m = patched_setup
+        m["worker"]._live_domains = {}
+        seen_handles: list[Any] = []
+        # Third call reverts to the ORIGINAL matching window_size (64) — still
+        # must raise, because the worker is poisoned by the second call's
+        # mismatch, not because 64 itself is invalid.
+        m["load_entry"].return_value = (_persistent_entry_variable_size([64, 128, 64], seen_handles), None)
+        compiled = _fake_compiled([_param("a", [16, 16])], [])
+
+        rt = DistributedWorker(compiled, persistent=True)
+        try:
+            arg = _resident(rt, (16, 16))
+            rt(arg)
+            with pytest.raises(ValueError, match="changed specification") as first:
+                rt(arg)
+            with pytest.raises(ValueError, match="changed specification") as second:
+                rt(arg)
+            # The exact same stored error is redelivered, not a fresh evaluation.
+            assert second.value is first.value
+        finally:
+            rt.close()
+
+    def test_close_after_a_shape_mismatch_does_not_hang_or_reraise(self, patched_setup):
+        m = patched_setup
+        m["worker"]._live_domains = {}
+        seen_handles: list[Any] = []
+        m["load_entry"].return_value = (_persistent_entry_variable_size([64, 128], seen_handles), None)
+        compiled = _fake_compiled([_param("a", [16, 16])], [])
+
+        rt = DistributedWorker(compiled, persistent=True)
+        arg = _resident(rt, (16, 16))
+        rt(arg)
+        with pytest.raises(ValueError, match="changed specification"):
+            rt(arg)
+
+        # Already delivered to the caller above — close() must not raise it again.
         rt.close()
 
 

--- a/tests/ut/runtime/test_distributed_worker.py
+++ b/tests/ut/runtime/test_distributed_worker.py
@@ -2966,6 +2966,28 @@ class TestPersistentDistributedWorker:
         with pytest.raises(ValueError, match="requires regenerated host orchestration"):
             DistributedWorker(compiled, persistent=True)
 
+    def test_implicit_default_falls_back_on_artifact_without_domain_provider_hook(self, patched_setup):
+        """persistent=None (unset) must warn and fall back, never raise.
+
+        A caller who did not ask for persistence must not see one just because the
+        library's own default happens to resolve to True and this artifact predates
+        the domain-provider hook (`persistent=True` explicit, above, still raises).
+
+        ``_PERSISTENT_DEFAULT`` is ``False`` today, so the fallback branch this test
+        targets is unreachable through the real default until a later Phase A flips
+        it — patch the constant to exercise the fallback mechanism itself now.
+        """
+        compiled = _fake_compiled([_param("a", [16, 16])], [])
+
+        with patch("pypto.runtime.distributed_runner._PERSISTENT_DEFAULT", True):
+            with pytest.warns(RuntimeWarning, match="predates persistent-domain codegen"):
+                rt = DistributedWorker(compiled)
+
+            assert rt._persistent is False
+            a = _resident(rt, (16, 16))
+            rt(a)  # falls back to ordinary transient dispatch, does not raise
+            rt.close()
+
     @pytest.mark.parametrize("attribute", ["_live_domains", "_building_run_resources"])
     def test_rejects_missing_persistent_runtime_hooks_before_init(self, patched_setup, attribute):
         m = patched_setup


### PR DESCRIPTION
## Summary

This PR removes pypto's persistent-distributed-mode dependency on Simpler **private** internals, and prepares the persistent dispatch path for a future default. It is **groundwork only — no default is flipped**: `_PERSISTENT_DEFAULT` stays `False`, so behaviour for every existing caller is unchanged.

Closes #2284.

## Motivation

Persistent distributed execution retained `CommDomain`s by reaching into `simpler.worker.Worker` privates by name (`_live_domains`, `_RunResources.live_domains` / `domain_lock` / `retired`), and even documented that dependency in its own error text ("requires Simpler's private retention hooks"). Two independent Simpler refactors have already broken the mode (see #2284): a `_execute_pending_domain_releases` signature change, and the per-run registry split that left a retained handle in the run-local journal — silently freed at the first fence, after which the next request failed on the dead handle (`CommDomainHandle already released; do not pass it to submit_*`). Every future Simpler change can invalidate this contract again unless retention moves onto a public API.

## Changes

**1. Migrate retention off Simpler privates (`68dfa3ef`)**
- `_detach_persistent_domain` becomes a one-line delegation to the new public `Worker.detach_persistent_domain(handle)`.
- `_validate_persistent_runtime_hooks` now probes `hasattr(worker, "detach_persistent_domain")` instead of shape-checking two private attributes.

**2. Artifact-compatible persistent default (`af9d6a62`)**
- `persistent` goes `bool=False` → `bool | None = None` across `DistributedCompiledProgram.prepare()` / `DistributedWorker` / `benchmark()`.
- `None` resolves through one module-level seam, `_PERSISTENT_DEFAULT` (today `False`), so a future default flip touches a single line.
- An artifact predating the `_domain_provider` codegen hook now **raises only when `persistent=True` was requested explicitly**; when persistence is merely the (future) unrequested default, it emits a `RuntimeWarning` and falls back to transient dispatch — preventing a later default flip from silently breaking pre-existing artifacts.

**3. Shape-change policy proven + documented (`4ec16d8b`)**
- A retained domain's spec is an identity; a mismatch raises and **poisons the worker** (deliberate — an earlier domain in the same dispatch may already have issued real device-side effects, so there is no safe point to swap out just the mismatched domain). The error is redelivered on every later call, and `close()` still cleans up without re-raising a delivered error.
- UT coverage added; behaviour documented in `docs/en+zh/dev/06-persistent-l3.md` (new "Artifact compatibility" and "Shape stability" sections).

## Dependency — REQUIRED Simpler change (must land first)

This PR requires the new public Simpler API `Worker.detach_persistent_domain`:

- **Simpler PR: [hw-native-sys/simpler#2120](https://github.com/hw-native-sys/simpler/pull/2120)** — "Add: `Worker.detach_persistent_domain` public retention API" (head branch **`feat/persistent-domain-detach-api`** on `georgebisbas/simpler`, commit `135ead53`; the same logical change is also carried on fork branch `feat/persistent-domain-detach-api-on-pin` as `56c9f416`).
- The `runtime` submodule here is pinned to **`56c9f416`** = the currently-pinned Simpler base **`77fa0171`** plus the single detach-API commit (cherry-picked so the submodule bump carries exactly one commit — no unrelated upstream drift).
- ⚠️ Until [hw-native-sys/simpler#2120](https://github.com/hw-native-sys/simpler/pull/2120) merges into `hw-native-sys/simpler`, commit `56c9f416` exists only on the `georgebisbas/simpler` fork, so a fresh submodule checkout of this branch will not fetch it from `hw-native-sys/simpler`. **Merge order: [hw-native-sys/simpler#2120](https://github.com/hw-native-sys/simpler/pull/2120) first**, then re-point the runtime pin to the merged mainline commit (or keep `56c9f416` once it is reachable from `hw-native-sys/simpler`).
- Opened as a **draft** until that dependency is resolved and CI can fetch the submodule.

## Testing

**Sim-Docker unit/regression (development):** full `tests/ut/runtime` + `tests/ut/ir` green (7935/7935); new targeted UTs:
- `test_implicit_default_falls_back_on_artifact_without_domain_provider_hook`
- `test_rejects_missing_persistent_runtime_hooks_before_init`
- `TestPersistentDomainShapeChangePolicy` (×3: clear raise message; poison-once including reverting to the original shape; `close()` after a mismatch does not hang or re-raise)

**NPU — real Ascend 910B2 (`a2a3`), P=2 on devices 0–1, pypto rebuilt from this branch:**

- Issue #2284's two named on-board STs, run explicitly:
  - `tests/st/distributed/test_l3_notify_wait.py::TestL3NotifyWait::test_persistent_signal_exchange_resets_retained_window` — **PASS**
  - `tests/st/distributed/test_l3_self_notify_credit_reset.py::TestL3SelfNotifyCreditReset::test_persistent_self_notify_credit_reset_without_window_reset` — **PASS**
- Distributed collectives (`tests/st/distributed/collectives`): **52 passed, 37 skipped, 0 failed** (skips are the P=4/P=8 variants; 2-device grant).
- Remaining distributed STs (`tests/st/distributed`, excluding `collectives`), each file in a fresh process — **all pass**:
  - persistent paths: `test_l3_notify_wait.py`, `test_l3_self_notify_credit_reset.py`, `test_l3_deferred_completion.py` (2 persistent, reset-off)
  - `test_l2_multi_orch.py`, `test_l3_comm_dispatch_order.py`, `test_l3_composite_shape_dim.py`, `test_l3_device_tensor.py`, `test_l3_dfx_per_rank.py`, `test_l3_distributed.py`, `test_l3_ep_dispatch_combine.py`, `test_l3_explicit_dispatch_onboard.py`, `test_l3_gemm.py`, `test_l3_get.py`, `test_l3_host_tensor_all_to_all(_v).py`, `test_l3_host_tensor_allgather.py`, `test_l3_host_tensor_allreduce(_ring).py`, `test_l3_host_tensor_barrier.py`, `test_l3_host_tensor_broadcast.py`, `test_l3_host_tensor_reduce_scatter.py`, `test_l3_manual.py`, `test_l3_parallel_reduce.py`, `test_l3_put.py`, `test_l3_rank_slice_dispatch.py`, `test_l3_remote_store.py`, `test_l3_remote_store_window_raw.py`, `test_l3_ring_sizing_prewarm.py`, `test_l3_stacked_device_tensor.py`, `test_l3_tuple_return.py`, `test_l3_window_slice_incore.py`
  - (Per-file fresh processes were used because a single long process on this shared box wedges after a forked child crash — a known environmental issue on this box, not a branch regression. `test_l3_multi_group.py` skips on a 2-device grant.)
- The Simpler API itself was additionally validated on the same real hardware: domain `allocate_domain` → `detach_persistent_domain` → domain survives the run fence → `close()` releases **and** frees; a second detach of the same handle raises; detach outside a run raises.

## Out of scope

The known `--profile l2 --persistent` crash ("mailbox has an unresolved timed-out control command" at domain release) is a separate runtime defect, tracked separately; this PR does not touch that path.
