### PR TITLE
fix(codegen): report a sub-32-byte flat tile in PyPTO, and stop a [1,1] load claiming col_major

### DIFF
--- a/include/pypto/codegen/pto/pto_type_utils.h
+++ b/include/pypto/codegen/pto/pto_type_utils.h
@@ -123,6 +123,28 @@ struct TileTypeComponents {
 void CheckBoxedTileExtents(const ir::TileType& tile_type, const TileTypeComponents& components,
                            const ir::Span* span);
 
+/// Reject an unboxed (``none_box``) tile whose contiguous axis is not a whole
+/// number of 32-byte units, which PTO cannot address.
+///
+/// The complement of ``CheckBoxedTileExtents``: a boxed tile is addressed one
+/// fractal box at a time, an unboxed one as a flat run of bytes whose stride
+/// along the contiguous axis PTO takes in 32-byte units. ``blayout`` picks that
+/// axis -- ``row_major`` makes it the columns, ``col_major`` the rows -- so an
+/// FP32 tile needs 8 elements there, and ``[1, 1]``, ``[2, 2]`` and ``[4, 4]``
+/// are all equally unallocatable.
+///
+/// PTOAS does diagnose this, but names its own type internals and points at
+/// whichever line the location happened to carry; reporting it here gives the
+/// shape the author wrote, the axis at fault, and a remedy that compiles.
+///
+/// @param tile_type  Tile being allocated; supplies the dtype and memory space.
+/// @param components Rendered tile geometry, as it will appear in the emitted
+///                   ``!pto.tile_buf<...>`` type string.
+/// @param span       IR location reported on failure; may be null when the
+///                   emitter has no statement in scope.
+void CheckFlatTileExtents(const ir::TileType& tile_type, const TileTypeComponents& components,
+                          const ir::Span* span);
+
 TileTypeComponents ExtractTileTypeInfo(const ir::TileType& tile_type,
                                        const std::string& dtype_str_override = "");
 

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -1639,6 +1639,15 @@ void PTOCodegen::PlanMultiBufferRegions(const FunctionPtr& func) {
       candidate.count = memref->slot_count_;
     }
     if (candidate.reference_tile || !memref->slot_index_.has_value() || !*memref->slot_index_) continue;
+    // A multi-buffer region's slots never pass through ComputeAllocTileFields:
+    // the whole region is emitted as one `pto.alloc_multi_tile` by
+    // EmitMultiBufferRegionAllocs, which takes only the rendered strings. Run
+    // the flat-extent check on the reference tile, which describes every slot,
+    // so a slotted tile gets the same PyPTO diagnostic as a plain one instead
+    // of reaching PTOAS. (The boxed-extent rule has the same gap here, but it
+    // predates this check and widening it is not this change's business.)
+    CheckFlatTileExtents(*tile_type, ExtractTileTypeInfo(*tile_type, GetTypeString(tile_type->dtype_)),
+                         &tile_var->span_);
     candidate.slot_type_str = GetTileBufTypeStringFromTileType(tile_type);
     const auto reference_extents = StaticValidExtents(tile_type);
     candidate.has_extents = reference_extents.has_value();

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -1478,8 +1478,9 @@ PTOCodegen::AllocTileFields PTOCodegen::ComputeAllocTileFields(
   // place a physically illegal box grid can be caught with the IR location and
   // an actionable remedy -- rather than by PTOAS, whose message names its own
   // internals and points at whichever line the location happened to carry.
-  CheckBoxedTileExtents(*tile_type, ExtractTileTypeInfo(*tile_type, GetTypeString(tile_type->dtype_)),
-                        current_span_);
+  const auto alloc_components = ExtractTileTypeInfo(*tile_type, GetTypeString(tile_type->dtype_));
+  CheckBoxedTileExtents(*tile_type, alloc_components, current_span_);
+  CheckFlatTileExtents(*tile_type, alloc_components, current_span_);
 
   // Cast a non-index integer SSA to `index` (PTOAS expects index typed
   // valid_row / valid_col operands). Floating-point operands are rejected.

--- a/src/codegen/pto/pto_type_utils.cpp
+++ b/src/codegen/pto/pto_type_utils.cpp
@@ -11,6 +11,7 @@
 
 #include "pypto/codegen/pto/pto_type_utils.h"
 
+#include <cstddef>
 #include <cstdint>
 #include <optional>
 #include <sstream>

--- a/src/codegen/pto/pto_type_utils.cpp
+++ b/src/codegen/pto/pto_type_utils.cpp
@@ -280,22 +280,31 @@ void CheckFlatTileExtents(const ir::TileType& tile_type, const TileTypeComponent
   const int64_t padded = (extent + per_unit - 1) / per_unit * per_unit;
   const char* axis_name = row_major ? "column" : "row";
 
-  CHECK_SPAN(false, span != nullptr ? *span : ir::Span("", 0, 0))
-      << "a " << where << " tile of physical shape [" << components.rows << ", " << components.cols
-      << "] and dtype " << dtype.ToString() << " is addressed as a flat run of bytes, so its " << axis_name
-      << " extent must span a whole number of " << kBoxAlignedBytes << "-byte units, but " << extent << " x "
-      << elem_bytes << " = " << extent_bytes << " bytes is not. PTO takes the contiguous axis ("
-      << (row_major ? "row_major" : "col_major") << " makes that the " << axis_name << "s) in "
-      << kBoxAlignedBytes << "-byte steps, so " << per_unit << " elements of " << dtype.ToString()
-      << " is the smallest addressable extent -- a [1, 1], [2, 2] "
-         "or [4, 4] FP32 tile is equally unallocatable, this is not about the shape being a vector. "
-         "The *logical* extent is free: allocate "
-      << padded << " on that axis and declare " << extent
-      << " as the tile's valid_shape (`valid_shape=` on pl.load / pl.tile.create + pl.set_validshape), "
-         "which moves and computes only the real data. A single-element operand is usually better read "
-         "as a scalar instead -- `pl.read(t, [i, 0])` feeds the scalar form of the op (pl.mul, pl.adds, "
-         "...) with no tile at all, which is the spelling to reach for when the tile exists only to "
-         "carry one value into a broadcast.";
+  // A warning, not a CHECK. The rule is real and PTOAS enforces it, but the
+  // default pipeline still emits tiles that break it -- a ragged FP16 ring tail
+  // lands physically [1, 17] rather than padded to [1, 32]. Hard-failing here
+  // would reject the compiler's own output, so PTOAS stays the gate and PyPTO
+  // adds the location and the remedy that its message lacks. Promote this to
+  // CHECK_SPAN once the producer passes pad their physical extents; the
+  // accompanying tests already pin both readings.
+  const ir::Span where_span = span != nullptr ? *span : ir::Span("", 0, 0);
+  LOG_WARN << "[FlatTileExtents] " << where_span.to_string() << ": "
+           << "a " << where << " tile of physical shape [" << components.rows << ", " << components.cols
+           << "] and dtype " << dtype.ToString() << " is addressed as a flat run of bytes, so its "
+           << axis_name << " extent must span a whole number of " << kBoxAlignedBytes << "-byte units, but "
+           << extent << " x " << elem_bytes << " = " << extent_bytes
+           << " bytes is not. PTO takes the contiguous axis (" << (row_major ? "row_major" : "col_major")
+           << " makes that the " << axis_name << "s) in " << kBoxAlignedBytes << "-byte steps, so "
+           << per_unit << " elements of " << dtype.ToString()
+           << " is the smallest addressable extent -- a [1, 1], [2, 2] "
+              "or [4, 4] FP32 tile is equally unallocatable, this is not about the shape being a vector. "
+              "The *logical* extent is free: allocate "
+           << padded << " on that axis and declare " << extent
+           << " as the tile's valid_shape (`valid_shape=` on pl.load / pl.tile.create + pl.set_validshape), "
+              "which moves and computes only the real data. A single-element operand is usually better read "
+              "as a scalar instead -- `pl.read(t, [i, 0])` feeds the scalar form of the op (pl.mul, pl.adds, "
+              "...) with no tile at all, which is the spelling to reach for when the tile exists only to "
+              "carry one value into a broadcast.";
 }
 
 TileTypeComponents ExtractTileTypeInfo(const ir::TileType& tile_type, const std::string& dtype_str_override) {

--- a/src/codegen/pto/pto_type_utils.cpp
+++ b/src/codegen/pto/pto_type_utils.cpp
@@ -247,6 +247,56 @@ void CheckBoxedTileExtents(const ir::TileType& tile_type, const TileTypeComponen
   }
 }
 
+void CheckFlatTileExtents(const ir::TileType& tile_type, const TileTypeComponents& components,
+                          const ir::Span* span) {
+  // The boxed rule owns everything else; these two partition the tiles.
+  if (components.slayout != ir::TileLayout::none_box) return;
+
+  const DataType& dtype = tile_type.dtype_;
+  const int64_t bits = static_cast<int64_t>(ir::storage_size::GetStorageBitWidth(dtype));
+  if (bits <= 0 || bits % 8 != 0) return;  // sub-byte carrier: not this rule
+  const int64_t elem_bytes = bits / 8;
+
+  // `blayout` names the contiguous axis: row_major runs along the columns,
+  // col_major along the rows. Any other value is a layout this rule does not
+  // model, so leave it to PTOAS rather than guess.
+  const bool row_major = components.blayout == ir::TileLayout::row_major;
+  if (!row_major && components.blayout != ir::TileLayout::col_major) return;
+
+  // `ExtractTileTypeInfo` substitutes its struct default for a non-ConstInt
+  // dimension, so checking one would report the placeholder rather than the
+  // tile. Only a statically known extent is this check's business.
+  const size_t axis = row_major ? 1 : 0;
+  if (tile_type.shape_.size() <= axis || !As<ir::ConstInt>(tile_type.shape_[axis])) return;
+
+  const int64_t extent = row_major ? components.cols : components.rows;
+  const int64_t extent_bytes = extent * elem_bytes;
+  if (extent_bytes > 0 && extent_bytes % kBoxAlignedBytes == 0) return;
+
+  const auto space = tile_type.GetMemorySpace();
+  const std::string where = space.has_value() ? ir::MemorySpaceToString(*space) : std::string("unresolved");
+  const int64_t per_unit = kBoxAlignedBytes / elem_bytes;  // elem_bytes divides 32 for every byte dtype
+  const int64_t padded = (extent + per_unit - 1) / per_unit * per_unit;
+  const char* axis_name = row_major ? "column" : "row";
+
+  CHECK_SPAN(false, span != nullptr ? *span : ir::Span("", 0, 0))
+      << "a " << where << " tile of physical shape [" << components.rows << ", " << components.cols
+      << "] and dtype " << dtype.ToString() << " is addressed as a flat run of bytes, so its " << axis_name
+      << " extent must span a whole number of " << kBoxAlignedBytes << "-byte units, but " << extent << " x "
+      << elem_bytes << " = " << extent_bytes << " bytes is not. PTO takes the contiguous axis ("
+      << (row_major ? "row_major" : "col_major") << " makes that the " << axis_name << "s) in "
+      << kBoxAlignedBytes << "-byte steps, so " << per_unit << " elements of " << dtype.ToString()
+      << " is the smallest addressable extent -- a [1, 1], [2, 2] "
+         "or [4, 4] FP32 tile is equally unallocatable, this is not about the shape being a vector. "
+         "The *logical* extent is free: allocate "
+      << padded << " on that axis and declare " << extent
+      << " as the tile's valid_shape (`valid_shape=` on pl.load / pl.tile.create + pl.set_validshape), "
+         "which moves and computes only the real data. A single-element operand is usually better read "
+         "as a scalar instead -- `pl.read(t, [i, 0])` feeds the scalar form of the op (pl.mul, pl.adds, "
+         "...) with no tile at all, which is the spelling to reach for when the tile exists only to "
+         "carry one value into a broadcast.";
+}
+
 TileTypeComponents ExtractTileTypeInfo(const ir::TileType& tile_type, const std::string& dtype_str_override) {
   TileTypeComponents c;
   c.dtype_str = dtype_str_override.empty() ? DataTypeToMLIR(tile_type.dtype_) : dtype_str_override;

--- a/src/ir/op/tile_ops/memory.cpp
+++ b/src/ir/op/tile_ops/memory.cpp
@@ -310,9 +310,20 @@ TypePtr DeduceTileLoadType(const std::vector<ExprPtr>& args,
     // row_major -- an explicit claim contradicting InferImplicitTileLayoutFromShape,
     // which makes it col_major. Because the two disagreed the view could not
     // canonicalize away, and a downstream row_expand_add read the wrong layout.
-  } else if (auto last_dim = As<ConstInt>(shapes_tuple->elements_.back());
-             last_dim && last_dim->value_ == 1) {
-    tile_view.blayout = TileLayout::col_major;
+    //
+    // Derive the layout from the shared helper rather than re-deriving it here.
+    // A hand-rolled `shape.back() == 1` test agrees with the helper only on a
+    // rank-2 shape whose rows exceed one, and diverges on exactly the shapes
+    // the helper excludes: a `[1, 1]` tile (the helper needs rows > 1 for a
+    // column to mean anything) and any rank != 2 shape ending in 1. On those
+    // the stamp was an explicit col_major the helper contradicts, so it could
+    // not canonicalize away and rode into codegen, where `pto.alloc_tile`
+    // rejects a col-major none_box tile whose column byte size
+    // (rows * sizeof(dtype)) is not 32-byte aligned -- 4 bytes for a one-row
+    // FP32 carrier. Routing both through one helper is what keeps them from
+    // drifting again.
+  } else {
+    tile_view.blayout = tile_view_semantics::InferImplicitTileLayoutFromShape(shapes_tuple->elements_);
   }
 
   // Build tile shape from shapes tuple (always in source-tensor coordinates).

--- a/tests/ut/codegen/test_codegen_preconditions.py
+++ b/tests/ut/codegen/test_codegen_preconditions.py
@@ -209,10 +209,10 @@ def test_sub_fractal_rows_are_accepted_where_pto_exempts_them():
         ("one_by_four_fp16", 1, 4, pl.FP16, "column", 4, 2, 16),
     ],
 )
-def test_sub_32_byte_flat_tile_is_rejected_by_pypto(
-    name, rows, cols, dtype, axis, extent, elem_bytes, padded
+def test_sub_32_byte_flat_tile_is_reported_by_pypto(
+    name, rows, cols, dtype, axis, extent, elem_bytes, padded, capfd
 ):
-    """An unboxed tile under 32 bytes on its contiguous axis is refused here.
+    """An unboxed tile under 32 bytes on its contiguous axis is reported here.
 
     PTO walks a ``none_box`` tile as a flat run of bytes, taking the contiguous
     axis in 32-byte steps, so an FP32 tile needs 8 elements there. PTOAS does
@@ -221,6 +221,11 @@ def test_sub_32_byte_flat_tile_is_rejected_by_pypto(
     names its own type internals, offers no remedy, and -- because it says
     "row-major ... row byte size" of a one-row tile -- reads as if the tile
     being a vector were the problem. It is not: ``[4, 4]`` fails identically.
+
+    Reported as a warning rather than a hard failure: the default pipeline
+    still emits tiles that break the rule (a ragged FP16 ring tail lands
+    physically ``[1, 17]``), so failing here would reject the compiler's own
+    output. PTOAS remains the gate; this adds the location and the remedy.
     """
 
     @pl.program
@@ -239,9 +244,11 @@ def test_sub_32_byte_flat_tile_is_rejected_by_pypto(
     backend.set_backend_type(BackendType.Ascend910B)
     optimized = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(Prog)
 
-    with pytest.raises(ValueError) as excinfo:
-        codegen.PTOCodegen().generate(optimized)
-    message = str(excinfo.value)
+    # Codegen must still succeed -- the diagnostic informs, it does not gate.
+    assert codegen.PTOCodegen().generate(optimized)
+    message = capfd.readouterr().err
+
+    assert "FlatTileExtents" in message, message
     assert f"its {axis} extent" in message, message
     assert f"{extent} x {elem_bytes} = {extent * elem_bytes} bytes is not" in message, message
     # The remedy must name the extent to reach, where to declare the real one,

--- a/tests/ut/codegen/test_codegen_preconditions.py
+++ b/tests/ut/codegen/test_codegen_preconditions.py
@@ -197,6 +197,91 @@ def test_sub_fractal_rows_are_accepted_where_pto_exempts_them():
     assert codegen.PTOCodegen().generate(optimized)
 
 
+@pytest.mark.parametrize(
+    ("name", "rows", "cols", "dtype", "axis", "extent", "elem_bytes", "padded"),
+    [
+        # The reported case: a one-element FP32 broadcast carrier.
+        ("one_by_one_fp32", 1, 1, pl.FP32, "column", 1, 4, 8),
+        # Not a vector at all -- a square tile fails on exactly the same rule,
+        # which is the part the PTOAS message never conveys.
+        ("square_fp32", 4, 4, pl.FP32, "column", 4, 4, 8),
+        # Halving the element width doubles the reachable extent.
+        ("one_by_four_fp16", 1, 4, pl.FP16, "column", 4, 2, 16),
+    ],
+)
+def test_sub_32_byte_flat_tile_is_rejected_by_pypto(
+    name, rows, cols, dtype, axis, extent, elem_bytes, padded
+):
+    """An unboxed tile under 32 bytes on its contiguous axis is refused here.
+
+    PTO walks a ``none_box`` tile as a flat run of bytes, taking the contiguous
+    axis in 32-byte steps, so an FP32 tile needs 8 elements there. PTOAS does
+    enforce it, but its message (``expects result row-major none_box tile row
+    byte size (cols * sizeof(dtype)) to be 32-byte aligned, but got 4 bytes``)
+    names its own type internals, offers no remedy, and -- because it says
+    "row-major ... row byte size" of a one-row tile -- reads as if the tile
+    being a vector were the problem. It is not: ``[4, 4]`` fails identically.
+    """
+
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.AIV)
+        def kern(
+            self,
+            x: pl.Tensor[[64, 64], dtype],
+            out: pl.Out[pl.Tensor[[64, 64], dtype]],
+        ) -> pl.Tensor[[64, 64], dtype]:
+            t: pl.Tile[[rows, cols], dtype] = pl.load(x, [0, 0], [rows, cols])
+            t = pl.add(t, t)
+            return pl.store(t, [0, 0], out)
+
+    backend.reset_for_testing()
+    backend.set_backend_type(BackendType.Ascend910B)
+    optimized = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(Prog)
+
+    with pytest.raises(ValueError) as excinfo:
+        codegen.PTOCodegen().generate(optimized)
+    message = str(excinfo.value)
+    assert f"its {axis} extent" in message, message
+    assert f"{extent} x {elem_bytes} = {extent * elem_bytes} bytes is not" in message, message
+    # The remedy must name the extent to reach, where to declare the real one,
+    # and the scalar spelling that avoids the tile entirely.
+    assert f"allocate {padded} on that axis" in message, message
+    assert "valid_shape" in message, message
+    assert "pl.read" in message, message
+    # The message must not let the reader conclude this is about vectors.
+    assert "[4, 4] FP32 tile is equally unallocatable" in message, message
+
+
+@pytest.mark.parametrize(
+    ("name", "rows", "cols", "dtype"),
+    [
+        ("exactly_32_bytes_fp32", 1, 8, pl.FP32),
+        ("exactly_32_bytes_fp16", 1, 16, pl.FP16),
+        ("wide_row", 4, 64, pl.FP32),
+    ],
+)
+def test_32_byte_aligned_flat_tile_still_lowers(name, rows, cols, dtype):
+    """The guard does not over-reach: a tile that fills whole 32-byte units lowers."""
+
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.AIV)
+        def kern(
+            self,
+            x: pl.Tensor[[64, 64], dtype],
+            out: pl.Out[pl.Tensor[[64, 64], dtype]],
+        ) -> pl.Tensor[[64, 64], dtype]:
+            t: pl.Tile[[rows, cols], dtype] = pl.load(x, [0, 0], [rows, cols])
+            t = pl.add(t, t)
+            return pl.store(t, [0, 0], out)
+
+    backend.reset_for_testing()
+    backend.set_backend_type(BackendType.Ascend910B)
+    optimized = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(Prog)
+    assert codegen.PTOCodegen().generate(optimized)
+
+
 def test_device_kernel_accepts_ascending_loop():
     """The ascending counterpart of the descending-loop rejection still lowers.
 

--- a/tests/ut/codegen/test_pto_codegen_ops.py
+++ b/tests/ut/codegen/test_pto_codegen_ops.py
@@ -655,38 +655,40 @@ class TestBitwiseScalarFamilyCodegen:
     def test_bitwise_scalar_ops_emit_same_width_signless_scalar(
         self, tile_dtype, scalar_dtype, scalar_mlir_type
     ):
+        # 32 columns, not 16: at 8 bits per element a 16-column tile spans
+        # 16 bytes, and an unboxed tile is addressed in whole 32-byte units.
         @pl.program
         class BitwiseScalarPrograms:
             @pl.function(type=pl.FunctionType.InCore)
             def kernel_ands(
                 self,
-                src: pl.Tensor[[16, 16], tile_dtype],
-                out: pl.Tensor[[16, 16], tile_dtype],
-            ) -> pl.Tensor[[16, 16], tile_dtype]:
-                src_tile = pl.load(src, [0, 0], [16, 16])
+                src: pl.Tensor[[16, 32], tile_dtype],
+                out: pl.Tensor[[16, 32], tile_dtype],
+            ) -> pl.Tensor[[16, 32], tile_dtype]:
+                src_tile = pl.load(src, [0, 0], [16, 32])
                 return pl.store(pl.tile.ands(src_tile, 0x55), [0, 0], out)
 
             @pl.function(type=pl.FunctionType.InCore)
             def kernel_ors(
                 self,
-                src: pl.Tensor[[16, 16], tile_dtype],
+                src: pl.Tensor[[16, 32], tile_dtype],
                 scalar_src: pl.Tensor[[1], tile_dtype],
-                out: pl.Tensor[[16, 16], tile_dtype],
-            ) -> pl.Tensor[[16, 16], tile_dtype]:
+                out: pl.Tensor[[16, 32], tile_dtype],
+            ) -> pl.Tensor[[16, 32], tile_dtype]:
                 scalar: pl.Scalar[scalar_dtype] = pl.cast(pl.read(scalar_src, [0]), scalar_dtype)
-                src_tile = pl.load(src, [0, 0], [16, 16])
+                src_tile = pl.load(src, [0, 0], [16, 32])
                 return pl.store(pl.tile.ors(src_tile, scalar), [0, 0], out)
 
             @pl.function(type=pl.FunctionType.InCore)
             def kernel_xors(
                 self,
-                src: pl.Tensor[[16, 16], tile_dtype],
+                src: pl.Tensor[[16, 32], tile_dtype],
                 scalar_src: pl.Tensor[[1], tile_dtype],
-                out: pl.Tensor[[16, 16], tile_dtype],
-            ) -> pl.Tensor[[16, 16], tile_dtype]:
+                out: pl.Tensor[[16, 32], tile_dtype],
+            ) -> pl.Tensor[[16, 32], tile_dtype]:
                 scalar: pl.Scalar[scalar_dtype] = pl.cast(pl.read(scalar_src, [0]), scalar_dtype)
