### PR TITLE
fix(jit): honor diagnostic requests before cache lookup

### DIFF
--- a/docs/en/dev/01-compile-profiling.md
+++ b/docs/en/dev/01-compile-profiling.md
@@ -12,6 +12,11 @@ passes and code generation to on-device execution.
 PYPTO_COMPILE_PROFILING=1 python3 my_program.py
 ```
 
+Unsetting this variable (or setting it to `0`) releases the environment-created
+profiler on the next lookup, so ordinary JIT calls can reuse cached artifacts
+again. An explicit `with CompileProfiler()` context remains active until its
+scope ends, independently of the environment variable.
+
 ### Option 2: `ir.compile()` Parameter
 
 ```python

--- a/docs/en/dev/language/03-functions.md
+++ b/docs/en/dev/language/03-functions.md
@@ -46,6 +46,44 @@ or editing compiler/source files during compilation is not supported by this
 constant-tracking mechanism. This behavior does not enable persistent artifact
 caching; compiled objects are still reused within the process.
 
+### Compile options and diagnostic requests
+
+JIT calls and `kernel.compile()` resolve compile options before looking up an
+in-process artifact. Omitting `config` uses the same defaults as `RunConfig()`:
+`a2a3sim`, the default optimization strategy, and pass dumps disabled. Semantic
+options (including the effective planner, runtime ABI, and source-location
+emission controlled by `PYPTO_EMIT_PTO_LOC`) participate in the key. Runtime
+controls such as `device_id`, `codegen_only`, and `save_kernels` alone do not.
+
+The following requests compile afresh on every call, without reading or adding
+an entry in the artifact cache:
+
+- `dump_passes=True` or a dump level other than `PassDumpLevel.NONE`, and
+  `dump_ptoas_passes=True`.
+- `compile_profiling=True`, an active `CompileProfiler`, or profiling enabled
+  through `PYPTO_COMPILE_PROFILING`.
+- An explicit `save_kernels_dir`, or a nonempty `PYPTO_PROG_BUILD_DIR`.
+- Explicit diagnostic settings, or an active `PassContext` with instruments
+  or verification/diagnostic settings different from the pipeline defaults.
+
+This ensures a warm kernel still emits requested dumps and reports. Repeating
+a request regenerates the output; a failed diagnostic compile leaves ordinary
+cached entries intact. Automatically allocated JIT output directories are unique
+per compilation, so fresh diagnostics cannot overwrite a cached artifact.
+Explicit output directories are used as requested. Diagnostic controls do not
+split compilation keys.
+Conflicting explicit settings and an active `PassContext` raise the same error
+on cache hits as on fresh compilation. A plain planner/runtime context can
+still reuse a matching cached artifact.
+
+```python
+from pypto.runtime import RunConfig
+
+cached = slice_kernel.compile()
+slice_kernel.compile(config=RunConfig(dump_passes=True, save_kernels_dir="debug_kernel"))
+assert slice_kernel.compile() is cached
+```
+
 ## Functions
 
 ```python

--- a/docs/zh/dev/01-compile-profiling.md
+++ b/docs/zh/dev/01-compile-profiling.md
@@ -11,6 +11,10 @@ Pass、代码生成到上板执行。
 PYPTO_COMPILE_PROFILING=1 python3 my_program.py
 ```
 
+取消此环境变量（或设为 `0`）后，下一次查询会解除环境变量创建的 profiler 绑定，
+普通 JIT 调用即可恢复缓存复用。显式的 `with CompileProfiler()` 上下文独立于
+此环境变量，仍会持续到作用域结束。
+
 ### 方式 2：`ir.compile()` 参数
 
 ```python

--- a/docs/zh/dev/language/03-functions.md
+++ b/docs/zh/dev/language/03-functions.md
@@ -38,6 +38,39 @@ second = slice_kernel.compile()  # A distinct specialization with 64 rows.
 快照仅复制绑定：此常量跟踪机制不支持编译期间修改任意配置对象
 内部状态，或修改编译器/源码文件。本改动不启用持久产物缓存，编译对象仍在进程内复用。
 
+### 编译选项与诊断请求
+
+JIT 调用和 `kernel.compile()` 在查找进程内产物之前解析编译选项。
+省略 `config` 时使用与 `RunConfig()` 相同的默认值：`a2a3sim`、默认优化策略，
+以及关闭 pass dump。影响产物的选项进入缓存键，包括实际内存规划器、运行时 ABI，
+以及由 `PYPTO_EMIT_PTO_LOC` 控制的源码位置输出。
+`device_id`、`codegen_only` 和单独的 `save_kernels` 等运行控制不进入键。
+
+以下请求每次都重新编译，不读取或添加产物缓存条目：
+
+- `dump_passes=True` 或除 `PassDumpLevel.NONE` 外的 dump 级别，
+  以及 `dump_ptoas_passes=True`。
+- `compile_profiling=True`、活跃的 `CompileProfiler`，或通过
+  `PYPTO_COMPILE_PROFILING` 启用的编译性能分析。
+- 显式指定 `save_kernels_dir`，或非空的 `PYPTO_PROG_BUILD_DIR`。
+- 显式诊断设置，或包含 instrument、验证/诊断设置不同于流水线默认值的活跃
+  `PassContext`。
+
+因此已有缓存的 kernel 仍会输出请求的 dump 和报告；重复请求会重新生成输出。
+诊断编译失败不会改变普通缓存条目。JIT 为每次编译自动分配唯一输出目录，
+避免新的诊断请求覆盖缓存产物；显式指定的输出目录按请求使用。
+诊断控制不进入编译键。
+显式设置与活跃 `PassContext` 冲突时，缓存命中与首次编译都会报告相同错误。
+仅选择规划器或运行时的普通上下文仍能复用匹配的缓存产物。
+
+```python
+from pypto.runtime import RunConfig
+
+cached = slice_kernel.compile()
+slice_kernel.compile(config=RunConfig(dump_passes=True, save_kernels_dir="debug_kernel"))
+assert slice_kernel.compile() is cached
+```
+
 ## 函数
 
 ```python

