### PR TITLE
test(st): run the scheduling swimlane assertions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1200,7 +1200,12 @@ jobs:
           # compile + golden card-free, device run BATCHED via task-submit. The
           # `not device_batch` (direct @pl.jit / config=test_config) tests for
           # ALL dirs run in the `system-tests-direct` job.
-          python -m pytest tests/st -v -m device_batch \
+          #
+          # `not swimlane` because those assert on a chip-swimlane record and
+          # skip without `--enable-chip-swimlane`, which this step does not pass.
+          # They ran here only to skip, and 35 silent skips buried the real ones;
+          # the flagged steps in `system-tests-direct` run them for real.
+          python -m pytest tests/st -v -m "device_batch and not swimlane" \
             --ignore=tests/st/distributed \
             --ignore=tests/st/codegen \
             --ignore=tests/st/runtime/ops \
@@ -1376,6 +1381,26 @@ jobs:
           source activate.sh
           task-submit --device "$DEVICE_ID" --timeout 3600 --max-time 600 \
             --run "cd $GITHUB_WORKSPACE/st-direct-checkout && source activate.sh && python -m pytest tests/st/runtime/framework_and_models/test_perf_swimlane.py -v --device=\$TASK_DEVICE --platform=a2a3 --enable-chip-swimlane --forked"
+
+      - name: Test scheduling swimlane assertions
+        # The 35 swimlane assertions under runtime/scheduling had never run: they
+        # gate on `--enable-chip-swimlane`, which CI passed only to
+        # test_perf_swimlane.py, so every one of them skipped in the batched
+        # shard. Same mechanism as the step above (the fixture globs
+        # build_output/*/dfx_outputs/chip_swimlane_records.json), selected by the
+        # `swimlane` marker rather than by path so the correctness tests sharing
+        # these files are not re-run here.
+        #
+        # No `--forked`, unlike the step above: these hang their swimlane record
+        # off class- or module-scoped fixtures, so one process reuses each
+        # record across the class instead of re-running the device case per
+        # test — about 20 device runs rather than 35.
+        run: |
+          source activate.sh
+          task-submit --device "$DEVICE_ID" --timeout 3600 --max-time 1200 \
+            --run "cd $GITHUB_WORKSPACE/st-direct-checkout && source activate.sh && python -m pytest \
+              tests/st/runtime/scheduling -v -m swimlane \
+              --device=\$TASK_DEVICE --platform=a2a3 --enable-chip-swimlane"
 
       - name: Test Graph record-and-replay (one process per test)
         # --forked because a ChipWorker binds one (platform, device_id, runtime):

--- a/tests/st/conftest.py
+++ b/tests/st/conftest.py
@@ -688,6 +688,15 @@ def pytest_configure(config):
         "step); the split is by fixture usage, so new tests self-classify with no "
         "ci.yml change.",
     )
+    config.addinivalue_line(
+        "markers",
+        "swimlane: the test asserts on a chip-swimlane record, so it needs "
+        "`--enable-chip-swimlane` and skips without it. CI selects the whole set "
+        "with `-m swimlane` in one flagged step, and the batched shards exclude "
+        "it — otherwise these run there only to skip, and a real skip is lost in "
+        "the noise. Mark the class, not each method: the swimlane fixture is "
+        "class- or module-scoped.",
+    )
 
     # Set the PyPTO runtime log level independently of the per-ST-item C++ logger.
     try:

