### PR TITLE
feat(jit): add artifact identity primitives and environment audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,6 +269,10 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
+    - name: Set up Python for lint hooks
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.10'
     - name: pre-commit
       uses: pre-commit/action@v3.0.0
       with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,7 +60,7 @@ repos:
           name: check-environment-inputs
           entry: python tests/lint/check_environment_inputs.py
           language: python
-          language_version: python3
+          language_version: python3.10
           pass_filenames: false
 
         - id: check-emitter-check-classification

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,6 +56,13 @@ repos:
           language_version: python3
           pass_filenames: false
 
+        - id: check-environment-inputs
+          name: check-environment-inputs
+          entry: python tests/lint/check_environment_inputs.py
+          language: python
+          language_version: python3
+          pass_filenames: false
+
         - id: check-emitter-check-classification
           name: check-emitter-check-classification
           entry: python tests/lint/check_emitter_check_classification.py

--- a/docs/en/dev/08-artifact-identity.md
+++ b/docs/en/dev/08-artifact-identity.md
@@ -1,0 +1,112 @@
+# Artifact Identity Foundations
+
+The internal `pypto._identity` module provides content hashing and deterministic
+record encoding for the persistent JIT cache proposed in [RFC #2653](https://github.com/hw-native-sys/pypto/issues/2653).
+It is not connected to JIT dispatch or artifact lookup. Existing in-process
+cache behavior and dispatch cost are unchanged.
+
+This is the first part of the identity milestone. Automatic inventories of the
+selected compilers, SDK resources, and dynamic dependencies remain a follow-up.
+The runtime's existing compiler-version tokens are not complete content
+identities and must not be promoted to persistent-cache keys.
+
+## Typed records
+
+`encode_record()` uses a versioned, type-tagged encoding. `digest_record()`
+returns its full SHA-256 digest. Supported values are `None`, booleans, integers,
+floats, strings, bytes, lists, tuples, and dictionaries with string keys.
+Dictionary insertion order does not affect the result; sequence order does.
+
+```python
+from pypto._identity import digest_record
+
+assert digest_record(True) != digest_record(1)
+assert digest_record(1) != digest_record(1.0)
+assert digest_record(0.0) != digest_record(-0.0)
+assert digest_record({"rows": 32, "cols": 64}) == digest_record({"cols": 64, "rows": 32})
+```
+
+Floats retain their IEEE-754 bits, including signed zero and NaN payloads.
+Unsupported objects, non-string dictionary keys, and cycles raise errors;
+there is no `str()`/`repr()` fallback. Adapters must explicitly normalize enum,
+path, and configuration values, preserving their semantic types. Bump the
+identity schema when changing this encoding.
+
+## File and directory inputs
+
+`ContentRoot` captures an absolute path when constructed. `fingerprint_content()`
+hashes the bytes of each supplied file and recursively enumerates directory
+inputs in sorted order. Root order and boundaries are retained. Paths remain
+part of identity until the compiler supplies stable source-location and include
+path mapping; identical content at different paths may therefore miss.
+
+Directory inventories exclude `.git`, `__pycache__`, `.pyc`, and `.pyo` metadata.
+All other resources contribute. `fingerprint_extra_sources()` filters directory
+inputs to Python sources; directly supplied files contribute regardless of
+extension. Empty additional-source lists are valid, but an empty required
+installation inventory is unavailable.
+
+Symlinks contribute resolved paths and target content. Broken links, directory
+cycles, non-regular files, unreadable inputs, and detected read-time changes
+produce an unavailable digest with a reason. Errors are not silently treated as
+empty files or omitted dependencies. File metadata helps detect races but never
+substitutes for content in an identity. This is not an atomic filesystem
+snapshot: later integration must revalidate mutable source inputs before
+publication, and installation inputs must remain immutable within a process.
+
+Additional application sources are reread for each request. An application's
+extra fingerprint supplements those inputs; it cannot replace missing files
+or toolchain evidence.
+
+## Installation inventories and missing evidence
+
+`ToolchainInputs` has five required components: PyPTO, runtime, PTO-ISA, ptoas,
+and the device/orchestration toolchain. A `ComponentInputs` inventory starts
+unavailable, even when some file paths are known. A dependency-aware adapter
+must establish completeness before clearing `unavailable_reason`.
+
+The adapter must account for actual imported code, native libraries, compiler
+resources, dynamic dependencies, headers, SDK/sysroot inputs, and link inputs.
+It must share resolution with the compilation path, including ptoas launchers
+and effective compiler selection. A file hash establishes that file's identity;
+it does not prove that the file is the complete dependency set.
+
+`InstallationIdentityCache.capture()` reports every unavailable component. Its
+result has `usable=False` and `digest=None` if any component is incomplete or
+unreadable. There is no shared `UNKNOWN` key. An extra application fingerprint
+cannot turn this result into a usable toolchain identity.
+
+Successful component reads are memoized by their complete resolved inventory,
+with synchronization for concurrent threads. Changed selection must produce a
+new inventory. Failed reads are retried rather than cached indefinitely.
+Replacing code, libraries, or tools at the same installation paths requires a
+process restart. Application source refresh never uses this memoization.
+
+## Environment classification
+
+`python/pypto/_environment.json` records environment inputs and their rationale:
+
+| Category | Required treatment at integration |
+| -------- | --------------------------------- |
+| `semantic` | Resolve effective precedence and include the value in compilation inputs. |
+| `tool_resolution` | Identify the selected tools and dependency contents, not just the search-path strings. |
+| `fresh_request` | Honor requested compilation/check/output behavior before cache lookup. |
+| `nonsemantic` | Exclude only with the recorded justification, such as terminal formatting or logging. |
+
+The registry is an audit inventory, not a blanket hash of the environment or
+an implementation of those policies. Existing diagnostic bypass behavior is
+described in [JIT functions](language/03-functions.md#compile-options-and-diagnostic-requests).
+
+`tests/lint/check_environment_inputs.py` runs in pre-commit without loading the
+native extension. It checks Python reads and C++ `getenv`/`secure_getenv` calls
+under `python/pypto`, `python/bindings`, `src`, and `include`. Recognized Python
+forms include imports, aliases, module string constants, mapping reads, and
+bulk reads. Dynamic reads need an exact file/function exception and a reason;
+that exception cannot hide a new literal variable. Unused exceptions fail.
+
+This static check does not certify dependencies inside downstream tools or
+arbitrary reflective Python code. The registry also records non-`PYPTO_*`
+inputs such as `PATH`, compiler include/library search variables, loader
+injection, and locale; the toolchain adapters must account for these before
+claiming complete identity. Unsupported dependency discovery must remain
+unavailable when persistent lookup is eventually connected.

--- a/docs/en/dev/08-artifact-identity.md
+++ b/docs/en/dev/08-artifact-identity.md
@@ -27,6 +27,8 @@ assert digest_record({"rows": 32, "cols": 64}) == digest_record({"cols": 64, "ro
 ```
 
 Floats retain their IEEE-754 bits, including signed zero and NaN payloads.
+String values and dictionary keys preserve Python code points, distinguishing
+non-BMP characters from explicit surrogate pairs before JSON serialization.
 Unsupported objects, non-string dictionary keys, and cycles raise errors;
 there is no `str()`/`repr()` fallback. Adapters must explicitly normalize enum,
 path, and configuration values, preserving their semantic types. Bump the
@@ -34,7 +36,8 @@ identity schema when changing this encoding.
 
 ## File and directory inputs
 
-`ContentRoot` captures an absolute path when constructed. `fingerprint_content()`
+`ContentRoot` captures an absolute path when constructed, preserving `..` so
+the filesystem resolves preceding symlinks correctly. `fingerprint_content()`
 hashes the bytes of each supplied file and recursively enumerates directory
 inputs in sorted order. Root order and boundaries are retained. Paths remain
 part of identity until the compiler supplies stable source-location and include
@@ -101,7 +104,9 @@ described in [JIT functions](language/03-functions.md#compile-options-and-diagno
 native extension. It checks Python reads and C++ `getenv`/`secure_getenv` calls
 under `python/pypto`, `python/bindings`, `src`, and `include`. Recognized Python
 forms include imports, aliases, module string constants, mapping reads, and
-bulk reads. Dynamic reads need an exact file/function exception and a reason;
+bulk reads. Aliases are scoped to their lexical context; ambiguous module
+constant assignments, including control-flow writes, remain dynamic.
+The hook uses Python 3.10. Dynamic reads need an exact file/function exception and a reason;
 that exception cannot hide a new literal variable. Unused exceptions fail.
 
 This static check does not certify dependencies inside downstream tools or

--- a/docs/zh/dev/08-artifact-identity.md
+++ b/docs/zh/dev/08-artifact-identity.md
@@ -1,0 +1,89 @@
+# 产物身份基础
+
+内部模块 `pypto._identity` 为 [RFC #2653](https://github.com/hw-native-sys/pypto/issues/2653)
+提出的持久 JIT 缓存提供内容哈希和确定性记录编码。
+目前未接入 JIT 调用或产物查找，现有进程内缓存行为及每次调用的开销保持不变。
+
+这是身份阶段的第一部分。实际编译器、SDK 资源和动态依赖的自动清单仍需后续实现。
+运行时已有的编译器版本 token 不是完整内容身份，不能直接作为持久缓存键。
+
+## 带类型的记录
+
+`encode_record()` 使用带版本和类型标签的编码；`digest_record()` 返回完整 SHA-256 摘要。
+支持 `None`、布尔值、整数、浮点数、字符串、字节串、列表、元组和字符串键字典。
+字典插入顺序不影响结果，序列顺序影响结果。
+
+```python
+from pypto._identity import digest_record
+
+assert digest_record(True) != digest_record(1)
+assert digest_record(1) != digest_record(1.0)
+assert digest_record(0.0) != digest_record(-0.0)
+assert digest_record({"rows": 32, "cols": 64}) == digest_record({"cols": 64, "rows": 32})
+```
+
+浮点数保留 IEEE-754 位表示，包括有符号零和 NaN payload。
+不支持的对象、非字符串字典键及循环引用会报错，不使用 `str()`/`repr()` 兜底。
+适配层必须显式转换枚举、路径和有效配置，并保留语义类型；修改编码时需提升身份 schema 版本。
+
+## 文件和目录输入
+
+`ContentRoot` 在构造时捕获绝对路径。`fingerprint_content()` 读取文件原始字节，
+并按排序后的路径递归枚举目录，保留输入根顺序及边界。
+在编译器提供稳定的源码位置和 include 路径映射之前，路径仍参与身份；
+相同内容位于不同路径时可能不命中。
+
+目录清单排除 `.git`、`__pycache__`、`.pyc` 和 `.pyo` 元数据，其他资源全部参与。
+`fingerprint_extra_sources()` 对目录只纳入 Python 源码；直接指定的文件不受扩展名限制。
+额外源码列表可以为空，但必需的安装清单为空时身份不可用。
+
+符号链接（symlink）计入实际目标路径及目标内容。断链、目录循环、非普通文件、
+不可读输入或检测到的读取期间变更，都会返回不可用摘要和原因，不能静默视为空文件或省略依赖。
+文件元数据只用于发现竞争，不能替代内容身份。这不是原子的文件系统快照：
+后续接线必须在发布前重新验证可变源码，进程内的安装输入必须保持不可变。
+
+应用额外源码在每次请求重新读取。应用提供的额外指纹只能补充输入，
+不能替代缺失文件或工具链证据。
+
+## 安装清单与缺失证据
+
+`ToolchainInputs` 包含五个必需分量：PyPTO、runtime、PTO-ISA、ptoas，
+以及设备/编排工具链。`ComponentInputs` 默认不可用，即使已经知道部分文件路径。
+具备依赖发现能力的适配层必须确认清单完整后，才能清除 `unavailable_reason`。
+
+适配层必须涵盖实际导入代码、原生库、编译器资源、动态依赖、头文件、SDK/sysroot 和链接输入。
+工具解析必须与实际编译路径共用，包括 ptoas 启动脚本及有效编译器选择。
+文件哈希只证明该文件的身份，不能证明它代表完整依赖集合。
+
+`InstallationIdentityCache.capture()` 报告所有不可用分量。
+任一清单不完整或不可读时，结果为 `usable=False`、`digest=None`，没有共享的 `UNKNOWN` 键。
+应用额外指纹不能把这个结果变成可用的工具链身份。
+
+成功的内容读取按完整解析清单记忆化，并在线程间同步。工具选择改变时必须形成新清单；
+读取失败会在下次重试，不永久缓存失败结果。在相同安装路径替换代码、库或工具需要重启进程。
+应用源码刷新不使用这种记忆化。
+
+## 环境变量分类
+
+`python/pypto/_environment.json` 登记环境输入及理由：
+
+| 类别 | 接线时必须完成的处理 |
+| ---- | -------------------- |
+| `semantic` | 按实际优先级解析有效值，纳入编译输入。 |
+| `tool_resolution` | 识别实际工具及依赖内容，不能只哈希搜索路径字符串。 |
+| `fresh_request` | 查缓存前满足重新编译、检查或输出请求。 |
+| `nonsemantic` | 仅按已记录的理由排除，例如终端格式或日志。 |
+
+登记表是审计清单，不是无差别哈希全部环境，也不代表上述策略已经接线。
+已有诊断旁路行为见 [JIT 函数](language/03-functions.md#编译选项与诊断请求)。
+
+`tests/lint/check_environment_inputs.py` 在 pre-commit 中运行，不加载原生扩展。
+它检查 `python/pypto`、`python/bindings`、`src` 和 `include` 中的 Python 读取，
+以及 C++ `getenv`/`secure_getenv` 调用。识别的 Python 写法包括导入、别名、
+模块字符串常量、映射读取和批量读取。动态读取必须有精确文件/函数及理由的例外；
+该例外不能隐藏新出现的字面量变量，未使用的例外也会导致检查失败。
+
+静态检查不能证明下游工具或任意 Python 反射代码的依赖完整性。
+登记表还列出 `PATH`、编译器 include/library 搜索变量、加载器注入和 locale 等非 `PYPTO_*` 输入；
+工具链适配层必须覆盖这些输入后，才能声称身份完整。
+后续接入持久查找时，不支持的依赖发现必须保持不可用。

--- a/docs/zh/dev/08-artifact-identity.md
+++ b/docs/zh/dev/08-artifact-identity.md
@@ -23,12 +23,14 @@ assert digest_record({"rows": 32, "cols": 64}) == digest_record({"cols": 64, "ro
 ```
 
 浮点数保留 IEEE-754 位表示，包括有符号零和 NaN payload。
+字符串值和字典键保留 Python 码点，在 JSON 序列化前区分非 BMP 字符和显式代理对。
 不支持的对象、非字符串字典键及循环引用会报错，不使用 `str()`/`repr()` 兜底。
 适配层必须显式转换枚举、路径和有效配置，并保留语义类型；修改编码时需提升身份 schema 版本。
 
 ## 文件和目录输入
 
-`ContentRoot` 在构造时捕获绝对路径。`fingerprint_content()` 读取文件原始字节，
+`ContentRoot` 在构造时捕获绝对路径，保留 `..`，让文件系统正确解析前面的符号链接。
+`fingerprint_content()` 读取文件原始字节，
 并按排序后的路径递归枚举目录，保留输入根顺序及边界。
 在编译器提供稳定的源码位置和 include 路径映射之前，路径仍参与身份；
 相同内容位于不同路径时可能不命中。
@@ -80,7 +82,9 @@ assert digest_record({"rows": 32, "cols": 64}) == digest_record({"cols": 64, "ro
 `tests/lint/check_environment_inputs.py` 在 pre-commit 中运行，不加载原生扩展。
 它检查 `python/pypto`、`python/bindings`、`src` 和 `include` 中的 Python 读取，
 以及 C++ `getenv`/`secure_getenv` 调用。识别的 Python 写法包括导入、别名、
-模块字符串常量、映射读取和批量读取。动态读取必须有精确文件/函数及理由的例外；
+模块字符串常量、映射读取和批量读取。别名按词法作用域解析；
+存在歧义的模块常量赋值（包括控制流内的写入）仍按动态读取处理。
+该 hook 使用 Python 3.10。动态读取必须有精确文件/函数及理由的例外；
 该例外不能隐藏新出现的字面量变量，未使用的例外也会导致检查失败。
 
 静态检查不能证明下游工具或任意 Python 反射代码的依赖完整性。

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -292,6 +292,7 @@ nav:
       - en/dev/index.md
       - en/dev/00-ecosystem.md
       - en/dev/01-compile-profiling.md
+      - en/dev/08-artifact-identity.md
       - en/dev/02-error-handling.md
       - en/dev/03-logging.md
       - en/dev/03-runtime-dfx.md

--- a/python/pypto/_environment.json
+++ b/python/pypto/_environment.json
@@ -1,0 +1,164 @@
+{
+  "dynamic_reads": [
+    {
+      "function": "_temporary_env",
+      "path": "python/pypto/runtime/device_runner.py",
+      "reason": "Restores caller-provided runtime overrides; each actual compilation input still needs classification at its consumer."
+    }
+  ],
+  "schema": 1,
+  "variables": {
+    "ASCEND_HOME_PATH": {
+      "category": "tool_resolution",
+      "reason": "Selects compiler, linker, SDK headers and libraries through simpler env_manager."
+    },
+    "CC": {
+      "category": "tool_resolution",
+      "reason": "Runtime build-tool selection; direct kernel compilation uses its selected toolchain object."
+    },
+    "COMPILER_PATH": {
+      "category": "tool_resolution",
+      "reason": "Can redirect compiler subprograms; resolve their contents."
+    },
+    "CPATH": {
+      "category": "tool_resolution",
+      "reason": "Additional implicit include roots; inventory ordered roots and contents."
+    },
+    "CPLUS_INCLUDE_PATH": {
+      "category": "tool_resolution",
+      "reason": "Additional C++ include roots; inventory ordered roots and contents."
+    },
+    "CXX": {
+      "category": "tool_resolution",
+      "reason": "Runtime build-tool selection and injected flags; do not substitute this for resolved tools."
+    },
+    "C_INCLUDE_PATH": {
+      "category": "tool_resolution",
+      "reason": "Additional C include roots; inventory ordered roots and contents."
+    },
+    "FORCE_COLOR": {
+      "category": "nonsemantic",
+      "reason": "Controls diagnostic terminal rendering only."
+    },
+    "GCC_EXEC_PREFIX": {
+      "category": "tool_resolution",
+      "reason": "Can redirect compiler subprograms and resources; resolve their contents."
+    },
+    "LANG": {
+      "category": "semantic",
+      "reason": "Tool locale can affect parsing and generated diagnostics; resolve with LC_ALL precedence."
+    },
+    "LC_ALL": {
+      "category": "semantic",
+      "reason": "Overrides tool locale; account for the effective compiler environment."
+    },
+    "LC_CTYPE": {
+      "category": "semantic",
+      "reason": "Character interpretation in compiler subprocesses; account for locale precedence."
+    },
+    "LD_AUDIT": {
+      "category": "tool_resolution",
+      "reason": "Injected loader code requires a complete dependency inventory or unavailable identity."
+    },
+    "LD_LIBRARY_PATH": {
+      "category": "tool_resolution",
+      "reason": "Dynamic dependency search input; fingerprint the libraries actually selected."
+    },
+    "LD_PRELOAD": {
+      "category": "tool_resolution",
+      "reason": "Injected dynamic code requires a complete dependency inventory or unavailable identity."
+    },
+    "LIBRARY_PATH": {
+      "category": "tool_resolution",
+      "reason": "Can change linker inputs; inventory the selected libraries."
+    },
+    "NO_COLOR": {
+      "category": "nonsemantic",
+      "reason": "Controls diagnostic terminal rendering only."
+    },
+    "PATH": {
+      "category": "tool_resolution",
+      "reason": "Executable search input; fingerprint resolved tools and their resources."
+    },
+    "PTOAS_ROOT": {
+      "category": "tool_resolution",
+      "reason": "Use the shared ptoas resolver; inventory the selected launcher and its dependencies."
+    },
+    "PTO_BACKTRACE": {
+      "category": "nonsemantic",
+      "reason": "Controls parser traceback presentation only."
+    },
+    "PTO_ISA_ROOT": {
+      "category": "tool_resolution",
+      "reason": "Derived runtime hint; the pinned PTO-ISA resolver owns the actual include root."
+    },
+    "PYPTO_AUTO_DEPS_LOOP_CARRY_DEBUG": {
+      "category": "nonsemantic",
+      "reason": "Diagnostic tracing of loop carry dependency analysis only."
+    },
+    "PYPTO_CODEGEN_MAX_WORKERS": {
+      "category": "nonsemantic",
+      "reason": "Bounds parallel codegen workers; does not select generated operations."
+    },
+    "PYPTO_COMPILE_PROFILING": {
+      "category": "fresh_request",
+      "reason": "Enabled compilation profiling must run compiler stages on each request."
+    },
+    "PYPTO_EMIT_DEBUG_RUNNER": {
+      "category": "fresh_request",
+      "reason": "Controls generated replay files; integration must honor output requests."
+    },
+    "PYPTO_EMIT_PTO_LOC": {
+      "category": "semantic",
+      "reason": "Resolve effective source-location emission into compilation options."
+    },
+    "PYPTO_LOG_LEVEL": {
+      "category": "nonsemantic",
+      "reason": "Logging threshold; does not select compiler transformations."
+    },
+    "PYPTO_PROG_BUILD_DIR": {
+      "category": "fresh_request",
+      "reason": "An explicit nonempty output root requests fresh JIT artifacts."
+    },
+    "PYPTO_REBUILD_FROM_PTO": {
+      "category": "fresh_request",
+      "reason": "Explicitly rebuilds edited artifacts; incompatible with immutable reuse."
+    },
+    "PYPTO_RUNTIME_LOG": {
+      "category": "nonsemantic",
+      "reason": "Runtime Python logging threshold only."
+    },
+    "PYPTO_RUNTIME_LOG_SYNC": {
+      "category": "nonsemantic",
+      "reason": "Synchronizes runtime and compiler logging thresholds only."
+    },
+    "PYPTO_VERIFY_LEVEL": {
+      "category": "fresh_request",
+      "reason": "C++ captures its default once; use the effective verification policy."
+    },
+    "PYPTO_WARNING_LEVEL": {
+      "category": "fresh_request",
+      "reason": "C++ captures its default once; use the effective diagnostic policy."
+    },
+    "PYTHONHASHSEED": {
+      "category": "semantic",
+      "reason": "Compiler Python hash iteration order must be audited before reuse across seeds."
+    },
+    "PYTHONHOME": {
+      "category": "tool_resolution",
+      "reason": "Interpreter resource selection; inventory the actual interpreter installation."
+    },
+    "PYTHONPATH": {
+      "category": "tool_resolution",
+      "reason": "Import search input; inventory actual imported compiler and runtime modules."
+    },
+    "SOURCE_DATE_EPOCH": {
+      "category": "semantic",
+      "reason": "Compiler date/time macro and reproducibility input; include the effective value."
+    },
+    "TERM": {
+      "category": "nonsemantic",
+      "reason": "Controls diagnostic terminal rendering only."
+    }
+  }
+}

--- a/python/pypto/_identity.py
+++ b/python/pypto/_identity.py
@@ -1,0 +1,306 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Content identity primitives for the planned persistent artifact store.
+
+These helpers are deliberately not called by JIT dispatch. A toolchain adapter
+must supply a complete dependency inventory before its component is usable;
+hashing a compiler executable alone is not evidence of a complete toolchain.
+No version string, Git revision, file timestamp, or build ID substitutes for
+file contents. Loaded installations are immutable during a process's lifetime.
+"""
+
+import hashlib
+import json
+import os
+import stat
+import struct
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+IDENTITY_SCHEMA = 1
+_COMPONENTS = ("pypto", "runtime", "pto_isa", "ptoas", "device_toolchain")
+_IGNORED_DIRECTORIES = frozenset({".git", "__pycache__"})
+_IGNORED_SUFFIXES = frozenset({".pyc", ".pyo"})
+
+
+def _typed_record(value: Any, ancestors: frozenset[int] = frozenset()) -> list[Any]:
+    """Encode only protocol values, preserving types and IEEE-754 bits."""
+    if value is None:
+        return ["none"]
+    if type(value) is bool:
+        return ["bool", value]
+    if type(value) is int:
+        return ["int", str(value)]
+    if type(value) is float:
+        return ["float64", struct.pack(">d", value).hex()]
+    if type(value) is str:
+        return ["str", value]
+    if type(value) is bytes:
+        return ["bytes", value.hex()]
+    if id(value) in ancestors:
+        raise ValueError("Identity records cannot contain cycles")
+    nested = ancestors | {id(value)}
+    if type(value) in (list, tuple):
+        return [type(value).__name__, [_typed_record(item, nested) for item in value]]
+    if type(value) is dict:
+        if any(type(key) is not str for key in value):
+            raise TypeError("Identity record dictionary keys must be strings")
+        return ["dict", [[key, _typed_record(value[key], nested)] for key in sorted(value)]]
+    raise TypeError(f"Unsupported identity record type: {type(value).__module__}.{type(value).__qualname__}")
+
+
+def encode_record(value: Any) -> bytes:
+    """Encode a versioned identity record without coercing unsupported objects.
+
+    Accepted values are None, bool, int, float, str, bytes, lists, tuples, and
+    dictionaries with string keys. Callers must explicitly normalize enums,
+    paths, and effective configuration objects into these protocol types.
+    """
+    return json.dumps(
+        ["pypto.identity", IDENTITY_SCHEMA, _typed_record(value)],
+        ensure_ascii=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("ascii")
+
+
+def digest_record(value: Any) -> str:
+    """Return the full SHA-256 digest of a typed, versioned record."""
+    return hashlib.sha256(encode_record(value)).hexdigest()
+
+
+@dataclass(frozen=True)
+class ContentRoot:
+    """One ordered content input, with its path captured at construction.
+
+    A file contributes its exact bytes. A directory contributes every regular
+    file recursively, except Git metadata and generated Python bytecode.
+    ``python_only`` filters directory entries to ``.py`` files for additional
+    application source roots; it never filters a directly supplied file.
+    Paths participate in identity because source locations and includes are
+    not yet remapped to a relocatable namespace.
+    """
+
+    path: Path
+    python_only: bool = False
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "path", Path(os.path.abspath(self.path)))
+
+
+@dataclass(frozen=True)
+class IdentityFailure:
+    """Why an input cannot be assigned a reusable content identity."""
+
+    component: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class ContentIdentity:
+    """A complete content digest or an explicit failure, never an UNKNOWN key."""
+
+    digest: str | None
+    failure: str | None = None
+
+
+def _file_digest(path: Path) -> tuple[int, str]:
+    with path.open("rb") as stream:
+        before = os.fstat(stream.fileno())
+        if not stat.S_ISREG(before.st_mode):
+            raise ValueError(f"Identity input is not a regular file: {path}")
+        digest = hashlib.sha256()
+        while chunk := stream.read(1024 * 1024):
+            digest.update(chunk)
+        after = os.fstat(stream.fileno())
+    # Metadata is a race detector, not an identity or a memoization key.
+    if (before.st_size, before.st_mtime_ns, before.st_ctime_ns) != (
+        after.st_size,
+        after.st_mtime_ns,
+        after.st_ctime_ns,
+    ):
+        raise ValueError(f"Identity input changed while being read: {path}")
+    current = path.stat()
+    if (after.st_dev, after.st_ino, after.st_size, after.st_mtime_ns, after.st_ctime_ns) != (
+        current.st_dev,
+        current.st_ino,
+        current.st_size,
+        current.st_mtime_ns,
+        current.st_ctime_ns,
+    ):
+        raise ValueError(f"Identity input was replaced while being read: {path}")
+    return after.st_size, digest.hexdigest()
+
+
+def _content_entries(
+    path: Path,
+    relative: str,
+    python_only: bool,
+    ancestors: frozenset[Path],
+) -> list[tuple[Any, ...]]:
+    resolved = path.resolve(strict=True)
+    mode = resolved.stat().st_mode
+    if stat.S_ISDIR(mode):
+        if resolved in ancestors:
+            raise ValueError(f"Identity input contains a directory symlink cycle: {path}")
+        # scandir propagates unreadable-directory errors; glob may silently
+        # omit them and give a smaller, apparently valid dependency set.
+        with os.scandir(path) as scan:
+            names = sorted(entry.name for entry in scan)
+        entries: list[tuple[Any, ...]] = [] if python_only else [("directory", relative, str(resolved))]
+        for name in names:
+            if name in _IGNORED_DIRECTORIES:
+                continue
+            child = path / name
+            child_relative = f"{relative}/{name}" if relative else name
+            if not child.is_dir() and (
+                child.suffix in _IGNORED_SUFFIXES or (python_only and child.suffix != ".py")
+            ):
+                continue
+            entries.extend(_content_entries(child, child_relative, python_only, ancestors | {resolved}))
+        with os.scandir(path) as scan:
+            after = sorted(entry.name for entry in scan)
+        if names != after or resolved != path.resolve(strict=True):
+            raise ValueError(f"Identity directory changed while being read: {path}")
+        return entries
+    if not stat.S_ISREG(mode):
+        raise ValueError(f"Identity input is not a regular file or directory: {path}")
+    size, digest = _file_digest(path)
+    if resolved != path.resolve(strict=True):
+        raise ValueError(f"Identity symlink changed while being read: {path}")
+    return [("file", relative, str(resolved), size, digest)]
+
+
+def fingerprint_content(roots: tuple[ContentRoot, ...]) -> ContentIdentity:
+    """Read every declared input and return its digest, or explain failure.
+
+    Input order and root boundaries are preserved, including roots with equal
+    basenames. Empty inventories are unavailable. This does not discover
+    dependencies or certify that a caller's inventory is complete.
+    """
+    if not roots:
+        return ContentIdentity(None, "No content inputs were supplied")
+    records = []
+    try:
+        for root in roots:
+            records.append(
+                (
+                    str(root.path),
+                    root.python_only,
+                    _content_entries(root.path, "", root.python_only, frozenset()),
+                )
+            )
+    except (OSError, RuntimeError, ValueError) as exc:
+        return ContentIdentity(None, str(exc))
+    return ContentIdentity(digest_record(("content", records)))
+
+
+def fingerprint_extra_sources(
+    paths: tuple[Path, ...], extra_fingerprint: str | None = None
+) -> ContentIdentity:
+    """Refresh application sources on every request, outside installation memoization."""
+    roots = tuple(ContentRoot(path, python_only=True) for path in paths)
+    content = fingerprint_content(roots) if roots else ContentIdentity(digest_record(("content", [])))
+    if content.digest is None:
+        return content
+    return ContentIdentity(digest_record(("extra_sources", content.digest, extra_fingerprint)))
+
+
+@dataclass(frozen=True)
+class ComponentInputs:
+    """Inventory supplied by a dependency-aware compiler/toolchain adapter.
+
+    An adapter must leave ``unavailable_reason`` set until it has accounted
+    for all resources and dynamic dependencies, even if it knows some files.
+    A caller-supplied application fingerprint cannot complete this inventory.
+    """
+
+    roots: tuple[ContentRoot, ...] = ()
+    unavailable_reason: str | None = "Dependency inventory has not been established"
+
+
+@dataclass(frozen=True)
+class ToolchainInputs:
+    """Required component inventories, selected by the actual compilation path."""
+
+    pypto: ComponentInputs
+    runtime: ComponentInputs
+    pto_isa: ComponentInputs
+    ptoas: ComponentInputs
+    device_toolchain: ComponentInputs
+
+
+@dataclass(frozen=True)
+class ToolchainIdentity:
+    """Content identities and actionable reasons for every unavailable component."""
+
+    pypto: str | None
+    runtime: str | None
+    pto_isa: str | None
+    ptoas: str | None
+    device_toolchain: str | None
+    failures: tuple[IdentityFailure, ...] = ()
+    schema: int = IDENTITY_SCHEMA
+
+    @property
+    def usable(self) -> bool:
+        """Whether all required inventories could be read completely."""
+        return not self.failures and all(getattr(self, name) is not None for name in _COMPONENTS)
+
+    @property
+    def digest(self) -> str | None:
+        """Return a combined identity only when all components are available."""
+        if not self.usable:
+            return None
+        return digest_record(("toolchain", self.schema, {name: getattr(self, name) for name in _COMPONENTS}))
+
+
+class InstallationIdentityCache:
+    """Memoize successful reads of a process's immutable installation inputs.
+
+    The complete resolved inventory selects the entry; there is no unkeyed
+    singleton identity. Adapters must resolve tools again when their selection
+    configuration changes. Replacing installed code or libraries at the same
+    paths requires a process restart. Per-request application sources must use
+    ``fingerprint_extra_sources`` instead of this cache.
+    """
+
+    def __init__(self) -> None:
+        self._components: dict[ComponentInputs, str] = {}
+        self._lock = threading.Lock()
+
+    def capture(self, inputs: ToolchainInputs) -> ToolchainIdentity:
+        """Hash complete component inventories, preserving every failure reason."""
+        digests: dict[str, str | None] = {}
+        failures = []
+        with self._lock:
+            for name in _COMPONENTS:
+                component: ComponentInputs = getattr(inputs, name)
+                if component.unavailable_reason is not None:
+                    result = ContentIdentity(None, component.unavailable_reason)
+                elif component in self._components:
+                    result = ContentIdentity(self._components[component])
+                else:
+                    result = fingerprint_content(component.roots)
+                    if result.digest is not None:
+                        self._components[component] = result.digest
+                digests[name] = result.digest
+                if result.digest is None:
+                    failures.append(IdentityFailure(name, result.failure or "Content identity unavailable"))
+        return ToolchainIdentity(
+            pypto=digests["pypto"],
+            runtime=digests["runtime"],
+            pto_isa=digests["pto_isa"],
+            ptoas=digests["ptoas"],
+            device_toolchain=digests["device_toolchain"],
+            failures=tuple(failures),
+        )

--- a/python/pypto/_identity.py
+++ b/python/pypto/_identity.py
@@ -43,7 +43,9 @@ def _typed_record(value: Any, ancestors: frozenset[int] = frozenset()) -> list[A
     if type(value) is float:
         return ["float64", struct.pack(">d", value).hex()]
     if type(value) is str:
-        return ["str", value]
+        # JSON escapes a non-BMP character and its explicit surrogate pair
+        # identically. Preserve Python code points before entering JSON.
+        return ["str", value.encode("utf-8", errors="surrogatepass").hex()]
     if type(value) is bytes:
         return ["bytes", value.hex()]
     if id(value) in ancestors:
@@ -54,7 +56,10 @@ def _typed_record(value: Any, ancestors: frozenset[int] = frozenset()) -> list[A
     if type(value) is dict:
         if any(type(key) is not str for key in value):
             raise TypeError("Identity record dictionary keys must be strings")
-        return ["dict", [[key, _typed_record(value[key], nested)] for key in sorted(value)]]
+        return [
+            "dict",
+            [[_typed_record(key, nested), _typed_record(value[key], nested)] for key in sorted(value)],
+        ]
     raise TypeError(f"Unsupported identity record type: {type(value).__module__}.{type(value).__qualname__}")
 
 
@@ -94,7 +99,9 @@ class ContentRoot:
     python_only: bool = False
 
     def __post_init__(self) -> None:
-        object.__setattr__(self, "path", Path(os.path.abspath(self.path)))
+        # abspath/normpath would collapse symlink/.. before the filesystem can
+        # resolve it, potentially selecting a different file.
+        object.__setattr__(self, "path", Path.cwd() / self.path)
 
 
 @dataclass(frozen=True)
@@ -162,7 +169,12 @@ def _content_entries(
                 continue
             child = path / name
             child_relative = f"{relative}/{name}" if relative else name
-            if not child.is_dir() and (
+            # is_dir() returns False for dangling links, which must not turn
+            # an unavailable source subtree into an excluded non-Python file.
+            child_mode = child.resolve(strict=True).stat().st_mode
+            if not (stat.S_ISDIR(child_mode) or stat.S_ISREG(child_mode)):
+                raise ValueError(f"Identity input is not a regular file or directory: {child}")
+            if stat.S_ISREG(child_mode) and (
                 child.suffix in _IGNORED_SUFFIXES or (python_only and child.suffix != ".py")
             ):
                 continue

--- a/tests/lint/check_environment_inputs.py
+++ b/tests/lint/check_environment_inputs.py
@@ -1,0 +1,234 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Require an identity classification for Python/C++ environment reads.
+
+Runs without importing PyPTO or its native extension. Python imports, aliases,
+module string constants, getenv, and environ access are recognized. Unresolved
+names and bulk reads require a reason attached to the exact file and function.
+C++ getenv/secure_getenv arguments must be string literals. This inventories
+PyPTO consumers; implicit tool inputs in the registry need separate toolchain
+dependency discovery and are not certified by this source scan.
+"""
+
+import ast
+import json
+import re
+from pathlib import Path
+from typing import Any, NamedTuple
+
+from _cpp_text import strip_cpp_comments
+
+_ROOT = Path(__file__).resolve().parents[2]
+_CATEGORIES = {"semantic", "tool_resolution", "fresh_request", "nonsemantic"}
+
+
+class EnvironmentRead(NamedTuple):
+    variable: str | None
+    line: int
+    function: str
+
+
+def _qualified(node: ast.AST, aliases: dict[str, str]) -> str:
+    if isinstance(node, ast.Name):
+        return aliases.get(node.id, node.id)
+    if isinstance(node, ast.Attribute):
+        return f"{_qualified(node.value, aliases)}.{node.attr}"
+    return ""
+
+
+def _string(node: ast.AST | None, constants: dict[str, str]) -> str | None:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.Constant) and isinstance(node.value, bytes):
+        try:
+            return node.value.decode("ascii")
+        except UnicodeDecodeError:
+            return None
+    if isinstance(node, ast.Name):
+        return constants.get(node.id)
+    return None
+
+
+def _import_aliases(tree: ast.Module) -> dict[str, str]:
+    aliases: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                aliases[alias.asname or alias.name] = alias.name
+        elif isinstance(node, ast.ImportFrom) and node.module == "os":
+            for alias in node.names:
+                aliases[alias.asname or alias.name] = f"os.{alias.name}"
+    return aliases
+
+
+def _bindings(tree: ast.Module) -> tuple[dict[str, str], dict[str, str]]:
+    aliases = _import_aliases(tree)
+    constants: dict[str, str] = {}
+    for node in tree.body:
+        if isinstance(node, (ast.Assign, ast.AnnAssign)):
+            targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+            for target in targets:
+                if isinstance(target, ast.Name):
+                    value = _string(node.value, constants)
+                    if value is not None:
+                        constants[target.id] = value
+                    else:
+                        constants.pop(target.id, None)
+                    qualified = _qualified(node.value, aliases) if node.value is not None else ""
+                    if qualified.startswith("os."):
+                        aliases[target.id] = qualified
+    # Local aliases need recognition too; otherwise assigning env=os.environ
+    # inside a function would hide every later env.get() from the inventory.
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Assign, ast.AnnAssign)):
+            qualified = _qualified(node.value, aliases) if node.value is not None else ""
+            if qualified.startswith("os."):
+                targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+                for target in targets:
+                    if isinstance(target, ast.Name):
+                        aliases[target.id] = qualified
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Global):
+            for name in node.names:
+                constants.pop(name, None)
+    return aliases, constants
+
+
+def _function_constants(node: ast.AST, constants: dict[str, str]) -> dict[str, str]:
+    """Do not mistake a shadowed module constant for a static environment name."""
+    shadowed = {
+        item.id for item in ast.walk(node) if isinstance(item, ast.Name) and isinstance(item.ctx, ast.Store)
+    }
+    shadowed.update(item.arg for item in ast.walk(node) if isinstance(item, ast.arg))
+    return {key: value for key, value in constants.items() if key not in shadowed}
+
+
+def python_reads(source: str) -> list[EnvironmentRead]:
+    """Find static and unresolved environment reads in Python source."""
+    tree = ast.parse(source)
+    aliases, constants = _bindings(tree)
+    parents = {child: node for node in ast.walk(tree) for child in ast.iter_child_nodes(node)}
+    reads = []
+    for node in ast.walk(tree):
+        argument: ast.AST | None = None
+        matched = False
+        if isinstance(node, ast.Call):
+            name = _qualified(node.func, aliases)
+            if name in {
+                "os.getenv",
+                "os.getenvb",
+                "os.environ.get",
+                "os.environ.pop",
+                "os.environ.setdefault",
+                "os.environb.get",
+                "os.environb.pop",
+                "os.environb.setdefault",
+            }:
+                argument = (
+                    node.args[0]
+                    if node.args
+                    else next((keyword.value for keyword in node.keywords if keyword.arg == "key"), None)
+                )
+                matched = True
+            elif name.startswith(("os.environ.", "os.environb.")):
+                matched = True
+        elif isinstance(node, ast.Subscript) and isinstance(node.ctx, ast.Load):
+            if _qualified(node.value, aliases) in {"os.environ", "os.environb"}:
+                argument = node.slice
+                matched = True
+        elif _qualified(node, aliases) in {"os.environ", "os.environb"}:
+            parent = parents.get(node)
+            # Accesses handled above. Storing the mapping in an alias is also
+            # recognized; passing/iterating/copying it is a dynamic bulk read.
+            matched = not isinstance(parent, (ast.Attribute, ast.Subscript, ast.Assign, ast.AnnAssign))
+        if matched and isinstance(node, ast.expr):
+            current = parents.get(node)
+            function = "<module>"
+            effective_constants = constants
+            while current is not None:
+                if isinstance(current, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    if function == "<module>":
+                        function = current.name
+                    effective_constants = _function_constants(current, effective_constants)
+                current = parents.get(current)
+            reads.append(EnvironmentRead(_string(argument, effective_constants), node.lineno, function))
+    return reads
+
+
+def cpp_reads(source: str) -> list[EnvironmentRead]:
+    """Find getenv calls outside C++ comments and string literals."""
+    source = strip_cpp_comments(source)
+    string = r'"(?:\\.|[^"\\])*"'
+    pattern = re.compile(rf"{string}|\b(?:getenv|secure_getenv)\s*\(")
+    argument_pattern = re.compile(rf"\s*((?:{string}\s*)+)\)")
+    reads = []
+    for match in pattern.finditer(source):
+        if match.group().startswith('"'):
+            continue
+        argument = argument_pattern.match(source, match.end())
+        variable = None
+        if argument is not None:
+            variable = "".join(ast.literal_eval(token) for token in re.findall(string, argument.group(1)))
+        reads.append(EnvironmentRead(variable, source.count("\n", 0, match.start()) + 1, "<cpp>"))
+    return reads
+
+
+def check_registry(registry: dict[str, Any]) -> None:
+    """Reject unreviewable classifications and broad dynamic-read exceptions."""
+    if registry.get("schema") != 1 or not isinstance(registry.get("variables"), dict):
+        raise ValueError("Environment registry must have schema=1 and a variables mapping")
+    for name, rule in registry["variables"].items():
+        if not re.fullmatch(r"[A-Z][A-Z0-9_]*", name):
+            raise ValueError(f"Invalid environment variable name: {name}")
+        if rule.get("category") not in _CATEGORIES or not rule.get("reason", "").strip():
+            raise ValueError(f"Environment classification needs a known category and reason: {name}")
+    for rule in registry.get("dynamic_reads", []):
+        if not all(
+            isinstance(rule.get(key), str) and rule[key].strip() for key in ("path", "function", "reason")
+        ):
+            raise ValueError("Dynamic-read exceptions require path, function, and reason")
+        if rule["path"].startswith("/") or "*" in rule["path"] or "*" in rule["function"]:
+            raise ValueError("Dynamic-read exceptions must name an exact relative path and function")
+
+
+def check_tree(root: Path, registry: dict[str, Any]) -> list[str]:
+    """Report every unclassified read in PyPTO Python/C++ production sources."""
+    check_registry(registry)
+    exceptions = {(item["path"], item["function"]) for item in registry.get("dynamic_reads", [])}
+    used = set()
+    errors = []
+    files = sorted((root / "python" / "pypto").rglob("*.py"))
+    for directory in ("src", "include", "python/bindings"):
+        files.extend(sorted(path for path in (root / directory).rglob("*") if path.suffix in {".cpp", ".h"}))
+    for path in files:
+        relative = path.relative_to(root).as_posix()
+        reads = python_reads(path.read_text()) if path.suffix == ".py" else cpp_reads(path.read_text())
+        for read in reads:
+            if read.variable is None and (relative, read.function) in exceptions:
+                used.add((relative, read.function))
+            elif read.variable not in registry["variables"]:
+                name = read.variable or f"dynamic read in {read.function}"
+                errors.append(f"{relative}:{read.line}: unclassified environment input: {name}")
+    errors.extend(
+        f"Unused dynamic-read exception: {path}:{function}" for path, function in sorted(exceptions - used)
+    )
+    return errors
+
+
+def main() -> int:
+    registry = json.loads((_ROOT / "python/pypto/_environment.json").read_text())
+    errors = check_tree(_ROOT, registry)
+    for error in errors:
+        print(error)
+    return int(bool(errors))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/lint/check_environment_inputs.py
+++ b/tests/lint/check_environment_inputs.py
@@ -35,12 +35,12 @@ class EnvironmentRead(NamedTuple):
     function: str
 
 
-def _qualified(node: ast.AST, aliases: dict[str, str]) -> str:
+def _qualified(node: ast.AST, aliases: dict[str, set[str]]) -> set[str]:
     if isinstance(node, ast.Name):
-        return aliases.get(node.id, node.id)
+        return aliases.get(node.id, set())
     if isinstance(node, ast.Attribute):
-        return f"{_qualified(node.value, aliases)}.{node.attr}"
-    return ""
+        return {f"{name}.{node.attr}" for name in _qualified(node.value, aliases)}
+    return set()
 
 
 def _string(node: ast.AST | None, constants: dict[str, str]) -> str | None:
@@ -56,49 +56,79 @@ def _string(node: ast.AST | None, constants: dict[str, str]) -> str | None:
     return None
 
 
-def _import_aliases(tree: ast.Module) -> dict[str, str]:
-    aliases: dict[str, str] = {}
-    for node in ast.walk(tree):
+_SCOPES = (ast.Module, ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Lambda)
+
+
+def _scope_nodes(scope: ast.AST) -> list[ast.AST]:
+    """Collect one lexical scope, including control flow but not nested bodies."""
+    nodes = []
+    pending = list(reversed(list(ast.iter_child_nodes(scope))))
+    while pending:
+        node = pending.pop()
+        nodes.append(node)
+        if not isinstance(node, _SCOPES):
+            pending.extend(reversed(list(ast.iter_child_nodes(node))))
+    return nodes
+
+
+def _bound_names(node: ast.AST) -> set[str]:
+    if isinstance(node, ast.Name) and isinstance(node.ctx, (ast.Store, ast.Del)):
+        return {node.id}
+    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+        return {node.name}
+    if isinstance(node, ast.arg):
+        return {node.arg}
+    if isinstance(node, (ast.Import, ast.ImportFrom)):
+        return {alias.asname or alias.name.split(".")[0] for alias in node.names}
+    if isinstance(node, ast.ExceptHandler) and node.name is not None:
+        return {node.name}
+    return set()
+
+
+def _bindings(scope: ast.AST, inherited: dict[str, set[str]]) -> tuple[dict[str, set[str]], dict[str, str]]:
+    nodes = _scope_nodes(scope)
+    stores: dict[str, int] = {}
+    for node in nodes:
+        for name in _bound_names(node):
+            stores[name] = stores.get(name, 0) + 1
+    aliases = {name: values.copy() for name, values in inherited.items() if name not in stores}
+    # Keep every possible imported/environment alias in this scope. A later
+    # assignment must not erase an earlier read, or a conditional read path.
+    for node in nodes:
         if isinstance(node, ast.Import):
             for alias in node.names:
-                aliases[alias.asname or alias.name] = alias.name
+                name = alias.asname or alias.name.split(".")[0]
+                aliases.setdefault(name, set()).add(alias.name if alias.asname else name)
         elif isinstance(node, ast.ImportFrom) and node.module == "os":
             for alias in node.names:
-                aliases[alias.asname or alias.name] = f"os.{alias.name}"
-    return aliases
+                aliases.setdefault(alias.asname or alias.name, set()).add(f"os.{alias.name}")
+    for node in nodes:
+        if isinstance(node, (ast.Assign, ast.AnnAssign)) and node.value is not None:
+            qualified = {name for name in _qualified(node.value, aliases) if name.startswith("os.")}
+            targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+            for target in targets:
+                if isinstance(target, ast.Name) and qualified:
+                    aliases.setdefault(target.id, set()).update(qualified)
+    return aliases, _scope_constants(scope, stores)
 
 
-def _bindings(tree: ast.Module) -> tuple[dict[str, str], dict[str, str]]:
-    aliases = _import_aliases(tree)
+def _scope_constants(scope: ast.AST, stores: dict[str, int]) -> dict[str, str]:
+    """Accept module constants only when no other write can change the name."""
     constants: dict[str, str] = {}
-    for node in tree.body:
+    body = scope.body if isinstance(scope, (ast.Module, ast.ClassDef)) else []
+    for node in body:
         if isinstance(node, (ast.Assign, ast.AnnAssign)):
             targets = node.targets if isinstance(node, ast.Assign) else [node.target]
             for target in targets:
-                if isinstance(target, ast.Name):
+                if isinstance(target, ast.Name) and stores.get(target.id) == 1:
                     value = _string(node.value, constants)
                     if value is not None:
                         constants[target.id] = value
-                    else:
-                        constants.pop(target.id, None)
-                    qualified = _qualified(node.value, aliases) if node.value is not None else ""
-                    if qualified.startswith("os."):
-                        aliases[target.id] = qualified
-    # Local aliases need recognition too; otherwise assigning env=os.environ
-    # inside a function would hide every later env.get() from the inventory.
-    for node in ast.walk(tree):
-        if isinstance(node, (ast.Assign, ast.AnnAssign)):
-            qualified = _qualified(node.value, aliases) if node.value is not None else ""
-            if qualified.startswith("os."):
-                targets = node.targets if isinstance(node, ast.Assign) else [node.target]
-                for target in targets:
-                    if isinstance(target, ast.Name):
-                        aliases[target.id] = qualified
-    for node in ast.walk(tree):
+    for node in ast.walk(scope):
         if isinstance(node, ast.Global):
             for name in node.names:
                 constants.pop(name, None)
-    return aliases, constants
+    return constants
 
 
 def _function_constants(node: ast.AST, constants: dict[str, str]) -> dict[str, str]:
@@ -113,15 +143,36 @@ def _function_constants(node: ast.AST, constants: dict[str, str]) -> dict[str, s
 def python_reads(source: str) -> list[EnvironmentRead]:
     """Find static and unresolved environment reads in Python source."""
     tree = ast.parse(source)
-    aliases, constants = _bindings(tree)
+    aliases, constants = _bindings(tree, {})
     parents = {child: node for node in ast.walk(tree) for child in ast.iter_child_nodes(node)}
+    scope_aliases: dict[ast.AST, dict[str, set[str]]] = {tree: aliases}
+
+    def aliases_for(scope: ast.AST) -> dict[str, set[str]]:
+        if scope not in scope_aliases:
+            parent = parents[scope]
+            while not isinstance(parent, _SCOPES):
+                parent = parents[parent]
+            # Method bodies use enclosing function/module globals, not class
+            # attributes; a class body itself still sees its own assignments.
+            if isinstance(scope, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+                while isinstance(parent, ast.ClassDef):
+                    parent = parents[parent]
+                    while not isinstance(parent, _SCOPES):
+                        parent = parents[parent]
+            scope_aliases[scope] = _bindings(scope, aliases_for(parent))[0]
+        return scope_aliases[scope]
+
     reads = []
     for node in ast.walk(tree):
+        scope = parents.get(node, tree)
+        while not isinstance(scope, _SCOPES):
+            scope = parents[scope]
+        aliases = aliases_for(scope)
         argument: ast.AST | None = None
         matched = False
         if isinstance(node, ast.Call):
-            name = _qualified(node.func, aliases)
-            if name in {
+            names = _qualified(node.func, aliases)
+            if names & {
                 "os.getenv",
                 "os.getenvb",
                 "os.environ.get",
@@ -137,13 +188,13 @@ def python_reads(source: str) -> list[EnvironmentRead]:
                     else next((keyword.value for keyword in node.keywords if keyword.arg == "key"), None)
                 )
                 matched = True
-            elif name.startswith(("os.environ.", "os.environb.")):
+            elif any(name.startswith(("os.environ.", "os.environb.")) for name in names):
                 matched = True
         elif isinstance(node, ast.Subscript) and isinstance(node.ctx, ast.Load):
-            if _qualified(node.value, aliases) in {"os.environ", "os.environb"}:
+            if _qualified(node.value, aliases) & {"os.environ", "os.environb"}:
                 argument = node.slice
                 matched = True
-        elif _qualified(node, aliases) in {"os.environ", "os.environb"}:
+        elif _qualified(node, aliases) & {"os.environ", "os.environb"}:
             parent = parents.get(node)
             # Accesses handled above. Storing the mapping in an alias is also
             # recognized; passing/iterating/copying it is a dynamic bulk read.
@@ -153,8 +204,10 @@ def python_reads(source: str) -> list[EnvironmentRead]:
             function = "<module>"
             effective_constants = constants
             while current is not None:
-                if isinstance(current, (ast.FunctionDef, ast.AsyncFunctionDef)):
-                    if function == "<module>":
+                if isinstance(current, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda, ast.ClassDef)):
+                    if function == "<module>" and isinstance(
+                        current, (ast.FunctionDef, ast.AsyncFunctionDef)
+                    ):
                         function = current.name
                     effective_constants = _function_constants(current, effective_constants)
                 current = parents.get(current)

--- a/tests/ut/jit/test_identity.py
+++ b/tests/ut/jit/test_identity.py
@@ -1,0 +1,358 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Protocol and content identity tests; no toolchain or device is required."""
+
+import os
+import struct
+import subprocess
+import sys
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import replace
+from enum import IntEnum
+from pathlib import Path
+
+import pytest
+from pypto import _identity
+from pypto._identity import (
+    ComponentInputs,
+    ContentRoot,
+    InstallationIdentityCache,
+    ToolchainInputs,
+    digest_record,
+    encode_record,
+    fingerprint_content,
+    fingerprint_extra_sources,
+)
+
+
+def test_protocol_is_typed_and_preserves_float_bits():
+    values = [None, False, True, 0, 1, 0.0, -0.0, 1.0, "1", b"1", [1], (1,), {"x": 1}]
+    assert len({digest_record(value) for value in values}) == len(values)
+    nans = [struct.unpack(">d", bytes.fromhex(bits))[0] for bits in ("7ff8000000000001", "7ff8000000000002")]
+    assert digest_record(nans[0]) != digest_record(nans[1])
+    assert digest_record(nans[0]) == digest_record(nans[0])
+    assert digest_record(float("inf")) != digest_record(float("-inf"))
+
+
+def test_record_order_boundaries_and_schema(monkeypatch):
+    assert encode_record({"b": [2], "a": 1}) == encode_record({"a": 1, "b": [2]})
+    assert digest_record(["ab", "c"]) != digest_record(["a", "bc"])
+    assert digest_record([1, 2]) != digest_record([2, 1])
+    before = digest_record({"a": 1})
+    assert len(before) == 64
+    monkeypatch.setattr(_identity, "IDENTITY_SCHEMA", _identity.IDENTITY_SCHEMA + 1)
+    assert digest_record({"a": 1}) != before
+
+
+def test_records_are_stable_across_process_hash_seeds():
+    code = (
+        "from pypto._identity import digest_record; "
+        'print(digest_record({key: key for key in {"alpha", "beta", "gamma"}}))'
+    )
+    outputs = [
+        subprocess.run(
+            [sys.executable, "-c", code],
+            env={**os.environ, "PYTHONHASHSEED": seed},
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=30,
+        ).stdout.strip()
+        for seed in ("1", "42")
+    ]
+    assert outputs[0] == outputs[1] == digest_record({key: key for key in ("alpha", "beta", "gamma")})
+
+
+@pytest.mark.parametrize("value", [object(), Path("input"), {1: "value"}, {1, 2}])
+def test_unsupported_values_are_not_stringified(value):
+    with pytest.raises(TypeError, match="identity record|Identity record"):
+        encode_record(value)
+
+
+def test_int_enum_is_not_silently_encoded_as_an_integer():
+    class Mode(IntEnum):
+        FAST = 1
+
+    with pytest.raises(TypeError, match="Unsupported identity record type"):
+        digest_record(Mode.FAST)
+
+
+def test_cycles_are_rejected_but_shared_subrecords_are_allowed():
+    value = []
+    value.append(value)
+    with pytest.raises(ValueError, match="cycles"):
+        encode_record(value)
+    shared = [1]
+    assert encode_record([shared, shared]) == encode_record([[1], [1]])
+
+
+def test_content_changes_with_unchanged_size_timestamp_and_build_id(tmp_path):
+    library = tmp_path / "compiler.so"
+    library.write_bytes(b"build-id:fixed;code:AAAA")
+    roots = (ContentRoot(library),)
+    before = fingerprint_content(roots)
+    metadata = library.stat()
+    library.write_bytes(b"build-id:fixed;code:BBBB")
+    os.utime(library, ns=(metadata.st_atime_ns, metadata.st_mtime_ns))
+    after = fingerprint_content(roots)
+    assert before.digest is not None
+    assert after.digest is not None
+    assert before.digest != after.digest
+    assert fingerprint_content(roots) == after
+
+
+def test_timestamp_only_change_keeps_content_identity(tmp_path):
+    source = tmp_path / "kernel.py"
+    source.write_text("rows = 32\n")
+    roots = (ContentRoot(source),)
+    before = fingerprint_content(roots)
+    os.utime(source, ns=(1_000_000_000, 1_000_000_000))
+    assert fingerprint_content(roots) == before
+
+
+def test_tree_tracks_resources_and_ignores_only_declared_metadata(tmp_path):
+    source = tmp_path / "compiler.py"
+    source.write_text("rows = 32\n")
+    resource = tmp_path / "resource.json"
+    resource.write_text('{"option": 1}')
+    roots = (ContentRoot(tmp_path),)
+    before = fingerprint_content(roots)
+    for directory in (".git", "__pycache__"):
+        (tmp_path / directory).mkdir()
+        (tmp_path / directory / "ignored").write_bytes(b"metadata")
+    (tmp_path / "compiler.pyc").write_bytes(b"bytecode")
+    assert fingerprint_content(roots) == before
+    resource.write_text('{"option": 2}')
+    assert fingerprint_content(roots).digest != before.digest
+
+
+def test_extra_directories_refresh_python_sources_and_preserve_roots(tmp_path):
+    roots = tuple(tmp_path / name for name in ("one", "two"))
+    for root in roots:
+        root.mkdir()
+        (root / "kernel.py").write_text("rows = 32\n")
+    before = fingerprint_extra_sources(roots)
+    (roots[1] / "kernel.py").write_text("rows = 64\n")
+    after = fingerprint_extra_sources(roots)
+    assert after.digest != before.digest
+    assert after.digest != fingerprint_extra_sources(tuple(reversed(roots))).digest
+    (roots[1] / "notes.txt").write_text("not an additional Python dependency")
+    (roots[1] / "empty-doc-directory").mkdir()
+    assert fingerprint_extra_sources(roots) == after
+    assert fingerprint_extra_sources((roots[1] / "notes.txt",)).digest is not None
+    assert fingerprint_extra_sources(roots, "config-a") != fingerprint_extra_sources(roots, "config-b")
+
+
+def test_paths_remain_semantic_until_codegen_has_stable_path_mapping(tmp_path):
+    first, second = tmp_path / "one.py", tmp_path / "two.py"
+    first.write_text("rows = 32\n")
+    second.write_bytes(first.read_bytes())
+    assert fingerprint_extra_sources((first,)).digest != fingerprint_extra_sources((second,)).digest
+
+
+def test_relative_roots_capture_the_callers_working_directory(tmp_path, monkeypatch):
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    (first / "kernel.py").write_text("rows = 32\n")
+    monkeypatch.chdir(first)
+    root = ContentRoot(Path("kernel.py"))
+    before = fingerprint_content((root,))
+    monkeypatch.chdir(second)
+    assert root.path == first / "kernel.py"
+    assert fingerprint_content((root,)) == before
+
+
+def test_missing_inputs_do_not_shrink_an_inventory(tmp_path):
+    present = tmp_path / "present.py"
+    missing = tmp_path / "missing.py"
+    present.write_text("rows = 32\n")
+    identity = fingerprint_extra_sources((present, missing), "cannot-replace-missing-evidence")
+    assert identity.digest is None
+    assert identity.failure is not None and "missing.py" in identity.failure
+    assert fingerprint_content(()).digest is None
+    assert fingerprint_extra_sources(()).digest is not None
+
+
+def test_unreadable_directory_is_not_silently_omitted(tmp_path, monkeypatch):
+    (tmp_path / "kernel.py").write_text("rows = 32\n")
+
+    def denied(_path):
+        raise PermissionError("source directory is not readable")
+
+    monkeypatch.setattr(os, "scandir", denied)
+    identity = fingerprint_content((ContentRoot(tmp_path),))
+    assert identity.digest is None
+    assert identity.failure is not None and "not readable" in identity.failure
+
+
+def test_file_size_change_during_hashing_is_unavailable(tmp_path, monkeypatch):
+    source = tmp_path / "compiler.bin"
+    source.write_bytes(b"original")
+    original_sha256 = _identity.hashlib.sha256
+
+    class EditingDigest:
+        def __init__(self, data=b""):
+            self.digest = original_sha256(data)
+
+        def update(self, chunk):
+            self.digest.update(chunk)
+            source.write_bytes(b"modified-and-longer")
+
+        def hexdigest(self):
+            return self.digest.hexdigest()
+
+    monkeypatch.setattr(_identity.hashlib, "sha256", EditingDigest)
+    identity = fingerprint_content((ContentRoot(source),))
+    assert identity.digest is None
+    assert identity.failure is not None and "changed while being read" in identity.failure
+
+
+def test_symlinks_track_target_contents_and_reject_cycles(tmp_path):
+    target = tmp_path / "target"
+    target.mkdir()
+    source = target / "kernel.py"
+    source.write_text("rows = 32\n")
+    link = tmp_path / "link"
+    link.symlink_to(target, target_is_directory=True)
+    roots = (ContentRoot(link),)
+    before = fingerprint_content(roots)
+    source.write_text("rows = 64\n")
+    assert fingerprint_content(roots).digest != before.digest
+    (target / "cycle").symlink_to(target, target_is_directory=True)
+    identity = fingerprint_content(roots)
+    assert identity.digest is None
+    assert identity.failure is not None and "cycle" in identity.failure
+
+
+def test_special_files_are_rejected_without_opening_them(tmp_path):
+    fifo = tmp_path / "pipe"
+    os.mkfifo(fifo)
+    identity = fingerprint_content((ContentRoot(fifo),))
+    assert identity.digest is None
+    assert identity.failure is not None and "regular file" in identity.failure
+
+
+@pytest.fixture
+def inventories(tmp_path):
+    components = {}
+    for name in ("pypto", "runtime", "pto_isa", "ptoas", "device_toolchain"):
+        path = tmp_path / name
+        path.mkdir()
+        (path / "input.bin").write_bytes(name.encode())
+        components[name] = ComponentInputs((ContentRoot(path),), unavailable_reason=None)
+    return ToolchainInputs(**components)
+
+
+@pytest.mark.parametrize("component", ["pypto", "runtime", "pto_isa", "ptoas", "device_toolchain"])
+def test_every_required_component_must_have_a_complete_inventory(inventories, component):
+    cache = InstallationIdentityCache()
+    complete = cache.capture(inventories)
+    assert complete.usable
+    assert complete.digest is not None and len(complete.digest) == 64
+    partial = replace(inventories, **{component: ComponentInputs(getattr(inventories, component).roots)})
+    identity = cache.capture(partial)
+    assert not identity.usable
+    assert identity.digest is None
+    assert [failure.component for failure in identity.failures] == [component]
+
+
+def test_all_missing_components_are_reported(inventories):
+    inputs = replace(inventories, ptoas=ComponentInputs(), device_toolchain=ComponentInputs())
+    identity = InstallationIdentityCache().capture(inputs)
+    assert {failure.component for failure in identity.failures} == {"ptoas", "device_toolchain"}
+    assert identity.digest is None
+
+
+def test_failed_component_reads_can_be_retried(inventories):
+    path = inventories.ptoas.roots[0].path / "input.bin"
+    contents = path.read_bytes()
+    path.unlink()
+    missing = replace(inventories, ptoas=ComponentInputs((ContentRoot(path),), unavailable_reason=None))
+    cache = InstallationIdentityCache()
+    assert not cache.capture(missing).usable
+    path.write_bytes(contents)
+    assert cache.capture(missing).usable
+
+
+def test_installation_cache_is_keyed_by_resolved_inputs(inventories, tmp_path):
+    cache = InstallationIdentityCache()
+    first = cache.capture(inventories)
+    tool = tmp_path / "other-compiler"
+    tool.write_bytes(b"different compiler")
+    selected = replace(
+        inventories, device_toolchain=ComponentInputs((ContentRoot(tool),), unavailable_reason=None)
+    )
+    assert cache.capture(selected).digest != first.digest
+    assert cache.capture(inventories) == first
+
+
+def test_replacing_an_installation_requires_a_new_snapshot(inventories):
+    cache = InstallationIdentityCache()
+    first = cache.capture(inventories)
+    library = inventories.pypto.roots[0].path / "input.bin"
+    metadata = library.stat()
+    library.write_bytes(b"other")
+    os.utime(library, ns=(metadata.st_atime_ns, metadata.st_mtime_ns))
+    assert cache.capture(inventories) == first
+    assert InstallationIdentityCache().capture(inventories).digest != first.digest
+
+
+def test_new_process_reads_replaced_native_file_contents(tmp_path):
+    library = tmp_path / "compiler.so"
+    library.write_bytes(b"same-build-id;old-code")
+    code = (
+        "import sys; from pathlib import Path; "
+        "from pypto._identity import ContentRoot, fingerprint_content; "
+        "print(fingerprint_content((ContentRoot(Path(sys.argv[1])),)).digest)"
+    )
+
+    def child_digest():
+        return subprocess.run(
+            [sys.executable, "-c", code, str(library)],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=30,
+        ).stdout.strip()
+
+    before = child_digest()
+    metadata = library.stat()
+    library.write_bytes(b"same-build-id;new-code")
+    os.utime(library, ns=(metadata.st_atime_ns, metadata.st_mtime_ns))
+    assert child_digest() != before
+
+
+def test_threads_share_one_successful_inventory_read(inventories, monkeypatch):
+    cache = InstallationIdentityCache()
+    original = _identity.fingerprint_content
+    seen = []
+
+    def count(roots):
+        seen.append(roots)
+        return original(roots)
+
+    monkeypatch.setattr(_identity, "fingerprint_content", count)
+    barrier = threading.Barrier(4)
+
+    def capture(inputs):
+        barrier.wait(timeout=10)
+        return cache.capture(inputs)
+
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        identities = list(executor.map(capture, [inventories] * 8))
+    assert all(identity == identities[0] for identity in identities)
+    assert len(seen) == 5
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/jit/test_identity.py
+++ b/tests/ut/jit/test_identity.py
@@ -71,6 +71,15 @@ def test_records_are_stable_across_process_hash_seeds():
     assert outputs[0] == outputs[1] == digest_record({key: key for key in ("alpha", "beta", "gamma")})
 
 
+def test_unicode_code_points_do_not_collide_with_explicit_surrogates():
+    character = "\U0001f600"
+    surrogates = "\ud83d\ude00"
+    assert character != surrogates
+    assert encode_record(character) != encode_record(surrogates)
+    assert digest_record({character: 1}) != digest_record({surrogates: 1})
+    assert digest_record({character: 1, surrogates: 2}) == digest_record({surrogates: 2, character: 1})
+
+
 @pytest.mark.parametrize("value", [object(), Path("input"), {1: "value"}, {1, 2}])
 def test_unsupported_values_are_not_stringified(value):
     with pytest.raises(TypeError, match="identity record|Identity record"):
@@ -172,6 +181,27 @@ def test_relative_roots_capture_the_callers_working_directory(tmp_path, monkeypa
     assert fingerprint_content((root,)) == before
 
 
+@pytest.mark.parametrize("relative", [False, True])
+def test_parent_component_after_symlink_preserves_filesystem_meaning(tmp_path, monkeypatch, relative):
+    actual = tmp_path / "actual"
+    (actual / "child").mkdir(parents=True)
+    (tmp_path / "link").symlink_to(actual / "child", target_is_directory=True)
+    source = actual / "kernel.py"
+    source.write_text("rows = 32\n")
+    decoy = tmp_path / "kernel.py"
+    decoy.write_text("rows = 99\n")
+    monkeypatch.chdir(tmp_path)
+    supplied = Path("link/../kernel.py")
+    root = ContentRoot(supplied if relative else tmp_path / supplied)
+    assert root.path.read_bytes() == source.read_bytes()
+    before = fingerprint_content((root,))
+    assert before.digest is not None
+    decoy.write_text("rows = 88\n")
+    assert fingerprint_content((root,)) == before
+    source.write_text("rows = 64\n")
+    assert fingerprint_content((root,)).digest != before.digest
+
+
 def test_missing_inputs_do_not_shrink_an_inventory(tmp_path):
     present = tmp_path / "present.py"
     missing = tmp_path / "missing.py"
@@ -232,6 +262,30 @@ def test_symlinks_track_target_contents_and_reject_cycles(tmp_path):
     identity = fingerprint_content(roots)
     assert identity.digest is None
     assert identity.failure is not None and "cycle" in identity.failure
+
+
+@pytest.mark.parametrize("name", ["plugins", "plugin.py", "plugin.data"])
+def test_extra_source_filter_cannot_hide_broken_symlinks(tmp_path, name):
+    (tmp_path / name).symlink_to(tmp_path / "missing-directory", target_is_directory=True)
+    identity = fingerprint_extra_sources((tmp_path,))
+    assert identity.digest is None
+    assert identity.failure is not None and "missing-directory" in identity.failure
+
+
+def test_extra_source_filter_cannot_hide_unreadable_subtrees(tmp_path, monkeypatch):
+    directory = tmp_path / "plugins"
+    directory.mkdir()
+    original_stat = Path.stat
+
+    def stat_with_unreadable_directory(path, *args, **kwargs):
+        if path == directory:
+            raise PermissionError("Cannot inspect plugins")
+        return original_stat(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "stat", stat_with_unreadable_directory)
+    identity = fingerprint_extra_sources((tmp_path,))
+    assert identity.digest is None
+    assert identity.failure is not None and "Cannot inspect plugins" in identity.failure
 
 
 def test_special_files_are_rejected_without_opening_them(tmp_path):

--- a/tests/ut/tools/test_check_environment_inputs.py
+++ b/tests/ut/tools/test_check_environment_inputs.py
@@ -84,6 +84,66 @@ def test_shadowing_and_reassignment_cannot_hide_dynamic_inputs(lint, source):
     assert [read.variable for read in lint.python_reads(source)] == [None]
 
 
+@pytest.mark.parametrize(
+    "assignment",
+    [
+        'if enabled:\n    _ENV = "PYPTO_NEW"',
+        "for _ENV in names:\n    pass",
+        'try:\n    _ENV = "PYPTO_NEW"\nexcept RuntimeError:\n    pass',
+        'with context():\n    _ENV = "PYPTO_NEW"',
+        '_ENV += "_NEW"',
+    ],
+)
+def test_module_control_flow_cannot_hide_unclassified_inputs(lint, tmp_path, assignment):
+    directory = tmp_path / "python/pypto"
+    directory.mkdir(parents=True)
+    (directory / "compiler.py").write_text(
+        f'import os\n_ENV = "PYPTO_KNOWN"\n{assignment}\nos.getenv(_ENV)\n'
+    )
+    errors = lint.check_tree(tmp_path, _registry())
+    assert len(errors) == 1 and "dynamic read" in errors[0]
+
+
+def test_later_assignment_cannot_relabel_an_earlier_read(lint):
+    source = 'import os\n_ENV = "PYPTO_NEW"\nos.getenv(_ENV)\n_ENV = "PYPTO_KNOWN"'
+    assert [read.variable for read in lint.python_reads(source)] == [None]
+
+
+def test_import_aliases_do_not_leak_between_functions(lint):
+    source = """def compiler():
+    import os as platform
+    return platform.getenv("PYPTO_NEW")
+def unrelated():
+    import sys as platform
+    return platform.version
+"""
+    assert [(read.variable, read.function) for read in lint.python_reads(source)] == [
+        ("PYPTO_NEW", "compiler")
+    ]
+
+
+def test_aliases_follow_closures_but_respect_parameter_shadowing(lint):
+    source = """import os as platform
+def outer():
+    read = platform.getenv
+    def inner():
+        return read("PYPTO_NEW")
+def unrelated(platform):
+    return platform.getenv("NOT_AN_ENVIRONMENT_READ")
+"""
+    assert [(read.variable, read.function) for read in lint.python_reads(source)] == [("PYPTO_NEW", "inner")]
+
+
+def test_conditional_import_aliases_preserve_all_environment_reads(lint):
+    source = """if enabled:
+    import os as platform
+else:
+    import sys as platform
+platform.getenv("PYPTO_NEW")
+"""
+    assert [read.variable for read in lint.python_reads(source)] == ["PYPTO_NEW"]
+
+
 def test_cpp_comments_strings_and_concatenated_literals(lint):
     source = """// getenv("COMMENT")
 /* getenv("BLOCK_COMMENT") */

--- a/tests/ut/tools/test_check_environment_inputs.py
+++ b/tests/ut/tools/test_check_environment_inputs.py
@@ -1,0 +1,156 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Regression tests for the environment-input inventory, including aliases."""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def lint(monkeypatch):
+    directory = Path(__file__).resolve().parents[2] / "lint"
+    monkeypatch.syspath_prepend(str(directory))
+    spec = importlib.util.spec_from_file_location(
+        "check_environment_inputs", directory / "check_environment_inputs.py"
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, spec.name, module)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        'import os\nos.environ.get("PYPTO_NEW")',
+        'import os as operating\noperating.getenv("PYPTO_NEW")',
+        'from os import getenv as read\nread("PYPTO_NEW")',
+        'from os import environ as env\nenv["PYPTO_NEW"]',
+        'import os\n_ENV: str = "PYPTO_NEW"\nos.getenv(_ENV)',
+        'import os\nread = os.environ.get\nread("PYPTO_NEW")',
+        'import os\ndef work():\n    env = os.environ\n    return env.get("PYPTO_NEW")',
+        'import os\ndef work():\n    env: object = os.environ\n    return env.get("PYPTO_NEW")',
+        'import os\nos.environ.setdefault("PYPTO_NEW", "default")',
+        'import os\nos.getenvb(b"PYPTO_NEW")',
+        'import os\nos.environb[b"PYPTO_NEW"]',
+    ],
+)
+def test_python_recognizes_literal_constants_and_aliases(lint, source):
+    assert [read.variable for read in lint.python_reads(source)] == ["PYPTO_NEW"]
+
+
+@pytest.mark.parametrize(
+    "expression",
+    ["os.getenv(name)", "os.environ[name]", "dict(os.environ)", "os.environ.copy()", "list(os.environ)"],
+)
+def test_dynamic_and_bulk_python_reads_need_explicit_audit(lint, expression):
+    reads = lint.python_reads(f"import os\ndef work(name):\n    return {expression}\n")
+    assert len(reads) == 1
+    assert reads[0].variable is None
+    assert reads[0].function == "work"
+
+
+def test_python_writes_and_prose_are_not_environment_reads(lint):
+    source = """import os
+# os.getenv("PYPTO_COMMENT")
+message = 'os.getenv("PYPTO_STRING")'
+os.environ["PYPTO_DERIVED"] = "value"
+"""
+    assert lint.python_reads(source) == []
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        'import os\n_ENV="PYPTO_KNOWN"\ndef work(_ENV):\n    return os.getenv(_ENV)',
+        'import os\n_ENV="PYPTO_KNOWN"\ndef work(name):\n    _ENV=name\n    return os.getenv(_ENV)',
+        'import os\n_ENV="PYPTO_KNOWN"\n_ENV=compute_name()\nos.getenv(_ENV)',
+        'import os\n_ENV="PYPTO_KNOWN"\ndef change(name):\n    global _ENV\n    _ENV=name\nos.getenv(_ENV)',
+        'import os\n_ENV="PYPTO_KNOWN"\ndef outer(_ENV):\n    def inner():\n        return os.getenv(_ENV)',
+    ],
+)
+def test_shadowing_and_reassignment_cannot_hide_dynamic_inputs(lint, source):
+    assert [read.variable for read in lint.python_reads(source)] == [None]
+
+
+def test_cpp_comments_strings_and_concatenated_literals(lint):
+    source = """// getenv("COMMENT")
+/* getenv("BLOCK_COMMENT") */
+const char *message = "getenv(\\\"STRING\\\")";
+auto value = std::getenv("PYPTO_" "NEW");
+auto other = secure_getenv(variable);
+"""
+    reads = lint.cpp_reads(source)
+    assert [read.variable for read in reads] == ["PYPTO_NEW", None]
+    assert [read.line for read in reads] == [4, 5]
+
+
+def _registry():
+    return {
+        "schema": 1,
+        "variables": {"PYPTO_KNOWN": {"category": "semantic", "reason": "Changes generated operations."}},
+        "dynamic_reads": [],
+    }
+
+
+def test_tree_checks_non_pypto_names_and_bindings(lint, tmp_path):
+    python_dir = tmp_path / "python/pypto"
+    binding_dir = tmp_path / "python/bindings"
+    python_dir.mkdir(parents=True)
+    binding_dir.mkdir()
+    (python_dir / "compiler.py").write_text('import os\nos.getenv("COMPILER_PATH")\n')
+    (binding_dir / "entry.cpp").write_text('auto x = getenv("BINDING_OPTION");\n')
+    errors = lint.check_tree(tmp_path, _registry())
+    assert len(errors) == 2
+    assert any("COMPILER_PATH" in error for error in errors)
+    assert any("BINDING_OPTION" in error for error in errors)
+
+
+def test_dynamic_exception_is_scoped_and_cannot_hide_new_literal_reads(lint, tmp_path):
+    directory = tmp_path / "python/pypto"
+    directory.mkdir(parents=True)
+    (directory / "compiler.py").write_text(
+        'import os\ndef restore(name):\n    os.getenv(name)\n    os.getenv("PYPTO_NEW")\n'
+        "def compile(name):\n    os.getenv(name)\n"
+    )
+    registry = _registry()
+    registry["dynamic_reads"] = [
+        {"path": "python/pypto/compiler.py", "function": "restore", "reason": "Restores runtime overrides."}
+    ]
+    errors = lint.check_tree(tmp_path, registry)
+    assert len(errors) == 2
+    assert any("PYPTO_NEW" in error for error in errors)
+    assert any("dynamic read in compile" in error for error in errors)
+
+
+def test_stale_dynamic_exceptions_fail(lint, tmp_path):
+    registry = _registry()
+    registry["dynamic_reads"] = [
+        {"path": "python/pypto/removed.py", "function": "restore", "reason": "Old consumer."}
+    ]
+    assert lint.check_tree(tmp_path, registry) == [
+        "Unused dynamic-read exception: python/pypto/removed.py:restore"
+    ]
+
+
+@pytest.mark.parametrize("category, reason", [("unknown", "Some input"), ("semantic", "")])
+def test_registry_requires_a_supported_category_and_reason(lint, category, reason):
+    registry = _registry()
+    registry["variables"]["PYPTO_KNOWN"] = {"category": category, "reason": reason}
+    with pytest.raises(ValueError, match="category and reason"):
+        lint.check_registry(registry)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

The persistent JIT cache proposed in RFC #2653 needs content identities that distinguish semantic inputs and refuse reuse when dependency evidence is incomplete. This PR establishes the identity foundation after #2660: versioned typed records, content-based file inventories, and an audited environment-input registry. It is the first part of the toolchain-identity milestone; the helpers are internal and are not connected to JIT dispatch or persistent artifact lookup, so existing cache behavior and dispatch cost are unchanged.

## Changes

- Encode records with explicit type tags, IEEE-754 float bits, distinct Python Unicode code points, deterministic dictionary ordering, and full SHA-256 digests; reject unsupported values rather than falling back to string representations.
- Preserve filesystem resolution of symlink/.. paths, validate source entries before extension filtering, hash ordered file/resource inventories, and report missing, unreadable, or incomplete components as unavailable. Memoize successful immutable installation inventories while refreshing additional application sources independently.
- Require all five toolchain components and explicit evidence of complete dependency inventories before producing a usable identity. Automatic adapters for the actual selected compilers, SDK resources, and dynamic dependencies remain a follow-up; existing compiler-version tokens are insufficient.
- Classify environment inputs and add a pre-commit check for Python and C++ reads, with lexical alias scopes and narrowly scoped dynamic-read exceptions. Reassigned module constants, including control-flow writes, remain dynamic; the hook uses Python 3.10, which the lint CI job explicitly provisions with `actions/setup-python`. The registry records integration requirements; it does not itself enforce runtime cache policy.
- Add filesystem, process, concurrency, encoding, and scanner regressions, plus synchronized English/Chinese developer documentation. Document that hashing is not an atomic filesystem snapshot and mutable sources will need revalidation before future publication.

## Verification

Build and test results below are from `866d56f31053a66f31b165daf45da4e5899e163b` in its own worktree. The subsequent CI-only correction in `522c7cbca4b4cb916922e4483bce82178a1fa8bc` provisions the lint interpreter and passed all local hooks again; Python/C++ source code is unchanged between these commits.

- `cmake --build build --parallel "$PYPTO_BUILD_JOBS"`: passed with the worktree's own native extension.
- `build/test-venv/bin/python -m pytest tests/ut/ -n "$PYPTO_TEST_JOBS" -q --tb=short --disable-warnings`: **11,675 passed, 10 skipped, 1 xfailed**. Machine limits came from `.claude/skills/testing/load-env.sh`.
- `build/test-venv/bin/python -m pytest tests/ut/jit/test_identity.py tests/ut/tools/test_check_environment_inputs.py -q --tb=short`: **75 passed**.
- Pinned pre-commit 4.3.0, invoked as below: all hooks passed, including the environment audit, Ruff, Pyright, and documentation checks.
- `git diff --check`: passed.

```bash
python /tmp/pypto-jit-pr-tools/pre-commit-4.3.0.pyz run --files \
  .github/workflows/ci.yml .pre-commit-config.yaml mkdocs.yml \
  docs/en/dev/08-artifact-identity.md docs/zh/dev/08-artifact-identity.md \
  python/pypto/_environment.json python/pypto/_identity.py \
  tests/lint/check_environment_inputs.py tests/ut/jit/test_identity.py \
  tests/ut/tools/test_check_environment_inputs.py
```

No hardware system tests were run; this PR does not alter compilation or execution paths.