--- a/python/pypto/compile_profiling.py
+++ b/python/pypto/compile_profiling.py
@@ -210,14 +210,15 @@ def get_active_profiler() -> CompileProfiler | None:
     1. An explicit ``CompileProfiler`` on the thread-local stack.
     2. The ``PYPTO_COMPILE_PROFILING`` environment variable.
 
-    Returns ``None`` when profiling is not enabled.
+    Returns ``None`` when profiling is not enabled. Disabling the environment
+    variable releases its thread-local binding; explicit contexts stay active.
     """
+    global _env_profiler  # noqa: PLW0603
     prof = CompileProfiler.current()
-    if prof is not None:
+    if prof is not None and prof is not _env_profiler:
         return prof
 
     if os.environ.get(_ENV_VAR, "").strip() in ("1", "true", "yes"):
-        global _env_profiler  # noqa: PLW0603
         if _env_profiler is None:
             with _env_profiler_lock:
                 if _env_profiler is None:
@@ -226,6 +227,8 @@ def get_active_profiler() -> CompileProfiler | None:
         CompileProfiler._local.current = _env_profiler
         return _env_profiler
 
+    if prof is not None:
+        CompileProfiler._local.current = None
     return None
 
 

--- a/python/pypto/jit/cache.py
+++ b/python/pypto/jit/cache.py
@@ -142,7 +142,7 @@ def make_cache_key(  # noqa: PLR0913 — args are the key's components, one per 
     strategy: "OptimizationStrategy | None" = None,
     distributed_config: Any = None,
     analyze_auto_scopes_for_deps: bool = False,
-    dump_ptoas_passes: bool = False,
+    emit_source_loc: bool = True,
     memory_planner: "MemoryPlanner | None" = None,
     enable_pypto_l0c_double_buffer: bool = False,
     tensor_layouts: dict[str, "TensorLayout | None"] | None = None,
@@ -190,9 +190,9 @@ def make_cache_key(  # noqa: PLR0913 — args are the key's components, one per 
         analyze_auto_scopes_for_deps: Compile-side switch for deriving explicit
             task dependencies from AUTO runtime scopes. Included in the key
             because it changes generated orchestration dependencies.
-        dump_ptoas_passes: Whether ptoas writes intermediate IR after every
-            pass. Included in the key so enabling dumps cannot reuse an
-            artifact compiled without the requested dump output.
+        emit_source_loc: Whether codegen emits source locations, resolved from
+            the environment before key construction and passed to the compiler.
+            Diagnostic-only controls bypass caching and do not enter the key.
         memory_planner: Effective on-chip memory planner (``PYPTO``,
             ``DSA_RP``, or ``PTOAS``) as resolved from the ``RunConfig`` field
             and any active ``PassContext``. Included in the key because it
@@ -243,7 +243,7 @@ def make_cache_key(  # noqa: PLR0913 — args are the key's components, one per 
     )
     compile_opts = (
         ("analyze_auto_scopes_for_deps", analyze_auto_scopes_for_deps),
-        ("dump_ptoas_passes", dump_ptoas_passes),
+        ("emit_source_loc", emit_source_loc),
         ("memory_planner", None if memory_planner is None else str(memory_planner)),
         ("enable_pypto_l0c_double_buffer", effective_pypto_dbc),
         ("dep_layouts", dep_layouts),

--- a/python/pypto/jit/cache.py
+++ b/python/pypto/jit/cache.py
@@ -192,7 +192,8 @@ def make_cache_key(  # noqa: PLR0913 — args are the key's components, one per 
             because it changes generated orchestration dependencies.
         emit_source_loc: Whether codegen emits source locations, resolved from
             the environment before key construction and passed to the compiler.
-            Diagnostic-only controls bypass caching and do not enter the key.
+            Changing this option changes generated code and splits the key.
+            Dump, profiling, and other cache-bypass controls are excluded.
         memory_planner: Effective on-chip memory planner (``PYPTO``,
             ``DSA_RP``, or ``PTOAS``) as resolved from the ``RunConfig`` field
             and any active ``PassContext``. Included in the key because it

--- a/python/pypto/jit/decorator.py
+++ b/python/pypto/jit/decorator.py
@@ -49,9 +49,10 @@ JITFunction.__call__ flow
 2. Classify args: tensor vs scalar.
 3. Extract TensorMeta from torch.Tensor arguments.
 4. Scan entry + dep ASTs for bind_dynamic declarations.
-5. Build CacheKey including referenced constants (dynamic dims → None in shape tuple).
-6. Cache hit  → execute cached CompiledProgram on device → return result.
-7. Cache miss → specialize (entry + deps) → pl.parse() → ir.compile() → cache → execute → return.
+5. Resolve compile options; bypass caching for diagnostics or explicit output requests.
+6. Build CacheKey including referenced constants (dynamic dims → None in shape tuple).
+7. Cache hit  → execute cached CompiledProgram on device → return result.
+8. Cache miss → specialize (entry + deps) → pl.parse() → ir.compile() → cache → execute → return.
 """
 
 from __future__ import annotations
