### PR TITLE
chore(runtime): pin the runtime submodule to simpler 4e4d3a4a

### DIFF
--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -733,7 +733,7 @@ def _make_call_config(
             )
             call_config.enable_scope_stats = dfx.enable_scope_stats
             call_config.enable_chip_swimlane = dfx.enable_chip_swimlane
-            # Base dir shared by every chip; ``_submit_chip`` namespaces it per
+            # Base dir shared by every chip; the runtime namespaces it per
             # dispatch (``<dfx_base>/rank{worker}/d{k}``) so per-dispatch
             # artifacts (pmu.csv, deps.json, chip_swimlane_records.json, ...) don't
             # overwrite each other — even when one card runs multiple dispatches.
@@ -796,11 +796,11 @@ def _run_l3_swimlane_two_pass(
 
 
 # A dispatch's DFX artifacts live at ``<dfx_base>/<rank label>/d{k}``. The
-# producer (``_submit_chip``) and the consumers (``_clear_dfx_dispatch_dirs``,
+# producer (the ChipWorker child) and the consumers (``_clear_dfx_dispatch_dirs``,
 # ``_collect_l3_swimlane``) must agree on that scheme, and drift between them is
 # *silent* — a glob that no longer matches simply clears/converts nothing rather
 # than raising. The globs below are what the two consumers share; the label
-# builder names the producer's half of the contract in one place.
+# builder names this side's half of the contract in one place.
 _RANK_DIR_GLOB = "rank*"
 _DISPATCH_DIR_GLOB = "d[0-9]*"
 
@@ -896,7 +896,7 @@ def _record_dispatch_program(orch: Any, callable_id: Any, disp_dir: Path) -> Non
 
 
 def _submit_chip(orch: Any, callable_id: Any, task_args: Any, config: Any, worker: int | None) -> Any:
-    """``orch.submit_next_level`` with per-dispatch DFX ``output_prefix`` isolation.
+    """``orch.submit_next_level`` that stamps each dispatch's DFX directory.
 
     The runtime path helpers root every diagnostic artifact at a fixed filename
     under ``output_prefix`` (``<prefix>/pmu.csv`` etc.), so any two dispatches
@@ -904,21 +904,19 @@ def _submit_chip(orch: Any, callable_id: Any, task_args: Any, config: Any, worke
     enough: one card may receive several dispatches in a single host_orch run
     (pipeline stages, expert kernels, or genuinely different chip programs all
     pinned to the same ``device``), and each re-init+finalize of the runtime's
-    per-run collector rewrites the fixed-name file. So this wrapper appends
-    ``/rank{worker}/d{k}`` — card *and* the card's k-th dispatch — for the
-    duration of the submit, then restores the shared ``config``. The restore is
-    safe because ``submit_next_level`` copies the ``CallConfig`` into the task
-    slot synchronously (orchestrator ``s.config = config``) before it returns,
-    so it never races the already-queued task.
+    per-run collector rewrites the fixed-name file.
+
+    The ChipWorker child applies that ``rank{worker}/d{k}`` split itself, so
+    this wrapper only derives the same directory — for the marker below and the
+    offline post-pass — and forwards ``config`` untouched.
 
     ``k`` comes from a per-card counter on ``orch`` reset at the top of every
     run (see :func:`_reset_dfx_dispatch_state`), so the numbering is
-    deterministic and matches across the swimlane two-pass. The dispatched
-    program is stamped into the same directory by
+    deterministic, matches across the swimlane two-pass, and tracks the child's
+    own counter. The dispatched program is stamped into that directory by
     :func:`_record_dispatch_program`, so the offline post-pass can label the
     records with the right program's kernel names.
 
-    Every dispatch is namespaced ``rank{worker}/d{k}`` by the chip it runs on.
     When DFX is off (``output_prefix`` unset) the call is forwarded unchanged.
 
     The codegen routes every chip dispatch through this wrapper — a rank-pinned
@@ -938,12 +936,8 @@ def _submit_chip(orch: Any, callable_id: Any, task_args: Any, config: Any, worke
     rank_label = _dfx_rank_label(worker)
     k = idx_map.get(rank_label, 0)
     idx_map[rank_label] = k + 1
-    config.output_prefix = f"{base}/{rank_label}/d{k}"
-    _record_dispatch_program(orch, callable_id, Path(config.output_prefix))
-    try:
-        return orch.submit_next_level(callable_id, task_args, config, worker=worker)
-    finally:
-        config.output_prefix = base
+    _record_dispatch_program(orch, callable_id, Path(f"{base}/{rank_label}/d{k}"))
+    return orch.submit_next_level(callable_id, task_args, config, worker=worker)
 
 
 def _clear_dfx_dispatch_dirs(dfx_base: Path) -> None:
@@ -1034,8 +1028,8 @@ def _collect_l3_swimlane(output_dir: Path, platform: str) -> None:
 
     The runtime writes ``rank{r}/d{k}/deps.json`` in the graph pass and
     ``rank{r}/d{k}/chip_swimlane_records.json`` in the clean timing pass
-    (``_submit_chip`` namespaces the directory by card *and* the card's k-th
-    dispatch, and both passes reset that counter). Globbing ``rank*`` — rather
+    (the directory is namespaced by card *and* the card's k-th dispatch, and
+    both passes restart that numbering). Globbing ``rank*`` — rather
     than iterating a rank count — picks up
     whichever cards actually ran, so a comm-less / single-card L3 program (which never
     creates ``rank{0..n}``) still has its records converted. This best-effort
@@ -1087,7 +1081,7 @@ def _collect_l3_swimlane(output_dir: Path, platform: str) -> None:
     rank_dirs = sorted(d for d in dfx_base.glob(_RANK_DIR_GLOB) if d.is_dir())
     for rank_dir in rank_dirs:
         # One card may have run several dispatches: ``<rank>/d0``, ``d1``, ...
-        # Match only ``d`` + digits (the names ``_submit_chip`` emits) so an
+        # Match only ``d`` + digits (the names the runtime emits) so an
         # unrelated diagnostic dir under rank_dir is never picked up.
         dispatch_dirs = sorted(d for d in rank_dir.glob(_DISPATCH_DIR_GLOB) if d.is_dir())
         for disp_dir in dispatch_dirs:
@@ -1170,8 +1164,8 @@ def _make_dispatch_orchestration(
 
     def orch_fn(orch, _unused_args, _unused_cfg):
         # Reset the per-card DFX dispatch counter at the start of every run so
-        # ``_submit_chip`` numbers a card's dispatches ``d0, d1, ...`` fresh each
-        # pass. Two-pass swimlane reissues the same dispatch order, so pass 1
+        # a card's dispatches are numbered ``d0, d1, ...`` fresh each pass.
+        # Two-pass swimlane reissues the same dispatch order, so pass 1
         # (deps.json) and pass 2 (records) land the same dispatch in the same
         # ``rank{w}/d{k}`` dir — letting the converter join them. The same call
         # publishes the callable -> L2 program names ``_submit_chip`` stamps into

--- a/tests/st/distributed/test_l3_dfx_per_rank.py
+++ b/tests/st/distributed/test_l3_dfx_per_rank.py
@@ -24,8 +24,8 @@ separate. Each rank here runs exactly one dispatch, so the dir is ``d0``:
       rank1/d0/scope_stats/scope_stats.jsonl
 
 This exercises the driver wiring (``_make_call_config`` setting the DFX flags +
-base ``output_prefix``) and the codegen wiring (``_submit_chip`` appending the
-``/rank{worker}/d{k}`` suffix per dispatch).
+base ``output_prefix``) and the runtime wiring that splits it into
+``/rank{worker}/d{k}`` per dispatch.
 
 ``enable_chip_swimlane`` is also covered: on L3 it co-enables dep_gen and emits
 ``rank{r}/d{k}/chip_swimlane_records.json`` + ``rank{r}/d{k}/deps.json`` per

--- a/tests/ut/runtime/test_distributed_worker.py
+++ b/tests/ut/runtime/test_distributed_worker.py
@@ -2227,11 +2227,7 @@ class _SpyDfxConfig:
 
 
 class _RecordingOrch:
-    """Records the ``output_prefix`` observed at each ``submit_next_level``.
-
-    Captures the prefix *at submit time* (not after) so tests can prove
-    ``_submit_chip`` applied the per-dispatch suffix before the task was queued.
-    """
+    """Records the ``output_prefix`` each ``submit_next_level`` was handed."""
 
     def __init__(self, chip_count: int | None = None) -> None:
         self.calls: list[tuple[Any, int, str]] = []
@@ -2251,60 +2247,54 @@ class _RecordingOrch:
 
 
 class TestSubmitChip:
-    """``_submit_chip`` namespaces per-dispatch DFX ``output_prefix`` then restores it."""
+    """``_submit_chip`` derives each dispatch's DFX dir; the runtime applies it."""
 
-    def test_suffixes_prefix_at_submit_and_restores(self):
+    def test_forwards_the_base_prefix_unchanged(self):
         orch = _RecordingOrch()
         cfg = _SpyDfxConfig(output_prefix="/work/dfx_outputs")
         ret = _submit_chip(orch, "chip_a", "ta", cfg, 3)
-        # Card + the card's 0th dispatch was visible to the runtime at submit
-        # time...
-        assert orch.calls == [("chip_a", 3, "/work/dfx_outputs/rank3/d0")]
-        # ...and the shared config is restored afterward.
+        # The ChipWorker child appends ``rank{r}/d{k}``; this side must not.
+        assert orch.calls == [("chip_a", 3, "/work/dfx_outputs")]
         assert cfg.output_prefix == "/work/dfx_outputs"
         assert ret == "submitted"
 
-    def test_distinct_ranks_get_distinct_dirs(self):
+    def test_distinct_ranks_get_distinct_dirs(self, tmp_path):
+        chip_cids = {"chip": object()}
         orch = _RecordingOrch()
-        cfg = _SpyDfxConfig(output_prefix="/work/dfx_outputs")
+        _reset_dfx_dispatch_state(orch, chip_cids)
+        cfg = _SpyDfxConfig(output_prefix=str(tmp_path))
         for r in (0, 1, 2):
-            _submit_chip(orch, "chip", "ta", cfg, r)
-        # Each card's first dispatch is ``d0``.
-        assert [c[2] for c in orch.calls] == [
-            "/work/dfx_outputs/rank0/d0",
-            "/work/dfx_outputs/rank1/d0",
-            "/work/dfx_outputs/rank2/d0",
-        ]
-        assert cfg.output_prefix == "/work/dfx_outputs"
+            _submit_chip(orch, chip_cids["chip"], "ta", cfg, r)
+        # Each card's first dispatch is ``d0``, named by where the marker lands.
+        for r in (0, 1, 2):
+            assert (tmp_path / f"rank{r}" / "d0" / "dispatch_program.json").is_file()
+        assert [c[2] for c in orch.calls] == [str(tmp_path)] * 3
 
-    def test_multiple_dispatches_same_card_get_distinct_dirs(self):
-        # The bug this fix targets: several dispatches to ONE card must not
-        # share a dir (the runtime rewrites fixed-name artifacts per run, so a
-        # shared dir means all-but-the-last are clobbered). Each gets ``d{k}``.
+    def test_multiple_dispatches_same_card_get_distinct_dirs(self, tmp_path):
+        # Several dispatches to ONE card must not share a dir (the runtime
+        # rewrites fixed-name artifacts per run, so a shared dir means
+        # all-but-the-last are clobbered). Each gets ``d{k}``.
+        chip_cids = {"chip_a": object(), "chip_b": object()}
         orch = _RecordingOrch()
-        cfg = _SpyDfxConfig(output_prefix="/work/dfx_outputs")
-        _submit_chip(orch, "chip_a", "ta", cfg, 0)
-        _submit_chip(orch, "chip_b", "ta", cfg, 0)  # different program, same card
-        _submit_chip(orch, "chip_a", "ta", cfg, 0)  # repeat dispatch, same card
-        assert [c[2] for c in orch.calls] == [
-            "/work/dfx_outputs/rank0/d0",
-            "/work/dfx_outputs/rank0/d1",
-            "/work/dfx_outputs/rank0/d2",
-        ]
-        assert cfg.output_prefix == "/work/dfx_outputs"
+        _reset_dfx_dispatch_state(orch, chip_cids)
+        cfg = _SpyDfxConfig(output_prefix=str(tmp_path))
+        _submit_chip(orch, chip_cids["chip_a"], "ta", cfg, 0)
+        _submit_chip(orch, chip_cids["chip_b"], "ta", cfg, 0)  # different program, same card
+        _submit_chip(orch, chip_cids["chip_a"], "ta", cfg, 0)  # repeat dispatch, same card
+        assert sorted(d.name for d in (tmp_path / "rank0").iterdir()) == ["d0", "d1", "d2"]
+        assert [c[2] for c in orch.calls] == [str(tmp_path)] * 3
 
-    def test_counter_resets_when_orch_dispatch_idx_cleared(self):
+    def test_counter_resets_when_orch_dispatch_idx_cleared(self, tmp_path):
         # ``orch_fn`` clears ``_dfx_dispatch_idx`` at the top of every run, so a
         # given card's dispatch numbering matches across the swimlane two-pass.
+        chip_cids = {"chip": object()}
         orch = _RecordingOrch()
-        cfg = _SpyDfxConfig(output_prefix="/work/dfx_outputs")
-        _submit_chip(orch, "chip", "ta", cfg, 0)  # pass 1: d0
+        _reset_dfx_dispatch_state(orch, chip_cids)
+        cfg = _SpyDfxConfig(output_prefix=str(tmp_path))
+        _submit_chip(orch, chip_cids["chip"], "ta", cfg, 0)  # pass 1: d0
         orch._dfx_dispatch_idx = {}  # what orch_fn does between passes
-        _submit_chip(orch, "chip", "ta", cfg, 0)  # pass 2: d0 again
-        assert [c[2] for c in orch.calls] == [
-            "/work/dfx_outputs/rank0/d0",
-            "/work/dfx_outputs/rank0/d0",
-        ]
+        _submit_chip(orch, chip_cids["chip"], "ta", cfg, 0)  # pass 2: d0 again
+        assert [d.name for d in (tmp_path / "rank0").iterdir()] == ["d0"]
 
     def test_dfx_off_forwards_unchanged(self):
         orch = _RecordingOrch()
@@ -2313,23 +2303,22 @@ class TestSubmitChip:
         assert orch.calls == [("chip", 5, "")]
         assert cfg.output_prefix == ""
 
-    def test_commless_dispatches_round_robin_over_chips(self):
+    def test_commless_dispatches_round_robin_over_chips(self, tmp_path):
         # A comm-less dispatch (``worker=None``) names no chip, but simpler
         # #1436 requires an exact target, so consecutive ones are handed out
         # round-robin over the program's chips — a host_orch with one comm-less
         # dispatch per chip still spreads across them.
+        chip_cids = {"chip": object()}
         orch = _RecordingOrch(chip_count=2)
-        cfg = _SpyDfxConfig(output_prefix="/work/dfx_outputs")
+        _reset_dfx_dispatch_state(orch, chip_cids)
+        cfg = _SpyDfxConfig(output_prefix=str(tmp_path))
         for _ in range(3):
-            _submit_chip(orch, "chip", "ta", cfg, None)
+            _submit_chip(orch, chip_cids["chip"], "ta", cfg, None)
         assert [c[1] for c in orch.calls] == [0, 1, 0]
         # Each resolved chip gets its own dispatch counter.
-        assert [c[2] for c in orch.calls] == [
-            "/work/dfx_outputs/rank0/d0",
-            "/work/dfx_outputs/rank1/d0",
-            "/work/dfx_outputs/rank0/d1",
-        ]
-        assert cfg.output_prefix == "/work/dfx_outputs"
+        for rel in ("rank0/d0", "rank1/d0", "rank0/d1"):
+            assert (tmp_path / rel / "dispatch_program.json").is_file()
+        assert [c[2] for c in orch.calls] == [str(tmp_path)] * 3
 
     def test_commless_dispatch_without_chip_count_falls_back_to_chip_zero(self):
         # A caller that bypassed ``orch_fn`` leaves no chip count on ``orch``;
@@ -2380,7 +2369,7 @@ class TestSubmitChip:
 
         _submit_chip(orch, "chip_a", "ta", cfg, 0)
 
-        assert orch.calls == [("chip_a", 0, f"{tmp_path}/rank0/d0")]
+        assert orch.calls == [("chip_a", 0, str(tmp_path))]
         assert not (tmp_path / "rank0" / "d0" / "dispatch_program.json").exists()
 
 


### PR DESCRIPTION
## Summary

Move the `runtime` gitlink from `77fa0171` (main today, #2641) to `4e4d3a4a` — simpler "CI: bump pinned pto-isa to a8040450" (#2123), 27 commits forward. This re-lands the range #2641 stepped back over (`77fa0171..15f5cbd9`) and adds what simpler has merged since.

The pin chain moves with it:

- **pto-isa `96ba706c` → `a8040450`.** `runtime/pto_isa.pin` is the source of truth and `toolchain/versions.env` derives pto-isa from that file, so there is no pypto-side pin to edit. The one onboard-relevant fix in the range is `5d0fb9a8` "fix TCI A2A3 for prefill EP=2 NAN problem"; `07953421` corrects the `tsort32` golden to the stable-quicksort order VBS32 actually produces, and `9c864fb4` reverts the TMATMUL_MX ping-pong change from earlier in the same range. The rest is CPU_SIM work (TLOAD padding, TMATMUL_ACC/TGEMV_ACC seeding, mixed-type TADD/TABS, TCI/TCVT scratch overloads, GM/UB transfer layout, DIR_BOTH FIFO order, FP4 ConvTile) plus A5 fixes (int64 shift carry, UB ND→NZ, `TSel` bf16).
- **ptoas stays at `v0.57`.**

Simpler commits entering the pin (`77fa0171..4e4d3a4a`, newest first):

| simpler PR | Change |
|---|---|
| #2123 | CI: bump pinned pto-isa to `a8040450` |
| #2070 | elide A5 terminal releases after orchestration |
| #2099 | dispatch-correlated same-host multi-rank swimlane timeline |
| #2117 | docs: the device log threshold is fixed at device init |
| #2105 | skip the empty Tier-0 staging order in the a5 dispatch loop |
| #2118 | drain the host-log writer before scene tests read captured spans |
| #2112 | rename `maybe_rendezvous_ring` to `try_launch_sync_start_cohort` |
| #2107 | fix the swimlane pool layout at compile time |
| #2113 | drop `SimplerHostSpan`'s version and size words |
| #2110 | classify Graph tensor sources by address, name them by kind |
| #2111 | CI: bump pinned pto-isa to `c0e28cfb` |
| #2108 | docs: why the host-log claim budget is not the knob it looks like |
| #2095 | `host_build_graph` early dispatch via an ED publish list |
| #2029 | host logging becomes nonblocking with accountable loss |
| #2101 | `host_build_graph` includes say what each file uses |
| #2090 | A5 HBG single-lane scheduling switches to AICore |
| #2100 | AICPU scheduler timeout collapses to one 20 s constant |
| #2098 | `host_build_graph`'s host side stops reaching into device facilities |
| #2093 | DFX collectors bind their per-run output separately |
| #2094 | `host_build_graph` orchestration confined to the host |
| #2092 | `simpler_init` provisions the async-DMA workspace itself |
| #2087 | each runtime gets its own `TaskId` type |
| #2089 | async-DMA provisioning asks for one flag, not an engine set |
| #2091 | `ProfilerBase::quiesce()` drains without retiring the threads |
| #2088 | docs for the async-DMA workspace |
| #2072 | complete A5 HBG single-lane scheduling |
| #2086 | one signed counting domain for `host_build_graph` |

## One source change: the per-dispatch DFX directory

simpler #2099 appends `rank{r}/d{k}` to `output_prefix` inside the ChipWorker child, for every diagnostic that writes below it. `_submit_chip` was appending the same suffix on the driver side, so under this pin the two nest and every artifact lands at `<dfx_base>/rank{r}/d{k}/rank{r}/d{k}/` — two levels below where the post-pass looks. `dist-system-tests` caught it: `test_l3_dfx_per_rank` found the outer directory (this driver still stamps `dispatch_program.json` into it) and none of the files in it.

The driver now only *derives* that directory, for the dispatch-program marker, `_clear_dfx_dispatch_dirs` and the `_collect_l3_swimlane` globs, and forwards `config` untouched. `TestSubmitChip` asserted the mutation, so its cases now assert what is left: the base prefix reaches the submit un-suffixed, and the derived directory is named by where `dispatch_program.json` lands. The two counters stay in step because both count exactly the dispatches this driver marks: `_make_call_config` sets `output_prefix` only when a DFX flag is on, and the runtime splits only a config that carries one.

Known gap, recorded rather than papered over: a prepared `DistributedWorker` running the swimlane two-pass reuses its Worker, so the runtime's per-child capture counter does not reset alongside this driver's and pass 2 would land in `d{k+1}`. The one-shot path — which is what the ST covers — creates a fresh Worker per pass, resetting both. Pairing those captures by the `dispatch_identity.json` sidecar #2099 now writes is the durable fix and belongs in its own change.

## Nothing else needed a source change

The other refactors that touch what pypto emits or includes were checked directly:

- **#2087 split `task_interface/task_id.h` per runtime.** Codegen emits `TaskId` and `TaskId::invalid()` into orchestration TUs (`src/codegen/array_op_codegen.cpp`); both are present in the new `host_build_graph/task_id.h`, which the orchestration include path already reaches. Nothing in pypto includes the moved headers by name.
- **#2094 / #2101 moved `RuntimeOps` out of `orchestration_api.h` into `runtime_ops.h` and dropped its transitive `<vector>` / `<array>` / `<mutex>` / `<thread>` includes.** Generated orchestration includes only `orchestration_api.h` and `tensor.h` (plus the standard headers codegen emits itself), and a probe TU built with the exact `-I` list from `test_generated_orchestration_compiles_against_the_pinned_runtime` syntax-checks clean — no repeat of the `common/hierarchical/types.h` shadowing that #2617 had to work around.
- **#2110 added `is_graph_record_address` and #2113/#2107/#2099 reworked the span and swimlane internals** without touching `orchestration_api.h`, `host_build_graph/types.h`, `tensor.h` or `task_id.h`, so nothing pypto compiles against moved.
- `GRAPH_MAX_TENSOR_ARGS` is still 128, matching the `kMaxBoundaryTensors` constant in `legalize_graph_boundary_pass.cpp` and `verify_graph_functions.cpp`.
- `CallConfig` grows a `capture_clock_anchors` field (#2099). pypto constructs `CallConfig()` and sets named attributes through simpler's nanobind binding rather than mirroring the struct, so the wire-layout change is contained in the runtime.
- The only pypto include of a runtime header, `platform_comm/comm_context.h` from the collective kernel templates, is unaffected across this range.

One consumer-side note that is not a pypto change: #2029 adds `_flush_host_log`, `_start_host_log_writer` and the two host-log counters to simpler's `_task_interface` extension, so a local checkout needs its bindings rebuilt after this bump. pypto calls none of those symbols.

## Test plan

- [x] `pypto_core` builds clean against this pin, rebased onto #2642 (`cmake --build build --parallel 64`, exit 0).
- [x] Orchestration header probe compiles under the UT's include order (`g++ -std=c++17 -fsyntax-only`, exit 0).
- [x] First CI run on this pin: 19/20 green; `dist-system-tests` failed on the nested DFX directory, fixed above.
- [x] Second run: `dist-system-tests` green; `TestSubmitChip` still asserted the old contract, updated in the same commit.
- [x] `tests/ut/runtime` + `tests/ut/codegen` locally: 1719 passed, 63 skipped.
- [x] Fourth run: all 20 checks green.
- [ ] CI on the final (comment-only) revision.

One flake to flag rather than bury: `test_l3_host_tensor_allreduce.py::test_host_tensor_allreduce_loop[2]` failed once on the third run — round 2 read round 0's values (`max diff = 20155.0`, the offsets that test spaces its rounds by), i.e. the reused allreduce signal's self-clearing epilogue lost a race. The *same tree* passed it on the next run, and the run before it, so it is not deterministic. Worth watching under this pin all the same: simpler #2095 changes host_build_graph's dispatch timing, which is the kind of change that wakes a sleeping signal-reuse race. Three runs on this pin, one failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014EGTChvJLW5gXVDDMYzFdH
