### PR TITLE
fix(jit): uniquify generated names for deps that share a __name__

### DIFF
--- a/docs/en/user/language/01-functions.md
+++ b/docs/en/user/language/01-functions.md
@@ -98,7 +98,10 @@ Sub-function dependencies (`.incore` / `.inline` / `.opaque` / `.graph`) are aut
 the entry's body — call them by name. The name you call is resolved in the entry's own
 namespace, so an aliased import (`from kernels import matmul as mm`, or a plain
 `mm = matmul` rebinding) is discovered like any other binding; the generated program still
-names the function after its `def`. A `@pl.jit.host` entry additionally discovers
+names the function after its `def`. When two distinct sub-functions share that name — two
+modules each defining `helper`, or two kernels from one factory — the second one generated
+is suffixed (`helper`, `helper__2`), so both specializations survive; the entry keeps its
+own name. A `@pl.jit.host` entry additionally discovers
 `@pl.jit` chip-orchestration dependencies, so a full distributed program needs no
 `@pl.program` class.
 

--- a/docs/zh/user/language/01-functions.md
+++ b/docs/zh/user/language/01-functions.md
@@ -78,7 +78,7 @@ def decode(w: pl.Tensor, hidden: pl.InOut[pl.Tensor]):
 区域内，也不能嵌套在 `pl.at` / `pl.cluster` / `pl.spmd` 内 —— 后者会变成单个设备 task，
 而 Graph 区域录制的是 task 的拓扑。三种情况都是编译期错误。
 
-子函数依赖（`.incore` / `.inline` / `.opaque` / `.graph`）从入口函数体自动发现 —— 按名字调用即可。这里的名字在入口函数自身的命名空间中解析，因此别名导入（`from kernels import matmul as mm`，或普通的 `mm = matmul` 重绑定）与其他绑定一样能被发现；生成的程序仍以其 `def` 名字命名该函数。`@pl.jit.host` 入口还会额外发现 `@pl.jit`（chip 编排）依赖，因此一个完整的分布式程序无需任何 `@pl.program` 类。
+子函数依赖（`.incore` / `.inline` / `.opaque` / `.graph`）从入口函数体自动发现 —— 按名字调用即可。这里的名字在入口函数自身的命名空间中解析，因此别名导入（`from kernels import matmul as mm`，或普通的 `mm = matmul` 重绑定）与其他绑定一样能被发现；生成的程序仍以其 `def` 名字命名该函数。当两个不同的子函数同名时 —— 两个模块各自定义了 `helper`，或同一个工厂产出的两个 kernel —— 后生成的那个会被加上后缀（`helper`、`helper__2`），从而两份特化都得以保留；入口函数始终保留自己的名字。`@pl.jit.host` 入口还会额外发现 `@pl.jit`（chip 编排）依赖，因此一个完整的分布式程序无需任何 `@pl.program` 类。
 
 下面这段只展示发现结构 —— kernel 体已省略，它用到的分布式类型见[分布式](../distributed/index.md)：
 

