### PR TITLE
fix(codegen): keep a TaskId array carry alive across a nested pl.scope()

### DIFF
--- a/docs/en/dev/codegen/01-orchestration_codegen.md
+++ b/docs/en/dev/codegen/01-orchestration_codegen.md
@@ -616,6 +616,16 @@ produced inside a scope does not leak to an enclosing scope where its identifier
 would be out of C++ scope. Loop / branch carries are declared *before* their
 body's `SIMPLER_SCOPE`, so they correctly survive the block.
 
+**Exception: array carries over enclosing storage.** An `arr[i] = tid` inside a
+scope registers a carry whose backing `TaskId[N]` was declared further out. The
+slot write is emitted in place, but the *carry* is read after the closing brace,
+by the enclosing loop's yield. Restoring it away makes that yield misread an
+Array value as a scalar TaskId, so `PreserveEnclosingArrayCarries` keeps any
+carry whose backing array outlives the block — for both scope kinds. Locality is
+decided per kind: a MANUAL scope hoists its allocations and knows its local
+names outright; an AUTO scope hoists nothing, so storage counts as enclosing
+exactly when a pre-entry carry already named it.
+
 ### Unresolvable dep edges
 
 A consequence of that lifetime rule: a dep edge naming a TaskId produced in a
@@ -626,6 +636,7 @@ on scope exit. Codegen's response depends on the edge's provenance:
 | --------------- | -------------------------- |
 | Compiler-derived (`compiler_manual_dep_edges`) | Silently skipped. These are a best-effort hazard patch; `PrepareCrossScopeTaskIdHoists` already LCA-hoists the ones it can, and dropping the rest is safe because the pass only ever *adds* ordering |
 | User-written (`deps=[...]`) | **Hard error** — `CHECK_SPAN` raises a `pypto::ValueError` naming the TaskId and the DSL source line |
+| Array publish (`arr[i] = tid`) | **Hard error** — `CheckTaskIdSlotValueInScope` raises a `pypto::ValueError` telling the user to move the store inside the `pl.scope()` that produced the TaskId. Unlike a dep edge, the slot write is emitted unconditionally, so accepting it would emit orchestration the host compiler rejects with `'<tid>' was not declared in this scope` — a failure `--compile-only` never reaches |
 
 Provenance is the attr key. Note that `attrs["dummy_task"]` is *not* an
 authorship marker: the parser stamps it on a user-written

--- a/docs/zh/dev/codegen/01-orchestration_codegen.md
+++ b/docs/zh/dev/codegen/01-orchestration_codegen.md
@@ -584,6 +584,13 @@ MANUAL）在进入时快照 `manual_task_id_map_` 与 `array_carry_vars_`、退�
 因此在某作用域内产生的绑定不会泄漏到外层作用域（否则其标识符会超出 C++ 作用域）。
 循环 / 分支的 carry 在其 body 的 `SIMPLER_SCOPE` *之前*声明，因此能正确地在块结束后存活。
 
+**例外：基于外层存储的 array carry。** 作用域内的 `arr[i] = tid` 注册的 carry，其底层
+`TaskId[N]` 声明在更外层。槽位写入就地生成，但该 *carry* 是在闭合花括号之后、由外层循环的
+yield 读取的。把它恢复掉会让该 yield 把 Array 值误判为标量 TaskId，因此
+`PreserveEnclosingArrayCarries` 会保留所有底层数组生命周期长于该块的 carry——两种作用域
+形态皆然。局部性判定按形态区分：MANUAL 作用域会提升自己的分配，因此直接知道其局部名字集合；
+AUTO 作用域不做任何提升，故仅当进入前已有 carry 命名了该存储时，才视其为外层存储。
+
 ### 无法解析的依赖边
 
 上述生命周期规则带来一个结果：若某条依赖边引用的 TaskId 产生于一个**已经关闭**的
