### PR TITLE
fix(ir): accept a distributed-window operand in matmul, reductions and scalar access

### DIFF
--- a/.claude/rules/ir-kind-traits.md
+++ b/.claude/rules/ir-kind-traits.md
@@ -13,7 +13,7 @@ PyPTO's IR uses a single `ObjectKind` enum for runtime-type dispatch. `KindTrait
 | single `kind` member | every concrete node — `Var`, `IterArg`, `MemRef`, `WindowBuffer`, `TensorType`, … | that one kind — exact match, **never** subclasses |
 | `kinds[]` array | the seven base types `Expr`, `Stmt`, `Type`, `BinaryExpr`, `UnaryExpr`, `ScopeStmt`, `ShapedType` (the last is also concrete, and lists its own kind) | any kind listed in the array |
 
-The core rule is about the first row, which is where the bugs are: C++ inheritance doesn't help there. `IterArg` is a subclass of `Var`, but `IterArg` has its own `ObjectKind::IterArg`. So `As<Var>(iter_arg_ptr)` returns **null**, even though `iter_arg` IS-A Var.
+The first row is where the bugs are — C++ inheritance doesn't help there. `IterArg` subclasses `Var` and `DistributedTensorType` subclasses `TensorType`, but each has its own `ObjectKind`, so `As<Var>(iter_arg)` and `As<TensorType>(window_type)` both return **null**.
 
 `As<Expr>()` / `As<Stmt>()` / `As<Type>()` are the second row: they match whole subtrees by design and are correct as written — do **not** rewrite them into `*Like` helpers. Their arrays are hand-maintained, so a new kind must be appended to the base array too; `static_assert`s in `kind_traits.h` catch only the base-covers-derived case, not enum coverage.
 
@@ -23,46 +23,46 @@ The core rule is about the first row, which is where the bugs are: C++ inheritan
 | ---- | ---- | ----------- | --------- |
 | `ExprPtr` that may be `Var` or `IterArg` | Treat both as `Var` | `AsVarLike(expr)` (returns `VarPtr`) | `As<Var>(expr)` — misses `IterArg` |
 | Visitor override for both `Var` and `IterArg` | Single handler for both | Override `VisitVarLike_` | Override `VisitExpr_(VarPtr)` only — `IterArg` dispatches separately |