@@ -64,6 +65,7 @@ import json
 import os
 import re
 import struct
+import tempfile
 import textwrap
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
@@ -71,6 +73,10 @@ from typing import Any, NamedTuple
 
 from pypto._external_source import external_source_digest
 from pypto.backend._ptoas_locate import find_ptoas_binary
+from pypto.backend.pto_backend import emit_source_loc_default
+from pypto.compile_profiling import get_active_profiler
+from pypto.ir.compile import _validate_pass_context_conflicts
+from pypto.ir.pass_manager import PassDumpLevel, coerce_dump_level
 from pypto.pypto_core import DataType
 from pypto.pypto_core import ir as _ir
 from pypto.pypto_core import passes as _passes
@@ -1620,6 +1626,54 @@ def _resolve_runtime() -> _passes.RuntimeKind:
     return ctx.get_runtime() if ctx is not None else _passes.RuntimeKind.TENSORMAP_AND_RINGBUFFER
 
 
+def _resolve_compile_request(run_config: Any) -> tuple[dict[str, Any], bool]:
+    """Resolve compiler arguments and whether this call requires fresh compilation.
+
+    RunConfig's compile mapping is the source for both codegen and cache keys.
+    Diagnostics are requests to run the compiler, so decide bypass before any
+    cache lookup (including source-key construction). Tool discovery remains
+    on the compile path and adds no filesystem probes to ordinary cache hits.
+    """
+    if run_config is None:
+        from pypto.runtime import CompileOptions  # noqa: PLC0415
+
+        kwargs = CompileOptions().as_compile_kwargs()
+    else:
+        kwargs = run_config.compile_kwargs()
+    kwargs["dump_passes"] = coerce_dump_level(kwargs["dump_passes"])
+    kwargs["emit_source_loc"] = emit_source_loc_default()
+    outer = _validate_pass_context_conflicts(
+        operation="compile",
+        verification_level=kwargs.get("verification_level"),
+        diagnostic_phase=kwargs.get("diagnostic_phase"),
+        memory_planner=kwargs.get("memory_planner"),
+        runtime=kwargs.get("runtime"),
+    )
+    bypass = (
+        kwargs["dump_passes"] is not PassDumpLevel.NONE
+        or kwargs["dump_ptoas_passes"]
+        or kwargs["profiling"]
+        or get_active_profiler() is not None
+        or kwargs.get("output_dir") is not None
+        or bool(os.environ.get("PYPTO_PROG_BUILD_DIR"))
+        or kwargs.get("verification_level") is not None
+        or kwargs["diagnostic_phase"] is not None
+        or kwargs["disabled_diagnostics"] is not None
+    )
+    if not bypass and outer is not None:
+        # Match the pipeline defaults: ordinary planner/runtime contexts can
+        # reuse artifacts, but instruments and custom checks must actually run.
+        default_disabled = _passes.DiagnosticCheckSet()
+        default_disabled.insert(_passes.DiagnosticCheck.UnusedControlFlowResult)
+        bypass = (
+            bool(outer.get_instruments())
+            or outer.get_verification_level() != _passes.get_default_verification_level()
+            or outer.get_diagnostic_phase() != _passes.get_default_diagnostic_phase()
+            or outer.get_disabled_diagnostics() != default_disabled
+        )
+    return kwargs, bypass
+
+
 # ---------------------------------------------------------------------------
 
 
@@ -2242,34 +2296,21 @@ class JITFunction:
             allow_signature_mode=allow_signature_mode,
         )
 
-        # Compile-side knobs (platform, strategy, dump_passes, ...) come from
-        # the RunConfig, through the same mapping a direct
-        # ``ir.compile(program, **config.compile_kwargs())`` call uses. With no
-        # config there is nothing to forward and ir.compile()'s own defaults
-        # apply, platform included.
-        compile_kwargs = run_config.compile_kwargs() if run_config is not None else {}
+        compile_kwargs, bypass_cache = _resolve_compile_request(run_config)
+        ordered_args = [
+            specialization.arguments[n] for n in specialization.param_names if n in specialization.arguments
+        ]
+        if bypass_cache:
+            compiled = self._compile(
+                specialization.tensor_meta,
+                specialization.scalar_values,
+                specialization.scalar_dtypes,
+                specialization.per_func_dyn,
+                pl,
+                **compile_kwargs,
+            )
+            return compiled, ordered_args, run_config
 