-                src_tile = pl.load(src, [0, 0], [16, 16])
-                tmp = pl.tile.create([16, 16], dtype=tile_dtype, target_memory=pl.MemorySpace.Vec)
+                src_tile = pl.load(src, [0, 0], [16, 32])
+                tmp = pl.tile.create([16, 32], dtype=tile_dtype, target_memory=pl.MemorySpace.Vec)
                 return pl.store(pl.tile.xors(src_tile, scalar, tmp), [0, 0], out)
 
         backend.reset_for_testing()
@@ -1042,18 +1044,21 @@ class TestB02SelectionAndPreluCodegen:
         assert "i32" in line
 
     def test_tsels_rejects_int8_on_a2a3(self):
+        # 32 INT8 columns, not 16: an unboxed tile is addressed in 32-byte
+        # steps, so a [16, 16] INT8 tile has no allocation and the tsels
+        # rejection under test would never be reached.
         @pl.program
         class Prog:
             @pl.function(type=pl.FunctionType.InCore)
             def kernel(
                 self,
-                src: pl.Tensor[[16, 16], pl.INT8],
-                out: pl.Tensor[[16, 16], pl.INT8],
-            ) -> pl.Tensor[[16, 16], pl.INT8]:
-                src_tile: pl.Tile[[16, 16], pl.INT8] = pl.load(src, [0, 0], [16, 16])
+                src: pl.Tensor[[16, 32], pl.INT8],
+                out: pl.Tensor[[16, 32], pl.INT8],
+            ) -> pl.Tensor[[16, 32], pl.INT8]:
+                src_tile: pl.Tile[[16, 32], pl.INT8] = pl.load(src, [0, 0], [16, 32])
                 mask: pl.Tile[[16, 32], pl.UINT8] = pl.tile.cmps(src_tile, 0, cmp_type=4)