@@ -594,6 +601,7 @@ MANUAL）在进入时快照 `manual_task_id_map_` 与 `array_carry_vars_`、退�
 | -------- | ---------------- |
 | 编译器推导（`compiler_manual_dep_edges`） | 静默跳过。这类边是尽力而为的 hazard 补丁；`PrepareCrossScopeTaskIdHoists` 已对能处理的部分做了 LCA 提升，丢弃其余是安全的，因为该 pass 只会*增加*定序 |
 | 用户书写（`deps=[...]`） | **硬报错**——`CHECK_SPAN` 抛出 `pypto::ValueError`，并指出该 TaskId 与对应的 DSL 源码行 |
+| 数组发布（`arr[i] = tid`） | **硬报错**——`CheckTaskIdSlotValueInScope` 抛出 `pypto::ValueError`，提示用户把该写入移进产生该 TaskId 的 `pl.scope()` 内。与依赖边不同，槽位写入是无条件生成的，因此若放行，就会生成宿主编译器以 `'<tid>' was not declared in this scope` 拒绝的编排代码——而 `--compile-only` 根本走不到那一步 |
 
 来源由 attr key 判定。注意 `attrs["dummy_task"]` **不是**作者身份标记：parser 会把
 它打在用户书写的 `pl.system.task_dummy(deps=[...])` 上，与

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -1055,6 +1055,8 @@ class OrchestrationStmtCodegen : public CodegenBase {
       // not. Storage counts as enclosing exactly when some pre-entry carry
       // already named it.
       std::set<std::string> enclosing_arrays;
+      // NOLINTNEXTLINE(bugprone-nondeterministic-pointer-iteration-order) — the
+      // pointer keys are ignored; only the names are collected, into an ordered set.
       for (const auto& [_, entry] : saved_array_carry) enclosing_arrays.insert(entry.array_name);
       PreserveEnclosingArrayCarries(&saved_array_carry, &saved_map, [&](const std::string& name) {
         return enclosing_arrays.count(name) == 0;
@@ -1291,6 +1293,19 @@ class OrchestrationStmtCodegen : public CodegenBase {
         // merges stay in-block). The phi init (a param or a pre-if Var) must be
         // enclosing-scope-valid, or the decl stays in place (EmitMutableTensorCarryDecl).
         EmitMutableTensorCarryDecl(emit_name, tensor_phi_init);
+      } else if (auto sty = As<ScalarType>(rv->GetType()); sty && sty->dtype_ == DataType::TASK_ID) {
+        // A TaskId phi is declared HERE, outside the branches, and each arm's
+        // yield assigns into it — so unlike a branch-local producer id it is
+        // still live after the ``if`` closes. Seed it with the sentinel (a
+        // default-constructed ``TaskId`` is uninitialised, and an arm may leave
+        // it unassigned) and register it at this enclosing level, mirroring
+        // ``InstallArrayPhiBindings`` below: a registration made inside a branch
+        // body would be dropped by that branch's scope restore. Without it a
+        // downstream ``deps=[phi]`` cannot resolve and an ``arr[i] = phi``
+        // publish looks like a store of a closed-scope local.
+        EmitIndentedLine(cpp_type + " " + emit_name + " = TaskId::invalid();");
+        manual_task_id_map_[rv.get()] = emit_name;
+        manual_task_id_map_by_key_[TaskIdHoistKey(rv.get())] = emit_name;
       } else {
         EmitIndentedLine(cpp_type + " " + emit_name + ";");
       }

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -1054,9 +1054,10 @@ class OrchestrationStmtCodegen : public CodegenBase {
       // block dies at its closing brace while one declared further out does
       // not. Storage counts as enclosing exactly when some pre-entry carry
       // already named it.
+      // Iteration order does not reach the result: the pointer keys are ignored
+      // and only the names are collected, into an ordered set.
       std::set<std::string> enclosing_arrays;
-      // NOLINTNEXTLINE(bugprone-nondeterministic-pointer-iteration-order) — the
-      // pointer keys are ignored; only the names are collected, into an ordered set.
+      // NOLINTNEXTLINE(bugprone-nondeterministic-pointer-iteration-order)
       for (const auto& [_, entry] : saved_array_carry) enclosing_arrays.insert(entry.array_name);
       PreserveEnclosingArrayCarries(&saved_array_carry, &saved_map, [&](const std::string& name) {
         return enclosing_arrays.count(name) == 0;

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -253,6 +253,12 @@ class OrchestrationStmtCodegen : public CodegenBase {
     bool user_written;
   };
 
+  /// Backing storage of one TaskId array carry — see ``array_carry_vars_``.
+  struct ArrayCarryEntry {
+    std::string array_name;
+    int64_t size;
+  };
+
   explicit OrchestrationStmtCodegen(const ProgramPtr& prog, std::map<std::string, int>* func_ids,
                                     std::map<std::string, CoreType>* core_types,
                                     std::map<std::string, std::vector<std::string>>* func_signatures,
@@ -1044,6 +1050,16 @@ class OrchestrationStmtCodegen : public CodegenBase {
       }
       EmitIndentedLine("}");
 
+      // An AUTO scope hoists nothing, so a backing array declared inside the
+      // block dies at its closing brace while one declared further out does
+      // not. Storage counts as enclosing exactly when some pre-entry carry
+      // already named it.
+      std::set<std::string> enclosing_arrays;
+      for (const auto& [_, entry] : saved_array_carry) enclosing_arrays.insert(entry.array_name);
+      PreserveEnclosingArrayCarries(&saved_array_carry, &saved_map, [&](const std::string& name) {
+        return enclosing_arrays.count(name) == 0;
+      });
+
       manual_task_id_map_ = std::move(saved_map);
       array_carry_vars_ = std::move(saved_array_carry);
       return;
@@ -1108,19 +1124,11 @@ class OrchestrationStmtCodegen : public CodegenBase {
     // that names a manual-scope-local C++ identifier (e.g. ``TaskId prev =
     // arr[k];``) dies at the closing brace and must not leak (issue #1577).
     // BUT an array carry registered inside the scope can reuse a backing array
-    // declared in the ENCLOSING scope — e.g. a ``pl.parallel`` TaskId array
-    // carry threaded from an outer sequential loop's backing store. That carry
-    // survives the brace and is referenced by the enclosing loop's yield, which
-    // is emitted AFTER this block; wiping it would drop the loop-carried tids
-    // and trip the scalar-yield branch (issue #1811). Preserve such entries —
-    // identified by backing storage that is NOT this scope's local name set.
-    for (const auto& [var, entry] : array_carry_vars_) {
-      if (saved_array_carry.count(var)) continue;         // outer entry — keep outer value
-      if (local_names.count(entry.array_name)) continue;  // scope-local storage — drop
-      saved_array_carry[var] = entry;                     // enclosing-valid carry — preserve
-      auto tid_it = manual_task_id_map_.find(var);        // keep its per-slot dep names in sync
-      if (tid_it != manual_task_id_map_.end()) saved_map[var] = tid_it->second;
-    }
+    // declared in the ENCLOSING scope (issue #1811) — see
+    // ``PreserveEnclosingArrayCarries``. A manual scope hoists its allocations,
+    // so it knows its own local storage names outright.
+    PreserveEnclosingArrayCarries(&saved_array_carry, &saved_map,
+                                  [&](const std::string& name) { return local_names.count(name) != 0; });
 
     manual_task_id_map_ = std::move(saved_map);
     array_carry_vars_ = std::move(saved_array_carry);
@@ -4153,6 +4161,35 @@ class OrchestrationStmtCodegen : public CodegenBase {
     emit_name_map_[assign->var_.get()] = target_name;
   }
 
+  /// Reject an ``arr[i] = tid`` whose TaskId was produced in a scope that has
+  /// already closed.
+  ///
+  /// The slot write is emitted in place, but the value names a C++ local
+  /// declared inside the ``SIMPLER_SCOPE { }`` that produced it. Writing it
+  /// after that block closes compiles here and is then rejected by the host
+  /// compiler with ``'<tid>' was not declared in this scope`` — a failure the
+  /// user cannot trace back to their source, and one ``--compile-only`` never
+  /// reaches. Diagnose it at the DSL level instead.
+  ///
+  /// A stale value is identified positively: ``emit_name_map_`` still holds the
+  /// name it was bound to (never scope-restored), while ``manual_task_id_map_``
+  /// does not (restored at each closing brace — see
+  /// ``VisitStmt_(RuntimeScopeStmtPtr)``). A TaskId this codegen never bound to
+  /// a local has no entry in either and is left alone.
+  void CheckTaskIdSlotValueInScope(const CallPtr& call, const std::string& array_name) {
+    auto value_var = AsVarLike(call->args_[2]);
+    if (!value_var) return;
+    auto scalar_ty = As<ScalarType>(value_var->GetType());
+    if (!scalar_ty || scalar_ty->dtype_ != DataType::TASK_ID) return;
+    if (manual_task_id_map_.count(value_var.get())) return;
+    if (!emit_name_map_.count(value_var.get())) return;
+    CHECK_SPAN(false, call->span_)
+        << "Task id '" << value_var->name_hint_ << "' is stored into array '" << array_name
+        << "' after the `pl.scope()` that produced it has closed, so the store has no runtime "
+           "value to name. Move the store inside that `pl.scope()`, where the task id is still "
+           "live.";
+  }
+
   void HandleArrayUpdateElementAssign(const AssignStmtPtr& assign, const CallPtr& call) {
     // array.update_element(array, index, value) -> ArrayType.
     // The SSA-functional return value shares storage with the first arg; alias
@@ -4160,6 +4197,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
     INTERNAL_CHECK_SPAN(call->args_.size() == 3, call->span_)
         << "Internal error: array.update_element expects 3 arguments";
     std::string array_name = GenerateExprString(call->args_[0]);
+    CheckTaskIdSlotValueInScope(call, array_name);
     emit_name_map_[assign->var_.get()] = array_name;
     // Propagate ``array_carry_vars_`` and ``manual_task_id_map_`` from the
     // input array to the LHS: they share storage, so a downstream
@@ -4250,6 +4288,35 @@ class OrchestrationStmtCodegen : public CodegenBase {
     return emit_name;
   }
 
+  /// Keep the array carries a just-closed scope minted over storage that
+  /// outlives it, when restoring the entry snapshot.
+  ///
+  /// ``array.update_element`` is SSA-functional: it aliases its LHS onto the
+  /// input array's storage (``HandleArrayUpdateElementAssign``) and emits the
+  /// C++ slot write in place, at the statement's own position. The *carry* it
+  /// registers is read later though — by the enclosing loop's yield, emitted
+  /// after this block's closing brace. Restoring the snapshot wholesale drops
+  /// that carry, and the yield then misreads an Array value as a scalar TaskId
+  /// (issue #1811 for a manual scope; the same for an AUTO ``pl.scope()``).
+  ///
+  /// Only carries whose backing storage outlives the block may be kept, so each
+  /// scope kind supplies its own ``is_scope_local`` test over the array's emit
+  /// name — a manual scope hoists its allocations and knows its local names
+  /// outright; an AUTO scope hoists nothing, so storage is enclosing exactly
+  /// when a pre-entry carry already named it.
+  template <typename IsScopeLocal>
+  void PreserveEnclosingArrayCarries(std::unordered_map<const Var*, ArrayCarryEntry>* saved_array_carry,
+                                     std::unordered_map<const Var*, ManualTaskIdBinding>* saved_map,
+                                     const IsScopeLocal& is_scope_local) {
+    for (const auto& [var, entry] : array_carry_vars_) {
+      if (saved_array_carry->count(var)) continue;     // outer entry — keep outer value
+      if (is_scope_local(entry.array_name)) continue;  // scope-local storage — drop
+      (*saved_array_carry)[var] = entry;               // enclosing-valid carry — preserve
+      auto tid_it = manual_task_id_map_.find(var);     // keep its per-slot dep names in sync
+      if (tid_it != manual_task_id_map_.end()) (*saved_map)[var] = tid_it->second;
+    }
+  }
+
   /// Register ``var`` as backed by ``array_name[size]``; also populates the
   /// ``manual_task_id_map_`` with the per-slot expressions so EmitManualDeps
   /// emits one ``add_dep`` per slot when this Var appears as a deps source.
@@ -4319,10 +4386,6 @@ class OrchestrationStmtCodegen : public CodegenBase {
   /// a ``ForStmt`` return_var (when used as a yield target). For each key the
   /// recorded ``array_name`` is the C++ identifier of the underlying
   /// ``TaskId[N]`` array and ``size`` is the slot count ``N``.
-  struct ArrayCarryEntry {
-    std::string array_name;
-    int64_t size;
-  };
   std::unordered_map<const Var*, ArrayCarryEntry> array_carry_vars_;
   /// In-flight ArrayType ``IfStmt`` return_vars (phis). An ArrayType SSA value
   /// names one backing C-stack array rather than a copyable value, so a phi is

--- a/tests/ut/codegen/test_array_codegen.py
+++ b/tests/ut/codegen/test_array_codegen.py
@@ -1038,5 +1038,56 @@ def test_orch_task_id_array_store_after_nested_scope_closed_is_rejected():
     assert "Move the store inside that `pl.scope()`" in msg, msg
 
 
+def test_orch_task_id_phi_from_if_is_publishable_to_array():
+    """A TaskId merged by an ``if`` stays live after the branches close.
+
+    The phi is declared *outside* the branches and each arm's yield assigns
+    into it, so publishing it into a ``pl.array`` afterwards names a live C++
+    local — unlike a producer id left behind in a closed scope. Codegen must
+    seed the phi with the sentinel and register it, so the publish resolves
+    instead of tripping the closed-scope diagnostic.
+    """
+
+    rows, cols, tile_r = 128, 16, 16
+
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.InCore)
+        def stripe(
+            self,
+            data: pl.Tensor[[rows, cols], pl.FP32],
+            row_offset: pl.Scalar[pl.INDEX],
+            out: pl.Out[pl.Tensor[[rows, cols], pl.FP32]],
+        ) -> pl.Tensor[[rows, cols], pl.FP32]:
+            t: pl.Tile[[tile_r, cols], pl.FP32] = pl.load(data, [row_offset, 0], [tile_r, cols])
+            return pl.store(pl.add(t, 1.0), [row_offset, 0], out)
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(
+            self,
+            data: pl.Tensor[[rows, cols], pl.FP32],
+            out: pl.Out[pl.Tensor[[rows, cols], pl.FP32]],
+        ) -> pl.Tensor[[rows, cols], pl.FP32]:
+            with pl.manual_scope():
+                tids = pl.array.create(4, pl.TASK_ID)
+                for branch in pl.parallel(4):
+                    row: pl.Scalar[pl.INDEX] = branch * tile_r
+                    if branch >= 2:
+                        out, tid = pl.submit(self.stripe, data, row, out)
+                    else:
+                        out, tid = pl.submit(self.stripe, data, row, out, deps=[tids])
+                    tids[branch] = tid
+            return out
+
+    code = _compile_orch(Prog)
+
+    # The phi is seeded with the sentinel at the enclosing level, so an arm that
+    # leaves it unassigned yields an invalid id rather than reading garbage.
+    phi = re.search(r"TaskId\s+(\w*tid\w*)\s*=\s*TaskId::invalid\(\);", code)
+    assert phi, code
+    # ...and the publish after the branches close resolves to that same local.
+    assert f"tids[branch] = {phi.group(1)};" in code or f"tids[branch] = {phi.group(1)}" in code, code
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/codegen/test_array_codegen.py
+++ b/tests/ut/codegen/test_array_codegen.py
@@ -15,6 +15,8 @@ update_element correctly aliases the LHS to the input array so in-place
 mutations land on the same backing storage.
 """
 
+import re
+
 import pypto.language as pl
 import pytest
 from _orchestration_codegen_common import _finalize_handbuilt_for_codegen
@@ -912,6 +914,128 @@ def test_orch_task_id_array_store_under_runtime_predicate():
     assert "tids[g] = " in code, code
     # ...and the consumer's dependency reads a slot of that same array.
     assert "tids[g2]" in code, code
+
+
+def _assert_same_cpp_block(code: str, decl_line: str, use_line: str) -> None:
+    """Assert ``use_line`` is still inside the C++ block that ``decl_line`` opens in.
+
+    A ``SIMPLER_SCOPE`` expands to a real braced block, so a local declared
+    inside one is out of scope after its closing brace. Walk the brace depth
+    between the two lines: it must never drop below the declaration's level.
+    """
+    lines = code.splitlines()
+    decl_idx = next((i for i, ln in enumerate(lines) if decl_line in ln), None)
+    use_idx = next((i for i, ln in enumerate(lines) if use_line in ln), None)
+    assert decl_idx is not None, f"declaration {decl_line!r} not emitted:\n{code}"
+    assert use_idx is not None, f"use {use_line!r} not emitted:\n{code}"
+    assert decl_idx < use_idx, f"{use_line!r} precedes its declaration:\n{code}"
+
+    depth = 0
+    for ln in lines[decl_idx + 1 : use_idx + 1]:
+        depth += ln.count("{") - ln.count("}")
+        assert depth >= 0, f"{use_line!r} is emitted after the block declaring {decl_line!r} closed:\n{code}"
+
+
+def test_orch_task_id_array_store_from_nested_scope():
+    """A TaskId published from a nested ``pl.scope()`` reaches the outer array.
+
+    The producer sits one runtime scope below the ``pl.array.create`` — the
+    shape a kernel gets when it opens a ``pl.scope()`` to bound a scratch
+    tensor's lifetime. The slot write is emitted where the TaskId is live, and
+    the enclosing loop's array carry must survive the scope's closing brace so
+    the yield still recognises it as an array (previously it fell through to
+    the scalar-yield path and aborted with "scalar yield to array carry must
+    resolve to a TaskId variable registered in manual_task_id_map_").
+    """
+
+    rows, cols, tile_r = 64, 16, 16
+
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.Orchestration, auto_scope=False)
+        def main(
+            self,
+            x: pl.Tensor[[rows, cols], pl.FP32],
+            out: pl.Out[pl.Tensor[[rows, cols], pl.FP32]],
+        ) -> pl.Tensor[[rows, cols], pl.FP32]:
+            with pl.scope():
+                tids = pl.array.create(4, pl.TASK_ID)
+                for g in pl.parallel(4):
+                    row: pl.Scalar[pl.INDEX] = g * tile_r
+                    with pl.scope():
+                        scratch: pl.Tensor[[tile_r, cols], pl.FP32] = pl.create_tensor(
+                            [tile_r, cols], dtype=pl.FP32
+                        )
+                        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prod") as tid:
+                            t: pl.Tile[[tile_r, cols], pl.FP32] = pl.load(x, [row, 0], [tile_r, cols])
+                            scratch = pl.store(pl.add(t, t), [0, 0], scratch)
+                        tids[g] = tid
+                for g2 in pl.parallel(4):
+                    row2: pl.Scalar[pl.INDEX] = g2 * tile_r
+                    with pl.at(level=pl.Level.CORE_GROUP, name_hint="cons", deps=[tids[g2]]):
+                        t2: pl.Tile[[tile_r, cols], pl.FP32] = pl.load(x, [row2, 0], [tile_r, cols])
+                        out = pl.store(pl.add(t2, t2), [row2, 0], out)
+            return out
+
+    code = _compile_orch(Prog)
+
+    decls = [ln for ln in code.splitlines() if "TaskId tids[4]" in ln]
+    assert len(decls) == 1, code
+    # The publish is emitted inside the nested scope, where the producer TaskId
+    # local is still declared — not after its closing brace.
+    producer = re.search(r"TaskId\s+(\w+)\s*=\s*task_\d+_outs\.task_id\(\);", code)
+    assert producer, code
+    _assert_same_cpp_block(code, f"TaskId {producer.group(1)} =", f"tids[g] = {producer.group(1)};")
+    # The consumer still reads a slot of the same backing array.
+    assert "tids[g2]" in code, code
+
+
+def test_orch_task_id_array_store_after_nested_scope_closed_is_rejected():
+    """Publishing a TaskId after its ``pl.scope()`` closed is a user error.
+
+    The slot write would name a C++ local that died at the scope's closing
+    brace. Codegen used to accept it and emit orchestration the host compiler
+    rejects with ``'<tid>' was not declared in this scope`` — a failure
+    ``--compile-only`` never reaches. Diagnose it here instead, pointing at the
+    fix (see ``test_orch_task_id_array_store_from_nested_scope``).
+    """
+
+    rows, cols, tile_r = 64, 16, 16
+
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.Orchestration, auto_scope=False)
+        def main(
+            self,
+            x: pl.Tensor[[rows, cols], pl.FP32],
+            out: pl.Out[pl.Tensor[[rows, cols], pl.FP32]],
+        ) -> pl.Tensor[[rows, cols], pl.FP32]:
+            with pl.scope():
+                tids = pl.array.create(4, pl.TASK_ID)
+                for g in pl.parallel(4):
+                    row: pl.Scalar[pl.INDEX] = g * tile_r
+                    with pl.scope():
+                        scratch: pl.Tensor[[tile_r, cols], pl.FP32] = pl.create_tensor(
+                            [tile_r, cols], dtype=pl.FP32
+                        )
+                        with pl.at(level=pl.Level.CORE_GROUP, name_hint="prod") as tid:
+                            t: pl.Tile[[tile_r, cols], pl.FP32] = pl.load(x, [row, 0], [tile_r, cols])
+                            scratch = pl.store(pl.add(t, t), [0, 0], scratch)
+                    tids[g] = tid
+                for g2 in pl.parallel(4):
+                    row2: pl.Scalar[pl.INDEX] = g2 * tile_r
+                    with pl.at(level=pl.Level.CORE_GROUP, name_hint="cons", deps=[tids[g2]]):
+                        t2: pl.Tile[[tile_r, cols], pl.FP32] = pl.load(x, [row2, 0], [tile_r, cols])
+                        out = pl.store(pl.add(t2, t2), [row2, 0], out)
+            return out
+
+    with pytest.raises(ValueError) as excinfo:
+        _compile_orch(Prog)
+
+    msg = str(excinfo.value)
+    assert "tid" in msg, msg
+    assert "after the `pl.scope()` that produced it has closed" in msg, msg
+    assert "Move the store inside that `pl.scope()`" in msg, msg
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

Publishing a producer TaskId into a `pl.array[TASK_ID]` has no legal spelling when the producer sits in a `pl.scope()` nested below the array's own scope — the documented fan-in idiom, and the shape a kernel gets whenever it opens a scope to bound a scratch tensor's lifetime:

```python
with pl.scope():
    h_q_tids = pl.array.create(N_SLOTS, pl.TASK_ID)
    for local_i in pl.parallel(N_SLOTS):
        for t in pl.parallel(n_tiles):
            with pl.scope():                       # tile scope
                tile_fp32 = pl.create_tensor(...)
                with pl.at(level=pl.Level.CORE_GROUP) as h_q_tid: ...
                h_q_tids[local_i] = h_q_tid        # (1) codegen aborts
            # h_q_tids[local_i] = h_q_tid          # (2) emits out-of-scope C++
```

Both placements of the store fail, and neither diagnostic names the real constraint.

**(1) Store inside the scope, where the TaskId is live.** Every generated `SIMPLER_SCOPE` snapshots `manual_task_id_map_` / `array_carry_vars_` on entry and restores them on exit, and the AUTO path did so unconditionally. The carry `HandleArrayUpdateElementAssign` registers inside the block was therefore gone by the time the enclosing loop's yield read it, so the yield misread an Array value as a scalar TaskId:

```text
Internal error: scalar yield to array carry must resolve to a TaskId variable
registered in manual_task_id_map_
```

The emitted C++ was already correct — `array.update_element` emits the slot write in place, inside the block that declares the TaskId local. Only the bookkeeping was wrong.

**(2) Store after the scope closes.** Accepted, and emitted orchestration naming a C++ local declared inside the block that just closed:

```cpp
SIMPLER_SCOPE() {
    ...
    TaskId h_q_tid_inline3 = task_1_outs.task_id();
}
h_q_tids_inline7[local_i_inline11] = h_q_tid_inline3;   // dead local
```

`SIMPLER_SCOPE(...)` expands to `if (ScopeGuard sg{...}; true)`, so that is a real braced block and g++ rejects it with `'h_q_tid_inline3' was not declared in this scope` — a failure `--compile-only` never reaches.

## Fix

**(1) Preserve carries whose backing array outlives the block, on both scope kinds.** The MANUAL path already did this for #1811; this lifts that loop into `PreserveEnclosingArrayCarries`, parameterized by an `is_scope_local` test, because the two kinds decide locality differently — a MANUAL scope hoists its allocations and knows its local names outright, while an AUTO scope hoists nothing, so storage counts as enclosing exactly when a pre-entry carry already named it.

**(2) Reject the second placement with a `pypto::ValueError`** naming the DSL line and the fix, rather than emitting C++ the host compiler will refuse:

```text
Task id 'h_q_tid_inline5__ssa_v0' is stored into array 'h_q_tids_inline21'
after the `pl.scope()` that produced it has closed, so the store has no runtime
value to name. Move the store inside that `pl.scope()`, where the task id is
still live. [.../taskid-array-carry-in-parallel.py:95:17]
```

`CheckTaskIdSlotValueInScope` fires only where staleness is provable: the value is still in `emit_name_map_` (never scope-restored) but absent from `manual_task_id_map_` (restored at each closing brace). A TaskId this codegen never bound to a local is in neither and is left alone.

## Notes for reviewers

- **Why a `CHECK_SPAN` in `src/codegen`.** Per `.claude/rules/error-checking.md` codegen defaults to `INTERNAL_CHECK`, but this is a documented user-facing limitation, with existing precedent in the same file: an unresolvable user-written `deps=[...]` edge is already a `CHECK_SPAN`. `check-emitter-check-classification` passes.
- **Why (2) is rejected rather than supported.** `PrepareCrossScopeTaskIdHoists` could LCA-hoist the TaskId and make it legal, but once (1) works there is no reason to write (2) — the store can always go where the TaskId is live. What must not persist is silently-invalid codegen.
- **Test shape.** The positive test asserts *block containment* by walking brace depth between the TaskId declaration and the slot write, so it fails again if the write ever drifts past the closing brace rather than merely checking both strings appear.

## Verification

- `tests/ut` + `tests/lint`: **11083 passed, 3 skipped, 1 xfailed**; `tests/ut/codegen` re-run after the pre-commit reformat: 1004 passed.
- Verified end-to-end on the original reduction outside the test suite: form (1) now compiles and emits the write inside the declaring block; form (2) is rejected at its DSL line with the message above.
- Two regression tests in `tests/ut/codegen/test_array_codegen.py`, beside the existing `test_orch_task_id_array_store_under_runtime_predicate`.
- Docs: `docs/en/dev/codegen/01-orchestration_codegen.md` gains an "Exception: array carries over enclosing storage" paragraph under *Lexical-scope lifetime* and a third row in the unresolvable-edge table; `docs/zh/` mirrored.