-        # Build cache key. Platform and strategy are included so artifacts
-        # compiled for different targets or optimization strategies never
-        # collide in the same cache. With no RunConfig the strategy is
-        # normalized to ir.compile()'s own default so the key holds the
-        # effective strategy rather than a None sentinel.
-        from pypto.ir.pass_manager import OptimizationStrategy  # noqa: PLC0415
-
-        platform = run_config.platform if run_config is not None else None
-        strategy = run_config.strategy if run_config is not None else OptimizationStrategy.Default
-        # distributed_config is baked into the DistributedCompiledProgram and
-        # drives per-rank dispatch, so it must split the cache: two @pl.jit.host
-        # calls with different device_ids compile to distinct artifacts.
-        distributed_config = run_config.distributed_config if run_config is not None else None
-        analyze_auto_scopes_for_deps = (
-            run_config.analyze_auto_scopes_for_deps if run_config is not None else False
-        )
-        dump_ptoas_passes = run_config.dump_ptoas_passes if run_config is not None else False
-        # The planner decides whether physical addresses are baked into the
-        # artifact, so it must split the cache: compiling one kernel under both
-        # planners must not hand the second call the first one's artifact.
-        memory_planner = _resolve_memory_planner(run_config)
         key = make_cache_key(
             source_hash=self._get_source_hash(),
             param_names=specialization.param_names,
@@ -2281,12 +2322,12 @@ class JITFunction:
                 (n, i) for n, m in specialization.tensor_meta.items() for i in m.dynamic_dim_indices()
             },
             scalar_values=specialization.scalar_values,
-            platform=platform,
-            strategy=strategy,
-            distributed_config=distributed_config,
-            analyze_auto_scopes_for_deps=analyze_auto_scopes_for_deps,
-            dump_ptoas_passes=dump_ptoas_passes,
-            memory_planner=memory_planner,
+            platform=compile_kwargs["platform"],
+            strategy=compile_kwargs["strategy"],
+            distributed_config=compile_kwargs.get("distributed_config"),
+            analyze_auto_scopes_for_deps=compile_kwargs["analyze_auto_scopes_for_deps"],
+            emit_source_loc=compile_kwargs["emit_source_loc"],
+            memory_planner=compile_kwargs.get("memory_planner", _resolve_memory_planner(None)),
             enable_pypto_l0c_double_buffer=_resolve_enable_pypto_l0c_double_buffer(),
             runtime=_resolve_runtime(),
         )
@@ -2302,14 +2343,7 @@ class JITFunction:
                 **compile_kwargs,
             )
 
-        # Use bound.arguments (in signature order) so keyword-style calls
-        # like kernel(a=x, b=y) are routed correctly regardless of how the
-        # caller passed them.
-        compiled = self._cache[key]
-        ordered_args = [
-            specialization.arguments[n] for n in specialization.param_names if n in specialization.arguments
-        ]
-        return compiled, ordered_args, run_config
+        return self._cache[key], ordered_args, run_config
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
         """Specialize, compile (or serve from cache), and execute on device.
@@ -2318,7 +2352,8 @@ class JITFunction:
         specialized into ``@pl.program`` source, parsed, and compiled via
         ``ir.compile()`` (passes + codegen).  The resulting ``CompiledProgram``
         is stored in the L1 in-memory cache so subsequent calls with the same
-        specialization key skip compilation entirely.
+        specialization key skip compilation entirely. Diagnostic and explicit
+        output requests bypass both cache lookup and insertion on every call.
 
         The compiled kernel is then executed on the NPU device with the given
         torch tensor arguments (Triton-like API).
@@ -2371,7 +2406,10 @@ class JITFunction:
 
         Subsequent calls (either ``__call__`` or [`compile`][pypto.language.JITFunction.compile]) with the
         same specialization key hit the L1 cache and return the same
-        ``CompiledProgram`` instance.
+        ``CompiledProgram`` instance. Dump, compile-profiling, explicit output,
+        and custom pass-diagnostic requests always compile afresh, preserving
+        ordinary cached entries. Omitting ``config`` uses ``RunConfig`` defaults,
+        including disabled dumps.
 
         **Compiling without tensors.** When called with **no tensor
         arguments** — neither positional nor keyword — the shape/dtype contract
@@ -2590,6 +2628,8 @@ class JITFunction:
         compile-side knobs (``platform``, ``strategy``, ``dump_passes``,
         ``output_dir``, ``profiling``, diagnostics, ...) that the JIT caller
         derives from a ``RunConfig`` via ``RunConfig.compile_kwargs``.
+        If no output directory is supplied, allocate one for this compilation
+        so a fresh diagnostic request cannot overwrite a cached artifact.
         """
         from pypto.ir.compile import compile as ir_compile  # noqa: PLC0415
 
