### PR TITLE
fix(codegen): reserve a Graph body's parameter names

### DIFF
--- a/docs/en/dev/codegen/01-orchestration_codegen.md
+++ b/docs/en/dev/codegen/01-orchestration_codegen.md
@@ -409,6 +409,21 @@ names in the output), but never for identity decisions.
 | Tensor arg index | `orch_args.tensor(N)` | `orch_args.tensor(0)` |
 | Scalar arg index | `orch_args.scalar(N)` | `orch_args.scalar(0)` |
 
+### Graph function bodies
+
+A `FunctionType.Graph` body is emitted by a second `OrchestrationStmtCodegen`
+instance whose parameters are ordinary C++ parameters bound at the top of the
+helper (`const Tensor& c = args.tensor(1).ref();`), not entry arguments. So its
+`param_name_set` is empty — `GetExternalTensorName` must not rewrite them to
+`ext_<name>` — but the names are still reserved via `ReserveDeclaredNames`.
+
+Both halves are load-bearing. Without the reservation, the first body SSA rename
+of a parameter takes the parameter's own name; reserved inside a
+`pl.manual_scope`, that name then reads as scope-local, every later writeback
+mints a block-scoped `const Tensor& c__ssa_vN = c;` alias instead of remapping
+onto the parameter, and a launch placed after the block names an identifier that
+has fallen out of C++ scope.
+
 ## Control Flow Generation
 
 ### ForStmt

