### PR TITLE
fix(jit): resolve metadata for tensors a dep allocates and returns

### DIFF
--- a/docs/en/user/language/01-functions.md
+++ b/docs/en/user/language/01-functions.md
@@ -167,12 +167,20 @@ A device kernel (`@pl.jit.incore`) cannot allocate, so it always takes the secon
 `pl.create_tensor` belongs on the control plane. An `@pl.jit.inline` helper is spliced into
 the caller, so either form is available to it.
 
-What does *not* resolve is a returned tensor whose shape no static rule can reach — a
-`pl.create_tensor` sized from a value only the device knows, or a result rebound through an
-operation the specializer does not model. That surfaces as
+An extent the specializer cannot compute statically is *not* by itself a problem. A
+`pl.create_tensor` sized from a value only the device knows — `pl.tensor.read(cfg, [0])`,
+`pld.world_size()` — becomes a dynamic dimension and keeps flowing, and the shared pass
+pipeline judges whatever the program then does with it (loading the whole tensor as a tile,
+say, gets you `InitMemRef requires static shape` — the same error the equivalent
+`@pl.program` earns).
+
+What does not resolve is a returned tensor whose shape the specializer cannot *reach* at
+all: a `pl.reshape` whose target shape is not static (a reshape is constrained by its
+source's element count, so no dynamic dimension can stand in for it), or a result rebound
+through an operation the specializer does not model. That surfaces as
 `missing inferred tensor metadata for parameter '<name>'` at the *next* call that consumes
-it; annotate the producing allocation with static extents, or pass the buffer in as a
-`pl.Out[...]` parameter.
+it — the error names the consumer, but the fix belongs at the producer: give the producing
+statement a statically inferable shape, or pass the buffer in as a `pl.Out[...]` parameter.
 
 ### Three constraints that decide whether a jit kernel compiles
 

--- a/docs/en/user/language/01-functions.md
+++ b/docs/en/user/language/01-functions.md
@@ -135,6 +135,45 @@ silently folding into one program.
 
 `@pl.jit.host` rejects `level=` (HOST is implicit).
 
+### What a sub-function hands back keeps its shape and dtype
+
+Specialization stamps every generated parameter with a concrete shape and dtype, so a
+tensor a sub-function returns must be traceable to one. Both conventions work, and you can
+mix them in the same entry:
+
+```python
+@pl.jit.inline
+def make_pair(x: pl.Tensor[[1, 8], pl.FP32]):
+    a = pl.create_tensor([1, 8], dtype=pl.FP32)   # helper allocates its own results
+    b = pl.create_tensor([1, 8], dtype=pl.FP32)
+    with pl.at(level=pl.Level.CORE_GROUP):
+        a[:, :] = x[:, :]
+        b[:, :] = pl.mul(x[:, :], 2.0)
+    return a, b
+
+@pl.jit.incore
+def relu_kernel(x: pl.Tensor, out: pl.Out[pl.Tensor]):   # caller allocates, kernel fills
+    ...
+
+@pl.jit
+def entry(x: pl.Tensor[[1, 8], pl.FP32], out: pl.Out[pl.Tensor[[1, 8], pl.FP32]]):
+    a, b = make_pair(x)          # metas read out of make_pair's own body
+    buf = pl.create_tensor([1, 8], dtype=pl.FP32)
+    mid = relu_kernel(a, buf)    # mid aliases buf, so it inherits buf's meta
+    ...
+```
+
+A device kernel (`@pl.jit.incore`) cannot allocate, so it always takes the second form —
+`pl.create_tensor` belongs on the control plane. An `@pl.jit.inline` helper is spliced into
+the caller, so either form is available to it.
+
+What does *not* resolve is a returned tensor whose shape no static rule can reach — a
+`pl.create_tensor` sized from a value only the device knows, or a result rebound through an
+operation the specializer does not model. That surfaces as
+`missing inferred tensor metadata for parameter '<name>'` at the *next* call that consumes
+it; annotate the producing allocation with static extents, or pass the buffer in as a
+`pl.Out[...]` parameter.
+
 ### Three constraints that decide whether a jit kernel compiles
 
 These are the failures new `@pl.jit` code hits, in the order it hits them.

--- a/docs/zh/user/language/01-functions.md
+++ b/docs/zh/user/language/01-functions.md
@@ -139,10 +139,18 @@ def entry(x: pl.Tensor[[1, 8], pl.FP32], out: pl.Out[pl.Tensor[[1, 8], pl.FP32]]
 设备 kernel（`@pl.jit.incore`）不能分配内存，所以它只能用第二种写法 —— `pl.create_tensor`
 属于控制平面。`@pl.jit.inline` helper 会被拼接进调用方，两种写法都可以用。
 
-无法解析的情况是：返回的张量其 shape 没有任何静态规则能推导 —— 例如由只有设备才知道的值
-决定尺寸的 `pl.create_tensor`，或者经过特化器未建模的操作重新绑定的结果。它会在**下一个**
-消费该张量的调用处报出 `missing inferred tensor metadata for parameter '<name>'`；
-请为产生该分配的语句标注静态维度，或者把缓冲区作为 `pl.Out[...]` 参数传入。
+特化器无法静态计算某个维度本身**不是**问题。由只有设备才知道的值决定尺寸的
+`pl.create_tensor` —— `pl.tensor.read(cfg, [0])`、`pld.world_size()` —— 会变成一个动态
+维度并继续向下传递，之后由共享的 pass 流水线来判定程序对它做了什么（例如把整个张量作为
+tile 加载，就会得到 `InitMemRef requires static shape` —— 与等价的 `@pl.program` 写法
+报出的错误完全相同）。
+
+真正无法解析的情况是：返回张量的 shape 特化器根本**触及不到** —— 例如目标 shape 非静态的
+`pl.reshape`（reshape 受源张量元素总数约束，因此不能用动态维度顶替），或者经过特化器未
+建模的操作重新绑定的结果。它会在**下一个**消费该张量的调用处报出
+`missing inferred tensor metadata for parameter '<name>'` —— 错误指向的是消费方，但要改的
+是生产方：让产生该张量的语句具有可静态推导的 shape，或者把缓冲区作为 `pl.Out[...]`
+参数传入。
 
 ### 决定 jit kernel 能否编译的三条约束
 

--- a/docs/zh/user/language/01-functions.md
+++ b/docs/zh/user/language/01-functions.md
@@ -109,6 +109,41 @@ def host_orch(
 
 `@pl.jit.host` 拒绝 `level=`（HOST 是隐含的）。
 
+### 子函数返回的张量会保留 shape 和 dtype
+
+特化会给每个生成的参数打上具体的 shape 和 dtype，因此子函数返回的张量必须能追溯到某个来源。
+两种写法都可用，也可以在同一个入口中混用：
+
+```python
+@pl.jit.inline
+def make_pair(x: pl.Tensor[[1, 8], pl.FP32]):
+    a = pl.create_tensor([1, 8], dtype=pl.FP32)   # helper 自己分配结果
+    b = pl.create_tensor([1, 8], dtype=pl.FP32)
+    with pl.at(level=pl.Level.CORE_GROUP):
+        a[:, :] = x[:, :]
+        b[:, :] = pl.mul(x[:, :], 2.0)
+    return a, b
+
+@pl.jit.incore
+def relu_kernel(x: pl.Tensor, out: pl.Out[pl.Tensor]):   # 调用方分配，kernel 填充
+    ...
+
+@pl.jit
+def entry(x: pl.Tensor[[1, 8], pl.FP32], out: pl.Out[pl.Tensor[[1, 8], pl.FP32]]):
+    a, b = make_pair(x)          # 元数据从 make_pair 自身的函数体中读出
+    buf = pl.create_tensor([1, 8], dtype=pl.FP32)
+    mid = relu_kernel(a, buf)    # mid 别名到 buf，因此继承 buf 的元数据
+    ...
+```
+
+设备 kernel（`@pl.jit.incore`）不能分配内存，所以它只能用第二种写法 —— `pl.create_tensor`
+属于控制平面。`@pl.jit.inline` helper 会被拼接进调用方，两种写法都可以用。
+
+无法解析的情况是：返回的张量其 shape 没有任何静态规则能推导 —— 例如由只有设备才知道的值
+决定尺寸的 `pl.create_tensor`，或者经过特化器未建模的操作重新绑定的结果。它会在**下一个**
+消费该张量的调用处报出 `missing inferred tensor metadata for parameter '<name>'`；
+请为产生该分配的语句标注静态维度，或者把缓冲区作为 `pl.Out[...]` 参数传入。
+
 ### 决定 jit kernel 能否编译的三条约束
 
 这是新写的 `@pl.jit` 代码会依次撞上的三个失败。

--- a/python/pypto/jit/decorator.py
+++ b/python/pypto/jit/decorator.py
@@ -863,6 +863,23 @@ def _dep_out_metas(
     return result
 
 
+class _DepReturn(NamedTuple):
+    """What descending into a callee's ``return`` statement established.
+
+    ``metas`` are the targets the descent typed. ``stale`` are the targets it
+    proved it *cannot* type: the callee returns a named local its own extractor
+    declined, so whatever the caller knew about that name before the call no
+    longer describes it. Both are empty when the descent did not happen at all,
+    which leaves the caller's pre-call fallback in charge.
+    """
+
+    metas: dict[str, TensorMeta]
+    stale: frozenset[str]
+
+
+_DEP_RETURN_DECLINED = _DepReturn({}, frozenset())
+
+
 def _dep_return_metas(
     call: ast.Call,
     dep_name: str,
@@ -870,7 +887,7 @@ def _dep_return_metas(
     deps: _DepScan,
     local: dict[str, TensorMeta],
     scalars: Mapping[str, int | float | bool],
-) -> dict[str, TensorMeta]:
+) -> _DepReturn:
     """For ``v1, ..., vk = dep(args)`` where ``dep`` returns tensors it created
     itself, resolve each ``vi`` from the callee's own ``return`` statement.
 
@@ -882,20 +899,27 @@ def _dep_return_metas(
     callee. Re-run the extractor over the callee's body, seeded with the params
     this call site binds, and read the returned names' metas off that.
 
-    Returns ``{}`` (leaving the clear ``_build_params`` error) when the callee's
-    source is unavailable, its return arity doesn't match the target, or it is
-    already on the extraction stack.
+    A returned element that is a *named* callee local the descent could not type
+    comes back in ``stale`` rather than silently absent. The caller would
+    otherwise keep the meta the target carried before the call — demonstrably
+    the wrong tensor, since the callee rebinds it — and hand that shape to the
+    next dep. An element that is not a bare ``Name`` (a call, a literal)
+    establishes nothing either way and is simply left out.
+
+    Returns :data:`_DEP_RETURN_DECLINED` when the callee's source is
+    unavailable, its return arity doesn't match the target, or it is already on
+    the extraction stack.
     """
     dep = deps.funcs.get(dep_name)
     names = _target_names(target)
     if dep is None or not names or id(dep._func) in deps.seen:
-        return {}
+        return _DEP_RETURN_DECLINED
     try:
         ret_names = _return_element_names(_get_func_def(dep._func))
     except OSError:
-        return {}
+        return _DEP_RETURN_DECLINED
     if len(ret_names) != len(names):
-        return {}
+        return _DEP_RETURN_DECLINED
     dep_params, _ = deps.io[dep_name]
     seed_meta: dict[str, TensorMeta] = {}
     seed_scalars: dict[str, int | float | bool] = {}
@@ -916,7 +940,40 @@ def _dep_return_metas(
         caller_func_type=dep._func_type,
         dep_seen=deps.seen,
     )
-    return {v: callee_metas[r] for v, r in zip(names, ret_names, strict=True) if r in callee_metas}
+    resolved = {v: callee_metas[r] for v, r in zip(names, ret_names, strict=True) if r in callee_metas}
+    stale = {v for v, r in zip(names, ret_names, strict=True) if r and r not in callee_metas}
+    return _DepReturn(resolved, frozenset(stale))
+
+
+def _dep_out_metas_or_return(
+    call: ast.Call,
+    dep_name: str,
+    target: ast.expr,
+    deps: _DepScan,
+    local: dict[str, TensorMeta],
+    scalars: Mapping[str, int | float | bool],
+) -> _DepReturn:
+    """Resolve one ``v1, ..., vk = dep(args)`` target, ``Out`` convention first.
+
+    The ``Out`` rule needs nothing but the caller's own pool, and where both
+    rules apply they agree — a returned ``Out`` param resolves to the same
+    caller buffer either way — so it wins and never marks a target stale.
+    """
+    out_metas = _dep_out_metas(call, dep_name, target, deps, local)
+    if out_metas:
+        return _DepReturn(out_metas, frozenset())
+    return _dep_return_metas(call, dep_name, target, deps, local, scalars)
+
+
+def _apply_dep_return(local: dict[str, TensorMeta], dep_return: _DepReturn) -> None:
+    """Fold one dep-call target's resolution into the source-ordered pool.
+
+    Resolved names land; names the descent proved stale are dropped, so the
+    caller's pre-call fallback cannot hand a replaced tensor's shape onward.
+    """
+    local.update(dep_return.metas)
+    for name in dep_return.stale:
+        local.pop(name, None)
 
 
 def _fold_int_arith(op: ast.operator, lhs: int, rhs: int) -> int | None:
@@ -1058,7 +1115,7 @@ def _update_local_tensor_meta(
     has_named_target = named_target is not None
     meta: TensorMeta | None = None
     preserve_existing = False
-    dep_target_metas: list[dict[str, TensorMeta]] = [{} for _ in targets]
+    dep_returns: list[_DepReturn] = [_DEP_RETURN_DECLINED for _ in targets]
 
     # Python evaluates the RHS once before assigning any target. Infer all RHS
     # effects from the same pre-assignment state so a self-referential chained
@@ -1083,21 +1140,20 @@ def _update_local_tensor_meta(
         elif isinstance(fn, ast.Name) and fn.id in deps.io:
             # The in-place ``Out``-param convention first; a callee that
             # allocates its own results falls through to its return statement.
-            dep_target_metas = [
-                _dep_out_metas(value, fn.id, target, deps, local)
-                or _dep_return_metas(value, fn.id, target, deps, local, scalars)
-                for target in targets
+            dep_returns = [
+                _dep_out_metas_or_return(value, fn.id, target, deps, local, scalars) for target in targets
             ]
             # Preserve the existing dependency-result behavior when neither
             # rule resolves the callee's results: an already-known target keeps
             # its metadata until a later supported rebinding can refine it.
             # This is how bare inline helpers propagate same-shaped results
-            # today.
+            # today. A target the return descent proved stale is exempt — see
+            # ``_dep_return_metas``.
             preserve_existing = True
 
     alias = _extract_dim_alias(value)
-    for target, target_metas in zip(targets, dep_target_metas, strict=True):
-        local.update(target_metas)
+    for target, dep_return in zip(targets, dep_returns, strict=True):
+        _apply_dep_return(local, dep_return)
         named = target if isinstance(target, ast.Name) else None
 
         if named is None:

--- a/python/pypto/jit/decorator.py
+++ b/python/pypto/jit/decorator.py
@@ -760,7 +760,10 @@ def _scan_dep_io(
 
     Used by ``_extract_local_tensor_metas`` to propagate metas through
     ``v1, ..., vk = dep(args)`` assignments (each ``vi`` inherits the meta of
-    the caller arg bound to the i-th output-like parameter).
+    the caller arg bound to the i-th output-like parameter). A dep with no
+    output-like params is still recorded: ``_dep_return_metas`` needs
+    ``param_names`` to bind the call site's args when it descends into the
+    callee's body.
 
     ``output_param_names`` covers both ``pl.Out[...]`` and ``pl.InOut[...]``
     params — a caller can capture either from ``v = dep(...)`` — and is kept in
@@ -783,11 +786,54 @@ def _scan_dep_io(
     return out
 
 
+class _DepScan(NamedTuple):
+    """Everything the local-meta walk needs to know about one caller's deps.
+
+    ``io`` and ``funcs`` are both keyed by the name the caller's *source*
+    calls the dep by (see :class:`_DepBinding`). ``seen`` holds the ``id()`` of
+    every Python function already on the extraction stack, so the recursive
+    descent :func:`_dep_return_metas` performs cannot loop.
+    """
+
+    io: dict[str, tuple[list[str], list[str]]]
+    funcs: dict[str, JITFunction]
+    seen: frozenset[int]
+
+
+def _target_names(target: ast.expr) -> list[str]:
+    """Return the bound names of ``v = ...`` / ``v1, ..., vk = ...``.
+
+    Empty for any other target shape (a subscript, an attribute, a nested
+    unpack) — those are not local tensor rebindings this extractor models.
+    """
+    if isinstance(target, ast.Name):
+        return [target.id]
+    if isinstance(target, ast.Tuple) and all(isinstance(e, ast.Name) for e in target.elts):
+        return [e.id for e in target.elts if isinstance(e, ast.Name)]
+    return []
+
+
+def _return_element_names(func_def: ast.FunctionDef) -> list[str]:
+    """Return the names a function's first value-carrying ``return`` hands back.
+
+    ``return a, b`` → ``["a", "b"]``; ``return a`` → ``["a"]``. An element that
+    is not a bare ``Name`` (a call, a subscript, a literal) yields ``""`` so the
+    positional alignment with the caller's targets survives — the empty name
+    simply resolves to no meta.
+    """
+    for node in ast.walk(func_def):
+        if not (isinstance(node, ast.Return) and node.value is not None):
+            continue
+        elts = node.value.elts if isinstance(node.value, ast.Tuple) else [node.value]
+        return [e.id if isinstance(e, ast.Name) else "" for e in elts]
+    return []
+
+
 def _dep_out_metas(
     call: ast.Call,
     dep_name: str,
     target: ast.expr,
-    dep_io: dict[str, tuple[list[str], list[str]]],
+    deps: _DepScan,
     local: dict[str, TensorMeta],
 ) -> dict[str, TensorMeta]:
     """For ``v1, ..., vk = dep(args)`` where ``dep`` has ``k`` ``Out`` params,
@@ -795,16 +841,12 @@ def _dep_out_metas(
     parameter.
 
     Mapping handles both positional and keyword args. No-op when the dep has
-    no ``Out`` params or when target/arity don't match.
+    no ``Out`` params or when target/arity don't match — ``_dep_return_metas``
+    then covers the callee-allocated case.
     """
-    dep_params, out_params = dep_io[dep_name]
-    if isinstance(target, ast.Name):
-        names = [target.id]
-    elif isinstance(target, ast.Tuple) and all(isinstance(e, ast.Name) for e in target.elts):
-        names = [e.id for e in target.elts if isinstance(e, ast.Name)]
-    else:
-        return {}
-    if not out_params or len(names) != len(out_params):
+    dep_params, out_params = deps.io[dep_name]
+    names = _target_names(target)
+    if not names or not out_params or len(names) != len(out_params):
         return {}
     mapping: dict[str, str | None] = {}
     for i, arg in enumerate(call.args):
@@ -819,6 +861,62 @@ def _dep_out_metas(
         if caller_arg is not None and caller_arg in local:
             result[vname] = local[caller_arg]
     return result
+
+
+def _dep_return_metas(
+    call: ast.Call,
+    dep_name: str,
+    target: ast.expr,
+    deps: _DepScan,
+    local: dict[str, TensorMeta],
+    scalars: Mapping[str, int | float | bool],
+) -> dict[str, TensorMeta]:
+    """For ``v1, ..., vk = dep(args)`` where ``dep`` returns tensors it created
+    itself, resolve each ``vi`` from the callee's own ``return`` statement.
+
+    ``_dep_out_metas`` covers the in-place convention, where every returned
+    tensor is also an ``Out`` parameter the *caller* allocated, so its meta is
+    already in the caller's pool. A helper may instead ``pl.create_tensor`` its
+    results and hand them back — the classic ``a, b = make_pair(x)`` inline
+    preparation step — and then the shape and dtype exist only inside the
+    callee. Re-run the extractor over the callee's body, seeded with the params
+    this call site binds, and read the returned names' metas off that.
+
+    Returns ``{}`` (leaving the clear ``_build_params`` error) when the callee's
+    source is unavailable, its return arity doesn't match the target, or it is
+    already on the extraction stack.
+    """
+    dep = deps.funcs.get(dep_name)
+    names = _target_names(target)
+    if dep is None or not names or id(dep._func) in deps.seen:
+        return {}
+    try:
+        ret_names = _return_element_names(_get_func_def(dep._func))
+    except OSError:
+        return {}
+    if len(ret_names) != len(names):
+        return {}
+    dep_params, _ = deps.io[dep_name]
+    seed_meta: dict[str, TensorMeta] = {}
+    seed_scalars: dict[str, int | float | bool] = {}
+    for dep_param, caller_arg in _build_param_mapping(dep_params, _call_arg_refs(call)).items():
+        # A ``_SlicedArg`` (``chip_orch(x[r], ...)``) seeds nothing: that
+        # per-rank dispatch form returns through ``Out`` params, so the
+        # descent below never needs the sliced param's meta.
+        if not isinstance(caller_arg, str):
+            continue
+        if caller_arg in local:
+            seed_meta[dep_param] = local[caller_arg]
+        elif caller_arg in scalars:
+            seed_scalars[dep_param] = scalars[caller_arg]
+    callee_metas = _extract_local_tensor_metas(
+        dep._func,
+        seed_meta=seed_meta,
+        seed_scalars=seed_scalars,
+        caller_func_type=dep._func_type,
+        dep_seen=deps.seen,
+    )
+    return {v: callee_metas[r] for v, r in zip(names, ret_names, strict=True) if r in callee_metas}
 
 
 def _fold_int_arith(op: ast.operator, lhs: int, rhs: int) -> int | None:
@@ -946,9 +1044,10 @@ def _update_local_tensor_meta(
     stmt: ast.stmt,
     local: dict[str, TensorMeta],
     dim_aliases: dict[str, tuple[str, int]],
-    dep_io: dict[str, tuple[list[str], list[str]]],
+    deps: _DepScan,
     resolve_int: Callable[[ast.expr], int | None],
     pl_attr_handlers: dict[str, Callable[[ast.Call, str | None], TensorMeta | None]],
+    scalars: Mapping[str, int | float | bool],
 ) -> None:
     """Apply one assignment's metadata effects to the source-ordered state."""
     parts = _assignment_parts(stmt)
@@ -981,13 +1080,19 @@ def _update_local_tensor_meta(
                 # result metadata this extractor does not model (for example,
                 # same-shaped pl.assemble rebindings).
                 preserve_existing = True
-        elif isinstance(fn, ast.Name) and fn.id in dep_io:
-            dep_target_metas = [_dep_out_metas(value, fn.id, target, dep_io, local) for target in targets]
-            # Preserve the existing dependency-result behavior when the
-            # callee has no explicit Out/InOut metadata: an already-known
-            # target keeps its metadata until a later supported rebinding can
-            # refine it. This is how bare inline helpers propagate same-shaped
-            # results today.
+        elif isinstance(fn, ast.Name) and fn.id in deps.io:
+            # The in-place ``Out``-param convention first; a callee that
+            # allocates its own results falls through to its return statement.
+            dep_target_metas = [
+                _dep_out_metas(value, fn.id, target, deps, local)
+                or _dep_return_metas(value, fn.id, target, deps, local, scalars)
+                for target in targets
+            ]
+            # Preserve the existing dependency-result behavior when neither
+            # rule resolves the callee's results: an already-known target keeps
+            # its metadata until a later supported rebinding can refine it.
+            # This is how bare inline helpers propagate same-shaped results
+            # today.
             preserve_existing = True
 
     alias = _extract_dim_alias(value)
@@ -1016,15 +1121,16 @@ def _walk_local_tensor_meta_stmts(
     stop_at_dep: str | None,
     local: dict[str, TensorMeta],
     dim_aliases: dict[str, tuple[str, int]],
-    dep_io: dict[str, tuple[list[str], list[str]]],
+    deps: _DepScan,
     resolve_int: Callable[[ast.expr], int | None],
     pl_attr_handlers: dict[str, Callable[[ast.Call, str | None], TensorMeta | None]],
+    scalars: Mapping[str, int | float | bool],
 ) -> bool:
     """Walk supported DSL scopes in source order until the selected call."""
     for stmt in stmts:
         if _stmt_calls_dep(stmt, stop_at_dep):
             return True
-        _update_local_tensor_meta(stmt, local, dim_aliases, dep_io, resolve_int, pl_attr_handlers)
+        _update_local_tensor_meta(stmt, local, dim_aliases, deps, resolve_int, pl_attr_handlers, scalars)
         for attr in ("body", "orelse", "finalbody"):
             nested = getattr(stmt, attr, None)
             if isinstance(nested, list) and _walk_local_tensor_meta_stmts(
@@ -1032,9 +1138,10 @@ def _walk_local_tensor_meta_stmts(
                 stop_at_dep,
                 local,
                 dim_aliases,
-                dep_io,
+                deps,
                 resolve_int,
                 pl_attr_handlers,
+                scalars,
             ):
                 return True
     return False
@@ -1046,6 +1153,7 @@ def _extract_local_tensor_metas(
     seed_scalars: dict[str, int | float | bool] | None = None,
     caller_func_type: str = "orchestration",
     stop_at_dep: str | None = None,
+    dep_seen: frozenset[int] = frozenset(),
 ) -> dict[str, TensorMeta]:
     """Infer ``TensorMeta`` for the local tensor variables in ``func``'s body.
 
@@ -1077,6 +1185,12 @@ def _extract_local_tensor_metas(
        argument bound to the i-th ``Out`` parameter (the in-place-output
        convention every such kernel follows, and the same heuristic
        ``_infer_return_type`` uses on the callee side).
+    4. ``v1, ..., vk = jit_dep(args)`` where ``jit_dep`` instead allocates its
+       own results (``a = pl.create_tensor(...); ...; return a, b``) — the
+       extractor descends into the callee's body, seeded with the params this
+       call site binds, and each ``vi`` takes the meta of the i-th returned
+       name (see :func:`_dep_return_metas`). ``dep_seen`` carries the ``id()``
+       of every function already on that stack so the descent cannot loop.
 
     ``seed_meta`` pre-populates the table with the caller's parameter metas
     (including any ``DynDim`` entries those carry) so a ``pl.slice`` of a
@@ -1277,7 +1391,11 @@ def _extract_local_tensor_metas(
             dims.append(v if v is not None else parent_dim)
         return TensorMeta(shape=tuple(dims), dtype=src_meta.dtype, layout=src_meta.layout)
 
-    dep_io = _scan_dep_io(func, caller_func_type)
+    deps = _DepScan(
+        io=_scan_dep_io(func, caller_func_type),
+        funcs={b.call_name: b.dep for b in _discover_dep_bindings(func, caller_func_type)},
+        seen=dep_seen | {id(func)},
+    )
 
     # Dispatch table: pl.<attr>(...) → meta extraction function.
     # Replaces sequential if-chains, reducing branch and statement counts.
@@ -1293,9 +1411,10 @@ def _extract_local_tensor_metas(
         stop_at_dep,
         local,
         dim_aliases,
-        dep_io,
+        deps,
         _resolve_int,
         _pl_attr_handlers,
+        scalars,
     )
     return local
 
@@ -1369,13 +1488,19 @@ def _extract_call_args_for_dep(
     ]
     if not calls:
         return None
-    node = min(calls, key=lambda call: (call.lineno, call.col_offset))
+    return _call_arg_refs(min(calls, key=lambda call: (call.lineno, call.col_offset)))
+
+
+def _call_arg_refs(node: ast.Call) -> list[tuple[str | None, str | _SlicedArg | None]]:
+    """Unify one call node's positional and keyword args into ``(param, ref)`` pairs.
+
+    ``param`` is ``None`` for a positional argument (paired with the callee's
+    parameter list by index in :func:`_build_param_mapping`) and the keyword
+    name otherwise. ``**kwargs`` splats are skipped — they carry no name to
+    bind against.
+    """
     result: list[tuple[str | None, str | _SlicedArg | None]] = [(None, _arg_ref(arg)) for arg in node.args]
-    result.extend(
-        (kw.arg, _arg_ref(kw.value))
-        for kw in node.keywords
-        if kw.arg is not None  # skip **kwargs splats
-    )
+    result.extend((kw.arg, _arg_ref(kw.value)) for kw in node.keywords if kw.arg is not None)
     return result
 
 

--- a/tests/ut/jit/test_decorator.py
+++ b/tests/ut/jit/test_decorator.py
@@ -1078,6 +1078,27 @@ def _arity_mismatch_body(x: pl.Tensor) -> pl.Tensor:
     return only_one
 
 
+@jit.inline
+def _mixed_pair_inline(x: pl.Tensor):
+    """Inline helper returning one typeable local and one the extractor declines.
+
+    ``pl.reshape`` with a non-static shape is strict on purpose (a reshape's
+    dims are constrained by the source's element count), so ``opaque`` has no
+    meta on the callee side either.
+    """
+    opaque = pl.reshape(x, [2, pl.tensor.dim(x, 1)])
+    known = pl.create_tensor([4, 4], dtype=pl.FP16)
+    return opaque, known
+
+
+def _mixed_pair_body(x: pl.Tensor) -> pl.Tensor:
+    """Plain (undecorated) caller: rebinds a known local through a helper that
+    returns one typeable result and one it cannot type."""
+    a = pl.create_tensor([16, 8], dtype=pl.FP32)
+    a, b = _mixed_pair_inline(a)
+    return b
+
+
 # --- Runtime-sized local extents (synthesized DynDim) ------------------------
 # Fixtures for the tests covering a local tensor whose extent is only known at
 # runtime: one decorated dep, then plain (undecorated) caller bodies fed straight
@@ -1336,11 +1357,19 @@ class TestSliceAndDepReturnMetadata:
         assert metas["a"] == TensorMeta(shape=(1, 8), dtype=DataType.FP32)
         assert metas["b"] == TensorMeta(shape=(16, 8), dtype=DataType.FP16)
 
-    def test_callee_allocated_tuple_return_flows_into_next_dep(self):
+    def test_callee_allocated_tuple_return_flows_into_next_dep(self, monkeypatch, tmp_path):
         """The reported failure: two tensors an inline helper created itself are
         unpacked and passed to a second inline helper, whose params then have no
-        inferred metadata."""
+        inferred metadata.
+
+        Driven through ``compile()``, not ``lower()``: ``lower()`` stops after
+        the passes, so a codegen precondition the metadata affects would not
+        fire here. ``PTOAS_ROOT`` is pointed at nothing so the run stays
+        source-only and needs no assembler (the
+        ``test_jit_compile_extraction`` pattern).
+        """
         torch = pytest.importorskip("torch")
+        monkeypatch.setenv("PTOAS_ROOT", str(tmp_path / "missing_ptoas"))
 
         @jit.inline
         def make_pair(x: pl.Tensor[[1, 8], pl.FP32]):
@@ -1361,13 +1390,15 @@ class TestSliceAndDepReturnMetadata:
             a, b = make_pair(x)
             consume_pair(a, b, out)
 
-        program = pair_entry.lower(torch.randn(1, 8), torch.empty(1, 8))
-        assert isinstance(program, ir.Program)
+        compiled = pair_entry.compile(torch.randn(1, 8), torch.empty(1, 8))
+        assert isinstance(compiled, CompiledProgram)
 
-    def test_callee_allocated_single_return_flows_into_next_dep(self):
+    def test_callee_allocated_single_return_flows_into_next_dep(self, monkeypatch, tmp_path):
         """The single-value shape of the same rule: ``buf = helper(x)`` where
-        ``helper`` allocates ``buf`` itself."""
+        ``helper`` allocates ``buf`` itself. Compiled, not just lowered, for the
+        reason given above."""
         torch = pytest.importorskip("torch")
+        monkeypatch.setenv("PTOAS_ROOT", str(tmp_path / "missing_ptoas"))
 
         @jit.inline
         def double_inline(x: pl.Tensor[[1, 8], pl.FP32]):
@@ -1386,8 +1417,8 @@ class TestSliceAndDepReturnMetadata:
             scaled = double_inline(x)
             copy_inline(scaled, out)
 
-        program = single_entry.lower(torch.randn(1, 8), torch.empty(1, 8))
-        assert isinstance(program, ir.Program)
+        compiled = single_entry.compile(torch.randn(1, 8), torch.empty(1, 8))
+        assert isinstance(compiled, CompiledProgram)
 
     def test_callee_allocated_return_sized_from_its_param(self):
         """A callee whose allocation is sized off a parameter resolves through
@@ -1397,6 +1428,19 @@ class TestSliceAndDepReturnMetadata:
         # ``pl.create_tensor(..., dtype=pl.FP32)`` sized by ``pl.tensor.dim(src, 1)``
         # of the caller's ``x``.
         assert metas["wide"] == TensorMeta(shape=(2, 64), dtype=DataType.FP32)
+
+    def test_partially_resolved_tuple_clears_the_unresolved_target(self):
+        """A target the callee rebinds to something untypeable must not keep the
+        metadata it carried *before* the call — that shape describes a tensor
+        the helper already replaced, and the next dep would silently receive it.
+        Clearing it restores the clear ``_build_params`` error."""
+        seed = {"x": TensorMeta(shape=(16, 8), dtype=DataType.FP32)}
+        metas = _extract_local_tensor_metas(_mixed_pair_body, seed_meta=seed)
+        # ``b`` still resolves from the callee's own pl.create_tensor ...
+        assert metas["b"] == TensorMeta(shape=(4, 4), dtype=DataType.FP16)
+        # ... while ``a`` drops its stale pre-call [16, 8] FP32 rather than
+        # advertising it to whatever consumes ``a`` next.
+        assert "a" not in metas
 
     def test_callee_return_arity_mismatch_resolves_nothing(self):
         """A target that does not line up with the callee's return list is

--- a/tests/ut/jit/test_decorator.py
+++ b/tests/ut/jit/test_decorator.py
@@ -1035,6 +1035,49 @@ def _callsite_metadata_kernel(x: pl.Tensor, out: pl.Out[pl.Tensor]) -> pl.Tensor
     return out
 
 
+# --- Callee-allocated dep results -------------------------------------------
+# A helper that allocates its own outputs and returns them, rather than writing
+# into pl.Out params the caller allocated. Its results' shape/dtype live only in
+# its body, so the caller's metadata pool has to descend into it.
+
+
+@jit.inline
+def _make_pair_inline(x: pl.Tensor):
+    """Inline helper returning two tensors it created itself."""
+    a = pl.create_tensor([1, 8], dtype=pl.FP32)
+    b = pl.create_tensor([16, 8], dtype=pl.FP16)
+    with pl.at(level=pl.Level.CORE_GROUP):
+        a[:, :] = x[0:1, :]
+        b[:, :] = pl.cast(x[0:16, :], pl.FP16)
+    return a, b
+
+
+def _tuple_dep_return_body(x: pl.Tensor, out: pl.Out[pl.Tensor]) -> pl.Tensor:
+    """Plain (undecorated) caller: unpacks a tuple of callee-allocated tensors."""
+    a, b = _make_pair_inline(x)  # noqa: F841 — the metas under test
+    return out
+
+
+@jit.inline
+def _widen_inline(src: pl.Tensor):
+    """Inline helper whose own allocation is sized off its parameter."""
+    cols = pl.tensor.dim(src, 1)
+    wide = pl.create_tensor([2, cols], dtype=pl.FP32)
+    return wide
+
+
+def _param_sized_dep_body(x: pl.Tensor) -> pl.Tensor:
+    """Plain (undecorated) caller: the callee sizes its result from the arg."""
+    wide = _widen_inline(x)
+    return wide
+
+
+def _arity_mismatch_body(x: pl.Tensor) -> pl.Tensor:
+    """Plain (undecorated) caller: one target against a two-element return."""
+    only_one = _make_pair_inline(x)
+    return only_one
+
+
 # --- Runtime-sized local extents (synthesized DynDim) ------------------------
 # Fixtures for the tests covering a local tensor whose extent is only known at
 # runtime: one decorated dep, then plain (undecorated) caller bodies fed straight
@@ -1279,6 +1322,89 @@ class TestSliceAndDepReturnMetadata:
         out = torch.empty(16, 32)
         program = split_entry.lower(src, out)
         assert isinstance(program, ir.Program)
+
+    def test_extract_local_tensor_metas_callee_allocated_tuple_return(self):
+        """A dep with no ``Out`` params still resolves: its returned locals'
+        metas are read out of the callee's own body."""
+        seed = {
+            "x": TensorMeta(shape=(16, 8), dtype=DataType.FP32),
+            "out": TensorMeta(shape=(16, 8), dtype=DataType.FP32),
+        }
+        metas = _extract_local_tensor_metas(_tuple_dep_return_body, seed_meta=seed)
+        # Each target takes the pl.create_tensor meta of the matching returned
+        # name — including the dtype, which differs between the two.
+        assert metas["a"] == TensorMeta(shape=(1, 8), dtype=DataType.FP32)
+        assert metas["b"] == TensorMeta(shape=(16, 8), dtype=DataType.FP16)
+
+    def test_callee_allocated_tuple_return_flows_into_next_dep(self):
+        """The reported failure: two tensors an inline helper created itself are
+        unpacked and passed to a second inline helper, whose params then have no
+        inferred metadata."""
+        torch = pytest.importorskip("torch")
+
+        @jit.inline
+        def make_pair(x: pl.Tensor[[1, 8], pl.FP32]):
+            a = pl.create_tensor([1, 8], dtype=pl.FP32)
+            b = pl.create_tensor([1, 8], dtype=pl.FP32)
+            with pl.at(level=pl.Level.CORE_GROUP):
+                a[:, :] = x[:, :]
+                b[:, :] = pl.mul(x[:, :], 2.0)
+            return a, b
+
+        @jit.inline
+        def consume_pair(a: pl.Tensor, b: pl.Tensor, out: pl.Tensor):
+            with pl.at(level=pl.Level.CORE_GROUP):
+                out[:, :] = pl.add(a[:, :], b[:, :])
+
+        @jit
+        def pair_entry(x: pl.Tensor[[1, 8], pl.FP32], out: pl.Out[pl.Tensor[[1, 8], pl.FP32]]):
+            a, b = make_pair(x)
+            consume_pair(a, b, out)
+
+        program = pair_entry.lower(torch.randn(1, 8), torch.empty(1, 8))
+        assert isinstance(program, ir.Program)
+
+    def test_callee_allocated_single_return_flows_into_next_dep(self):
+        """The single-value shape of the same rule: ``buf = helper(x)`` where
+        ``helper`` allocates ``buf`` itself."""
+        torch = pytest.importorskip("torch")
+
+        @jit.inline
+        def double_inline(x: pl.Tensor[[1, 8], pl.FP32]):
+            scaled = pl.create_tensor([1, 8], dtype=pl.FP32)
+            with pl.at(level=pl.Level.CORE_GROUP):
+                scaled[:, :] = pl.mul(x[:, :], 2.0)
+            return scaled
+
+        @jit.inline
+        def copy_inline(src: pl.Tensor, out: pl.Tensor):
+            with pl.at(level=pl.Level.CORE_GROUP):
+                out[:, :] = src[:, :]
+
+        @jit
+        def single_entry(x: pl.Tensor[[1, 8], pl.FP32], out: pl.Out[pl.Tensor[[1, 8], pl.FP32]]):
+            scaled = double_inline(x)
+            copy_inline(scaled, out)
+
+        program = single_entry.lower(torch.randn(1, 8), torch.empty(1, 8))
+        assert isinstance(program, ir.Program)
+
+    def test_callee_allocated_return_sized_from_its_param(self):
+        """A callee whose allocation is sized off a parameter resolves through
+        the call site: the seed metas descend with the recursion."""
+        seed = {"x": TensorMeta(shape=(4, 64), dtype=DataType.FP16)}
+        metas = _extract_local_tensor_metas(_param_sized_dep_body, seed_meta=seed)
+        # ``pl.create_tensor(..., dtype=pl.FP32)`` sized by ``pl.tensor.dim(src, 1)``
+        # of the caller's ``x``.
+        assert metas["wide"] == TensorMeta(shape=(2, 64), dtype=DataType.FP32)
+
+    def test_callee_return_arity_mismatch_resolves_nothing(self):
+        """A target that does not line up with the callee's return list is
+        declined rather than mis-paired — the clear ``_build_params`` error
+        beats a wrong shape."""
+        seed = {"x": TensorMeta(shape=(16, 8), dtype=DataType.FP32)}
+        metas = _extract_local_tensor_metas(_arity_mismatch_body, seed_meta=seed)
+        assert "only_one" not in metas
 
     def test_runtime_sized_slice_uses_static_parent_dim(self):
         """A pl.slice with a runtime-scalar width is advertised to the consuming


### PR DESCRIPTION
## What

Teach the `@pl.jit` specializer to type tensors that a sub-function **allocates itself and
returns**, so they can be passed on to the next call.

## Why

The local-metadata extractor in `python/pypto/jit/decorator.py` resolved
`v1, ..., vk = dep(args)` through exactly one rule (`_dep_out_metas`): each target inherits
the shape/dtype of the *caller argument* bound to the callee's i-th `pl.Out` / `pl.InOut`
parameter. That is the in-place convention every device kernel follows, and it is the only
one the extractor knew.

An inline helper may instead allocate its own results and hand them back. It then has no
output-like params, the rule returns nothing, and the unpacked targets never enter the
caller's metadata pool:

```python
@pl.jit.inline
def make_pair(x: pl.Tensor[[1, 8], pl.FP32]):
    a = pl.create_tensor([1, 8], dtype=pl.FP32)   # no Out param ...
    b = pl.create_tensor([1, 8], dtype=pl.FP32)
    with pl.at(level=pl.Level.CORE_GROUP):
        a[:, :] = x[:, :]
        b[:, :] = pl.mul(x[:, :], 2.0)
    return a, b                                    # ... so out_params == []

@pl.jit
def pair_test(x: pl.Tensor[[1, 8], pl.FP32], out: pl.Out[pl.Tensor[[1, 8], pl.FP32]]):
    a, b = make_pair(x)
    consume_pair(a, b, out)
```

The shape and dtype exist only inside `make_pair`'s body, which nothing read. Specialization
therefore failed at the *next* call, naming its innocent parameter:

```text
ValueError: @pl.jit: missing inferred tensor metadata for parameter 'a' of 'consume_pair'.
This usually means the tensor's shape/dtype could not be statically determined, or that the
call site passing it was not resolved ...
```

The message points at `consume_pair` and at shape inference, but neither is at fault — the
trigger is `make_pair`'s return, one statement earlier. The only workaround was to restructure
the helper around explicit `pl.Out` parameters the caller allocates.

## How

A second rule, `_dep_return_metas`: when the `Out` convention does not apply, re-run the
extractor over the **callee's** body — seeded with the params that call site binds — and take
each target's meta from the i-th name in the callee's `return` statement.

- `_DepScan` (new `NamedTuple`) carries the dep objects alongside `dep_io`, plus a `seen` set
  of function ids so the recursive descent cannot loop.
- The `Out` rule still runs first; the new one only fills what it declines. Where both apply
  they agree, since a returned `Out` param resolves to the same caller buffer either way.
- Declined cases (callee source unavailable, return arity mismatching the target, callee
  already on the stack) fall back to the previous behaviour, so the clear `_build_params`
  error still fires for a genuinely uninferable shape.
- `_target_names`, `_return_element_names` and `_call_arg_refs` are factored out; the last is
  now shared with `_extract_call_args_for_dep`.

## Reviewer notes

- **Scope of the recursion.** The descent runs only for dep-call assignments the `Out` rule
  declined, and `_get_func_def` is memoised, so the added cost is an AST walk of the callee
  body per such call site. Depth is bounded by the JIT call graph, which is acyclic; `seen`
  guards it regardless.
- A `_SlicedArg` call argument (`chip_orch(x[r], ...)`) seeds nothing in the descent. That
  per-rank dispatch form returns through `Out` params, so the descent is never reached for it.
- The generated `@pl.function(type=pl.FunctionType.Inline)` for such a helper still carries no
  return annotation — `_infer_return_type` sees only param metas — and the parser re-infers it
  from the body. Unchanged, and verified end to end below.

## Testing

- Five regression tests in `tests/ut/jit/test_decorator.py`: callee-allocated tuple return
  (unit + end-to-end lower), single return, a callee sizing its allocation from its own
  parameter, and the arity-mismatch guard.
- `tests/ut`: 11502 passed, 3 skipped, 1 xfailed.
- The originally reported reproducer (a pypto-lib compile-only case) goes from the `ValueError`
  above to `[RUN] PASS`.
- A second shape from the same report — an inline preparation helper feeding an
  `@pl.jit.incore` kernel, the `rope_cos` / `qkv_proj_rope` case — reproduces the identical
  failure on `main` and lowers *and* compiles with this change, confirming it is the same
  defect rather than a separate one.
- Not covered: device execution. `torch_npu` is not installed on the machine this was
  developed on, so verification stops at `compile()`. The failure was compile-time, so this
  exercises it, but the numerics are unproven here.

## Docs

`docs/en/user/language/01-functions.md` and its zh counterpart gain a short section
documenting both conventions, which one a device kernel is restricted to, and what still does
not resolve — including the `missing inferred tensor metadata` message, so the next person to
hit it lands on the explanation.