@@ -2601,6 +2641,10 @@ class JITFunction:
         try:
             parsed = pl.parse(source, filename=self._diagnostic_filename, source_map=specializer.source_map)
             skip_ptoas = not _ptoas_available()
+            if ir_compile_kwargs.get("output_dir") is None:
+                output_root = os.environ.get("PYPTO_PROG_BUILD_DIR") or "build_output"
+                os.makedirs(output_root, exist_ok=True)
+                ir_compile_kwargs["output_dir"] = tempfile.mkdtemp(prefix=f"{parsed.name}_", dir=output_root)
             return ir_compile(parsed, skip_ptoas=skip_ptoas, **ir_compile_kwargs)
         except Exception as exc:
             rewritten = _rewrite_jit_error(exc, rename_map)

--- a/tests/st/runtime/framework_and_models/conftest.py
+++ b/tests/st/runtime/framework_and_models/conftest.py
@@ -1,0 +1,23 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Output isolation for direct runtime and JIT integration tests."""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _redirect_prog_build_dir(request, tmp_path, monkeypatch):
+    """Keep normal JIT calls cacheable while isolating temporary artifacts."""
+    # PYPTO_PROG_BUILD_DIR is an explicit output request and bypasses the JIT
+    # cache. Use the working directory for test isolation instead, preserving
+    # the shared fixture's --save-kernels behavior.
+    monkeypatch.delenv("PYPTO_PROG_BUILD_DIR", raising=False)
+    if not request.config.getoption("--save-kernels"):
+        monkeypatch.chdir(tmp_path)

--- a/tests/ut/core/test_compile_profiling.py
+++ b/tests/ut/core/test_compile_profiling.py
@@ -237,6 +237,35 @@ class TestGetActiveProfiler:
             CompileProfiler._local.current = None
             _compile_profiling_mod._env_profiler = None
 
+    @pytest.mark.parametrize("disabled", [None, "0", "false"])
+    def test_disabling_environment_releases_its_profiler(self, monkeypatch, disabled):
+        """Turning off environment profiling clears its implicit thread binding."""
+        monkeypatch.setattr(_compile_profiling_mod, "_env_profiler", None)
+        monkeypatch.setattr(CompileProfiler._local, "current", None, raising=False)
+        monkeypatch.setenv("PYPTO_COMPILE_PROFILING", "1")
+        environment_profiler = get_active_profiler()
+        assert environment_profiler is not None
+        if disabled is None:
+            monkeypatch.delenv("PYPTO_COMPILE_PROFILING")
+        else:
+            monkeypatch.setenv("PYPTO_COMPILE_PROFILING", disabled)
+        assert get_active_profiler() is None
+        assert CompileProfiler.current() is None
+        monkeypatch.setenv("PYPTO_COMPILE_PROFILING", "1")
+        assert get_active_profiler() is environment_profiler
+
+    def test_explicit_context_survives_disabling_environment(self, monkeypatch):
+        """An explicit profiler retains scope even when the environment turns off."""
+        monkeypatch.setattr(_compile_profiling_mod, "_env_profiler", None)
+        monkeypatch.setattr(CompileProfiler._local, "current", None, raising=False)
+        monkeypatch.setenv("PYPTO_COMPILE_PROFILING", "1")
+        assert get_active_profiler() is not None
+        with CompileProfiler() as explicit:
+            monkeypatch.delenv("PYPTO_COMPILE_PROFILING")
+            assert get_active_profiler() is explicit
+        assert get_active_profiler() is None
+        assert CompileProfiler.current() is None
+
     def test_env_var_binds_to_thread_local_every_call(self, monkeypatch):
         """get_active_profiler() should always bind the env profiler to thread-local."""
         monkeypatch.setenv("PYPTO_COMPILE_PROFILING", "1")

--- a/tests/ut/jit/conftest.py
+++ b/tests/ut/jit/conftest.py
@@ -40,3 +40,10 @@ def pass_verification_context():
     means pass verification now works correctly.
     """
     yield
+
+
+@pytest.fixture(autouse=True)
+def _redirect_prog_build_dir(tmp_path, monkeypatch):
+    """Isolate artifacts without an explicit output request that bypasses JIT caching."""
+    monkeypatch.delenv("PYPTO_PROG_BUILD_DIR", raising=False)
+    monkeypatch.chdir(tmp_path)