+| `TypePtr` of a GM operand that may be a `pld.DistributedTensor` window | Treat a window as this rank's local GM | `AsTensorTypeLike(type)` (returns `TensorTypePtr`) | `As<TensorType>(type)` — misses `DistributedTensorType` |
+
+**The window pair bites hardest**, because a window reaches *every* layer that inspects a
+user operand: op type deducers (`src/ir/op/**`), the tensor→tile pass, and orchestration
+codegen. Before writing `As<TensorType>(<operand>->GetType())`, ask **"is this asking
+*whether* the operand is GM data, or *which kind* of GM it is?"**
+
+- *Whether* → `AsTensorTypeLike`. A window slice is this rank's local GM; ordinary compute
+  reads and writes it like any GM tensor. Exact-kind here rejects a legal program, or —
+  worse — skips the operand silently and fails later in a pass or emitter.
+- *Which kind* → `As<TensorType>` / `As<DistributedTensorType>`, and say why in a comment.
+  Legitimate uses: propagating the window kind onto a result (`tensor.slice`, `tensor.assemble`),
+  and withholding metadata a window has no lowering contract for (element-wise `valid_shape`).
+
+**Relaxing the deducer alone is not the fix.** Every operand crosses at least two gates —
+the type deducer *and* the lowering site (`BridgeInputSpaces` / the entry load in
+`ConvertTensorToTileOps`, the op's conversion rule, the emitter). Fix all of them together
+and add a lowering test, or the error just moves from a `CHECK` to an `INTERNAL_UNREACHABLE`.
 
 `MemRef` and `WindowBuffer` are intentionally **excluded** from `AsVarLike` — they carry allocation-source / window-slot semantics that don't fit the Var-bound-name model. Use `As<MemRef>()` / `As<WindowBuffer>()` directly. Both are still listed in `KindTrait<Expr>`, so `As<Expr>()` matches them.
 
 ## Examples
 
 ```cpp
-// ❌ WRONG — As<Var> won't match IterArg
-for (const auto& yield_value : yields) {
-  if (As<Var>(yield_value)) {     // returns null for IterArg!
-    // skip materialization
-  }
-  // ... materialization runs even for IterArg
-}
-
-// ✅ CORRECT — AsVarLike matches Var AND IterArg
-for (const auto& yield_value : yields) {
-  if (AsVarLike(yield_value)) {   // matches both
-    // skip materialization for any already-bound Var
-  }
-}
+// ❌ WRONG — null for IterArg, so materialization runs for an already-bound Var
+if (As<Var>(yield_value)) { /* skip materialization */ }
+// ✅ CORRECT — matches Var AND IterArg
+if (AsVarLike(yield_value)) { /* skip materialization */ }
 ```
 
 ```cpp
-// ❌ WRONG — only catches Var, IterArgs go through default
-class MyVisitor : public IRVisitor {
-  void VisitExpr_(const VarPtr& op) override { /* ... */ }
-};
+// ❌ WRONG — the window operand is skipped, then fails in a later pass
+auto tensor_type = As<TensorType>(args[0]->GetType());
 
-// ✅ CORRECT — VisitVarLike_ handles both Var and IterArg
-class MyVisitor : public IRVisitor {
-  void VisitVarLike_(const VarPtr& op) override { /* ... */ }
-};
+// ✅ CORRECT — a window is GM data here, same as a plain tensor
+auto tensor_type = AsTensorTypeLike(args[0]->GetType());
 ```
+
+The visitor form is the same mistake: override `VisitVarLike_`, not `VisitExpr_(VarPtr)`.
 
 ## Decision rule
 
-Before writing `As<T>(...)`, ask:
-
-1. Does `T` have subclasses with their own `ObjectKind` values? Check `include/pypto/ir/kind_traits.h` and the class hierarchy.
-2. If yes: is there an `As<T>Like()` helper? If yes, use it.
-3. If no `*Like` helper exists and you genuinely need union semantics: write one in `kind_traits.h` rather than re-rolling `dynamic_pointer_cast<...>` at the call site.
-
-When in doubt: grep for `AsVarLike` / `VisitVarLike_` in the codebase to confirm the pattern, then mirror it.
+Before writing `As<T>(...)`: does `T` have subclasses with their own `ObjectKind` (check `include/pypto/ir/kind_traits.h`)? If so, use the `As<T>Like()` helper — or write one there rather than re-rolling `dynamic_pointer_cast<...>` at the call site. Grep `AsVarLike` / `AsTensorTypeLike` and mirror the pattern.

--- a/docs/en/dev/ir/02-types.md
+++ b/docs/en/dev/ir/02-types.md
@@ -81,6 +81,18 @@ like `pld.DistributedTensor[[shape], dtype]` leave this field as `None`.
 Tile types do not have a distributed variant; cross-rank ops always operate
 on `DistributedTensor`.
 
+**Local compute over a window.** Inside an InCore scope a window slice *is*
+this rank's local GM, so the ordinary tensor ops read and write it like any
+other GM tensor. Those ops match their operand with
+[`AsTensorTypeLike`](../../../../include/pypto/ir/kind_traits.h) (both kinds)
+rather than the exact-kind `As<TensorType>`: `tensor.slice` / `tensor.assemble`,
+the element-wise and unary families, the reductions, and `tensor.matmul` /
+`tensor.matmul_acc`. Only `tensor.slice` and `tensor.assemble` propagate the
+window kind — a slice of a window is still a view into the same comm-group
+allocation. Every computing op returns a plain `TensorType`, because its result
+is fresh local data rather than a window view. `tensor.reinterpret_view` is the
+documented exception: it still rejects a window outright.
+
 ### TensorType with TensorView
 
 Tensor with layout and stride information for optimized memory access.

--- a/docs/en/dev/ir/02-types.md
+++ b/docs/en/dev/ir/02-types.md
@@ -85,13 +85,24 @@ on `DistributedTensor`.
 this rank's local GM, so the ordinary tensor ops read and write it like any
 other GM tensor. Those ops match their operand with
 [`AsTensorTypeLike`](../../../../include/pypto/ir/kind_traits.h) (both kinds)
-rather than the exact-kind `As<TensorType>`: `tensor.slice` / `tensor.assemble`,
-the element-wise and unary families, the reductions, and `tensor.matmul` /
-`tensor.matmul_acc`. Only `tensor.slice` and `tensor.assemble` propagate the
-window kind — a slice of a window is still a view into the same comm-group
-allocation. Every computing op returns a plain `TensorType`, because its result
-is fresh local data rather than a window view. `tensor.reinterpret_view` is the
-documented exception: it still rejects a window outright.
+rather than the exact-kind `As<TensorType>`. What the result type is depends on
+whether the op yields a *view of* the window or *new data*:
+
+| Ops accepting a window | Result kind |
+| ---------------------- | ----------- |
+| `tensor.slice`, `tensor.assemble`, `tensor.view`, `tensor.write` | `DistributedTensorType` — still a view into the same comm-group allocation |
+| the element-wise and unary families, the reductions, `tensor.matmul`, `tensor.matmul_acc` (`lhs` / `rhs` only) | plain `TensorType` — the result is fresh local data |
+| `tensor.read` | `ScalarType` — one element, no view |
+
+Two documented rejections: `tensor.reinterpret_view` refuses a window outright,
+and `tensor.matmul_acc`'s **`acc`** operand must be a plain `TensorType` — only
+the matrix unit writes L0C, so there is no data path from a window into a Cube
+accumulator. Accumulate locally and store into the window afterwards.
+
+Many other tensor ops still reject a window although they read or write plain
+GM (all the broadcasts, `reshape`, `transpose`, `concat`, the gather / scatter
+family, …). `tests/ut/ir/operators/test_window_operand_acceptance.py` holds the
+authoritative per-operator classification and keeps it honest.
 
 ### TensorType with TensorView
 

--- a/docs/zh/dev/ir/02-types.md
+++ b/docs/zh/dev/ir/02-types.md
@@ -79,6 +79,16 @@ op 所绑定的 `ir.WindowBuffer`（`Var` 子类）上。通过
 `None`）。Tile 类型没有 distributed 变体；跨 rank op 始终作用在
 `DistributedTensor` 上。
 
+**在 window 上做本地计算。** 在 InCore scope 内，一个 window 切片*就是*本 rank 的
+本地 GM，因此普通 tensor op 可以像读写任何 GM tensor 一样读写它。这些 op 用
+[`AsTensorTypeLike`](../../../../include/pypto/ir/kind_traits.h)（同时匹配两种
+kind）而不是精确匹配的 `As<TensorType>` 来匹配操作数：`tensor.slice` /
+`tensor.assemble`、逐元素与一元族、各类 reduction，以及 `tensor.matmul` /
+`tensor.matmul_acc`。其中只有 `tensor.slice` 和 `tensor.assemble` 会传播 window
+kind —— window 的切片仍然是同一个 comm-group 分配上的视图。所有计算类 op 都返回
+普通 `TensorType`，因为其结果是新产生的本地数据，而不是 window 视图。
+`tensor.reinterpret_view` 是已记录的例外：它仍然直接拒绝 window。
+
 ### 带 TensorView 的 TensorType
 
 带有布局和步长信息的张量，用于优化内存访问。

--- a/docs/zh/dev/ir/02-types.md
+++ b/docs/zh/dev/ir/02-types.md
@@ -82,12 +82,23 @@ op 所绑定的 `ir.WindowBuffer`（`Var` 子类）上。通过
 **在 window 上做本地计算。** 在 InCore scope 内，一个 window 切片*就是*本 rank 的
 本地 GM，因此普通 tensor op 可以像读写任何 GM tensor 一样读写它。这些 op 用
 [`AsTensorTypeLike`](../../../../include/pypto/ir/kind_traits.h)（同时匹配两种
-kind）而不是精确匹配的 `As<TensorType>` 来匹配操作数：`tensor.slice` /
-`tensor.assemble`、逐元素与一元族、各类 reduction，以及 `tensor.matmul` /
-`tensor.matmul_acc`。其中只有 `tensor.slice` 和 `tensor.assemble` 会传播 window
-kind —— window 的切片仍然是同一个 comm-group 分配上的视图。所有计算类 op 都返回
-普通 `TensorType`，因为其结果是新产生的本地数据，而不是 window 视图。
-`tensor.reinterpret_view` 是已记录的例外：它仍然直接拒绝 window。
+kind）而不是精确匹配的 `As<TensorType>` 来匹配操作数。结果类型取决于该 op 产生的
+是 window 的*视图*还是*新数据*：
+
+| 接受 window 的 op | 结果 kind |
+| ----------------- | --------- |
+| `tensor.slice`、`tensor.assemble`、`tensor.view`、`tensor.write` | `DistributedTensorType` —— 仍然是同一个 comm-group 分配上的视图 |
+| 逐元素与一元族、各类 reduction、`tensor.matmul`、`tensor.matmul_acc`（仅 `lhs` / `rhs`） | 普通 `TensorType` —— 结果是新产生的本地数据 |
+| `tensor.read` | `ScalarType` —— 单个元素，没有视图 |
+
+两处已记录的拒绝：`tensor.reinterpret_view` 直接拒绝 window；`tensor.matmul_acc`
+的 **`acc`** 操作数必须是普通 `TensorType` —— 只有矩阵单元会写 L0C，因此不存在从
+window 到 Cube 累加器的数据通路。请先在本地累加，再把结果存回 window。
+
+还有不少读写普通 GM 的 tensor op 目前仍然拒绝 window（全部 broadcast、`reshape`、
+`transpose`、`concat`、gather / scatter 族等）。
+`tests/ut/ir/operators/test_window_operand_acceptance.py` 保存了逐算子的权威分类，
+并负责保证它与实现一致。
 
 ### 带 TensorView 的 TensorType
 

--- a/src/codegen/tensor_op_codegen.cpp
+++ b/src/codegen/tensor_op_codegen.cpp
@@ -135,8 +135,15 @@ REGISTER_ORCHESTRATION_OP(tensor_read, ("tensor.read")) {
   std::string input_name = codegen.TryGetVarName(op->args_[0]);
   CHECK(!input_name.empty()) << "tensor.read input must be a variable";
 
-  auto input_type = As<TensorType>(op->args_[0]->GetType());
-  CHECK(input_type) << "tensor.read input must be TensorType";
+  // ``AsTensorTypeLike`` also matches a ``DistributedTensorType``: the deducer
+  // accepts a window source, and ConvertTensorToTileOps deliberately leaves
+  // ``tensor.read`` on a window unconverted so it lowers here as a local-rank
+  // scalar read. The exact-kind ``As<TensorType>`` made that documented path
+  // abort in codegen instead.
+  auto input_type = AsTensorTypeLike(op->args_[0]->GetType());
+  INTERNAL_CHECK_SPAN(input_type, op->span_)
+      << "Internal error: tensor.read input must be TensorType or DistributedTensorType, got "
+      << op->args_[0]->GetType()->TypeName();
 
   auto result_type = As<ScalarType>(op->GetType());
   CHECK(result_type) << "tensor.read must return ScalarType";
@@ -184,8 +191,11 @@ REGISTER_ORCHESTRATION_OP(tensor_write, ("tensor.write")) {
   std::string input_name = codegen.TryGetVarName(op->args_[0]);
   CHECK(!input_name.empty()) << "tensor.write input must be a variable";
 
-  auto input_type = As<TensorType>(op->args_[0]->GetType());
-  CHECK(input_type) << "tensor.write input must be TensorType";
+  // A window destination is accepted for the same reason as in tensor.read above.
+  auto input_type = AsTensorTypeLike(op->args_[0]->GetType());
+  INTERNAL_CHECK_SPAN(input_type, op->span_)
+      << "Internal error: tensor.write input must be TensorType or DistributedTensorType, got "
+      << op->args_[0]->GetType()->TypeName();
 
   std::string tensor_ref = codegen.GetExternalTensorName(input_name);
 

--- a/src/ir/op/tensor_ops/matmul.cpp
+++ b/src/ir/op/tensor_ops/matmul.cpp
@@ -260,17 +260,20 @@ TypePtr DeduceTensorMatMulAccType(const std::vector<ExprPtr>& args,
       << "predicate, but got " << args.size();
   CheckMatmulInitCond(args, 3, "tensor.matmul_acc");
 
-  // ``AsTensorTypeLike`` accepts a window operand here for the same reason as in
-  // tensor.matmul above. The accumulator is allowed to be one too: it is never a
-  // load target either way (its space req is ``OperandSpaceOf(..., Acc)``), so a
-  // window acc reaches exactly the diagnostic a plain GM acc reaches --
-  // InferTileMemorySpace's "no data path into Acc memory".
-  auto acc_type = AsTensorTypeLike(args[0]->GetType());
+  // lhs / rhs take a window operand for the same reason as in tensor.matmul above: the Cube
+  // loads them from GM. The accumulator does NOT -- it is never loaded at all (nothing but the
+  // matrix unit writes L0C), so a window has no data path into it and ConvertTensorToTileOps
+  // would reject it as "tile.matmul_acc requires acc to be a TileType". Keep the exact-kind
+  // match here so that limitation is reported at the call site, with a remedy.
+  auto acc_type = As<TensorType>(args[0]->GetType());
   auto lhs_type = AsTensorTypeLike(args[1]->GetType());
   auto rhs_type = AsTensorTypeLike(args[2]->GetType());
 
-  CHECK(acc_type) << "tensor.matmul_acc requires first argument (acc) to be a TensorType or "
-                  << "DistributedTensorType, but got " << args[0]->GetType()->TypeName();
+  CHECK(acc_type) << "tensor.matmul_acc requires first argument (acc) to be a TensorType, but got "
+                  << args[0]->GetType()->TypeName()
+                  << ". A distributed window cannot be a Cube accumulator: only the matrix unit "
+                     "writes L0C, so there is no data path from GM into it. Accumulate into a "
+                     "local tensor and store the result into the window afterwards.";
   CHECK(lhs_type) << "tensor.matmul_acc requires second argument (lhs) to be a TensorType or "
                   << "DistributedTensorType, but got " << args[1]->GetType()->TypeName();
   CHECK(rhs_type) << "tensor.matmul_acc requires third argument (rhs) to be a TensorType or "

--- a/src/ir/op/tensor_ops/matmul.cpp
+++ b/src/ir/op/tensor_ops/matmul.cpp
@@ -105,14 +105,18 @@ TypePtr DeduceTensorMatMulType(const std::vector<ExprPtr>& args,
   // tensor.matmul requires exactly 2 Expr arguments (lhs, rhs)
   CHECK(args.size() == 2) << "tensor.matmul requires exactly 2 arguments (lhs, rhs), but got " << args.size();
 
-  // First two arguments must be TensorType
-  auto lhs_type = As<TensorType>(args[0]->GetType());
-  auto rhs_type = As<TensorType>(args[1]->GetType());
+  // Both operands must be tensor-shaped. ``AsTensorTypeLike`` accepts a
+  // ``DistributedTensorType`` (window) operand the same as a plain tensor
+  // (issue #1694): inside an InCore scope a window is just this rank's local GM,
+  // so the Cube loads it through the same ``tile.load``. The product is fresh
+  // local data, so the result below is a plain ``TensorType``, never a window view.
+  auto lhs_type = AsTensorTypeLike(args[0]->GetType());
+  auto rhs_type = AsTensorTypeLike(args[1]->GetType());
 
-  CHECK(lhs_type) << "tensor.matmul requires first argument to be a TensorType, but got "
-                  << args[0]->GetType()->TypeName();
-  CHECK(rhs_type) << "tensor.matmul requires second argument to be a TensorType, but got "
-                  << args[1]->GetType()->TypeName();
+  CHECK(lhs_type) << "tensor.matmul requires first argument to be a TensorType or "
+                  << "DistributedTensorType, but got " << args[0]->GetType()->TypeName();
+  CHECK(rhs_type) << "tensor.matmul requires second argument to be a TensorType or "
+                  << "DistributedTensorType, but got " << args[1]->GetType()->TypeName();
 
   // Extract shapes
   const auto& lhs_shape = lhs_type->shape_;
@@ -256,16 +260,21 @@ TypePtr DeduceTensorMatMulAccType(const std::vector<ExprPtr>& args,
       << "predicate, but got " << args.size();
   CheckMatmulInitCond(args, 3, "tensor.matmul_acc");
 
-  auto acc_type = As<TensorType>(args[0]->GetType());
-  auto lhs_type = As<TensorType>(args[1]->GetType());
-  auto rhs_type = As<TensorType>(args[2]->GetType());
+  // ``AsTensorTypeLike`` accepts a window operand here for the same reason as in
+  // tensor.matmul above. The accumulator is allowed to be one too: it is never a
+  // load target either way (its space req is ``OperandSpaceOf(..., Acc)``), so a
+  // window acc reaches exactly the diagnostic a plain GM acc reaches --
+  // InferTileMemorySpace's "no data path into Acc memory".
+  auto acc_type = AsTensorTypeLike(args[0]->GetType());
+  auto lhs_type = AsTensorTypeLike(args[1]->GetType());
+  auto rhs_type = AsTensorTypeLike(args[2]->GetType());
 
-  CHECK(acc_type) << "tensor.matmul_acc requires first argument (acc) to be a TensorType, but got "
-                  << args[0]->GetType()->TypeName();
-  CHECK(lhs_type) << "tensor.matmul_acc requires second argument (lhs) to be a TensorType, but got "
-                  << args[1]->GetType()->TypeName();
-  CHECK(rhs_type) << "tensor.matmul_acc requires third argument (rhs) to be a TensorType, but got "
-                  << args[2]->GetType()->TypeName();
+  CHECK(acc_type) << "tensor.matmul_acc requires first argument (acc) to be a TensorType or "
+                  << "DistributedTensorType, but got " << args[0]->GetType()->TypeName();
+  CHECK(lhs_type) << "tensor.matmul_acc requires second argument (lhs) to be a TensorType or "
+                  << "DistributedTensorType, but got " << args[1]->GetType()->TypeName();
+  CHECK(rhs_type) << "tensor.matmul_acc requires third argument (rhs) to be a TensorType or "
+                  << "DistributedTensorType, but got " << args[2]->GetType()->TypeName();
 
   const auto& acc_shape = acc_type->shape_;
   const auto& lhs_shape = lhs_type->shape_;

--- a/src/ir/op/tensor_ops/reduction.cpp
+++ b/src/ir/op/tensor_ops/reduction.cpp
@@ -110,9 +110,14 @@ TypePtr DeduceTensorReductionType(const std::vector<ExprPtr>& args,
   CHECK(args.size() == 1) << "The operator " << op_name << " requires exactly 1 argument, but got "
                           << args.size();
 
-  // First argument must be TensorType
-  auto tensor_type = As<TensorType>(args[0]->GetType());
-  CHECK(tensor_type) << "The operator " << op_name << " requires first argument to be a TensorType, but got "
+  // First argument must be tensor-shaped. ``AsTensorTypeLike`` accepts a
+  // ``DistributedTensorType`` (window) source the same as a plain tensor (issue
+  // #1694): inside an InCore scope a window is this rank's local GM, so the
+  // reduction reads it through the same ``tile.load``. The reduced result is
+  // fresh local data, so ``MakeReductionResultType`` returns a plain TensorType.
+  auto tensor_type = AsTensorTypeLike(args[0]->GetType());
+  CHECK(tensor_type) << "The operator " << op_name
+                     << " requires first argument to be a TensorType or DistributedTensorType, but got "
                      << args[0]->GetType()->TypeName();
 
   const auto& input_shape = tensor_type->shape_;
@@ -170,7 +175,13 @@ REGISTER_OP("tensor.row_min")
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       auto result_type = DeduceTensorReductionType(args, kwargs, "tensor.row_min");
-      auto input_type = As<TensorType>(args[0]->GetType());
+      // The shared deducer above already validated the operand, so this second cast must use
+      // the same matcher: with the exact-kind ``As<TensorType>`` a window operand yielded null
+      // and the unguarded ``input_type->dtype_`` below dereferenced it.
+      auto input_type = AsTensorTypeLike(args[0]->GetType());
+      INTERNAL_CHECK_SPAN(input_type, args[0]->span_)
+          << "Internal error: tensor.row_min input passed reduction deduction but is not "
+          << "tensor-shaped: " << args[0]->GetType()->TypeName();
       CHECK_SPAN(IsPtoRowMinDtype(input_type->dtype_), args[0]->span_)
           << "The operator tensor.row_min requires input dtype in {INT16, INT32, FP16, FP32}, but got "
           << input_type->dtype_.ToString();
@@ -197,8 +208,10 @@ TypePtr DeduceTensorColReductionType(const std::vector<ExprPtr>& args,
   CHECK(args.size() == 1) << "The operator " << op_name << " requires exactly 1 argument, but got "
                           << args.size();
 
-  auto tensor_type = As<TensorType>(args[0]->GetType());
-  CHECK(tensor_type) << "The operator " << op_name << " requires first argument to be a TensorType, but got "
+  // Window sources are accepted here for the same reason as in the row form above.
+  auto tensor_type = AsTensorTypeLike(args[0]->GetType());
+  CHECK(tensor_type) << "The operator " << op_name
+                     << " requires first argument to be a TensorType or DistributedTensorType, but got "
                      << args[0]->GetType()->TypeName();
 
   const auto& input_shape = tensor_type->shape_;

--- a/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
+++ b/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
@@ -408,7 +408,7 @@ class TensorArgsInConvertedOpsCollector : public IRVisitor {
       for (const auto& [iter_arg_ptr, init_expr] : iter_arg_to_init_) {
         if (used_.count(iter_arg_ptr) == 0) continue;
         if (auto var = As<Var>(init_expr)) {
-          if (As<TensorType>(var->GetType()) && used_.insert(var.get()).second) {
+          if (AsTensorTypeLike(var->GetType()) && used_.insert(var.get()).second) {
             changed = true;
           }
         }
@@ -441,10 +441,15 @@ class TensorArgsInConvertedOpsCollector : public IRVisitor {
       for (size_t i = 0; i < call->args_.size(); ++i) {
         if (conv_entry->input_reqs.count(i)) continue;
         const auto& arg = call->args_[i];
+        // ``AsTensorTypeLike`` also collects ``DistributedTensorType`` params: inside
+        // an InCore scope a window is this rank's local GM, so an op with no
+        // input_req (e.g. tensor.row_max) needs the same Phase-1 entry load a plain
+        // tensor param gets. The exact-kind ``As<TensorType>`` skipped it, and the
+        // converter then saw an unbridged tensor operand.
         if (auto iter_arg = As<IterArg>(arg)) {
-          if (As<TensorType>(iter_arg->GetType())) used_.insert(iter_arg.get());
+          if (AsTensorTypeLike(iter_arg->GetType())) used_.insert(iter_arg.get());
         } else if (auto var = As<Var>(arg)) {
-          if (As<TensorType>(var->GetType())) used_.insert(var.get());
+          if (AsTensorTypeLike(var->GetType())) used_.insert(var.get());
         }
       }
     }
@@ -1255,7 +1260,12 @@ class TensorToTileMutator : public TypePropagatingMutator {
       // path into Acc memory" diagnostic, which names the real limitation.
       if (req.demanded_space.Get() == MemorySpace::Acc) continue;
       const bool use_view = req.trans_kwarg ? call->GetKwarg<bool>(*req.trans_kwarg, false) : false;
-      auto tensor_type = As<TensorType>(args[idx]->GetType());
+      // A window operand bridges exactly like a plain GM tensor (issue #1694):
+      // ``AsTensorTypeLike`` matches both kinds. With the exact-kind
+      // ``As<TensorType>`` a ``pld.DistributedTensor`` reaching a matmul directly
+      // fell through to the tile branch, passed through unbridged, and tripped the
+      // converter's unreachable guard.
+      auto tensor_type = AsTensorTypeLike(args[idx]->GetType());
 
       if (tensor_type) {
         // GM operand: load NATURAL (2D and ND alike), then reinterpret as its
@@ -2284,7 +2294,9 @@ IncoreTransformResult TransformIncoreFunction(const FunctionPtr& func) {
   const auto& params_used_by_converted_ops = collector.GetUsed();
 
   for (const auto& var : func->params_) {
-    auto tensor_type = As<TensorType>(var->GetType());
+    // ``AsTensorTypeLike`` covers ``DistributedTensorType`` window params too --
+    // the entry load reads this rank's local GM, same as for a plain tensor.
+    auto tensor_type = AsTensorTypeLike(var->GetType());
     if (!tensor_type) continue;
 
     if (params_used_by_converted_ops.find(var.get()) == params_used_by_converted_ops.end()) continue;

--- a/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
+++ b/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
@@ -154,7 +154,10 @@ int64_t ResolveCubeMAlignment(const CallPtr& call,
   const auto& arg_type = call->args_[decider_idx]->GetType();
   std::vector<ExprPtr> shape;
   DataType dtype = DataType::FP32;
-  if (auto tensor_type = As<TensorType>(arg_type)) {
+  // ``AsTensorTypeLike`` so a ``DistributedTensorType`` operand is boxed like the plain GM
+  // tensor it is. Falling through to the ``return 0`` below would leave a non-fractal window
+  // operand unboxed, and it would reach the cube with a physical geometry ptoas rejects.
+  if (auto tensor_type = AsTensorTypeLike(arg_type)) {
     shape = tensor_type->shape_;
     dtype = tensor_type->dtype_;
   } else if (auto tile_type = As<TileType>(arg_type)) {
@@ -204,7 +207,8 @@ int64_t ResolveCubeNAlignment(const CallPtr& call, const InputSpaceReq& req, siz
   const auto& arg_type = call->args_[idx]->GetType();
   std::vector<ExprPtr> shape;
   DataType dtype = DataType::FP32;
-  if (auto tensor_type = As<TensorType>(arg_type)) {
+  // Window operands are boxed like plain GM tensors here too -- see ResolveCubeMAlignment.
+  if (auto tensor_type = AsTensorTypeLike(arg_type)) {
     shape = tensor_type->shape_;
     dtype = tensor_type->dtype_;
   } else if (auto tile_type = As<TileType>(arg_type)) {

--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -1216,7 +1216,9 @@ void OpConversionRegistry::RegisterMatmulOps() {
   // tile- or tensor-typed.
   auto rank_of = [](const ExprPtr& e) -> size_t {
     if (auto t = As<TileType>(e->GetType())) return t->shape_.size();
-    if (auto t = As<TensorType>(e->GetType())) return t->shape_.size();
+    // ``AsTensorTypeLike`` so a window operand BridgeInputSpaces left tensor-typed
+    // (Acc reqs are never bridged) reports its rank instead of tripping the guard.
+    if (auto t = AsTensorTypeLike(e->GetType())) return t->shape_.size();
     INTERNAL_UNREACHABLE << "matmul conversion: argument has unexpected type " << e->GetType()->TypeName();
   };
 

--- a/tests/ut/codegen/test_orchestration_tensor_rw.py
+++ b/tests/ut/codegen/test_orchestration_tensor_rw.py
@@ -12,6 +12,7 @@
 import re
 
 import pypto.language as pl
+import pypto.language.distributed as pld
 import pytest
 from _orchestration_codegen_common import (
     _generate_orch_code,
@@ -1241,6 +1242,46 @@ class TestTensorReadWriteOffsetCodegen:
         task_add_text = "\n".join(task_add_lines)
         for expected in ("ext_q", "ext_sink", "ext_out", "gm_pipe_buffer_0", "task"):
             assert expected in task_add_text, code
+
+
+class TestWindowScalarReadWriteCodegen:
+    """``tensor.read`` / ``tensor.write`` on a ``pld.DistributedTensor`` window.
+
+    ``ConvertTensorToTileOps`` deliberately leaves these two ops unconverted for a window
+    operand (see its ``IncoreTileOps`` verifier), so orchestration codegen is where they
+    lower. The emitter matched its operand with the exact-kind ``As<TensorType>``, which a
+    window never satisfies, so that documented path aborted in codegen with
+    ``tensor.read input must be TensorType`` -- a late failure the type deducer had already
+    accepted. Both emitters now match with ``AsTensorTypeLike``.
+    """
+
+    @staticmethod
+    def _program():
+        @pl.program
+        class WindowScalarRW:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                win: pl.InOut[pld.DistributedTensor[[4, 8], pl.FP32]],
+            ) -> pld.DistributedTensor[[4, 8], pl.FP32]:
+                v: pl.Scalar[pl.FP32] = pl.tensor.read(win, [0, 0])
+                pl.tensor.write(win, [1, 2], v)
+                return win
+
+        return WindowScalarRW
+
+    def test_window_scalar_read_write_emit_runtime_accessors(self):
+        # A DistributedTensor param gets its CommCtx companion from pass 44; codegen
+        # asserts the two are in step, so a hand-built program has to run it here.
+        with passes.PassContext([]):
+            program = passes.materialize_dist_tensor_ctx()(self._program())
+        code = _generate_orch_code(program)
+        assert "get_tensor_data<float>" in code, (
+            f"tensor.read on a window must emit the runtime accessor:\n{code}"
+        )
+        assert "set_tensor_data<float>" in code, (
+            f"tensor.write on a window must emit the runtime accessor:\n{code}"
+        )
 
 
 if __name__ == "__main__":

--- a/tests/ut/ir/operators/test_tensor_ops.py
+++ b/tests/ut/ir/operators/test_tensor_ops.py
@@ -330,7 +330,7 @@ def test_tensor_matmul_accepts_window_operand(window_side):
 
 
 def test_tensor_matmul_acc_accepts_window_operand():
-    """matmul_acc accumulates from a window operand, same rule as matmul."""
+    """matmul_acc reads a window lhs/rhs from GM, same rule as matmul."""
     acc = _tensor_var("acc", [16, 64], DataType.FP32)
     lhs = _window_tensor_var("a", [16, 32], DataType.BF16)
     rhs = _tensor_var("b", [32, 64], DataType.BF16)
@@ -340,6 +340,21 @@ def test_tensor_matmul_acc_accepts_window_operand():
     assert call.op.name == ir.get_op("tensor.matmul_acc").name
     assert _const_shape(call) == [16, 64]
     assert not isinstance(call.type, ir.DistributedTensorType)
+
+
+def test_tensor_matmul_acc_rejects_window_accumulator():
+    """The accumulator is the one matmul operand a window can never be.
+
+    Nothing but the matrix unit writes L0C, so there is no data path from GM into a Cube
+    accumulator; the tile-level op would reject it as "acc must be a TileType". Report the
+    limitation at the call site instead, with a remedy.
+    """
+    acc = _window_tensor_var("acc", [16, 64], DataType.FP32)
+    lhs = _tensor_var("a", [16, 32], DataType.BF16)
+    rhs = _tensor_var("b", [32, 64], DataType.BF16)
+
+    with pytest.raises(ValueError, match="cannot be a Cube accumulator"):
+        ir.op.tensor.matmul_acc(acc, lhs, rhs)
 
 
 def test_tensor_row_max_accepts_window_source():

--- a/tests/ut/ir/operators/test_tensor_ops.py
+++ b/tests/ut/ir/operators/test_tensor_ops.py
@@ -303,6 +303,54 @@ def test_tensor_matmul_acc_nd_acc_batch_mismatch_fails():
         ir.op.tensor.matmul_acc(acc, lhs, rhs)
 
 
+def _window_tensor_var(name: str, shape: list[int], dtype: DataType = DataType.BF16) -> ir.Var:
+    """Build a Var of DistributedTensorType (an HCCL window view) with a static shape."""
+    span = ir.Span.unknown()
+    dims = [ir.ConstInt(d, DataType.INT32, span) for d in shape]
+    return ir.Var(name, ir.DistributedTensorType(dims, dtype), span)
+
+
+@pytest.mark.parametrize("window_side", ["lhs", "rhs", "both"])
+def test_tensor_matmul_accepts_window_operand(window_side):
+    """A window operand is this rank's local GM, so matmul must accept it.
+
+    Slicing a ``pld.DistributedTensor`` keeps ``DistributedTensorType``, so the
+    high-level matmul has to match it the way the elementwise ops already do.
+    The product is fresh local data, so the deduced result is a plain
+    ``TensorType`` -- never a window view.
+    """
+    make_lhs = _window_tensor_var if window_side in ("lhs", "both") else _tensor_var
+    make_rhs = _window_tensor_var if window_side in ("rhs", "both") else _tensor_var
+
+    call = ir.op.tensor.matmul(make_lhs("a", [16, 32], DataType.BF16), make_rhs("b", [32, 64], DataType.BF16))
+
+    assert call.op.name == ir.get_op("tensor.matmul").name
+    assert _const_shape(call) == [16, 64]
+    assert not isinstance(call.type, ir.DistributedTensorType)
+
+
+def test_tensor_matmul_acc_accepts_window_operand():
+    """matmul_acc accumulates from a window operand, same rule as matmul."""
+    acc = _tensor_var("acc", [16, 64], DataType.FP32)
+    lhs = _window_tensor_var("a", [16, 32], DataType.BF16)
+    rhs = _tensor_var("b", [32, 64], DataType.BF16)
+
+    call = ir.op.tensor.matmul_acc(acc, lhs, rhs)
+
+    assert call.op.name == ir.get_op("tensor.matmul_acc").name
+    assert _const_shape(call) == [16, 64]
+    assert not isinstance(call.type, ir.DistributedTensorType)
+
+
+def test_tensor_row_max_accepts_window_source():
+    """A reduction reads a window as local GM; the reduced result is local data."""
+    call = ir.op.tensor.row_max(_window_tensor_var("t", [16, 32], DataType.FP32))
+
+    assert call.op.name == ir.get_op("tensor.row_max").name
+    assert _const_shape(call) == [16, 1]
+    assert not isinstance(call.type, ir.DistributedTensorType)
+
+
 def test_tensor_row_max():
     """Test tensor.row_max reduction."""
     span = ir.Span.unknown()

--- a/tests/ut/ir/operators/test_window_operand_acceptance.py
+++ b/tests/ut/ir/operators/test_window_operand_acceptance.py
@@ -1,0 +1,476 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Every ``tensor.*`` operator states whether it accepts a window operand.
+
+Inside an InCore / chip-orchestration scope a ``pld.DistributedTensor`` window slice *is* this
+rank's local GM, so an ordinary tensor op should read and write it like any GM tensor. Whether it
+can is decided by one line in its type deducer: ``AsTensorTypeLike`` matches a window,
+the exact-kind ``As<TensorType>`` does not (see ``.claude/rules/ir-kind-traits.md``).
+
+That line is easy to get wrong, and wrong in a way nothing else notices — the op simply refuses a
+legal program, or silently skips the operand and fails later in a pass or emitter. This file makes
+the decision explicit and enforced:
+
+* Every registered ``tensor.*`` operator is classified into exactly one bucket below. Adding an
+  operator without classifying it fails ``test_every_registered_tensor_op_is_classified``.
+* Every classified operator with a GM operand is probed with a window in that slot, and its bucket
+  is checked against what the deducer actually does.
+
+``WINDOW_GAP`` is the honest part: those operators *should* accept a window but do not yet. The
+test asserts they still reject, so fixing one fails here and prompts moving it to ``WINDOW_OK``.
+A fix is not complete at the deducer, though — see the note on that constant.
+"""
+
+import re
+import subprocess
+from functools import partial
+from pathlib import Path
+
+import pytest
+from pypto import DataType as DT
+from pypto import ir
+
+SPAN = ir.Span.unknown()
+I32 = DT.INT32
+t = ir.op.tensor
+
+
+def _dims(shape):
+    return [ir.ConstInt(d, I32, SPAN) for d in shape]
+
+
+def W(name="win", shape=(16, 32), dtype=DT.FP32):
+    """A window operand: a Var whose type is DistributedTensorType."""
+    return ir.Var(name, ir.DistributedTensorType(_dims(list(shape)), dtype), SPAN)
+
+
+def T(name="t", shape=(16, 32), dtype=DT.FP32):
+    return ir.Var(name, ir.TensorType(_dims(list(shape)), dtype), SPAN)
+
+
+def S(name="s", dtype=DT.FP32):
+    return ir.Var(name, ir.ScalarType(dtype), SPAN)
+
+
+# --------------------------------------------------------------------------------------------
+# Classification
+# --------------------------------------------------------------------------------------------
+
+
+def _ops(*names: str) -> set[str]:
+    """Validate each operator-name literal through the registry getter.
+
+    ``ir.get_op`` raises on an unregistered name, so a typo in the classification below fails at
+    import instead of silently creating a bucket entry that matches nothing
+    (``.claude/rules/operator-identity-checks.md``).
+    """
+    return {ir.get_op(n).name for n in names}
+
+
+#: Operators with no GM tensor operand at all -- there is no slot a window could occupy.
+NO_GM_OPERAND = _ops(
+    "tensor.alloc",
+    "tensor.ci",
+    "tensor.create",
+    "tensor.create_l1",
+    "tensor.full",
+    "tensor.get_block_idx",
+    "tensor.get_block_num",
+    "tensor.get_subblock_idx",
+    "tensor.random",
+)
+
+#: Operators that reject a window on purpose. Each entry names the reason.
+WINDOW_REJECT_BY_DESIGN = {
+    # A window's storage is a comm-window slice; reinterpreting its dtype has no lowering
+    # contract yet, and the deducer says so in its own message.
+    ir.get_op(
+        "tensor.reinterpret_view"
+    ).name: "no zero-copy dtype reinterpretation contract for window storage",
+    # AIV/AIC split boundary ops are cube/vector-lane transfers, not GM reads; a window operand
+    # is out of scope and rejected upstream (docs/en/dev/passes/11-convert_tensor_to_tile_ops.md).
+    ir.get_op("tensor.aiv_shard").name: "cross-lane split boundary, not a GM read",
+    ir.get_op("tensor.aic_gather").name: "cross-lane split boundary, not a GM read",
+}
+
+#: Operators whose deducer accepts a window today. Keep this list growing, never shrinking.
+WINDOW_OK = _ops(
+    # element-wise / unary / scalar-rhs (relaxed by issue #1694)
+    "tensor.abs",
+    "tensor.add",
+    "tensor.adds",
+    "tensor.and",
+    "tensor.ands",
+    "tensor.cast",
+    "tensor.cmp",
+    "tensor.cos",
+    "tensor.div",
+    "tensor.divs",
+    "tensor.exp",
+    "tensor.fmod",
+    "tensor.fmods",
+    "tensor.log",
+    "tensor.maximum",
+    "tensor.minimum",
+    "tensor.mul",
+    "tensor.muls",
+    "tensor.neg",
+    "tensor.not",
+    "tensor.or",
+    "tensor.ors",
+    "tensor.part_add",
+    "tensor.part_max",
+    "tensor.part_min",
+    "tensor.part_mul",
+    "tensor.recip",
+    "tensor.rsqrt",
+    "tensor.shl",
+    "tensor.shls",
+    "tensor.shr",
+    "tensor.shrs",
+    "tensor.sin",
+    "tensor.sqrt",
+    "tensor.sub",
+    "tensor.subs",
+    "tensor.xor",
+    "tensor.xors",
+    # views and scalar access -- these propagate the window kind onto their result
+    "tensor.assemble",
+    "tensor.read",
+    "tensor.slice",
+    "tensor.view",
+    "tensor.write",
+    # reductions
+    "tensor.col_argmax",
+    "tensor.col_argmin",
+    "tensor.col_max",
+    "tensor.col_min",
+    "tensor.col_prod",
+    "tensor.col_sum",
+    "tensor.row_argmax",
+    "tensor.row_argmin",
+    "tensor.row_max",
+    "tensor.row_min",
+    "tensor.row_prod",
+    "tensor.row_sum",
+    # cube
+    "tensor.matmul",
+    "tensor.matmul_acc",
+)
+
+#: Operators that *should* accept a window (they read or write plain GM) but do not yet.
+#:
+#: Relaxing the deducer is only the first of two gates: the operand must also survive its
+#: lowering site. ``tensor.fillpad``, ``tensor.fillpad_expand``, ``tensor.expand_clone``,
+#: ``tensor.gather`` and ``tensor.paged_gather`` carry the same exact-kind cast inside their
+#: rules in ``src/ir/transforms/op_conversion_registry.cpp``, so relaxing the deducer alone
+#: turns a clear ``CHECK`` into an ``INTERNAL_UNREACHABLE`` deeper in the pipeline. Fix both,
+#: add a lowering test, then move the name into ``WINDOW_OK``.
+WINDOW_GAP = _ops(
+    "tensor.col_expand",
+    "tensor.col_expand_add",
+    "tensor.col_expand_div",
+    "tensor.col_expand_expdif",
+    "tensor.col_expand_max",
+    "tensor.col_expand_min",
+    "tensor.col_expand_mul",
+    "tensor.col_expand_sub",
+    "tensor.concat",
+    "tensor.dim",
+    "tensor.expand_clone",
+    "tensor.expands",
+    "tensor.fillpad",
+    "tensor.fillpad_expand",
+    "tensor.gather",
+    "tensor.gather_compare",
+    "tensor.gather_mask",
+    "tensor.gather_row",
+    "tensor.mrgsort_format1",
+    "tensor.mrgsort_format2",
+    "tensor.paged_gather",
+    "tensor.reshape",
+    "tensor.row_expand",
+    "tensor.row_expand_add",
+    "tensor.row_expand_div",
+    "tensor.row_expand_expdif",
+    "tensor.row_expand_max",
+    "tensor.row_expand_min",
+    "tensor.row_expand_mul",
+    "tensor.row_expand_sub",
+    "tensor.scatter",
+    "tensor.scatter_mask",
+    "tensor.scatter_update",
+    "tensor.set_validshape",
+    "tensor.sort32",
+    "tensor.transpose",
+)
+
+
+# --------------------------------------------------------------------------------------------
+# Probes: build each op's call with a window in its GM slot
+# --------------------------------------------------------------------------------------------
+
+#: Float-dtype families. The bitwise / shift ops below need an integer operand instead.
+_UNARY = ["abs", "cos", "exp", "log", "neg", "recip", "rsqrt", "sin", "sqrt"]
+_BINARY = [
+    "add",
+    "cmp",
+    "div",
+    "fmod",
+    "maximum",
+    "minimum",
+    "mul",
+    "part_add",
+    "part_max",
+    "part_min",
+    "part_mul",
+    "sub",
+]
+_SCALAR_RHS = ["adds", "divs", "expands", "fmods", "muls", "subs"]
+_INT_UNARY: list[str] = []  # tensor.not needs a 16-bit int; probed explicitly below
+_INT_BINARY = ["and_", "or_", "shl", "shr", "xor"]
+_INT_SCALAR_RHS = ["ands", "ors", "shls", "shrs", "xors"]
+_ROW_REDUCE = ["row_argmax", "row_argmin", "row_max", "row_min", "row_prod", "row_sum"]
+_COL_REDUCE = ["col_argmax", "col_argmin", "col_max", "col_min", "col_prod", "col_sum"]
+_ROW_EXPAND = [
+    "row_expand_add",
+    "row_expand_div",
+    "row_expand_expdif",
+    "row_expand_max",
+    "row_expand_min",
+    "row_expand_mul",
+    "row_expand_sub",
+]
+_COL_EXPAND = [
+    "col_expand_add",
+    "col_expand_div",
+    "col_expand_expdif",
+    "col_expand_max",
+    "col_expand_min",
+    "col_expand_mul",
+    "col_expand_sub",
+]
+
+#: op name -> zero-arg callable putting a window in the operand slot under test.
+PROBES: dict[str, object] = {}
+
+
+def _probe(fn, *arg_makers):
+    """Bind an op builder to zero-arg operand factories, evaluated when the probe runs."""
+    return lambda: fn(*(make() for make in arg_makers))
+
+
+_INT_W = partial(W, dtype=I32)
+_INT_T = partial(T, dtype=I32)
+_INT_S = partial(S, dtype=I32)
+_ROW_CARRIER = partial(T, shape=(16, 1))
+_COL_CARRIER = partial(T, shape=(1, 32))
+
+for _n in _UNARY:
+    PROBES[ir.get_op(f"tensor.{_n}").name] = _probe(getattr(t, _n), W)
+for _n in _BINARY:
+    PROBES[ir.get_op(f"tensor.{_n}").name] = _probe(getattr(t, _n), W, T)
+for _n in _SCALAR_RHS:
+    PROBES[ir.get_op(f"tensor.{_n}").name] = _probe(getattr(t, _n), W, S)
+for _n in _INT_BINARY:
+    PROBES[ir.get_op(f"tensor.{_n.rstrip('_')}").name] = _probe(getattr(t, _n), _INT_W, _INT_T)
+for _n in _INT_SCALAR_RHS:
+    PROBES[ir.get_op(f"tensor.{_n}").name] = _probe(getattr(t, _n), _INT_W, _INT_S)
+for _n in _ROW_REDUCE + _COL_REDUCE:
+    PROBES[ir.get_op(f"tensor.{_n}").name] = _probe(getattr(t, _n), W)
+for _n in _ROW_EXPAND:
+    PROBES[ir.get_op(f"tensor.{_n}").name] = _probe(getattr(t, _n), W, _ROW_CARRIER)
+for _n in _COL_EXPAND:
+    PROBES[ir.get_op(f"tensor.{_n}").name] = _probe(getattr(t, _n), W, _COL_CARRIER)
+
+PROBES.update(
+    {
+        ir.get_op("tensor.cast").name: lambda: t.cast(W(), DT.FP16),
+        # tensor.not accepts only 16-bit integer operands.
+        ir.get_op("tensor.not").name: lambda: t.not_(W(dtype=DT.INT16)),
+        ir.get_op("tensor.matmul").name: lambda: t.matmul(W(dtype=DT.BF16), T(shape=(32, 16), dtype=DT.BF16)),
+        ir.get_op("tensor.matmul_acc").name: lambda: t.matmul_acc(
+            T(shape=(16, 16)), W(dtype=DT.BF16), T(shape=(32, 16), dtype=DT.BF16)
+        ),
+        ir.get_op("tensor.slice").name: lambda: t.slice(W(), [8, 32], [0, 0]),
+        ir.get_op("tensor.assemble").name: lambda: t.assemble(W(), T(shape=(8, 32)), [0, 0]),
+        ir.get_op("tensor.view").name: lambda: t.view(W(), [16, 32]),
+        ir.get_op("tensor.read").name: lambda: t.read(
+            W(), [ir.ConstInt(0, I32, SPAN), ir.ConstInt(0, I32, SPAN)]
+        ),
+        ir.get_op("tensor.write").name: lambda: t.write(
+            W(), [ir.ConstInt(0, I32, SPAN), ir.ConstInt(0, I32, SPAN)], S()
+        ),
+        ir.get_op("tensor.reshape").name: lambda: t.reshape(W(), [512]),
+        ir.get_op("tensor.transpose").name: lambda: t.transpose(W(), 0, 1),
+        ir.get_op("tensor.set_validshape").name: lambda: t.set_validshape(W(), 8, 32),
+        ir.get_op("tensor.concat").name: lambda: t.concat(W(), T()),
+        ir.get_op("tensor.reinterpret_view").name: lambda: t.reinterpret_view(W(), dtype=DT.FP16),
+        ir.get_op("tensor.fillpad").name: lambda: t.fillpad(W()),
+        ir.get_op("tensor.fillpad_expand").name: lambda: t.fillpad_expand(W(), [16, 64]),
+        ir.get_op("tensor.dim").name: lambda: t.dim(W(), 0),
+        ir.get_op("tensor.expand_clone").name: lambda: t.expand_clone(W(), T(shape=(1, 32))),
+        ir.get_op("tensor.row_expand").name: lambda: t.row_expand(T(), W(shape=(16, 1))),
+        ir.get_op("tensor.col_expand").name: lambda: t.col_expand(T(), W(shape=(1, 32))),
+        ir.get_op("tensor.gather").name: lambda: t.gather(W(), 1, T(dtype=I32)),
+        ir.get_op("tensor.gather_mask").name: lambda: t.gather_mask(W(), 1),
+        ir.get_op("tensor.gather_row").name: lambda: t.gather_row(
+            T(shape=(16, 32)), W(shape=(64, 32)), [0, 0], [0, 0], [16, 32]
+        ),
+        ir.get_op("tensor.gather_compare").name: lambda: t.gather_compare(
+            W(), S(), cmp_mode="lt", out_cols=32
+        ),
+        ir.get_op("tensor.scatter").name: lambda: t.scatter(W(), 1, T(dtype=I32), T()),
+        ir.get_op("tensor.scatter_mask").name: lambda: t.scatter_mask(W(), T(), 1),
+        ir.get_op("tensor.scatter_update").name: lambda: t.scatter_update(
+            W(), 0, T(shape=(16, 1), dtype=I32), T()
+        ),
+        ir.get_op("tensor.sort32").name: lambda: t.sort32(W(), T(dtype=I32)),
+        ir.get_op("tensor.paged_gather").name: lambda: t.paged_gather(
+            W(shape=(64, 32), dtype=DT.FP16),
+            T(shape=(16, 1), dtype=I32),
+            T(shape=(1, 16), dtype=I32),
+            16,
+            16,
+            16,
+        ),
+        ir.get_op("tensor.mrgsort_format1").name: lambda: t.mrgsort_format1(W(), 16),
+        ir.get_op("tensor.mrgsort_format2").name: lambda: t.mrgsort_format2(W(), T()),
+    }
+)
+
+#: Classified operators with no ``ir.op.tensor`` entry point to probe through. Keep this set
+#: minimal and justified: an operator listed here is classified but not behaviourally checked.
+NO_PYTHON_ENTRY = _ops(
+    # Reachable only through the pl.split_aiv region, which supplies the split mode; there is no
+    # standalone tensor-level builder to call with a window.
+    "tensor.aiv_shard",
+    "tensor.aic_gather",
+)
+
+_REJECT_MESSAGE = re.compile(r"DistributedTensorType")
+
+
+def _rejects_window(name: str) -> tuple[bool, str]:
+    """Run the probe. Returns (rejected, detail). Raises if the probe itself is malformed."""
+    probe = PROBES.get(name)
+    assert probe is not None, (
+        f"{name} is classified but has no probe recipe in PROBES -- add one so its window "
+        f"behaviour is actually checked"
+    )
+    try:
+        call = probe()
+    except (ValueError, TypeError) as exc:
+        first = str(exc).splitlines()[0]
+        assert _REJECT_MESSAGE.search(first), (
+            f"{name}: probe recipe is malformed -- it failed for a reason unrelated to the "
+            f"window operand: {first}"
+        )
+        return True, first
+    return False, type(call.type).__name__
+
+
+# --------------------------------------------------------------------------------------------
+# Tests
+# --------------------------------------------------------------------------------------------
+
+
+def _registered_tensor_ops() -> set[str]:
+    """Every ``tensor.*`` name registered in C++, read from the sources.
+
+    The registry exposes no enumeration binding, so the names are read from the
+    ``REGISTER_OP("tensor.…")`` sites instead. That is the same list the runtime builds, and it
+    means a newly added operator is picked up here the moment it is registered.
+    """
+    root = Path(
+        subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"], capture_output=True, text=True, check=True
+        ).stdout.strip()
+    )
+    pattern = re.compile(r'REGISTER_OP\("(tensor\.[a-z0-9_]+)"\)')
+    names: set[str] = set()
+    for path in (root / "src" / "ir" / "op").rglob("*.cpp"):
+        names.update(pattern.findall(path.read_text(encoding="utf-8")))
+    assert names, 'found no REGISTER_OP("tensor.…") sites -- the scan path is wrong'
+    return names
+
+
+def test_every_registered_tensor_op_is_classified():
+    """A new ``tensor.*`` operator must declare whether it accepts a window operand."""
+    classified = NO_GM_OPERAND | set(WINDOW_REJECT_BY_DESIGN) | WINDOW_OK | WINDOW_GAP
+    registered = _registered_tensor_ops()
+
+    unclassified = sorted(registered - classified)
+    assert not unclassified, (
+        "these tensor operators are registered but not classified for window operands: "
+        f"{unclassified}. Decide whether each accepts a pld.DistributedTensor in its GM slot "
+        "(AsTensorTypeLike) or not (As<TensorType>), then add it to WINDOW_OK, WINDOW_GAP, "
+        "WINDOW_REJECT_BY_DESIGN or NO_GM_OPERAND in this file."
+    )
+
+    stale = sorted(classified - registered)
+    assert not stale, f"these classified operators are no longer registered: {stale}"
+
+
+def test_buckets_are_disjoint():
+    buckets = {
+        "NO_GM_OPERAND": NO_GM_OPERAND,
+        "WINDOW_REJECT_BY_DESIGN": set(WINDOW_REJECT_BY_DESIGN),
+        "WINDOW_OK": WINDOW_OK,
+        "WINDOW_GAP": WINDOW_GAP,
+    }
+    names = list(buckets)
+    for i, a in enumerate(names):
+        for b in names[i + 1 :]:
+            overlap = sorted(buckets[a] & buckets[b])
+            assert not overlap, f"{a} and {b} both claim {overlap}"
+
+
+@pytest.mark.parametrize("op_name", sorted(WINDOW_OK))
+def test_window_ok_ops_accept_a_window_operand(op_name):
+    """These deducers must keep accepting a window: it is this rank's local GM."""
+    if op_name in NO_PYTHON_ENTRY:
+        pytest.skip(f"{op_name} has no ir.op.tensor entry point to probe")
+    rejected, detail = _rejects_window(op_name)
+    assert not rejected, (
+        f"{op_name} regressed: it now rejects a window operand ({detail}). Its deducer must use "
+        f"AsTensorTypeLike, not the exact-kind As<TensorType> -- see .claude/rules/ir-kind-traits.md"
+    )
+
+
+@pytest.mark.parametrize("op_name", sorted(WINDOW_GAP))
+def test_window_gap_ops_still_reject(op_name):
+    """Inventory of known gaps -- shrink this list, never grow it.
+
+    If this fails because the operator now *accepts* a window, that is the intended fix: verify
+    its lowering path too (the conversion rule in ``op_conversion_registry.cpp`` and the entry
+    load in ``ConvertTensorToTileOps``), add a lowering test, and move the name to WINDOW_OK.
+    """
+    if op_name in NO_PYTHON_ENTRY:
+        pytest.skip(f"{op_name} has no ir.op.tensor entry point to probe")
+    rejected, detail = _rejects_window(op_name)
+    assert rejected, (
+        f"{op_name} now accepts a window operand (result: {detail}). Move it from WINDOW_GAP to "
+        "WINDOW_OK, and make sure its lowering path accepts one too."
+    )
+
+
+@pytest.mark.parametrize("op_name", sorted(WINDOW_REJECT_BY_DESIGN))
+def test_by_design_rejections_stay_rejections(op_name):
+    if op_name in NO_PYTHON_ENTRY:
+        pytest.skip(f"{op_name} has no ir.op.tensor entry point to probe")
+    rejected, detail = _rejects_window(op_name)
+    assert rejected, (
+        f"{op_name} is documented as rejecting a window "
+        f"({WINDOW_REJECT_BY_DESIGN[op_name]}) but accepted one (result: {detail})"
+    )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/ir/operators/test_window_operand_acceptance.py
+++ b/tests/ut/ir/operators/test_window_operand_acceptance.py
@@ -295,6 +295,8 @@ PROBES.update(
         # tensor.not accepts only 16-bit integer operands.
         ir.get_op("tensor.not").name: lambda: t.not_(W(dtype=DT.INT16)),
         ir.get_op("tensor.matmul").name: lambda: t.matmul(W(dtype=DT.BF16), T(shape=(32, 16), dtype=DT.BF16)),
+        # The window goes in `lhs`: `acc` is the one operand a window can never be (no data
+        # path from GM into L0C), and the deducer rejects it there with its own message.
         ir.get_op("tensor.matmul_acc").name: lambda: t.matmul_acc(
             T(shape=(16, 16)), W(dtype=DT.BF16), T(shape=(32, 16), dtype=DT.BF16)
         ),

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -5889,6 +5889,139 @@ class TestWindowSliceIncoreConversion:
         assert _find_first_call_to(kernel, "tensor.add") is None
         assert _find_first_call_to(kernel, "tensor.slice") is None
 
+    def test_matmul_on_window_slice(self):
+        """A window slice feeding ``pl.matmul`` must load straight into Mat.
+
+        The consumer-driven load (``HandleConsumerDrivenLoad``) already accepts a
+        window source; the gate that rejected this case was the *type* deducer.
+        Locking in the lowering shape here proves the Cube operand path is the
+        same one a plain GM tensor takes -- one ``tile.load`` with
+        ``target_memory=Mat``, no Vec round trip.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                win: pld.DistributedTensor[[16, 32], pl.BF16],
+                w: pl.Tensor[[32, 16], pl.BF16],
+                out: pl.InOut[pl.Tensor[[16, 16], pl.FP32]],
+            ):
+                a = pl.tensor.slice(win, [16, 32], [0, 0])
+                prod = pl.matmul(a, w)
+                out[0:16, 0:16] = prod
+                return  # noqa: PLR1711  (DSL return terminator)
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        kernel = After.get_function("kernel")
+        assert kernel is not None, "kernel function missing after conversion"
+        mm = _find_first_call_to(kernel, "tile.matmul")
+        assert mm is not None, "matmul over a window slice must lower to tile.matmul"
+        # Both operands arrive as Mat-resident tiles.
+        for operand in mm.args:
+            operand_type = operand.type
+            assert isinstance(operand_type, ir.TileType), (
+                f"tile.matmul operand must be a tile, got {type(operand_type).__name__}"
+            )
+            assert operand_type.memory_space == ir.MemorySpace.Mat, (
+                f"tile.matmul operand must be Mat-resident, got {operand_type.memory_space}"
+            )
+        assert _find_first_call_to(kernel, "tensor.matmul") is None
+        assert _find_first_call_to(kernel, "tensor.slice") is None
+
+    def test_matmul_acc_on_window_slice(self):
+        """``pl.matmul_acc`` accumulates a window-derived operand (split-K idiom)."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                win: pld.DistributedTensor[[16, 32], pl.BF16],
+                w: pl.Tensor[[32, 16], pl.BF16],
+                out: pl.InOut[pl.Tensor[[16, 16], pl.FP32]],
+            ):
+                acc = pl.create_tensor([16, 16], dtype=pl.FP32)
+                a = pl.tensor.slice(win, [16, 32], [0, 0])
+                acc2 = pl.matmul_acc(acc, a, w, init_cond=True)
+                out[0:16, 0:16] = acc2
+                return  # noqa: PLR1711  (DSL return terminator)
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        kernel = After.get_function("kernel")
+        assert kernel is not None, "kernel function missing after conversion"
+        assert _find_first_call_to(kernel, "tile.matmul_acc") is not None, (
+            "matmul_acc over a window slice must lower to tile.matmul_acc"
+        )
+        assert _find_first_call_to(kernel, "tensor.matmul_acc") is None
+        assert _find_first_call_to(kernel, "tensor.slice") is None
+
+    def test_matmul_on_window_param_without_slice(self):
+        """A window *parameter* fed straight to matmul must be auto-bridged.
+
+        No ``tensor.slice`` stands between the parameter and the matmul, so the
+        Mat load can only come from ``BridgeInputSpaces``. With the exact-kind
+        cast there the window fell through to the tile branch and reached the
+        converter unbridged, tripping its ``INTERNAL_UNREACHABLE`` guard.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                win: pld.DistributedTensor[[16, 32], pl.BF16],
+                w: pl.Tensor[[32, 16], pl.BF16],
+                out: pl.InOut[pl.Tensor[[16, 16], pl.FP32]],
+            ):
+                prod = pl.matmul(win, w)
+                out[0:16, 0:16] = prod
+                return  # noqa: PLR1711  (DSL return terminator)
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        kernel = After.get_function("kernel")
+        assert kernel is not None, "kernel function missing after conversion"
+        mm = _find_first_call_to(kernel, "tile.matmul")
+        assert mm is not None, "matmul over a window param must lower to tile.matmul"
+        for operand in mm.args:
+            assert isinstance(operand.type, ir.TileType), (
+                "every tile.matmul operand must be bridged to a tile"
+            )
+        assert _find_first_call_to(kernel, "tensor.matmul") is None
+
+    def test_row_max_on_window_param_without_slice(self):
+        """A window param feeding an op with no ``input_reqs`` needs a Phase-1 load.
+
+        ``tensor.row_max`` declares no input space requirement, so its operand is
+        loaded by the entry-load phase rather than by ``BridgeInputSpaces``. That
+        phase collected only exact ``TensorType`` params, so the window reached
+        the converter as a tensor and failed its ``input must be TileType`` check.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                win: pld.DistributedTensor[[16, 32], pl.FP32],
+                out: pl.InOut[pl.Tensor[[16, 1], pl.FP32]],
+            ):
+                r = pl.row_max(win)
+                out[0:16, 0:1] = r
+                return  # noqa: PLR1711  (DSL return terminator)
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        kernel = After.get_function("kernel")
+        assert kernel is not None, "kernel function missing after conversion"
+        assert _find_first_call_to(kernel, "tile.load") is not None, (
+            "the window param must get an entry tile.load"
+        )
+        assert _find_first_call_to(kernel, "tile.row_max") is not None, (
+            "row_max over a window param must lower to tile.row_max"
+        )
+        assert _find_first_call_to(kernel, "tensor.row_max") is None
+
     # ------------------------------------------------------------------
     # Composite intrinsic param-direction upgrade tests
     # ------------------------------------------------------------------

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -5990,6 +5990,63 @@ class TestWindowSliceIncoreConversion:
             )
         assert _find_first_call_to(kernel, "tensor.matmul") is None
 
+    def test_non_fractal_window_operand_is_row_boxed_like_a_plain_tensor(self):
+        """A window cube operand must get the same M boxing a plain GM tensor gets.
+
+        ``ResolveCubeMAlignment`` / ``ResolveCubeNAlignment`` decide the physical extent the
+        bridged load allocates. They matched only the exact ``TensorType``, so a window
+        returned alignment 0 and ``emit_load`` skipped the boxing: a 17-row BF16 operand
+        loaded as a physical ``[17, 32]`` tile instead of the ``[32, 32]`` box with
+        ``valid_shape=[17, 32]``, and reached the Cube with a geometry ptoas rejects.
+        """
+
+        @pl.program
+        class Plain:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                src: pl.Tensor[[17, 32], pl.BF16],
+                w: pl.Tensor[[32, 16], pl.BF16],
+                out: pl.InOut[pl.Tensor[[17, 16], pl.FP32]],
+            ):
+                prod = pl.matmul(src, w)
+                out[0:17, 0:16] = prod
+                return  # noqa: PLR1711  (DSL return terminator)
+
+        @pl.program
+        class Window:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                src: pld.DistributedTensor[[17, 32], pl.BF16],
+                w: pl.Tensor[[32, 16], pl.BF16],
+                out: pl.InOut[pl.Tensor[[17, 16], pl.FP32]],
+            ):
+                prod = pl.matmul(src, w)
+                out[0:17, 0:16] = prod
+                return  # noqa: PLR1711  (DSL return terminator)
+
+        def lhs_physical_shape(program):
+            kernel = passes.convert_tensor_to_tile_ops()(program).get_function("kernel")
+            assert kernel is not None, "kernel function missing after conversion"
+            mm = _find_first_call_to(kernel, "tile.matmul")
+            assert mm is not None, "matmul must lower to tile.matmul"
+            lhs_type = mm.args[0].type
+            assert isinstance(lhs_type, ir.TileType)
+            dims = []
+            for dim in lhs_type.shape:
+                assert isinstance(dim, ir.ConstInt), f"expected a static extent, got {dim}"
+                dims.append(dim.value)
+            return dims
+
+        plain_shape = lhs_physical_shape(Plain)
+        window_shape = lhs_physical_shape(Window)
+        assert plain_shape == [32, 32], f"plain operand must be row-boxed, got {plain_shape}"
+        assert window_shape == plain_shape, (
+            f"window operand must be boxed identically to a plain tensor: "
+            f"got {window_shape}, plain gets {plain_shape}"
+        )
+
     def test_row_max_on_window_param_without_slice(self):
         """A window param feeding an op with no ``input_reqs`` needs a Phase-1 load.
 


### PR DESCRIPTION
## What

Makes the high-level tensor ops accept a **local distributed-window slice** as a GM operand, and fixes two further defects of the same class found while sweeping for them.

Inside an InCore or chip-orchestration scope a `pld.DistributedTensor` window slice *is* this rank's local GM, so ordinary tensor ops should read and write it like any other GM tensor. `DistributedTensorType` subclasses `TensorType` in C++ but carries its own `ObjectKind`, so the exact-kind `As<TensorType>` never matches it — the union matcher `AsTensorTypeLike` does. #1694 applied that to `tensor.slice` / `tensor.assemble` and the element-wise and unary families; matmul, the reductions and the orchestration scalar-access emitters were never swept.

Before:

```python
@pl.jit.incore
def window_mm(
    win: pld.DistributedTensor[[16, 16], pl.BF16],
    w:   pl.Tensor[[16, 16], pl.BF16],
    y:   pl.Out[pl.Tensor[[16, 16], pl.FP32]],
):
    a = win[:, :]                 # tensor.slice keeps DistributedTensorType
    prod = pl.matmul(a, w)        # ← InvalidOperationError
    y[0:16, 0:16] = prod
```

```
InvalidOperationError: pl operation 'matmul':
  tensor.matmul requires first argument to be a TensorType, but got DistributedTensorType
```

The workaround was an explicit window-to-tensor gather before every high-level matmul. That is no longer needed.

## Three defects fixed

**1. Type deduction** — `tensor.matmul`, `tensor.matmul_acc` and the row/col reductions rejected a window operand outright.

**2. Lowering (`ConvertTensorToTileOps`)** — the same exact-kind cast at four sites, so relaxing the deducers alone was **not** enough:

- A window param reaching a matmul directly (no `tensor.slice`) fell through `BridgeInputSpaces` unbridged and tripped the converter's `INTERNAL_UNREACHABLE`.
- A window param feeding an op with no `input_reqs` (e.g. `tensor.row_max`) got no Phase-1 entry load and failed the converter's `input must be TileType` check.

**3. Orchestration codegen** — `pl.read` / `pl.write` on a window aborted codegen:

```
Failed to generate orchestration 'per_rank': tensor.read input must be TensorType
  at src/codegen/tensor_op_codegen.cpp:139
```

Worse than the matmul case, because the deducer *accepts* a window here and `ConvertTensorToTileOps` deliberately leaves both ops unconverted so they lower there — a documented path that could not compile. Those two argument checks are also reclassified `INTERNAL_CHECK_SPAN` per `.claude/rules/error-checking.md` (codegen operates on verified IR).

Separately, `tensor.row_min`'s dtype post-check re-cast the operand and dereferenced the result with **no null guard**, so a window **segfaulted the compiler** once the shared reduction deducer let one through (`EXIT=139`). It now uses the same matcher plus a guard. `tensor.div` two files over has the identical shape but already used `AsTensorTypeLike`, which is why it never crashed.

## Semantics

Computing ops keep returning a plain `TensorType` — a product or a reduction is fresh local data, not a window view. Only `tensor.slice` / `tensor.assemble` propagate the window kind, unchanged. `tensor.reinterpret_view` still rejects a window by design.

## Prevention

This is the third time the `TensorType` / `DistributedTensorType` pair has been missed, so the PR also closes the loop:

- **`.claude/rules/ir-kind-traits.md`** covered only `Var` / `IterArg`, so an author learned that lesson and never connected it to `TensorType`. It now carries the window row in "the cases that bite", the question that decides exact-kind vs union matching (*is this asking **whether** the operand is GM data, or **which kind** it is?*), the legitimate exact-kind uses, and a warning that the deducer is only the first of two gates. Condensed elsewhere so the rules directory stays within its 2500-line budget (2498).
- **`docs/{en,zh}/dev/ir/02-types.md`** state which local ops accept a window and which propagate its kind.
- **`tests/ut/ir/operators/test_window_operand_acceptance.py`** classifies every registered `tensor.*` operator into exactly one bucket and probes it with a window in its GM slot:

| Bucket | Count |
| --- | --- |
| `WINDOW_OK` — accepts a window | 57 |
| `WINDOW_GAP` — should accept, does not yet | 36 |
| `WINDOW_REJECT_BY_DESIGN` | 3 |
| `NO_GM_OPERAND` | 9 |

  Adding an operator without classifying it fails, naming the choice to make. An accepted operator that starts rejecting fails (this would have caught the original matmul bug). Op-name literals route through `ir.get_op(...).name`, so a typo raises at import.

## Known gap (deliberately not in this PR)

`WINDOW_GAP` lists 36 operators that should accept a window but do not yet — every broadcast, `reshape`, `transpose`, `concat`, `set_validshape`, `dim`, `fillpad*`, all of `gather` / `scatter` / `sort32` / `paged_gather`, and `expand_clone`.

They are left out on purpose: `fillpad`, `fillpad_expand`, `expand_clone`, `gather` and `paged_gather` carry the *same* exact-kind cast inside their rules in `op_conversion_registry.cpp`, so relaxing their deducers alone converts a clear `CHECK` into an `INTERNAL_UNREACHABLE` deeper in the pipeline — exactly what defect 2 above demonstrates. Each needs its lowering path fixed and a lowering test alongside. The test asserts they still reject, so fixing one fails here and prompts moving it to `WINDOW_OK`; suggest a follow-up PR per family.

## Reviewer notes

- All eight relaxed call sites are `As<TensorType>` → `AsTensorTypeLike`; no result type changes.
- The `tensor.row_min` null-deref was **latent behind** the reduction deducer's own rejection — it only became reachable because of this PR's fix, which is why it ships together with it.

## Verification

- End to end: a `@pl.jit.host` window matmul compiles (a2a3, compile-only) to `pto.tload` from the window pointer followed by `pto.tmatmul` — no gather.
- Orchestration: `pl.read` / `pl.write` on a window emit `get_tensor_data<float>(ext_win, …)` / `set_tensor_data<float>(…)`.
- `tests/ut`: **11441 passed**, 5 skipped, 1 xfailed. `ctest`: 1/1. Full `pre-commit`: all 22 hooks pass.
- Negative-checked the new coverage test by removing `tensor.matmul` from its bucket — fails with the intended message.

New tests: 4 type-deduction cases in `test_tensor_ops.py`, 4 lowering cases (sliced matmul / matmul_acc, direct-param matmul, direct-param row_max) in `test_convert_tensor_to_tile_ops.py`, 1 orchestration-codegen case in `test_orchestration_tensor_rw.py`, plus the 98-case classification file.
