### PR TITLE
fix(printer): collect dynamic symbols from DistributedTensor annotations

### DIFF
--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -3022,7 +3022,10 @@ static std::unordered_map<const Var*, std::string> CollectDynVarMapping(const Pr
   };
 
   std::function<void(const TypePtr&)> collect_from_type = [&](const TypePtr& type) {
-    if (auto tensor_type = As<TensorType>(type)) {
+    // AsTensorTypeLike, not As<TensorType>: DistributedTensorType has its own
+    // ObjectKind, so the exact-match As<TensorType> misses it and the symbols a
+    // pld.DistributedTensor annotation declares never reach dyn_var_rename_map_.
+    if (auto tensor_type = AsTensorTypeLike(type)) {
       for (const auto& dim : tensor_type->shape_) {
         collect_vars_from_expr(dim);
       }

--- a/tests/ut/ir/transforms/test_python_printer.py
+++ b/tests/ut/ir/transforms/test_python_printer.py
@@ -12,6 +12,7 @@
 import ast
 
 import pypto.language as pl
+import pypto.language.distributed as pld
 import pytest
 from pypto import DataType, ir, passes
 from pypto.ir.printer import python_print
@@ -367,6 +368,28 @@ class TestDynVarAndSSARename:
 
         src = Prog.as_python()
         assert 'N = pl.dynamic("N")' in src
+
+    def test_dyn_var_declared_by_distributed_tensor_param(self):
+        """A symbol declared only by a pld.DistributedTensor annotation still gets pl.dynamic().
+
+        DistributedTensorType subclasses TensorType but carries its own ObjectKind, so the
+        printer's exact-match As<TensorType> used to miss it: the symbol never reached
+        dyn_var_rename_map_, printed as ``N__FREE_VAR`` in both the signature and the body,
+        and the program failed to re-parse.
+        """
+        N = pl.dynamic("N")
+
+        @pl.program
+        class Prog:
+            @pl.function
+            def view(self, arg: pld.DistributedTensor[[N, 64], pl.FP32]):
+                return pl.tensor.slice(arg, [N, 64], [0, 0], valid_shape=[N - 1, 64])
+
+        src = Prog.as_python()
+        assert 'N = pl.dynamic("N")' in src
+        assert "__FREE_VAR" not in src
+        # The declaration makes the printed program valid standalone Python again.
+        pl.parse_program(src)
 
     def test_dyn_var_same_name_different_identity_disambiguated(self):
         """Two distinct Var objects with same name_hint_ get disambiguated (issue #618)."""


### PR DESCRIPTION
## What

A dynamic shape symbol declared **only** by a `pld.DistributedTensor` parameter annotation printed as `N__FREE_VAR` — in both the signature and the body — and the printed program no longer re-parsed. The equivalent `pl.Tensor` program round-tripped fine.

```python
N = pl.dynamic("N")

@pl.program
class Prog:
    @pl.function
    def view(self, arg: pld.DistributedTensor[[N, 64], pl.FP32]):
        return pl.tensor.slice(arg, [N, 64], [0, 0], valid_shape=[N - 1, 64])

pl.parse_program(ir.python_print(Prog))
# ParserSyntaxError: NameError: name 'N__FREE_VAR' is not defined
```

| | `pl.Tensor[[M, 64], …]` | `pld.DistributedTensor[[N, 64], …]` (before) |
| --- | --- | --- |
| declaration | `M = pl.dynamic("M")` | *(none emitted)* |
| signature | `arg: pl.Tensor[[M, 64], pl.FP32]` | `arg: pld.DistributedTensor[[N__FREE_VAR, 64], pl.FP32]` |
| body | `pl.tensor.slice(arg, [M, 64], [0, 0], [M - 1, 64])` | `pl.tensor.slice(arg, [N__FREE_VAR, 64], [0, 0], [N__FREE_VAR - 1, 64])` |
| round-trip | OK | `NameError` |

## Why

`CollectDynVarMapping`'s `collect_from_type` — the traversal that finds which symbols need a `pl.dynamic()` declaration — downcast with the exact-kind `As<TensorType>`:

```cpp
if (auto tensor_type = As<TensorType>(type)) {
  for (const auto& dim : tensor_type->shape_) collect_vars_from_expr(dim);
```

`DistributedTensorType` is a C++ subclass of `TensorType`, but it carries its own `ObjectKind`:

```cpp
// include/pypto/ir/kind_traits.h:117-118
DEFINE_KIND_TRAIT(TensorType,            ObjectKind::TensorType)
DEFINE_KIND_TRAIT(DistributedTensorType, ObjectKind::DistributedTensorType)
```

`KindTrait<TensorType>` is the single-`kind` shape, so `As<TensorType>()` matches that one kind and never subclasses — the case `.claude/rules/ir-kind-traits.md` documents. The consequences chain:

1. `collect_from_type` returns null → the symbol never enters `dyn_var_rename_map_` → no `pl.dynamic()` line is emitted.
2. `BuildVarRenameMap` then sees the symbol used in the body but bound by neither a parameter nor a body definition, so it lands in `free_body_vars_`.
3. `GetVarName` (`python_printer.cpp:2630`) appends the `__FREE_VAR` marker. The parameter annotation renders through the same `GetVarName`, so signature and body both carry it, and re-parse raises `NameError`.

Only step 1 differs for a plain `pl.Tensor`, which is the whole difference between the two paths.

## The fix

One cast swapped to `AsTensorTypeLike`, which matches both kinds. Notably, the sibling `read_in_param_types` traversal ~110 lines below in the same function **already** used `AsTensorTypeLike`, with a comment stating exactly this reason — the earlier fix was applied to one of the two traversals and not the other.

## Testing

- New regression test `TestDynVarAndSSARename::test_dyn_var_declared_by_distributed_tensor_param` in `tests/ut/ir/transforms/test_python_printer.py`. Confirmed it **fails** on the unpatched build (`assert 'N = pl.dynamic("N")' in src` → the printed source still shows `N__FREE_VAR`) and passes with the fix.
- Full unit suite: **11704 passed, 5 skipped, 1 xfailed** (11703 before, +1 new test). No other test changed behaviour.