--- a/tests/ut/jit/test_cache.py
+++ b/tests/ut/jit/test_cache.py
@@ -116,7 +116,7 @@ class TestMakeCacheKey:
         assert dist_part is None  # single-chip default
         assert compile_opts == (
             ("analyze_auto_scopes_for_deps", False),
-            ("dump_ptoas_passes", False),
+            ("emit_source_loc", True),
             ("memory_planner", None),
             ("enable_pypto_l0c_double_buffer", False),
             ("dep_layouts", ()),

--- a/tests/ut/jit/test_decorator.py
+++ b/tests/ut/jit/test_decorator.py
@@ -14,6 +14,7 @@ import importlib
 import inspect
 import re
 import warnings
+from pathlib import Path
 
 import pypto.language as pl
 import pypto.language.distributed as pld
@@ -2699,7 +2700,7 @@ class TestCompileKwargForwarding:
         assert first != second
         assert third == first
 
-    def test_resolve_compiled_splits_cache_on_ptoas_pass_dump(self, monkeypatch):
+    def test_resolve_compiled_bypasses_cache_on_ptoas_pass_dump(self, monkeypatch):
         """Enabling ptoas pass dumps cannot reuse an artifact compiled without them."""
         torch = pytest.importorskip("torch")
 
@@ -2725,11 +2726,13 @@ class TestCompileKwargForwarding:
 
         first = resolve(False)
         second = resolve(True)
+        repeated_dump = resolve(True)
         third = resolve(False)
 
-        assert compile_calls["n"] == 2
-        assert len(cfg_kernel._cache) == 2
+        assert compile_calls["n"] == 3
+        assert len(cfg_kernel._cache) == 1
         assert first != second
+        assert second != repeated_dump
         assert third == first
 
     def test_compile_forwards_run_config_kwargs(self, monkeypatch):
@@ -2787,14 +2790,8 @@ class TestCompileKwargForwarding:
         # compile to a DistributedCompiledProgram and dispatch per-rank.
         assert captured["distributed_config"] is dc
 
-    def test_compile_without_kwargs_forwards_only_skip_ptoas(self, monkeypatch):
-        """_compile with no extra kwargs forwards only skip_ptoas.
-
-        ``platform`` rides in the ``RunConfig.compile_kwargs`` mapping, so with
-        no config there is nothing to forward and ``ir.compile``'s own default
-        applies — the same effective platform the old explicit ``platform=None``
-        produced.
-        """
+    def test_compile_without_output_dir_allocates_one(self, monkeypatch):
+        """Each JIT compilation owns an automatic directory when none is supplied."""
         ir_compile_mod = importlib.import_module("pypto.ir.compile")
 
         @jit
@@ -2822,7 +2819,8 @@ class TestCompileKwargForwarding:
             per_func_dyn={id(plain_kernel._func): {}},
             pl=pl,
         )
-        assert set(captured) == {"skip_ptoas"}
+        assert set(captured) == {"skip_ptoas", "output_dir"}
+        assert Path(captured["output_dir"]).is_dir()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ut/jit/test_jit_compile_extraction.py
+++ b/tests/ut/jit/test_jit_compile_extraction.py
@@ -19,7 +19,8 @@ import importlib
 
 import pypto.language as pl
 import pytest
-from pypto.ir import OptimizationStrategy
+from pypto.compile_profiling import CompileProfiler
+from pypto.ir import OptimizationStrategy, PassDumpLevel
 from pypto.ir.compiled_program import CompiledProgram
 from pypto.jit.decorator import jit
 from pypto.language.parser.diagnostics.exceptions import ParserTypeError
@@ -693,6 +694,209 @@ class TestNzOnTensorIsNotJitSpecific:
         assert isinstance(param_type, ir.TensorType)
         assert param_type.tensor_view is not None
         assert param_type.tensor_view.layout == ir.TensorLayout.NZ