--- a/python/pypto/jit/cache.py
+++ b/python/pypto/jit/cache.py
@@ -159,11 +159,13 @@ def make_cache_key(  # noqa: PLR0913 — args are the key's components, one per 
         tensor_layouts: Annotated layout per tensor parameter name, where the
             annotation declares one. See :class:`TensorCacheInfo.layout` for
             why the layout has to split the key on its own.
-        dep_layouts: ``(dep name, parameter, layout)`` triples for layouts the
-            reachable deps declare themselves. Same reasoning as
+        dep_layouts: ``(generated dep name, parameter, layout)`` triples for
+            layouts the reachable deps declare themselves. Same reasoning as
             ``tensor_layouts``, one call deeper: they shape the generated dep
             signatures but appear in no entry-parameter meta, and a postponed
-            annotation hides a rebind from ``source_hash``.
+            annotation hides a rebind from ``source_hash``. The name is the
+            *generated* one, so two same-named deps stay distinguishable in
+            this sorted, position-free tuple.
         dynamic_dims: Set of (param_name, dim_index) pairs that are dynamic.
             Dynamic dims are stored as None in the cache key so different
             concrete values for that dimension produce the same cache entry.

--- a/python/pypto/jit/decorator.py
+++ b/python/pypto/jit/decorator.py
@@ -1820,8 +1820,16 @@ class JITFunction:
         annotations are unchanged. Retain the bindings themselves and compare
         identity, avoiding overloaded equality and recycled object IDs.
 
+        Keyed by the *generated* name, not ``dep.__name__``: the triples are
+        sorted, so position is not carried, and two same-named deps swapping
+        layouts (``helper`` from two modules going ``NZ``/``ND`` -> ``ND``/``NZ``)
+        would otherwise produce the same sorted set and hand the second call the
+        first one's artifact. The generated name is the disambiguator the
+        emitted signatures already carry.
+
         Returns:
-            Sorted ``(dep name, parameter, layout)`` triples for the cache key.
+            Sorted ``(generated dep name, parameter, layout)`` triples for the
+            cache key.
         """
         state = self._get_dep_graph_state()
         bindings = tuple(
@@ -1830,10 +1838,15 @@ class JITFunction:
         cached = state.layouts
         if cached is not None and all(a is b for a, b in zip(bindings, cached.bindings, strict=True)):
             return cached.layouts
+        # Same list ``_build_contexts`` allocates from, so the names agree with
+        # the ones the generated program actually uses.
+        gen_names = _allocate_generated_names(self, state.graph.deps)
         layouts = tuple(
             sorted(
-                (dep.__name__, param, str(layout))
+                (gen_names[id(dep._func)], param, str(layout))
                 for dep in state.graph.deps
+                # ``dep.__name__`` here is the diagnostic name only — a layout
+                # error should name the user's own function.
                 for param, layout in _param_layouts(dep._func, dep.__name__).items()
             )
         )

--- a/python/pypto/jit/decorator.py
+++ b/python/pypto/jit/decorator.py
@@ -2741,17 +2741,25 @@ class JITFunction:
             ],
         ] = {id(self._func): (tensor_meta, scalar_values, scalar_dtypes)}
 
+        # One generated ``@pl.function`` name per JIT function, unique across
+        # the program. Two distinct deps may share a ``__name__`` (two modules
+        # each defining ``helper``, or two kernels from the same factory);
+        # emitting both as ``def helper`` made the parser reject the program
+        # with a bare ``Duplicate function name "helper"``.
+        gen_names = _allocate_generated_names(self, deps_topo)
+
         # Walk caller-first (reverse of leaf-first topo order) so each dep's
         # caller metadata is already resolved when we get to it; collect
         # contexts caller-first, then reverse to restore leaf-first emit
         # order.
         # Per caller, ``call name → generated function name``. They differ
-        # under an aliased import: the body calls ``kern(...)`` while the
-        # generated ``@pl.function`` is named after ``dep.__name__``.
+        # under an aliased import (the body calls ``kern(...)`` while the
+        # generated ``@pl.function`` is named after ``dep.__name__``) and
+        # under a uniquified name (``helper`` → ``helper__2``).
         dep_func_names_by_caller: dict[int, dict[str, str]] = {}
         for dep in deps_topo:
             for caller_func, call_name in callers_by_id.get(id(dep._func), ()):
-                dep_func_names_by_caller.setdefault(id(caller_func), {})[call_name] = dep.__name__
+                dep_func_names_by_caller.setdefault(id(caller_func), {})[call_name] = gen_names[id(dep._func)]
 
         dep_contexts: list[SpecializeContext] = []
         for dep in reversed(deps_topo):
@@ -2776,7 +2784,7 @@ class JITFunction:
             dep_contexts.append(
                 build_specialize_context(
                     func=dep._func,
-                    func_name=dep.__name__,
+                    func_name=gen_names[id(dep._func)],
                     func_type=dep._func_type,
                     level=dep._level,
                     tensor_meta=dep_meta,
@@ -2796,7 +2804,7 @@ class JITFunction:
 
         entry_ctx = build_specialize_context(
             func=self._func,
-            func_name=self.__name__,
+            func_name=gen_names[id(self._func)],
             func_type=self._func_type,
             level=self._level,
             tensor_meta=tensor_meta,
@@ -2866,6 +2874,53 @@ def _discover_deps(func: Any, caller_func_type: str = "orchestration") -> list[J
     caller's source must use the bindings instead — see ``_DepBinding``.
     """
     return [binding.dep for binding in _discover_dep_bindings(func, caller_func_type)]
+
+
+def _generated_names_for(jit_func: JITFunction, base: str) -> tuple[str, ...]:
+    """Every generated ``@pl.function`` name ``jit_func`` would occupy as ``base``.
+
+    A single method for everything except an ``@pl.jit.extern`` mixed kernel,
+    which the specializer renders as an AIC member, an AIV member, and a Group
+    wrapper — three names derived from the same base.
+    """
+    if jit_func._func_type == "extern" and jit_func._external_core_type == "mixed":
+        return (base, f"{base}_aic", f"{base}_aiv")
+    return (base,)
+
+
+def _allocate_generated_names(entry: JITFunction, deps: list[JITFunction]) -> dict[int, str]:
+    """Map ``id(jit_func._func)`` → the unique name its ``@pl.function`` gets.
+
+    A generated ``@pl.program`` holds one method per JIT function, so their
+    names must be distinct — but two distinct deps may legitimately share a
+    ``__name__`` (two modules each defining ``helper``, or two kernels built by
+    the same factory). A clash is resolved by suffixing the later claimant
+    ``__2``, ``__3``, … so both specializations survive instead of the parser
+    rejecting the program with ``Duplicate function name "helper"``.
+
+    The entry is named first, so a clash never moves the name the user called;
+    deps follow in ``deps`` order, which is derived from source order, so the
+    same call graph always yields the same names.
+    """
+    used: set[str] = set()
+    names: dict[int, str] = {}
+    # Highest suffix already handed out per base name, so N functions sharing a
+    # base cost O(N) probes overall rather than rescanning from 2 each time.
+    next_suffix: dict[str, int] = {}
+    for jit_func in [entry, *deps]:
+        key = id(jit_func._func)
+        if key in names:
+            continue
+        base = jit_func.__name__
+        candidate = base
+        suffix = next_suffix.get(base, 2)
+        while not used.isdisjoint(_generated_names_for(jit_func, candidate)):
+            candidate = f"{base}__{suffix}"
+            suffix += 1
+        next_suffix[base] = suffix
+        names[key] = candidate
+        used.update(_generated_names_for(jit_func, candidate))
+    return names
 
 
 # ---------------------------------------------------------------------------

--- a/python/pypto/jit/specializer.py
+++ b/python/pypto/jit/specializer.py
@@ -125,7 +125,9 @@ class SpecializeContext:
     on demand via the :attr:`dynamic_dims` property.
 
     Attributes:
-        func_name: Python function name.
+        func_name: Name of the generated ``@pl.function`` method. Normally the
+            Python function's ``__name__``, but the JIT layer uniquifies it
+            when two distinct deps share a name (see ``source_func_name``).
         source: Dedented source code of the function.
         func_type: 'orchestration' | 'incore' | 'inline' | 'opaque' | 'graph' | None (auto).
         level: pl.Level value or None.
@@ -189,6 +191,17 @@ class SpecializeContext:
     # Also appended at the tail (see above): ``call name -> generated function
     # name`` for the deps this function reaches under a different name.
     dep_func_names: dict[str, str] = field(default_factory=dict)
+    # Name of the ``def`` inside ``source`` — the Python ``__name__``. It differs
+    # from ``func_name`` whenever the JIT layer had to uniquify the generated
+    # name (two deps sharing a ``__name__``). Anything that looks the definition
+    # up in the *original* source must use ``source_def_name``; anything naming
+    # the *generated* function uses ``func_name``.
+    source_func_name: str | None = None
+
+    @property
+    def source_def_name(self) -> str:
+        """Name of the ``def`` to find in :attr:`source` (the Python name)."""
+        return self.source_func_name or self.func_name
 
     @property
     def dynamic_dims(self) -> set[tuple[str, int]]:
@@ -1545,7 +1558,7 @@ def _original_def_line(ctx: SpecializeContext) -> int | None:
         tree = ast.parse(textwrap.dedent(ctx.source))
     except SyntaxError:
         return None
-    node = _find_func_def(tree, ctx.func_name)
+    node = _find_func_def(tree, ctx.source_def_name)
     return None if node is None else node.lineno
 
 
@@ -1724,8 +1737,8 @@ class Specializer:
         # Parse the source to AST
         src = textwrap.dedent(ctx.source)
         tree = ast.parse(src)
-        func_def = _find_func_def(tree, ctx.func_name)
-        assert func_def is not None, f"specialize: no def named {ctx.func_name!r} in its own source"
+        func_def = _find_func_def(tree, ctx.source_def_name)
+        assert func_def is not None, f"specialize: no def named {ctx.source_def_name!r} in its own source"
 
         # Classify parameters
         out_params, inout_params, tensor_params, scalar_dtype_strs, distributed_params = _classify_params(
@@ -1741,7 +1754,7 @@ class Specializer:
         is_inline = ctx.func_type == "inline"
         if is_inline and (out_params or inout_params):
             warnings.warn(
-                f"@pl.jit.inline helper '{ctx.func_name}' uses pl.Out[...]/pl.InOut[...] on "
+                f"@pl.jit.inline helper '{ctx.source_def_name}' uses pl.Out[...]/pl.InOut[...] on "
                 f"parameter(s) {(out_params + inout_params)!r}. Direction annotations are "
                 f"deprecated for inline helpers because the body is spliced at the call "
                 f"site before SSA conversion — the parameter is already an "
@@ -2108,7 +2121,10 @@ def build_specialize_context(  # noqa: PLR0913 — pass-through assembler; each 
 
     Args:
         func: The original Python function object.
-        func_name: The function name.
+        func_name: Name for the generated ``@pl.function``. Normally
+            ``func.__name__``; the JIT layer passes a uniquified name when two
+            distinct deps share a ``__name__``. The ``def`` is located in
+            ``func``'s own source by ``func.__name__`` either way.
         func_type: 'orchestration', 'incore', or None.
         level: pl.Level enum or None.
         tensor_meta: TensorMeta per tensor param name.
@@ -2153,6 +2169,7 @@ def build_specialize_context(  # noqa: PLR0913 — pass-through assembler; each 
 
     return SpecializeContext(
         func_name=func_name,
+        source_func_name=func.__name__,
         source=source,
         func_type=func_type,
         level=level,

--- a/tests/ut/jit/_dup_layout_fixture.py
+++ b/tests/ut/jit/_dup_layout_fixture.py
@@ -1,0 +1,35 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Fixture for a dep whose layout annotation is *postponed*.
+
+``from __future__ import annotations`` (PEP 563) keeps every annotation as
+source text, so ``LAYOUT`` is resolved from this module's globals when
+``@pl.jit`` reads the signature — not at ``def`` time. Rebinding
+``<module>.LAYOUT`` therefore changes the layout the dep declares while leaving
+the source text, and so the source hash, identical.
+
+Loading this file twice under two module names gives two distinct ``helper``
+functions that agree on ``__name__`` and can carry different layouts — the
+shape that made the name-keyed ``dep_layouts`` cache component collapse.
+"""
+
+from __future__ import annotations  # noqa: I001 — the point of the fixture
+
+import pypto.language as pl
+from pypto.jit.decorator import jit
+
+LAYOUT = pl.ND
+
+
+@jit.incore
+def helper(src: pl.Tensor[[64, 64], pl.FP16, LAYOUT], dst: pl.Out[pl.Tensor]) -> pl.Tensor:
+    tile = pl.load(src, [0, 0], [64, 64])
+    pl.store(tile, [0, 0], dst)
+    return dst

--- a/tests/ut/jit/test_decorator.py
+++ b/tests/ut/jit/test_decorator.py
@@ -24,6 +24,7 @@ from pypto.ir.compiled_program import CompiledProgram
 from pypto.jit.decorator import (
     _SYNTHESIZED_DYN_PREFIX,
     JITFunction,
+    _allocate_generated_names,
     _arg_ref,
     _build_param_mapping,
     _compute_per_func_dyndim_maps,
@@ -852,6 +853,209 @@ class TestAliasedDepCallName:
         # ``out`` captures the dep's Out param, which the call site bound to
         # ``buf`` — resolvable only if _scan_dep_io keyed the dep by "kern".
         assert metas["out"].shape == (32, 16)
+
+
+class TestDuplicateDepNames:
+    """Two distinct deps that share a ``__name__``.
+
+    Both emit into one ``@pl.program`` class, so the generated names must be
+    made unique — otherwise the parser refuses the whole program with a bare
+    ``Duplicate function name "helper"``, and the entry's two call sites both
+    rewrite to the same ``self.helper``.
+    """
+
+    @staticmethod
+    def _factory_entry():
+        """``entry`` calling two same-named kernels built by one factory."""
+
+        def make(rows):
+            @jit.incore
+            def helper(src: pl.Tensor, dst: pl.Out[pl.Tensor]) -> pl.Tensor:
+                tile = pl.load(src, [0, 0], [rows, 64])
+                pl.store(tile, [0, 0], dst)
+                return dst
+
+            return helper
+
+        first, second = make(32), make(64)
+
+        @jit
+        def entry(a: pl.Tensor, c: pl.Out[pl.Tensor]):
+            first(a, c)
+            second(a, c)
+            return c
+
+        return entry
+
+    @staticmethod
+    def _contexts_for(entry):
+        torch = pytest.importorskip("torch")
+        a = torch.empty(64, 64)
+        c = torch.empty(64, 64)
+        _pn, _, tmeta, sv, sd, pfd = entry._bind_args((a, c), {})
+        return entry._build_contexts(tmeta, sv, sd, pfd)
+
+    def test_same_named_deps_get_distinct_generated_names(self):
+        contexts = self._contexts_for(self._factory_entry())
+        assert [ctx.func_name for ctx in contexts] == ["helper", "helper__2", "entry"]
+        # The uniquified context still finds its ``def`` in its own source.
+        assert [ctx.source_def_name for ctx in contexts] == ["helper", "helper", "entry"]
+
+    def test_each_call_site_targets_its_own_specialization(self):
+        contexts = self._contexts_for(self._factory_entry())
+        entry_ctx = next(ctx for ctx in contexts if ctx.func_name == "entry")
+        assert entry_ctx.dep_func_names == {"first": "helper", "second": "helper__2"}
+
+    def test_generated_program_parses_and_keeps_both_bodies(self):
+        contexts = self._contexts_for(self._factory_entry())
+        source = Specializer("_jit_entry", contexts).specialize()
+
+        assert "def helper(self" in source
+        assert "def helper__2(self" in source
+        assert "self.helper(a, c)" in source
+        assert "self.helper__2(a, c)" in source
+        # Each specialization folded its own ``rows``; naming them apart is
+        # what keeps both bodies in the program.
+        assert "pl.load(src, [0, 0], [32, 64])" in source
+        assert "pl.load(src, [0, 0], [64, 64])" in source
+
+        program = pl.parse(source)
+        assert isinstance(program, ir.Program)
+        assert {f.name for f in program.functions} == {"helper", "helper__2", "entry"}
+
+    def test_deps_from_two_modules_sharing_a_name(self):
+        """The reported shape: two modules each defining the same kernel name.
+
+        The fixture module is loaded twice under different module names, so the
+        two ``copy_incore`` objects are genuinely distinct functions that agree
+        on ``__name__`` — exactly what two ``expert_routed`` definitions give.
+        """
+        import importlib.util  # noqa: PLC0415
+        import types  # noqa: PLC0415
+        from pathlib import Path  # noqa: PLC0415
+
+        fixture_path = Path(__file__).parent / "_alias_dep_fixture.py"
+
+        def _load(mod_name):
+            spec = importlib.util.spec_from_file_location(mod_name, fixture_path)
+            assert spec is not None and spec.loader is not None
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+            return module.copy_incore
+
+        left, right = _load("_dup_name_left"), _load("_dup_name_right")
+        assert left.__name__ == right.__name__ == "copy_incore"
+        assert left._func is not right._func
+
+        def _entry_raw(a: pl.Tensor, c: pl.Out[pl.Tensor]):
+            left(a, c)  # noqa: F821  # pyright: ignore[reportUndefinedVariable]
+            right(a, c)  # noqa: F821  # pyright: ignore[reportUndefinedVariable]
+            return c
+
+        new_globals = {**_entry_raw.__globals__, "left": left, "right": right}
+        entry = JITFunction(
+            types.FunctionType(
+                _entry_raw.__code__,
+                new_globals,
+                _entry_raw.__name__,
+                _entry_raw.__defaults__,
+                _entry_raw.__closure__,
+            ),
+            func_type="orchestration",
+        )
+
+        contexts = self._contexts_for(entry)
+        assert [ctx.func_name for ctx in contexts] == [
+            "copy_incore",
+            "copy_incore__2",
+            "_entry_raw",
+        ]
+        source = Specializer("_jit_entry_raw", contexts).specialize()
+        assert "self.copy_incore(a, c)" in source
+        assert "self.copy_incore__2(a, c)" in source
+        assert isinstance(pl.parse(source), ir.Program)
+
+    def test_dep_sharing_the_entry_name_yields_to_the_entry(self):
+        """The entry keeps the name the user called; the dep is the one moved."""
+
+        def make():
+            @jit.incore
+            def entry(src: pl.Tensor, dst: pl.Out[pl.Tensor]) -> pl.Tensor:
+                tile = pl.load(src, [0, 0], [64, 64])
+                pl.store(tile, [0, 0], dst)
+                return dst
+
+            return entry
+
+        dep = make()
+
+        @jit
+        def entry(a: pl.Tensor, c: pl.Out[pl.Tensor]):
+            dep(a, c)
+            return c
+
+        contexts = self._contexts_for(entry)
+        assert [ctx.func_name for ctx in contexts] == ["entry__2", "entry"]
+        entry_ctx = next(ctx for ctx in contexts if ctx.func_name == "entry")
+        assert entry_ctx.dep_func_names == {"dep": "entry__2"}
+        assert isinstance(pl.parse(Specializer("_jit_entry", contexts).specialize()), ir.Program)
+
+
+class TestAllocateGeneratedNames:
+    """Unit coverage for the generated-name allocator itself."""
+
+    @staticmethod
+    def _jit_named(name, *, func_type="incore", external_core_type=None):
+        """A JITFunction over a trivial body — the allocator reads only names.
+
+        Each call builds a fresh function object, so same-named holders are
+        distinct keys, exactly as two factory-built kernels are.
+        """
+
+        def _f():
+            pass
+
+        _f.__name__ = name
+        return JITFunction(_f, func_type=func_type, external_core_type=external_core_type)
+
+    def test_entry_is_named_first(self):
+        entry = self._jit_named("k")
+        dep = self._jit_named("k")
+        names = _allocate_generated_names(entry, [dep])
+        assert names[id(entry._func)] == "k"
+        assert names[id(dep._func)] == "k__2"
+
+    def test_three_way_clash_counts_up(self):
+        entry = self._jit_named("e")
+        deps = [self._jit_named("k") for _ in range(3)]
+        names = _allocate_generated_names(entry, deps)
+        assert [names[id(d._func)] for d in deps] == ["k", "k__2", "k__3"]
+
+    def test_suffix_shaped_user_name_does_not_collide(self):
+        """A user function literally named ``k__2`` still gets its own slot."""
+        entry = self._jit_named("e")
+        deps = [self._jit_named("k__2"), self._jit_named("k"), self._jit_named("k")]
+        names = _allocate_generated_names(entry, deps)
+        generated = [names[id(d._func)] for d in deps]
+        assert generated == ["k__2", "k", "k__3"]
+        assert len(set(generated)) == len(generated)
+
+    def test_mixed_extern_reserves_its_member_names(self):
+        """A mixed extern occupies ``base``, ``base_aic`` and ``base_aiv``."""
+        entry = self._jit_named("e")
+        mixed = self._jit_named("k", func_type="extern", external_core_type="mixed")
+        plain = self._jit_named("k_aic")
+        names = _allocate_generated_names(entry, [mixed, plain])
+        assert names[id(mixed._func)] == "k"
+        assert names[id(plain._func)] == "k_aic__2"
+
+    def test_one_function_reached_twice_keeps_one_name(self):
+        """A diamond dep appears once in the map, not twice."""
+        entry = self._jit_named("e")
+        dep = self._jit_named("k")
+        names = _allocate_generated_names(entry, [dep, dep])
+        assert names[id(dep._func)] == "k"
+        assert len(names) == 2
 
 
 class TestMultiFuncIntegration:

--- a/tests/ut/jit/test_decorator.py
+++ b/tests/ut/jit/test_decorator.py
@@ -1000,6 +1000,72 @@ class TestDuplicateDepNames:
         assert entry_ctx.dep_func_names == {"dep": "entry__2"}
         assert isinstance(pl.parse(Specializer("_jit_entry", contexts).specialize()), ir.Program)
 
+    def test_dep_layouts_cache_key_tracks_which_dep_declared_which_layout(self):
+        """Swapping two same-named deps' layouts must change the cache key.
+
+        ``dep_layouts`` is a *sorted* tuple, so it carries no position — keyed
+        by ``__name__`` it collapsed, and the second call got the first call's
+        artifact even though the generated signatures differ.
+        """
+        import importlib.util  # noqa: PLC0415
+        import types  # noqa: PLC0415
+        from pathlib import Path  # noqa: PLC0415
+
+        fixture_path = Path(__file__).parent / "_dup_layout_fixture.py"
+
+        def _load(mod_name):
+            """Load the fixture, returning ``(helper, its globals dict)``.
+
+            A postponed annotation is resolved against the function's own
+            globals, so rebinding ``LAYOUT`` there is what changes the layout
+            the dep declares — the module's ``__dict__`` is that same mapping.
+            """
+            spec = importlib.util.spec_from_file_location(mod_name, fixture_path)
+            assert spec is not None and spec.loader is not None
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+            return module.helper, module.__dict__
+
+        (left, left_globals), (right, right_globals) = (
+            _load("_dup_layout_left"),
+            _load("_dup_layout_right"),
+        )
+
+        def _entry_raw(a: pl.Tensor, c: pl.Out[pl.Tensor]):
+            left(a, c)  # noqa: F821  # pyright: ignore[reportUndefinedVariable]
+            right(a, c)  # noqa: F821  # pyright: ignore[reportUndefinedVariable]
+            return c
+
+        new_globals = {**_entry_raw.__globals__, "left": left, "right": right}
+        entry = JITFunction(
+            types.FunctionType(
+                _entry_raw.__code__,
+                new_globals,
+                _entry_raw.__name__,
+                _entry_raw.__defaults__,
+                _entry_raw.__closure__,
+            ),
+            func_type="orchestration",
+        )
+
+        left_globals["LAYOUT"], right_globals["LAYOUT"] = ir.TensorLayout.NZ, ir.TensorLayout.ND
+        first = entry._dep_declared_layouts()
+
+        left_globals["LAYOUT"], right_globals["LAYOUT"] = ir.TensorLayout.ND, ir.TensorLayout.NZ
+        second = entry._dep_declared_layouts()
+
+        # Each triple names the generated function whose signature carries the
+        # layout, so the swap is visible.
+        assert first == (
+            ("helper", "src", str(ir.TensorLayout.NZ)),
+            ("helper__2", "src", str(ir.TensorLayout.ND)),
+        )
+        assert second == (
+            ("helper", "src", str(ir.TensorLayout.ND)),
+            ("helper__2", "src", str(ir.TensorLayout.NZ)),
+        )
+        assert first != second
+
 
 class TestAllocateGeneratedNames:
     """Unit coverage for the generated-name allocator itself."""

--- a/tests/ut/jit/test_specializer.py
+++ b/tests/ut/jit/test_specializer.py
@@ -2054,5 +2054,58 @@ class TestTensorLayoutAnnotation:
         assert "c: pl.Out[pl.Tensor[[64, 128], pl.FP16]]" in out
 
 
+class TestRenamedGeneratedFunction:
+    """``func_name`` names the generated method; ``source_func_name`` the ``def``.
+
+    The two diverge when the JIT layer uniquifies a dep name (two distinct deps
+    sharing a ``__name__``). Everything that reads the *original* source must
+    still find the ``def`` under the Python name.
+    """
+
+    @staticmethod
+    def _renamed_ctx():
+        ctx = _make_ctx(
+            func_name="helper__2",
+            func_type="incore",
+            source=textwrap.dedent(
+                """
+                def helper(src: pl.Tensor, dst: pl.Out[pl.Tensor]):
+                    return dst
+                """
+            ),
+            param_names=["src", "dst"],
+            tensor_meta={
+                "src": TensorMeta((64, 64), DataType.FP32),
+                "dst": TensorMeta((64, 64), DataType.FP32),
+            },
+        )
+        ctx.source_func_name = "helper"
+        return ctx
+
+    def test_source_def_name_falls_back_to_func_name(self):
+        """A context that never renamed anything keeps one name for both roles."""
+        ctx = _make_ctx(func_name="kernel")
+        assert ctx.source_func_name is None
+        assert ctx.source_def_name == "kernel"
+
+    def test_generated_method_uses_the_renamed_name(self):
+        out = specialize("_T", [self._renamed_ctx()])
+        assert "def helper__2(self, src" in out
+        assert "def helper(self" not in out
+
+    def test_inline_deprecation_names_the_python_function(self):
+        """The user's own name is what they can act on, not the generated one."""
+        ctx = self._renamed_ctx()
+        ctx.func_type = "inline"
+        ctx.source = textwrap.dedent(
+            """
+            def helper(src: pl.Tensor, dst: pl.Out[pl.Tensor]):
+                return dst
+            """
+        )
+        with pytest.warns(DeprecationWarning, match="helper' uses pl.Out"):
+            specialize("_T", [ctx])
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Problem

`_build_contexts` named every generated `@pl.function` after `dep.__name__`, so two
distinct `@pl.jit` deps that agree on that name — two modules each defining `helper`, or
two kernels built by one factory — emitted two same-named methods into one `@pl.program`
class:

```python
def make(rows):
    @pl.jit.incore
    def helper(src: pl.Tensor, dst: pl.Out[pl.Tensor]) -> pl.Tensor:
        tile = pl.load(src, [0, 0], [rows, 64])
        pl.store(tile, [0, 0], dst)
        return dst
    return helper

first, second = make(32), make(64)

@pl.jit
def entry(a: pl.Tensor, c: pl.Out[pl.Tensor]):
    first(a, c)
    second(a, c)
    return c
```

Before, on `main`:

```text
context func_names: ['helper', 'helper', 'entry']
entry dep_func_names: {'first': 'helper', 'second': 'helper'}
...
    def helper(self, ...):     tile = pl.load(src, [0, 0], [32, 64])
    def helper(self, ...):     tile = pl.load(src, [0, 0], [64, 64])
    def entry(self, ...):      self.helper(a, c); self.helper(a, c)

ParserSyntaxError: ValueError: Duplicate function name "helper"
```

The refusal is loud, so nothing wrong shipped — but it names neither Python function nor
its module, and the only way out was renaming a `def`. It was also masking a second
defect: both call sites in the entry had already rewritten to `self.helper`, so the second
call lost its own specialization before the parser ever saw the program.

## Fix

Allocate one unique generated name per JIT function
(`_allocate_generated_names` in `python/pypto/jit/decorator.py`). The entry is named
first, so a clash never moves the name the user called; deps follow in source-derived
topo order, and a clash is suffixed `__2`, `__3`, …. The existing `dep_func_names`
channel — built for aliased imports — carries the rewrite, so call sites need no new
plumbing.

After:

```text
context func_names: ['helper', 'helper__2', 'entry']
entry dep_func_names: {'first': 'helper', 'second': 'helper__2'}
...
    def helper(self, ...):     tile = pl.load(src, [0, 0], [32, 64])
    def helper__2(self, ...):  tile = pl.load(src, [0, 0], [64, 64])
    def entry(self, ...):      self.helper(a, c); self.helper__2(a, c)

PARSE OK
```

Two cases handled beyond the reported one:

- **A dep sharing the entry's name.** The dep is the one that moves; the entry keeps the
  name the user called.
- **A mixed `@pl.jit.extern`.** It renders three members from one base, so it claims
  `base`, `base_aic` and `base_aiv` rather than just `base`.

### Supporting change in the specializer

`SpecializeContext.func_name` now means "the name of the generated method". A new
`source_func_name` (with the `source_def_name` accessor) holds the Python `__name__` used
to locate the `def` in the user's own source — the def lookup, the diagnostic line map,
and the inline `pl.Out[...]` deprecation warning all switch to it, so a uniquified context
still finds its own source and still names the user's function in diagnostics.

## Notes for reviewers

- **Name shape.** `__2` is a suffix, not a reservation: a user function literally named
  `k__2` keeps that name and the clashing `k` moves on to `k__3`. Covered by a test.
- **Determinism.** Allocation order is entry-then-topo-order, which is derived from source
  order, so one call graph always yields the same names.
- **Complexity.** A per-base high-water mark makes N functions sharing a base cost O(N)
  probes overall, not O(N²).
- **Cache safety was already fine and is unchanged.** `_get_source_hash` records folded
  constants with the dep's index, so `make(32)` and `make(64)` were already keyed apart.

## Testing

- 11 new tests in `tests/ut/jit/test_decorator.py` — factory-built kernels, two modules
  defining the same kernel name (the fixture module loaded twice), the entry-name clash,
  and unit coverage of the allocator itself — plus 3 in `tests/ut/jit/test_specializer.py`
  for the `func_name` / `source_def_name` split.
- `tests/ut/`: **11507 passed, 3 skipped, 1 xfailed**. `tests/ut/jit/`: 485 passed.
- ruff, pyright, markdownlint, and the doc parity / English-only lints all clean
  (pre-commit ran green on the commit).

## Docs

`docs/en/user/language/01-functions.md` and its zh mirror now state the collision rule
alongside the existing sentence about aliased imports.
