### PR TITLE
fix(st): stop collection-time case discovery from aborting the session

### DIFF
--- a/tests/st/codegen/dsl/__init__.py
+++ b/tests/st/codegen/dsl/__init__.py
@@ -1,0 +1,8 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------

--- a/tests/st/conftest.py
+++ b/tests/st/conftest.py
@@ -939,8 +939,39 @@ def _eval_arg_node(
         kw = {k.arg: _eval_arg_node(k.value, params, localns, globalns) for k in node.keywords if k.arg}
         if any(k.arg is None for k in node.keywords):
             raise _Unresolvable("**kwargs")
-        return fn(*a, **kw)
+        # This is the one place discovery *runs* code out of a test body, so it
+        # is the one place that can raise anything the body could — including
+        # pytest's own control-flow exceptions (``pytest.importorskip`` raises
+        # ``Skipped``), which derive from ``BaseException`` and would sail
+        # straight past the ``except Exception`` guards at both call sites. A
+        # ``Skipped`` escaping ``pytest_collection_finish`` is not a skip: under
+        # xdist it becomes a session-wide INTERNALERROR that reports zero tests.
+        # A call we cannot evaluate is just an unresolvable node.
+        try:
+            return fn(*a, **kw)
+        except (KeyboardInterrupt, SystemExit):
+            raise
+        except BaseException as exc:  # noqa: BLE001 — best-effort evaluation, never abort collection
+            raise _Unresolvable(f"{ast.unparse(node)}: {exc!r}") from exc
     raise _Unresolvable(ast.dump(node))
+
+
+def _is_st_item(item: pytest.Item) -> bool:
+    """Is *item* an ST test — i.e. was it collected from under ``tests/st/``?
+
+    ``pytest_collection_finish`` is a *session* hook, so once this conftest is
+    loaded it fires for every collected item, not just the ones underneath it.
+    In a combined ``pytest tests/ut tests/st`` run that means handing unit-test
+    bodies to a walk that parses and partially *evaluates* them, hunting for
+    ``PTOTestCase`` constructors they cannot contain. Scope the walk instead.
+    """
+    path = getattr(item, "path", None) or getattr(item, "fspath", None)
+    if path is None:
+        return False
+    try:
+        return Path(str(path)).resolve().is_relative_to(_ST_DIR.resolve())
+    except (OSError, ValueError):
+        return False
 
 
 def _collect_test_case_from_item(
@@ -1044,8 +1075,14 @@ def _collect_test_case_from_item(
             args = [_eval_arg_node(a, params, localns, globalns) for a in node.args]
             kwargs = {kw.arg: _eval_arg_node(kw.value, params, localns, globalns) for kw in node.keywords}
             instance = func(*args, **kwargs)
-        except Exception:
+        except (KeyboardInterrupt, SystemExit):
+            raise
+        except BaseException:  # noqa: BLE001
             # _Unresolvable arg, or a constructor mismatch — leave for inline.
+            # BaseException for the same reason as the invoke in
+            # ``_eval_arg_node``: this runs a constructor out of a test body, and
+            # a ``pytest.skip`` guard inside one must fall through to the inline
+            # path, not abort the whole collection.
             continue
         # Bind the item's platform so each matrix variant compiles its own
         # artefact; without this the variants share one cache key and only the
@@ -1087,6 +1124,8 @@ def pytest_collection_finish(session: pytest.Session) -> None:
     seen: dict[str, PTOTestCase] = {}  # effective cache_key → instance (deduped)
 
     for item in session.items:
+        if not _is_st_item(item):
+            continue
         _collect_test_case_from_item(item, seen, session_memory_planner, session_platform)
 
     # Read the task-submit / pipeline options *before* the empty-discovery guard:

--- a/tests/st/harness/test_case_declaration.py
+++ b/tests/st/harness/test_case_declaration.py
@@ -22,7 +22,9 @@ Nothing here touches a device, and the compile check is skipped when ``ptoas``
 is unavailable.
 """
 
+import ast
 import shutil
+import sys
 import tempfile
 from pathlib import Path
 from typing import Any
@@ -631,6 +633,80 @@ class TestCustomCompare:
                 _compare_persisted_outputs(empty, lambda a, e: None)
         finally:
             shutil.rmtree(empty, ignore_errors=True)
+
+
+def _body_that_skips_on_a_missing_optional_dep():
+    """Stand-in for a unit-test body guarding an optional dependency.
+
+    ``pytest.importorskip`` raises ``Skipped``, which derives from
+    ``BaseException`` — the exact shape that used to escape discovery.
+    """
+    msgpack = pytest.importorskip("_pypto_no_such_optional_module")
+    return msgpack
+
+
+class TestCollectionIsNeverAbortedByADiscoveredCall:
+    """Discovery runs code out of test bodies; it must never take the session down.
+
+    ``_eval_arg_node`` resolves a constructor argument by *invoking* the callee,
+    so a body containing ``pytest.importorskip("...")`` for an absent module
+    raised ``Skipped`` inside ``pytest_collection_finish``. ``Skipped`` is a
+    ``BaseException``, so both call sites' ``except Exception`` guards missed it,
+    and a skip escaping a collection hook is not a skip — under xdist it is a
+    session-wide INTERNALERROR that reports zero tests.
+    """
+
+    @staticmethod
+    def _conftest() -> Any:
+        return TestPlatformMatrixCollection._conftest()
+
+    @staticmethod
+    def _item(func: Any) -> Any:
+        """A stub item shaped like the attributes discovery actually reads."""
+
+        class _Item:
+            module = sys.modules[__name__]
+            callspec = None
+
+            def __init__(self) -> None:
+                self.function = func
+                self.path = Path(__file__)
+
+            def iter_markers(self, name: str | None = None) -> Any:
+                return iter(())
+
+        return _Item()
+
+    def test_a_call_that_raises_skipped_is_merely_unresolvable(self):
+        """The BaseException is converted at the one place discovery invokes code."""
+        conf = self._conftest()
+        node = ast.parse('pytest.importorskip("_pypto_no_such_optional_module")').body[0].value
+
+        with pytest.raises(conf._Unresolvable):
+            conf._eval_arg_node(node, {}, {}, {"pytest": pytest})
+
+    def test_such_a_body_leaves_collection_intact(self):
+        """End to end: the body is walked, nothing is discovered, nothing raises."""
+        conf = self._conftest()
+        seen: dict[str, Any] = {}
+
+        item = self._item(_body_that_skips_on_a_missing_optional_dep)
+        conf._collect_test_case_from_item(item, seen, None, "a2a3")
+
+        assert seen == {}, "no PTOTestCase in that body — and no crash reaching that conclusion"
+
+    def test_only_items_under_tests_st_are_walked(self):
+        """A session hook fires for every item; only ST bodies are ours to parse."""
+        conf = self._conftest()
+        tests_dir = Path(__file__).resolve().parents[2]
+
+        class _PathItem:
+            def __init__(self, path: Path) -> None:
+                self.path = path
+
+        ut_case = tests_dir / "ut" / "ir" / "expressions" / "test_call_arg_directions.py"
+        assert conf._is_st_item(_PathItem(Path(__file__)))
+        assert not conf._is_st_item(_PathItem(ut_case))
 
 
 if __name__ == "__main__":

--- a/tests/st/runtime/control_flow/__init__.py
+++ b/tests/st/runtime/control_flow/__init__.py
@@ -1,0 +1,8 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------

--- a/tests/st/runtime/external_kernel/__init__.py
+++ b/tests/st/runtime/external_kernel/__init__.py
@@ -1,0 +1,8 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------

--- a/tests/st/runtime/framework_and_models/__init__.py
+++ b/tests/st/runtime/framework_and_models/__init__.py
@@ -1,0 +1,8 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------

--- a/tests/st/runtime/scheduling/__init__.py
+++ b/tests/st/runtime/scheduling/__init__.py
@@ -1,0 +1,8 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
`pytest tests/ut tests/st` could not complete. Two independent defects, one masking the other.

## 1. Collection-time discovery aborted the whole session

`pytest_collection_finish` in `tests/st/conftest.py` recovers each ST kernel's sample arguments by AST-walking test bodies, and `_eval_arg_node` resolves an `ast.Call` by **invoking** the callee. Two things made that fatal.

**The guards are the wrong width.** Both call sites use `except Exception`, but pytest's control-flow exceptions do not derive from `Exception`:

```
Skipped mro: ['Skipped', 'OutcomeException', 'BaseException', 'object']
issubclass(Skipped, Exception) -> False
```

So a `pytest.importorskip` for an absent module in *any* collected body raised `Skipped` straight out of the hook. A skip escaping a collection hook is not a skip — under xdist it becomes a session-wide `INTERNALERROR` that reports zero tests:

```
INTERNALERROR> ... xdist/dsession.py", line 218, in worker_workerfinished
INTERNALERROR>     self._active_nodes.remove(node)
INTERNALERROR> KeyError: <WorkerController gw0>

no tests ran in 4.84s
```

**The walk is also unscoped.** `pytest_collection_finish` is a *session* hook, so once this conftest loads it fires for every collected item — handing `tests/ut` bodies to a walk that parses and partially evaluates them, hunting for `PTOTestCase` constructors they cannot contain.

Both are fixed, because either alone leaves a hole: scoping does not help if an ST body ever guards an optional dependency, and widening alone still parses ten thousand unrelated bodies.

- `_eval_arg_node` converts a non-`KeyboardInterrupt`/`SystemExit` `BaseException` from an invoked call into `_Unresolvable` — the existing "fall back to the inline path" outcome.
- The same widening on the `PTOTestCase` constructor call, which runs ST-authored code under the identical hazard.
- New `_is_st_item()` scopes discovery to items collected under `tests/st/`.

## 2. Six test basenames collide across the two trees

Fixing the abort let the session survive long enough to surface a second defect it had been hiding:

```
import file mismatch:
imported module 'test_dynamic_valid_shape_if_else' has this __file__ attribute:
  tests/ut/codegen/test_dynamic_valid_shape_if_else.py
which is not the same as the test file we want to collect:
  tests/st/codegen/dsl/test_dynamic_valid_shape_if_else.py
```

Under pytest's default `prepend` import mode a module's name is the dotted path from its first non-package ancestor, so both files in each pair want the same top-level name. The ST half was silently **not executed** in any combined run — one line in the ERROR summary next to five figures of passing tests.

Ten basenames are shared, but only six actually collide; the other four are already disambiguated by one side sitting in a package:

| Basename | UT module | ST module | |
| --- | --- | --- | --- |
| `test_gather` | `operators.test_gather` | `test_gather` | ok |
| `test_paged_gather` | `transforms.test_paged_gather` | `test_paged_gather` | ok |
| `test_spmd` | `jit.test_spmd` | `test_spmd` | ok |
| `test_dtype` | `test_dtype` | `harness.test_dtype` | ok |
| `test_compiled_program` | `test_compiled_program` | `test_compiled_program` | **collide** |
| `test_device_tensor` | `test_device_tensor` | `test_device_tensor` | **collide** |
| `test_dynamic_shape` | `test_dynamic_shape` | `test_dynamic_shape` | **collide** |
| `test_dynamic_valid_shape_if_else` | `test_dynamic_valid_shape_if_else` | `test_dynamic_valid_shape_if_else` | **collide** |
| `test_external_kernel` | `test_external_kernel` | `test_external_kernel` | **collide** |
| `test_phase_fence_dep_compression` | `test_phase_fence_dep_compression` | `test_phase_fence_dep_compression` | **collide** |

That table is also the fix: the repo already solves this with a package marker, so the same is extended to the five ST directories owning the colliding side. All 517 test modules now have unique module names.

### Alternatives considered

- **Renaming the six files** works, but every rename changes node ids and breaks references to them. A package marker changes none.
- **`importmode = "importlib"`** is not an option here. Fourteen test files import bare-name sibling helpers (`from _orchestration_codegen_common import ...`, `from _pto_loc_common import strip_loc`) that resolve *only* because `prepend` inserts their directory into `sys.path`; `importlib` mode inserts nothing and they would all fail to import.

## Verification

| | Before | After |
| --- | --- | --- |
| `pytest tests/ut tests/st/codegen -q -n 8` | `no tests ran in 19.22s`, session `INTERNALERROR` | `11553 passed, 3 skipped, 1 xfailed in 216.80s`, no error |

The intermediate state (abort fixed, collision not yet) gave `11551 passed ... 1 error`; the two extra tests now passing are exactly the ST file that had been erroring out instead of running.

Three regression tests in `tests/st/harness/test_case_declaration.py`, beside the existing `_collect_test_case_from_item` coverage: the `Skipped`→`_Unresolvable` conversion, an end-to-end walk of a body containing `importorskip`, and the ST/UT path predicate.

Also run: the five touched ST directories on hardware, and a collection check that the cross-tree dotted imports (`from tests.st.runtime...`) still resolve. That hardware run has one failure, `test_graph_execution.py::TestGraphExecution::test_no_graph_per_layer_accumulate`, which reproduces identically with and without these commits and is unrelated.