+
+
+def _request_kernel(x: pl.Tensor[[32, 32], pl.FP32]) -> pl.Tensor[[32, 32], pl.FP32]:
+    with pl.at(level=pl.Level.CORE_GROUP):
+        result = pl.add(x, x)
+    return result
+
+
+@pytest.fixture
+def kernel(monkeypatch):
+    monkeypatch.delenv("PYPTO_COMPILE_PROFILING", raising=False)
+    monkeypatch.setattr(CompileProfiler._local, "current", None, raising=False)
+    return pl.jit(_request_kernel)
+
+
+@pytest.fixture
+def compile_calls(kernel, monkeypatch):
+    calls = []
+
+    def record_compile(*_args, **kwargs):
+        artifact = object()
+        calls.append((kwargs, artifact))
+        return artifact
+
+    monkeypatch.setattr(kernel, "_compile", record_compile)
+    return calls
+
+
+def test_default_and_runtime_only_requests_share_cache(kernel, compile_calls):
+    cached = kernel.compile()
+    for config in (
+        RunConfig(),
+        RunConfig(dump_passes=PassDumpLevel.NONE),
+        RunConfig(device_id=3, codegen_only=True, save_kernels=True),
+    ):
+        assert kernel.compile(config=config) is cached
+    with passes.PassContext([]):
+        assert kernel.compile() is cached
+    assert len(compile_calls) == 1
+    kwargs = compile_calls[0][0]
+    assert kwargs["platform"] == "a2a3sim"
+    assert kwargs["dump_passes"] is PassDumpLevel.NONE
+
+
+@pytest.mark.parametrize(
+    "options",
+    [
+        {"dump_passes": True},
+        {"dump_passes": PassDumpLevel.EXPLICIT},
+        {"dump_ptoas_passes": True},
+        {"compile_profiling": True},
+        {"save_kernels_dir": "requested-output"},
+        {"diagnostic_phase": passes.DiagnosticPhase.PRE_PIPELINE},
+        {"disabled_diagnostics": passes.DiagnosticCheckSet()},
+    ],
+)
+@pytest.mark.parametrize("warm", [False, True])
+def test_diagnostic_requests_neither_lookup_nor_insert(kernel, compile_calls, monkeypatch, options, warm):
+    cached = kernel.compile() if warm else None
+    before = dict(kernel._cache)
+
+    def fail_key():
+        pytest.fail("diagnostic request constructed a cache key")
+
+    with monkeypatch.context() as patch:
+        patch.setattr(kernel, "_get_source_hash", fail_key)
+        first = kernel.compile(config=RunConfig(**options))
+        second = kernel.compile(config=RunConfig(**options))
+    assert first is not second
+    assert kernel._cache == before
+    assert len(compile_calls) == (3 if warm else 2)
+    if warm:
+        assert kernel.compile() is cached
+
+
+@pytest.mark.parametrize("env_name", ["PYPTO_PROG_BUILD_DIR", "PYPTO_COMPILE_PROFILING"])
+def test_environment_request_bypasses_warm_cache(kernel, compile_calls, monkeypatch, tmp_path, env_name):
+    kernel.compile()
+    before = dict(kernel._cache)
+    monkeypatch.setenv(env_name, "1" if env_name == "PYPTO_COMPILE_PROFILING" else str(tmp_path))
+    first = kernel.compile()
+    assert kernel.compile() is not first
+    assert len(compile_calls) == 3
+    assert kernel._cache == before
+
+
+def test_active_profiler_bypasses_warm_cache(kernel, compile_calls):
+    cached = kernel.compile()
+    with CompileProfiler():
+        assert kernel.compile() is not cached
+        assert kernel.compile() is not cached
+    assert kernel.compile() is cached
+    assert len(compile_calls) == 3
+
+
+@pytest.mark.parametrize(
+    "context_options",
+    [
+        {"verification_level": passes.VerificationLevel.ROUNDTRIP},
+        {"diagnostic_phase": passes.DiagnosticPhase.POST_PASS},
+        {"disabled_diagnostics": passes.DiagnosticCheckSet()},
+    ],
+)
+def test_custom_pass_checks_bypass_warm_cache(kernel, compile_calls, context_options):
+    cached = kernel.compile()
+    with passes.PassContext([], **context_options):
+        assert kernel.compile() is not cached
+        assert kernel.compile() is not cached
+    assert kernel.compile() is cached
+    assert len(compile_calls) == 3
+
+
+def test_pass_context_conflict_is_rejected_before_cache_lookup(kernel, compile_calls):
+    config = RunConfig(memory_planner=passes.MemoryPlanner.PYPTO)
+    kernel.compile(config=config)
+    with passes.PassContext([]), pytest.raises(RuntimeError, match="memory_planner.*PassContext"):
+        kernel.compile(config=config)
+    assert len(compile_calls) == 1
+
+
+def test_failed_diagnostic_compile_preserves_ordinary_entry(kernel, compile_calls, monkeypatch):
+    cached = kernel.compile()
+
+    def fail_compile(*_args, **_kwargs):
+        raise ValueError("diagnostic compilation failed")
+
+    with monkeypatch.context() as patch:
+        patch.setattr(kernel, "_compile", fail_compile)
+        with pytest.raises(ValueError, match="diagnostic compilation failed"):
+            kernel.compile(config=RunConfig(dump_passes=True))
+    assert kernel.compile() is cached
+    assert len(compile_calls) == 1
+
+
+def test_source_locations_use_captured_effective_option(kernel, compile_calls, monkeypatch):
+    monkeypatch.setenv("PYPTO_EMIT_PTO_LOC", "0")
+    without_locations = kernel.compile()
+    monkeypatch.setenv("PYPTO_EMIT_PTO_LOC", "1")
+    original_hash = kernel._get_source_hash
+
+    def change_environment_after_resolution():
+        monkeypatch.setenv("PYPTO_EMIT_PTO_LOC", "0")
+        return original_hash()
+
+    monkeypatch.setattr(kernel, "_get_source_hash", change_environment_after_resolution)
+    assert kernel.compile() is not without_locations
+    assert [kwargs["emit_source_loc"] for kwargs, _ in compile_calls] == [False, True]
+    assert kernel.compile() is without_locations
+
+
+def test_real_dumps_are_regenerated_after_ordinary_cache_hit(kernel, tmp_path):
+    cached = kernel.compile()
+    assert not (cached.output_dir / "passes_dump").exists()
+    for name in ("first", "second"):
+        output = tmp_path / name
+        config = RunConfig(save_kernels_dir=str(output), dump_passes=True)
+        compiled = kernel.compile(config=config)
+        assert compiled.output_dir == output
+        dumps = list((output / "passes_dump").glob("*.py"))
+        assert dumps
+        dump = dumps[0]
+        expected = dump.read_bytes()
+        dump.unlink()
+        assert kernel.compile(config=config) is not compiled
+        assert dump.read_bytes() == expected
+    assert kernel.compile() is cached
+
+
+def test_real_outer_instrument_runs_after_ordinary_cache_hit(kernel, tmp_path):
+    cached = kernel.compile()
+    calls = []
+    callback = passes.CallbackInstrument(
+        before_pass=lambda pass_obj, _program: calls.append(pass_obj.get_name()), name="observer"
+    )
+    with passes.PassContext([callback, passes.ReportInstrument(str(tmp_path))]):
+        first = kernel.compile()
+        assert first.output_dir != cached.output_dir
+        assert calls
+        calls.clear()
+        second = kernel.compile()
+        assert second.output_dir not in (cached.output_dir, first.output_dir)
+        assert calls
+    assert (tmp_path / "perf_hints.log").is_file()
+    assert kernel.compile() is cached
+
+
+def test_real_profile_contains_compile_stages_after_cache_hit(kernel):
+    cached = kernel.compile()
+    with CompileProfiler() as profiler:
+        compiled = kernel.compile()
+        assert compiled.output_dir != cached.output_dir
+    assert profiler.to_dict()["stages"]
+    assert kernel.compile() is cached
+
+
+def test_warm_cache_hit_does_not_probe_toolchain(kernel, monkeypatch):
+    cached = kernel.compile()
+
+    def fail_discovery():
+        pytest.fail("warm cache hit probed the toolchain")
+
+    monkeypatch.setattr(importlib.import_module("pypto.jit.decorator"), "find_ptoas_binary", fail_discovery)
+    assert kernel.compile() is cached
 
 
 if __name__ == "__main__":