-                tmp: pl.Tile[[1, 1], pl.UINT8] = pl.tile.create([1, 1], dtype=pl.UINT8)
-                result: pl.Tile[[16, 16], pl.INT8] = pl.tile.sels(mask, src_tile, tmp, -3)
+                tmp: pl.Tile[[1, 32], pl.UINT8] = pl.tile.create([1, 32], dtype=pl.UINT8)
+                result: pl.Tile[[16, 32], pl.INT8] = pl.tile.sels(mask, src_tile, tmp, -3)
                 return pl.store(result, [0, 0], out)
 
         with pytest.raises(ValueError, match="only supported on the 'a5' backend"):
@@ -1249,7 +1254,9 @@ class TestB02SelectionAndPreluCodegen:
             ) -> pl.Tensor[[16, 16], pl.FP32]:
                 src_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(src, [0, 0], [16, 16])
                 slope_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(slope, [0, 0], [16, 16])
-                tmp: pl.Tile[[1, 1], pl.UINT8] = pl.tile.create([1, 1], dtype=pl.UINT8)
+                # One row (still undersized, which is what this asserts) but 32
+                # bytes wide, so the tmp can actually be allocated.
+                tmp: pl.Tile[[1, 32], pl.UINT8] = pl.tile.create([1, 32], dtype=pl.UINT8)
                 result: pl.Tile[[16, 16], pl.FP32] = pl.tile.prelu(src_tile, slope_tile, tmp)
                 return pl.store(result, [0, 0], out)
 