--- a/docs/zh/dev/codegen/01-orchestration_codegen.md
+++ b/docs/zh/dev/codegen/01-orchestration_codegen.md
@@ -396,6 +396,19 @@ void aicpu_orchestration_entry(const ChipTaskArgs& orch_args) {
 | 张量参数索引 | `orch_args.tensor(N)` | `orch_args.tensor(0)` |
 | 标量参数索引 | `orch_args.scalar(N)` | `orch_args.scalar(0)` |
 
+### Graph 函数体
+
+`FunctionType.Graph` 的函数体由第二个 `OrchestrationStmtCodegen` 实例生成，它
+的参数是在辅助函数开头绑定的普通 C++ 参数（`const Tensor& c =
+args.tensor(1).ref();`），而非入口参数。因此它的 `param_name_set` 为空——
+`GetExternalTensorName` 不应把它们改写成 `ext_<name>`——但这些名字仍要通过
+`ReserveDeclaredNames` 预留。
+
+两者缺一不可。若不预留，函数体中该参数的第一个 SSA 重命名就会占用参数自身的
+名字；当它是在 `pl.manual_scope` 内被预留时，该名字随后会被当作作用域局部名，
+之后每一次回写都会在块内生成 `const Tensor& c__ssa_vN = c;` 别名，而不是重映射
+到参数上，于是块之后的任务启动引用到的标识符已经脱离了 C++ 作用域。
+
 ## 控制流生成
 
 ### ForStmt

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -300,6 +300,26 @@ class OrchestrationStmtCodegen : public CodegenBase {
   /// it makes every generated identifier ambiguous to read and to grep.
   void SetTaskVarPrefix(std::string prefix) { task_var_prefix_ = std::move(prefix); }
 
+  /// Reserve identifiers the emitted C++ function already declares outside the
+  /// body this instance generates, so no body Var can be handed one of them.
+  ///
+  /// The entry gets this for free: its ``param_name_set`` seeds
+  /// ``declared_var_names_``. A Graph function passes an empty set (its
+  /// parameters must not be ``ext_``-rewritten), so without this its
+  /// ``const Tensor& <p> = args.tensor(i).ref();`` prologue names are invisible
+  /// to ``ReserveVarEmitName``. The first body SSA rename of a parameter then
+  /// takes the parameter's own name — shadowing the prologue decl and, when it
+  /// happens inside a ``pl.manual_scope``, recording that name in
+  /// ``manual_local_names_`` as if it were scope-local. ``IsEnclosingScopeValid``
+  /// then reports the *parameter* as unreachable from outside the block, so
+  /// every later writeback mints a block-scoped ``const Tensor& <p>__ssa_vN =
+  /// <p>;`` alias instead of remapping onto the parameter — and a task placed
+  /// after the block references an identifier that has fallen out of C++ scope
+  /// (issue #2605).
+  void ReserveDeclaredNames(const std::set<std::string>& names) {
+    declared_var_names_.insert(names.begin(), names.end());
+  }
+
   void SetEffectiveUses(std::unordered_set<const Var*> uses) { effective_uses_ = std::move(uses); }
   [[nodiscard]] bool NeedsVectorInclude() const { return needs_vector_include_; }
 
@@ -4498,7 +4518,10 @@ std::string GenerateDynamicDimDefs(const std::vector<VarPtr>& params, const std:
 /// * ``param_name_set`` is empty. `GetExternalTensorName` rewrites any name in
 ///   that set to ``ext_<name>``, which is right for the entry (whose parameters
 ///   arrive through ``orch_args``) and wrong here, where they are ordinary
-///   function parameters bound at the top of the body.
+///   function parameters bound at the top of the body. The parameter names are
+///   still handed to `ReserveDeclaredNames`, which is the other half of what
+///   ``param_name_set`` does for the entry: it keeps a body Var from taking a
+///   name the prologue already declares (issue #2605).
 /// * A task-var prefix, because this instance's counters restart at 0.
 ///
 /// Boundary scalars are bound as ``const uint64_t&``, never by value. The
@@ -4529,14 +4552,21 @@ std::string GenerateGraphFunctions(const ProgramPtr& program, const FunctionPtr&
     // the two disagree the body would reference a symbol the header never
     // declared. Seeding makes them agree by construction.
     std::unordered_map<const Var*, std::string> emit_name_map;
+    std::set<std::string> param_emit_names;
     for (const auto& param : graph_func->params_) {
-      emit_name_map[param.get()] = auto_name::GetCompatibleBaseName(param->name_hint_);
+      std::string name = auto_name::GetCompatibleBaseName(param->name_hint_);
+      emit_name_map[param.get()] = name;
+      param_emit_names.insert(std::move(name));
     }
     OrchestrationStmtCodegen body_codegen(program, func_name_to_id, func_name_to_core_type,
                                           func_name_to_signature, next_func_id, std::move(emit_name_map),
                                           /*param_name_set=*/{}, /*param_name_to_orch_index=*/{},
                                           /*packed_fp4_axis=*/{}, /*dist_param_to_ctx_param=*/{});
     body_codegen.SetTaskVarPrefix("g" + std::to_string(graph_index) + "_");
+    // The prologue below declares one C++ name per parameter. They are not in
+    // ``param_name_set``, so reserve them explicitly or a body SSA rename will
+    // shadow one (issue #2605; see ReserveDeclaredNames).
+    body_codegen.ReserveDeclaredNames(param_emit_names);
     body_codegen.SetCallTupleElements(graph_info.call_tuple_elements);
     body_codegen.SetTupleVarToKey(graph_info.tuple_var_to_key);
     body_codegen.SetEffectiveUses(std::move(use_collector.var_uses));

--- a/tests/ut/codegen/test_orchestration_codegen_graph.py
+++ b/tests/ut/codegen/test_orchestration_codegen_graph.py
@@ -31,6 +31,7 @@ from unittest import mock
 
 import pypto.language as pl
 import pytest
+from _orchestration_codegen_common import _out_of_scope_tensor_refs
 from pypto.ir.compile import compile as ir_compile
 from pypto.pypto_core import passes
 
@@ -668,6 +669,80 @@ def test_a_region_allocation_is_hoisted_to_the_call_site():
     # allocation out of its own loop needs successive launches ordered.
     assert entry.count(".add_inout(s0") == 1, entry
     assert entry.count(".add_inout(s1") == 1, entry
+
+
+@pl.program
+class _ScopeEscapingWriteback:
+    """A Graph whose boundary tensor is written twice inside a ``manual_scope``
+    and then read by a launch placed *after* the block."""
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def accum(
+        self,
+        c: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+        a: pl.Tensor[[512, 128], pl.FP32],
+        base: pl.Scalar[pl.INDEX],
+    ) -> pl.Tensor[[128, 128], pl.FP32]:
+        t: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [base, 0], [128, 128])
+        pl.store(t, [0, 0], c)
+        return c
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def sink(
+        self,
+        c: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+        a: pl.Tensor[[512, 128], pl.FP32],
+    ) -> pl.Tensor[[128, 128], pl.FP32]:
+        t: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [256, 0], [128, 128])
+        pl.store(t, [0, 0], c)
+        return c
+
+    @pl.function(type=pl.FunctionType.Graph)
+    def layer(
+        self,
+        a: pl.Tensor[[512, 128], pl.FP32],
+        c: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+        layer_idx: pl.Scalar[pl.INDEX],
+    ) -> pl.Tensor[[128, 128], pl.FP32]:
+        with pl.manual_scope():
+            c, t0 = pl.submit(self.accum, c, a, 0)
+            c, _t1 = pl.submit(self.accum, c, a, 128, deps=[t0])
+        c = self.sink(c, a)
+        return c
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def main(
+        self,
+        a: pl.Tensor[[512, 128], pl.FP32],
+        c: pl.InOut[pl.Tensor[[128, 128], pl.FP32]],
+    ) -> pl.Tensor[[128, 128], pl.FP32]:
+        for i in pl.range(4):
+            c = self.layer(a, c, i)
+        return c
+
+
+def test_a_boundary_writeback_never_becomes_a_block_scoped_rename():
+    """Issue #2605: the second writer's rename fell out of C++ scope.
+
+    A Graph body is emitted with an empty ``param_name_set``, so its parameter
+    names were absent from ``declared_var_names_``. The first writeback SSA
+    rename of ``c`` then took the parameter's own name and — because it was
+    reserved inside a ``pl.manual_scope`` — registered it in
+    ``manual_local_names_``. From there the parameter read as scope-*local*, so
+    the second writeback could no longer collapse onto it and minted
+    ``const Tensor& c__ssa_v2 = c;`` inside the block. The post-block launch
+    named it, and the orchestration ``.cpp`` failed to compile with
+    ``'c__ssa_v2' was not declared in this scope``.
+
+    Every reference must resolve to the parameter, which is what the same kernel
+    emits on the non-Graph path.
+    """
+    orch = _compile_orch(_ScopeEscapingWriteback)
+    body = _graph_body(orch)
+    assert _out_of_scope_tensor_refs(orch) == [], orch
+    # No alias is minted at all: writer and post-block reader name the parameter.
+    assert not re.search(r"const Tensor&\s+c__\w+\s*=", body), body
+    assert body.count("add_inout(c);") == 3, body
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

A `FunctionType.Graph` body is emitted by a second `OrchestrationStmtCodegen`
instance constructed with an empty `param_name_set`. That set does two jobs for
the entry function, and only one of them is wrong for a Graph:
`GetExternalTensorName` must not rewrite a Graph parameter to `ext_<name>`, but
the set also seeds `declared_var_names_` — so dropping it left the prologue's
`const Tensor& <p> = args.tensor(i).ref();` names invisible to
`ReserveVarEmitName`.

The first body SSA rename of a parameter therefore took the parameter's own
name. Reserved inside a `pl.manual_scope`, that name also landed in
`manual_local_names_`, so `IsEnclosingScopeValid` reported the *parameter* as
scope-local and the issue #1697 emit-name remap stopped firing: every later
writeback minted a block-scoped `const Tensor& <p>__ssa_vN = <p>;` alias
instead of collapsing onto the parameter. A launch placed after the block named
the last alias, and the orchestration `.cpp` failed to C++-compile with
`'<p>__rv_v14' was not declared in this scope`. Only a boundary parameter whose
last in-block rename is read after the block hit it, which is why it stayed
narrow — the other dead aliases were harmless.

This reserves the parameter emit names explicitly through a new
`ReserveDeclaredNames`. The rename chain now collapses onto the parameter,
which is what the same kernel already emitted on the non-Graph path. No
interface change and no migration step; the only observable difference is the
emitted orchestration C++ for a Graph body.

Fixes #2605.

## Changes

- `src/codegen/orchestration/orchestration_codegen.cpp`: add
  `OrchestrationStmtCodegen::ReserveDeclaredNames` and call it from
  `GenerateGraphFunctions` with the Graph function's parameter emit names
  (tensor and scalar alike — the prologue declares a C++ name for both).
- `tests/ut/codegen/test_orchestration_codegen_graph.py`: add
  `_ScopeEscapingWriteback` — a Graph whose `InOut` boundary tensor is written
  by two `pl.submit`s inside a `pl.manual_scope` and then read by a launch
  after the block — and assert through the shared `_out_of_scope_tensor_refs`
  checker that no identifier escapes its declaring brace scope, and that no
  alias is minted at all.
- `docs/{en,zh}/dev/codegen/01-orchestration_codegen.md`: document the Graph
  body's naming rules under *Variable Naming* — why `param_name_set` is empty
  there and why the names must still be reserved.

## Verification

- `cmake --build build --parallel 32`: exit 0.
- `pytest tests/ut/codegen/test_orchestration_codegen_graph.py`: exit 0,
  17 passed.
- `pytest tests/ut/codegen -n 16`: exit 0, 1025 passed, 2 skipped.
- `pytest tests/ut -n 16`: 11303 passed. The single failure,
  `test_unified_ops.py::TestUnifiedSlicePadValue::test_symlinked_import_path_still_names_the_caller`,
  is a local environment artifact — its subprocess resets `PYTHONPATH`, so an
  editable-install meta-path finder redirects `pypto` to another checkout — and
  is unrelated to this change.
- New test is a true regression guard: rebuilt with the one-line fix disabled
  behind a temporary env switch, it fails with
  `AssertionError: ['c__ssa_v2']` while the other 16 in the file still pass.
- Reported reproducer (pypto-lib Qwen3-14B,
  `models/qwen3_14b/decode_fwd_hbg.py -p a2a3 --layers 8 --mode hbg-graph --smoke`):
  fails before this change with
  `'post_norm_partial_inline264__rv_v14' was not declared in this scope`;
  after it, the orchestration compiles and the run reaches
  `compile-only smoke complete`. In the emitted `.cpp` the whole
  `__rv_v5/v8/v11/v14` chain is gone and the post-block launch reads the
  boundary parameter directly.
- clang-format 21.1.0 `--dry-run --Werror`, `tests/lint/clang_tidy.py
  --strict-version --diff-base=HEAD`, ruff 0.14.8 `check` and
  `format --check`, pyright, markdownlint-cli2 0.20.0 on both docs, and
  `check_headers` / `check_english_only` / `check_docs_en_zh_parity` /
  `check_docs_nav`: all exit 0.

No device run: this is orchestration codegen, and the reported failure is a
host C++ compile error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)