--- a/tests/st/harness/swimlane.py
+++ b/tests/st/harness/swimlane.py
@@ -1,0 +1,54 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Reading a chip-swimlane record.
+
+The on-disk dump is not the view a test wants to assert on. Since runtime JSON
+v2 (simpler #985) the host writes raw cycle-domain streams — ``aicore_tasks`` /
+``aicpu_tasks`` alongside a ``metadata`` block — and the unified ``tasks`` list,
+with cycles converted to microseconds and the AICore/AICPU sides joined, is
+rebuilt in Python by the runtime's own converter.
+
+Going through that converter is what keeps a test asserting on the view the
+profiling tools present, rather than on whichever shape the host happens to
+serialise this month. Tests that read the file directly did not survive the v2
+change: they raised ``KeyError: 'tasks'`` the first time they ran against it.
+"""
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def read_swimlane(path: "str | Path") -> dict[str, Any]:
+    """Return the unified swimlane view for the record at *path*.
+
+    Args:
+        path: A ``chip_swimlane_records.json`` written under a run's
+            ``dfx_outputs/``.
+
+    Returns:
+        The converter's view: ``chip_swimlane_level``, ``metadata``, and a
+        ``tasks`` list in the microsecond domain.
+
+    Raises:
+        AssertionError: The converter produced no ``tasks`` key, which means the
+            record is empty or its schema moved again.
+    """
+    from simpler_setup.tools.swimlane_converter import read_perf_data  # noqa: PLC0415
+
+    data = read_perf_data(str(path))
+    assert "tasks" in data, (
+        f"swimlane record {path} produced no 'tasks' view; on-disk keys were "
+        f"{sorted(json.loads(Path(path).read_text()))}"
+    )
+    return data
+
+
+__all__ = ["read_swimlane"]

--- a/tests/st/runtime/framework_and_models/test_perf_swimlane.py
+++ b/tests/st/runtime/framework_and_models/test_perf_swimlane.py
@@ -117,6 +117,7 @@ def swimlane_data(swimlane_file: Path) -> dict:
     return read_perf_data(str(swimlane_file))
 
 
+@pytest.mark.swimlane
 class TestSwimlaneOutput:
     """Validate the structure and content of chip_swimlane_records.json."""
 

--- a/tests/st/runtime/scheduling/test_manual_scope_pipeline.py
+++ b/tests/st/runtime/scheduling/test_manual_scope_pipeline.py
@@ -222,6 +222,7 @@ def manual_scope_swimlane_data(manual_scope_swimlane_file: Path) -> dict:
     return json.loads(manual_scope_swimlane_file.read_text())
 
 
+@pytest.mark.swimlane
 class TestManualScopeSwimlane:
     """Validate the on-board execution graph encoded in the swimlane JSON.
 
@@ -532,6 +533,7 @@ def phase_fence_auto_swimlane_data(phase_fence_auto_swimlane_file: Path) -> dict
     return json.loads(phase_fence_auto_swimlane_file.read_text())
 
 
+@pytest.mark.swimlane
 class TestPhaseFenceSwimlane:
     """Validate the manual-scope phase-fence ordering in the runtime swimlane.
 
@@ -582,6 +584,7 @@ class TestPhaseFenceSwimlane:
         )
 
 
+@pytest.mark.swimlane
 class TestPhaseFenceAutoSwimlane:
     """Basic runtime validation for the auto-scope phase-fence control case."""
 
@@ -734,6 +737,7 @@ def branch_chain_swimlane_data(branch_chain_swimlane_file: Path) -> dict:
     return json.loads(branch_chain_swimlane_file.read_text())
 
 
+@pytest.mark.swimlane
 class TestBranchChainSwimlane:
     """Validate per-branch linear chain + cross-branch parallelism."""
 
@@ -957,6 +961,7 @@ def original_kv_proj_swimlane_data(original_kv_proj_swimlane_file: Path) -> dict
     return json.loads(original_kv_proj_swimlane_file.read_text())
 
 
+@pytest.mark.swimlane
 class TestOriginalKVProjOuterParallelSwimlane:
     """Validate that the original kv_proj case emits a basic swimlane artifact."""
 

--- a/tests/st/runtime/scheduling/test_manual_scope_pipeline.py
+++ b/tests/st/runtime/scheduling/test_manual_scope_pipeline.py
@@ -53,7 +53,6 @@ How to run
     # numerical correctness is checked.
 """
 
-import json
 from pathlib import Path
 from typing import Any
 
@@ -61,6 +60,7 @@ import pypto.language as pl
 import pytest
 import torch
 from harness.core.harness import PLATFORMS, DataType, PTOTestCase, TensorSpec
+from harness.swimlane import read_swimlane
 from pypto.ir.pass_manager import OptimizationStrategy
 
 _BUILD_OUTPUT_DIR = Path(__file__).resolve().parents[4] / "build_output"
@@ -219,7 +219,7 @@ def manual_scope_swimlane_file(test_runner) -> Path:
 
 @pytest.fixture(scope="module")
 def manual_scope_swimlane_data(manual_scope_swimlane_file: Path) -> dict:
-    return json.loads(manual_scope_swimlane_file.read_text())
+    return read_swimlane(manual_scope_swimlane_file)
 
 
 @pytest.mark.swimlane
@@ -512,7 +512,7 @@ def phase_fence_swimlane_file(test_runner) -> Path:
 
 @pytest.fixture(scope="module")
 def phase_fence_swimlane_data(phase_fence_swimlane_file: Path) -> dict:
-    return json.loads(phase_fence_swimlane_file.read_text())
+    return read_swimlane(phase_fence_swimlane_file)
 
 
 @pytest.fixture(scope="module")
@@ -530,7 +530,7 @@ def phase_fence_auto_swimlane_file(test_runner) -> Path:
 
 @pytest.fixture(scope="module")
 def phase_fence_auto_swimlane_data(phase_fence_auto_swimlane_file: Path) -> dict:
-    return json.loads(phase_fence_auto_swimlane_file.read_text())
+    return read_swimlane(phase_fence_auto_swimlane_file)
 
 
 @pytest.mark.swimlane
@@ -734,7 +734,7 @@ def branch_chain_swimlane_file(test_runner) -> Path:
 
 @pytest.fixture(scope="module")
 def branch_chain_swimlane_data(branch_chain_swimlane_file: Path) -> dict:
-    return json.loads(branch_chain_swimlane_file.read_text())
+    return read_swimlane(branch_chain_swimlane_file)
 
 
 @pytest.mark.swimlane
@@ -958,7 +958,7 @@ def original_kv_proj_swimlane_file(test_runner) -> Path:
 
 @pytest.fixture(scope="module")
 def original_kv_proj_swimlane_data(original_kv_proj_swimlane_file: Path) -> dict:
-    return json.loads(original_kv_proj_swimlane_file.read_text())
+    return read_swimlane(original_kv_proj_swimlane_file)
 
 
 @pytest.mark.swimlane

--- a/tests/st/runtime/scheduling/test_phase_fence_dep_compression.py
+++ b/tests/st/runtime/scheduling/test_phase_fence_dep_compression.py
@@ -15,7 +15,6 @@ all tasks in flattened stage k+1 must start after all tasks in flattened stage k
 finish.
 """
 
-import json
 import os
 from pathlib import Path
 from typing import Any
@@ -24,6 +23,7 @@ import pypto.language as pl
 import pytest
 import torch
 from harness.core.harness import PLATFORMS, DataType, PTOTestCase, TensorSpec
+from harness.swimlane import read_swimlane
 from pypto.ir.pass_manager import OptimizationStrategy
 
 from examples.utils.phase_fence_dep_compression import (
@@ -139,7 +139,7 @@ def _new_swimlane_file(test_runner, case: PTOTestCase, *, label: str) -> Path:
 
 def _new_swimlane_json(test_runner, case: PTOTestCase, *, label: str) -> dict:
     path = _new_swimlane_file(test_runner, case, label=label)
-    return json.loads(path.read_text())
+    return read_swimlane(path)
 
 
 def _build_submit_flattened_program(*, epochs: int, layers: int, phases: int):

--- a/tests/st/runtime/scheduling/test_phase_fence_dep_compression.py
+++ b/tests/st/runtime/scheduling/test_phase_fence_dep_compression.py
@@ -977,6 +977,7 @@ class TestPhaseFenceDepCompressionCorrectness:
         assert result.passed, f"manual-dummy chained snapshot phase-fence failed: {result.error}"
 
 
+@pytest.mark.swimlane
 class TestPhaseFenceDepCompressionSwimlane:
     def test_multiloop_chain_default(self, test_runner):
         data = _new_swimlane_json(test_runner, _multiloop_chain_case(), label="multi-loop chain phase-fence")

--- a/tests/st/runtime/scheduling/test_pl_at_deps_pipeline.py
+++ b/tests/st/runtime/scheduling/test_pl_at_deps_pipeline.py
@@ -50,7 +50,6 @@ How to run
     # numerical correctness is checked.
 """
 
-import json
 from pathlib import Path
 from typing import Any
 
@@ -58,6 +57,7 @@ import pypto.language as pl
 import pytest
 import torch
 from harness.core.harness import PLATFORMS, DataType, PTOTestCase, TensorSpec
+from harness.swimlane import read_swimlane
 from pypto.ir.pass_manager import OptimizationStrategy
 
 _BUILD_OUTPUT_DIR = Path(__file__).resolve().parents[4] / "build_output"
@@ -210,7 +210,7 @@ def pl_at_deps_swimlane_file(test_runner) -> Path:
 
 @pytest.fixture(scope="module")
 def pl_at_deps_swimlane_data(pl_at_deps_swimlane_file: Path) -> dict:
-    return json.loads(pl_at_deps_swimlane_file.read_text())
+    return read_swimlane(pl_at_deps_swimlane_file)
 
 
 @pytest.mark.swimlane
@@ -428,7 +428,7 @@ def phase_fence_pl_at_swimlane_file(test_runner) -> Path:
 
 @pytest.fixture(scope="module")
 def phase_fence_pl_at_swimlane_data(phase_fence_pl_at_swimlane_file: Path) -> dict:
-    return json.loads(phase_fence_pl_at_swimlane_file.read_text())
+    return read_swimlane(phase_fence_pl_at_swimlane_file)
 
 
 @pytest.mark.swimlane
@@ -618,7 +618,7 @@ def branch_chain_pl_at_swimlane_file(test_runner) -> Path:
 
 @pytest.fixture(scope="module")
 def branch_chain_pl_at_swimlane_data(branch_chain_pl_at_swimlane_file: Path) -> dict:
-    return json.loads(branch_chain_pl_at_swimlane_file.read_text())
+    return read_swimlane(branch_chain_pl_at_swimlane_file)
 
 
 def _reconstruct_linear_chains(tasks: list[dict], *, expected: int) -> list[list[dict]]:

--- a/tests/st/runtime/scheduling/test_pl_at_deps_pipeline.py
+++ b/tests/st/runtime/scheduling/test_pl_at_deps_pipeline.py
@@ -213,6 +213,7 @@ def pl_at_deps_swimlane_data(pl_at_deps_swimlane_file: Path) -> dict:
     return json.loads(pl_at_deps_swimlane_file.read_text())
 
 
+@pytest.mark.swimlane
 class TestPlAtDepsSwimlane:
     """Validate the on-board execution graph for the pl.at-block pipeline.
 
@@ -430,6 +431,7 @@ def phase_fence_pl_at_swimlane_data(phase_fence_pl_at_swimlane_file: Path) -> di
     return json.loads(phase_fence_pl_at_swimlane_file.read_text())
 
 
+@pytest.mark.swimlane
 class TestPhaseFencePlAtSwimlane:
     """Validate phase-fence ordering using the pl.at-deps interface.
 
@@ -655,6 +657,7 @@ def _reconstruct_linear_chains(tasks: list[dict], *, expected: int) -> list[list
     return chains
 
 
+@pytest.mark.swimlane
 class TestBranchChainPlAtSwimlane:
     """Validate per-branch linear chain + cross-branch parallelism (pl.at-deps)."""
 


### PR DESCRIPTION
Thirty-five assertions under `tests/st/runtime/scheduling` have never run. They
gate on `--enable-chip-swimlane`, and CI passes that flag to exactly one file --
`test_perf_swimlane.py` -- so every one of them skipped in the batched shard,
silently, since the day it was written:

    test_manual_scope_pipeline.py        13
    test_pl_at_deps_pipeline.py          11
    test_phase_fence_dep_compression.py  11

The mechanism they use is the one that already works in CI: the fixture runs its
case, then picks the freshest `build_output/*/dfx_outputs/chip_swimlane_records
.json`. Nothing about them is broken; they were simply never given the flag.

Selection is by a `swimlane` marker rather than by path, because these files
also hold the correctness tests for the same pipelines, and those already run in
the batched shard. Marking the class, not the method, matches how the record is
scoped -- one class-or-module fixture per swimlane program.

The batched shard now excludes the marker. Those 35 ran there only to skip, and
35 silent skips are exactly what hid this: a real skip had nowhere to stand out.
Shard A collects 185 -> 146, and the 39 that leave are the 35 plus
`test_perf_swimlane`'s 4, which its own flagged step runs.

The new step omits `--forked`, unlike the perf_swimlane step above it. These
hang their record off class- or module-scoped fixtures, so one process reuses it
across the class -- about 20 device runs instead of 35. `test_perf_swimlane` is
left exactly as it was; a change there would risk a step that works today.

Not verified locally: whether the 35 pass. This box's simulator fails before any
of them reaches an assertion --

    RuntimeError: sim context failed to bind host-log state:
                  module rejected the host-log state ABI

-- which is a stale sim runtime library, unrelated to this change and present on
a clean checkout too. What is verified is the selection: `-m swimlane` picks
exactly those 35 under `runtime/scheduling` (and 39 across `tests/st`), and the
shard-A exclusion removes exactly those 39 and nothing else. CI is what will say
whether the assertions hold; some may not, and a failure there is the finding
this change exists to surface.