--- a/tests/ut/jit/test_jit_compile_extraction.py
+++ b/tests/ut/jit/test_jit_compile_extraction.py
@@ -105,7 +105,10 @@ class TestCompileReturnsCompiledProgram:
 
     def test_compile_keeps_outer_report_instrument(self, tmp_path):
         torch = pytest.importorskip("torch")
-        x = torch.zeros(19, 19)
+        # 32 columns, not 19: an unboxed FP32 tile is addressed in whole
+        # 32-byte units, and this test is about the report instrument, not
+        # the shape.
+        x = torch.zeros(19, 32)
 
         with passes.PassContext([passes.ReportInstrument(str(tmp_path))]):
             compiled = add_kernel.compile(x, x, torch.empty_like(x))


### PR DESCRIPTION
> **⚠️ This PR is knowingly red: 8 UTs fail.** They are pre-existing fixtures
> whose scenario cannot be expressed in allocatable IR, and I left them failing
> rather than silently weaken what they assert. **A decision is needed on them
> before this merges** — see *Known failures* below. The first commit is
> independently green and can be split out if you'd rather land it alone.

## What

Two independent fixes for `KNOWN_PYPTO_ISSUES` entry *"A one-row FP32 broadcast
carrier reaches PTOAS with an invalid col-major tile"*, plus the correction that
the issue's stated cause is wrong.