--- a/tests/ut/jit/test_jit_compile_extraction.py
+++ b/tests/ut/jit/test_jit_compile_extraction.py
@@ -889,6 +889,27 @@ def test_real_profile_contains_compile_stages_after_cache_hit(kernel):
     assert kernel.compile() is cached
 
 
+@pytest.mark.parametrize("fail", [False, True])
+def test_disabling_environment_profiling_restores_warm_cache(kernel, monkeypatch, fail):
+    """Real successful and failed compiles must not make profiling sticky."""
+    cached = kernel.compile()
+    monkeypatch.setenv("PYPTO_COMPILE_PROFILING", "1")
+    if fail:
+
+        def fail_parse(*_args, **_kwargs):
+            raise ValueError("profiling compilation failed")
+
+        with monkeypatch.context() as patch:
+            patch.setattr(pl, "parse", fail_parse)
+            with pytest.raises(ValueError, match="profiling compilation failed"):
+                kernel.compile()
+    else:
+        assert kernel.compile() is not cached
+    monkeypatch.delenv("PYPTO_COMPILE_PROFILING")
+    assert kernel.compile() is cached
+    assert CompileProfiler.current() is None
+
+
 def test_warm_cache_hit_does_not_probe_toolchain(kernel, monkeypatch):
     cached = kernel.compile()
 


### PR DESCRIPTION
## Summary

A cached JIT call could silently skip newly requested dumps, compilation profiling, or output files. Resolve the compile request before cache lookup and bypass both lookup and insertion for these requests, including active profiler/pass instruments and custom diagnostic settings. Repeating a diagnostic request recompiles; ordinary cached artifacts remain reusable, with unique automatic output directories preventing accidental overwrites.

This is PR 2 of RFC #2653, following merged #2651. Persistent artifact caching is not enabled by this change.

## Changes

- Use the compiler argument mapping for cache-key options. JIT calls without `config` now share `RunConfig()` defaults (`a2a3sim`, default strategy, dumps disabled).
- Capture effective source-location emission (`PYPTO_EMIT_PTO_LOC`) in both the key and compiler arguments; remove the diagnostic-only ptoas dump field from the key.
- Validate `PassContext` conflicts before cache lookup. Ordinary runtime controls and matching planner/runtime contexts preserve reuse.
- Release environment-created profiler bindings when the variable is disabled, preserving explicit profiler contexts and restoring ordinary cache reuse.
- Isolate direct framework ST outputs with a temporary working directory so the fixture does not request cache bypass.
- Cover cold/warm bypass, repeated outputs, failure preservation, real dump files and profiler/instrument execution; synchronize English and Chinese docs.

## Verification

- `cmake --build build --parallel "$PYPTO_BUILD_JOBS"`: passed in this worktree.
- `build/test-venv/bin/python -m pytest tests/ut/ -n "$PYPTO_TEST_JOBS" -q --tb=short --disable-warnings -rs` with this worktree's `PYTHONPATH`: 11,364 passed, 8 skipped, 1 xfailed.
- Pinned pre-commit 4.3.0 on all 13 changed paths: passed, including Ruff, Pyright, Markdown and repository checks.
- Targeted NPU execution via `task-submit --device auto`: `test_jit.py`, `test_compiled_program.py`, and `test_device_tensor.py` in `tests/st/runtime/framework_and_models/`: all 20 passed on `a2a3`. The full system-test suite runs in CI.