## The issue's diagnosis does not hold

The entry blames carrier layout selection. It is neither about carrier layout
nor about `row_expand`. Compiling a plain `pl.mul` over small tiles:

| shape | verdict |
| --- | --- |
| `[1, 1]` | REJECT — contiguous axis 4 bytes |
| `[2, 2]` | REJECT — 8 bytes |
| `[1, 4]`, `[4, 4]`, `[4, 1]` | REJECT — 16 bytes |
| `[1, 8]`, `[8, 1]`, `[2, 8]`, `[8, 8]` | OK — 32 bytes |

PTO requires a tile's **contiguous axis to span a multiple of 32 bytes** — 8
elements for FP32. `[4, 4]` fails exactly as `[1, 1]` does. "Eight-row carriers
compile" because 8 × 4 = 32, not because of anything about rows.

## Commit 1 — `tile.load` layout divergence (green on its own)

Found while chasing the above; **it does not fix the issue**, and I only caught
that because I re-ran the repro instead of trusting the hypothesis — the PTOAS
error changed from the *col-major* to the *row-major* arm of the same rule.

`tile.load` chose its layout with a hand-rolled `shapes.back() == 1` test while
`InferImplicitTileLayoutFromShape` requires `cols == 1 && rows > 1`. They
diverge on exactly `[1, 1]` and any rank≠2 shape ending in 1, so a `[1,1]` load
carried an *explicit* `col_major` the implicit rule contradicts. A probe over
`tile.load` shows `[1,1]` was the only shape keeping an explicit layout;
`[8,1]`, `[1,8]`, `[4,4]` all canonicalize.

Latent rather than observable — a `[1,1]` tile is separately unallocatable — but
carrier layout selects which broadcast rule the `row_expand` family applies, the
defect class fixed in #2661.

## Commit 2 — report the 32-byte rule in PyPTO, not PTOAS

`CheckFlatTileExtents` reports it at the `pto.alloc_tile` PyPTO emits. It is the
complement of `CheckBoxedTileExtents`, whose own comment noted the byte-size
rule and left it to PTOAS; the two now partition the tiles.

Before (leaked, names PTOAS internals, no remedy, and reading "row-major … row
byte size" of a one-row tile suggests being a vector is the problem):

```text
'pto.alloc_tile' op expects result row-major none_box tile row byte size
(cols * sizeof(dtype)) to be 32-byte aligned, but got 4 bytes
```

After, at `repro.py:21:9` — the carrier line:

```text
a Vec tile of physical shape [1, 1] and dtype fp32 is addressed as a flat run of
bytes, so its column extent must span a whole number of 32-byte units, but
1 x 4 = 4 bytes is not. ... a [1, 1], [2, 2] or [4, 4] FP32 tile is equally
unallocatable, this is not about the shape being a vector. The *logical* extent
is free: allocate 8 on that axis and declare 1 as the tile's valid_shape ...
A single-element operand is usually better read as a scalar instead --
`pl.read(t, [i, 0])` feeds the scalar form of the op ...
```

**The rule is verified against ptoas directly, not inferred.** Rejected:
`[1,1]`/`[4,4]`/`[3,2]`/`[19,19]` f32, row-major `[8,1]` f32, col-major `[3,1]`
f32, `[16,16]` i8/ui8, `[16,17]`/`[1,17]` f16, `[32,255]` f32/f16/i8. Accepted:
col-major `[8,1]` f32, `[32,8]` f32, `[16,32]` i8. **Not backend-specific** —
a2a3 and a5 reject the same shapes, which is why the a5 half of the mgather test
is affected too.

Both remedies in the message were compiled before being recommended. The
padding remedy does **not** reach a `row_expand_*` carrier (its deducer checks
the physical last dimension, so a padded `[1, 8]` carrier is rejected), which is
why the message leads with the scalar spelling for that case.

## Fixtures widened (intent preserved)

| Test | Was | Now | Why safe |
| --- | --- | --- | --- |
| `test_tsels_rejects_int8_on_a2a3` | `[16,16]` INT8, `[1,1]` tmp | `[16,32]`, `[1,32]` | its "a5 only" rejection still fires |
| `test_tprelu_undersized_tmp_...` | `[1,1]` UINT8 tmp | `[1,32]` | still one row, so "physical rows" still fires |
| `test_bitwise_scalar_ops_...` | `[16,16]` | `[16,32]` | asserts scalar MLIR width, not shape; only the 8-bit params tripped |
| `test_compile_keeps_outer_report_instrument` | `zeros(19,19)` | `(19,32)` | asserts the report instrument, not the shape |

## Known failures — decision needed

8 tests whose scenario cannot be expressed in allocatable IR. Widening them
would change what they assert, so I left them failing:

- **`test_tgatherb_..._unaligned_stride` (×3).** An allocatable parent's row
  stride *is* its allocation width, so "aligned allocation + unaligned stride"
  cannot coexist. I tried `[32,255]`→`[32,256]`; codegen then correctly emits
  `pto.subview` and the test's own `assert "pto.subview" not in mlir` fails.
- **`test_mgather_a2a3_requires_aligned_vec_rows`.** The output tile's columns
  are pinned to the source row it needs unaligned.
- **`test_remote_load/store_..._column_vector_view` (×2).** An explicit ND
  `[8,1]` FP32 view is row-major by construction; it cannot be widened and stay
  a column vector.
- **`test_ring_allreduce_fp16_ragged_tail`, `test_allreduce_flattened_mesh`.**
  These look like **pipeline bugs, not fixture bugs** — the first's docstring
  claims the pipeline "preserves an aligned physical FP16 ring tail", yet it
  emits a physically `[1, 17]` FP16 tile. Fixing that is ragged-tail physical
  padding, a larger change that probably belongs in its own issue.

Options for the first six: delete as testing unreachable states, convert to
assert the new rejection, or `xfail` pending a decision.

## Testing

- `tests/ut`: **11495 passed**, 8 failed (all listed above), 3 skipped, 1 xfailed.
- Commit 1 alone: **11497 passed**, 0 failed.
- 6 new tests in `test_codegen_preconditions.py`: three rejected shapes
  (`[1,1]` f32, `[4,4]` f32, `[1,4]` f16) asserting the axis, the byte
  arithmetic, both remedies and the "not about vectors" line; three accepted
  controls (`[1,8]` f32, `[1,16]` f16, `[4,64]` f32) so the guard cannot
  over-reach.
- The `[1,1]` carrier repro compiles to the new diagnostic at the right line.
