### PR TITLE
fix(codegen): keep loop-carried TaskIds live for array republish

### DIFF
--- a/docs/en/dev/codegen/01-orchestration_codegen.md
+++ b/docs/en/dev/codegen/01-orchestration_codegen.md
@@ -627,8 +627,8 @@ TaskId keeps the guard. Array-carry iter_args fill one guarded slot per element.
 
 **Lexical-scope lifetime.** TaskId bindings name C++ locals (`TaskId tid
 = ...`) declared inside the generated `SIMPLER_SCOPE { ... }` block they are
-produced in. Each `SIMPLER_SCOPE` (AUTO or MANUAL) snapshots `manual_task_id_map_`
-and `array_carry_vars_` on entry and restores them on exit, so a binding
+produced in. Each `SIMPLER_SCOPE` (AUTO or MANUAL) snapshots `manual_task_id_map_`,
+`manual_task_id_map_by_key_`, and `array_carry_vars_` on entry and restores them on exit, so a binding
 produced inside a scope does not leak to an enclosing scope where its identifier
 would be out of C++ scope. Loop / branch carries are declared *before* their
 body's `SIMPLER_SCOPE`, so they correctly survive the block.
@@ -654,6 +654,7 @@ on scope exit. Codegen's response depends on the edge's provenance:
 | Compiler-derived (`compiler_manual_dep_edges`) | Silently skipped. These are a best-effort hazard patch; `PrepareCrossScopeTaskIdHoists` already LCA-hoists the ones it can, and dropping the rest is safe because the pass only ever *adds* ordering |
 | User-written (`deps=[...]`) | **Hard error** — `CHECK_SPAN` raises a `pypto::ValueError` naming the TaskId and the DSL source line |
 | Array publish (`arr[i] = tid`) | **Hard error** — `CheckTaskIdSlotValueInScope` raises a `pypto::ValueError` telling the user to move the store inside the `pl.scope()` that produced the TaskId. Unlike a dep edge, the slot write is emitted unconditionally, so accepting it would emit orchestration the host compiler rejects with `'<tid>' was not declared in this scope` — a failure `--compile-only` never reaches |
+| Loop / branch yield | **Hard error** — `FindClosedScopeTaskId` checks the source before emitting the yield. A live destination carry does not make a producer local from a closed nested scope readable. Publish the TaskId into an array declared outside that scope before it closes, then yield a read of the array element |
 
 Provenance is the attr key. Note that `attrs["dummy_task"]` is *not* an
 authorship marker: the parser stamps it on a user-written
@@ -670,11 +671,14 @@ both `CountManualDeps` (array sizing) and `EmitManualDeps` (array fill) route
 through, so the two can never disagree on which edges survive.
 
 The scope that closed need not be user-written. `MaterializeRuntimeScopes` wraps
-every `ForStmt` body and every `IfStmt` branch body in its own AUTO scope, so
-this fires on ordinary orchestration code with no `pl.scope()` / `pl.manual_scope()`
-in sight — e.g. a TaskId captured inside a `pl.range` body and depended on after
-the loop. The fix is to keep the consumer in the producer's scope, or hoist the
-producer outward.
+`ForStmt` and `IfStmt` bodies in AUTO scopes outside manual regions. Sequential
+TaskId carries and branch phis remain usable after those bodies close because
+their declarations and bindings live outside the bodies. Function
+`Scalar[TASK_ID]` parameters are registered as live at codegen construction for
+the same reason — yielding or storing a parameter must not look like a producer
+from a closed scope. Their yield sources must still be live at the assignment: a
+producer inside a nested `pl.scope()` that closes before the yield must first be
+published through an enclosing array.
 
 One exception applies to the `array_carry_vars_` restore on a `MANUAL` scope: an
 array carry registered *inside* the scope whose backing array was declared in

--- a/docs/zh/dev/codegen/01-orchestration_codegen.md
+++ b/docs/zh/dev/codegen/01-orchestration_codegen.md
@@ -595,7 +595,8 @@ call 上）。该 pass 从不分析用户写的 MANUAL scope——在 `pl.manual
 
 **词法作用域生命周期。** TaskId 绑定命名的是在其产生所在的 `SIMPLER_SCOPE { ... }`
 块内声明的 C++ 局部变量（`TaskId tid = ...`）。每个 `SIMPLER_SCOPE`（AUTO 或
-MANUAL）在进入时快照 `manual_task_id_map_` 与 `array_carry_vars_`、退出时恢复，
+MANUAL）在进入时快照 `manual_task_id_map_`、`manual_task_id_map_by_key_` 与
+`array_carry_vars_`、退出时恢复，
 因此在某作用域内产生的绑定不会泄漏到外层作用域（否则其标识符会超出 C++ 作用域）。
 循环 / 分支的 carry 在其 body 的 `SIMPLER_SCOPE` *之前*声明，因此能正确地在块结束后存活。
 
@@ -617,6 +618,7 @@ AUTO 作用域不做任何提升，故仅当进入前已有 carry 命名了该�
 | 编译器推导（`compiler_manual_dep_edges`） | 静默跳过。这类边是尽力而为的 hazard 补丁；`PrepareCrossScopeTaskIdHoists` 已对能处理的部分做了 LCA 提升，丢弃其余是安全的，因为该 pass 只会*增加*定序 |
 | 用户书写（`deps=[...]`） | **硬报错**——`CHECK_SPAN` 抛出 `pypto::ValueError`，并指出该 TaskId 与对应的 DSL 源码行 |
 | 数组发布（`arr[i] = tid`） | **硬报错**——`CheckTaskIdSlotValueInScope` 抛出 `pypto::ValueError`，提示用户把该写入移进产生该 TaskId 的 `pl.scope()` 内。与依赖边不同，槽位写入是无条件生成的，因此若放行，就会生成宿主编译器以 `'<tid>' was not declared in this scope` 拒绝的编排代码——而 `--compile-only` 根本走不到那一步 |
+| 循环 / 分支 yield | **硬报错**——`FindClosedScopeTaskId` 在生成 yield 前检查源值。目标携带变量（carry）仍存活，并不意味着已关闭的嵌套作用域中的生产者局部变量可读。应在该作用域关闭前，把 TaskId 写入声明于其外部的数组，再读取数组元素作为 yield 的源值 |
 
 来源由 attr key 判定。注意 `attrs["dummy_task"]` **不是**作者身份标记：parser 会把
 它打在用户书写的 `pl.system.task_dummy(deps=[...])` 上，与
@@ -629,11 +631,13 @@ barrier 打的完全相同，因此所有 `manual_dep_edges` 载体一律强制�
 解析并校验入口，`CountManualDeps`（数组定长）与 `EmitManualDeps`（数组填充）都经由
 它，因此两者对"哪些边存活"的判断绝不会不一致。
 
-被关闭的作用域不一定由用户书写。`MaterializeRuntimeScopes` 会把每个 `ForStmt`
-body 和每个 `IfStmt` 分支 body 各自包进一个 AUTO 作用域，因此在完全没有出现
-`pl.scope()` / `pl.manual_scope()` 的普通编排代码中也会触发——例如在 `pl.range`
-body 内捕获 TaskId、却在循环之后依赖它。修复方式是把消费者放到生产者所在的
-作用域内，或把生产者外提。
+被关闭的作用域不一定由用户书写。`MaterializeRuntimeScopes` 会在 manual 区域之外，
+把 `ForStmt` 和 `IfStmt` 的 body 包进 AUTO 作用域。顺序循环的 TaskId 携带变量（carry）
+和分支合流变量（phi）的声明与绑定位于 body 外部，因此在 body 关闭后仍可使用。
+函数的 `Scalar[TASK_ID]` 参数在 codegen 构造时即注册为存活绑定，同理——对参数的
+yield 或存入数组不得被误判为来自已关闭作用域的生产者。但 yield 的源值在赋值时
+必须仍存活：若生产者位于嵌套的 `pl.scope()` 内，且该作用域在 yield 之前已关闭，
+就必须先通过外层数组发布该 TaskId。
 
 对 `MANUAL` 作用域的 `array_carry_vars_` 恢复有一个例外：在该作用域 *内部* 注册、
 但其底层数组声明于 *外层* 作用域的 array carry 必须在恢复后存活。这就是将

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -279,6 +279,12 @@ class OrchestrationStmtCodegen : public CodegenBase {
         packed_fp4_axis_(std::move(packed_fp4_axis)),
         dist_param_to_ctx_param_(std::move(dist_param_to_ctx_param)) {
     declared_var_names_ = param_name_set_;
+    // Function ``Scalar[TASK_ID]`` parameters (and lineage aliases seeded into
+    // ``emit_name_map_`` before construction) are live for the whole body.
+    // Register them in the TaskId binding maps / live-emit set so
+    // ``FindClosedScopeTaskId`` does not treat a branch/loop yield of a
+    // parameter as a producer local from a closed scope.
+    RegisterFunctionTaskIdParams();
     CollectCompilerDepTaskIds(program_);
   }
 
@@ -916,11 +922,19 @@ class OrchestrationStmtCodegen : public CodegenBase {
         emit_name_map_[return_var.get()] = carry_name;
         emit_name_map_[iter_arg.get()] = carry_name;
         // Sequential TaskId carry: register both endpoints in the task-id
-        // map so EmitManualDeps and yield writes can find the carry name.
+        // map so EmitManualDeps / yield writes / CheckTaskIdSlotValueInScope
+        // can find the live carry name. Must not gate on manual_scope depth:
+        // AUTO-scope loops (and inlined callees that re-publish the incoming
+        // carry into a pl.array) still need the binding, otherwise the
+        // closed-scope store diagnostic false-positives on a legal loop-carried
+        // TaskId (issue #2677).
         auto sty = As<ScalarType>(iter_arg->GetType());
-        if (in_manual_scope_depth_ > 0 && sty && sty->dtype_ == DataType::TASK_ID) {
+        if (sty && sty->dtype_ == DataType::TASK_ID) {
           manual_task_id_map_[iter_arg.get()] = carry_name;
           manual_task_id_map_[return_var.get()] = carry_name;
+          manual_task_id_map_by_key_[TaskIdHoistKey(iter_arg.get())] = carry_name;
+          manual_task_id_map_by_key_[TaskIdHoistKey(return_var.get())] = carry_name;
+          NoteLiveManualTaskIdEmitName(carry_name);
         }
       } else {
         // Trivial yield: preserve the legacy aliasing — both names route to
@@ -1054,7 +1068,13 @@ class OrchestrationStmtCodegen : public CodegenBase {
     // produced by tasks emitted in the enclosing (auto or outer) scope. Loop /
     // branch carries are registered *before* their body's SIMPLER_SCOPE (outside
     // this frame), so they correctly survive the block.
+    //
+    // ``manual_task_id_map_by_key_`` is snapshotted with the pointer map: UniqueId
+    // entries added inside the block must die with it, or
+    // ``ResolveManualTaskIdBinding`` / ``CheckTaskIdSlotValueInScope`` would treat
+    // a dead loop-carry local as still live after the closing brace.
     auto saved_map = manual_task_id_map_;
+    auto saved_map_by_key = manual_task_id_map_by_key_;
     auto saved_array_carry = array_carry_vars_;
 
     if (!scope->manual_) {
@@ -1079,12 +1099,14 @@ class OrchestrationStmtCodegen : public CodegenBase {
       std::set<std::string> enclosing_arrays;
       // NOLINTNEXTLINE(bugprone-nondeterministic-pointer-iteration-order)
       for (const auto& [_, entry] : saved_array_carry) enclosing_arrays.insert(entry.array_name);
-      PreserveEnclosingArrayCarries(&saved_array_carry, &saved_map, [&](const std::string& name) {
-        return enclosing_arrays.count(name) == 0;
-      });
+      PreserveEnclosingArrayCarries(
+          &saved_array_carry, &saved_map, &saved_map_by_key,
+          [&](const std::string& name) { return enclosing_arrays.count(name) == 0; });
 
       manual_task_id_map_ = std::move(saved_map);
+      manual_task_id_map_by_key_ = std::move(saved_map_by_key);
       array_carry_vars_ = std::move(saved_array_carry);
+      RebuildLiveManualTaskIdEmitNames();
       return;
     }
 
@@ -1150,11 +1172,13 @@ class OrchestrationStmtCodegen : public CodegenBase {
     // declared in the ENCLOSING scope (issue #1811) — see
     // ``PreserveEnclosingArrayCarries``. A manual scope hoists its allocations,
     // so it knows its own local storage names outright.
-    PreserveEnclosingArrayCarries(&saved_array_carry, &saved_map,
+    PreserveEnclosingArrayCarries(&saved_array_carry, &saved_map, &saved_map_by_key,
                                   [&](const std::string& name) { return local_names.count(name) != 0; });
 
     manual_task_id_map_ = std::move(saved_map);
+    manual_task_id_map_by_key_ = std::move(saved_map_by_key);
     array_carry_vars_ = std::move(saved_array_carry);
+    RebuildLiveManualTaskIdEmitNames();
   }
 
   /// Mark each ArrayType ``IfStmt`` return_var (a phi) as bound-by-yield, so no
@@ -1327,6 +1351,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
         EmitIndentedLine(cpp_type + " " + emit_name + " = TaskId::invalid();");
         manual_task_id_map_[rv.get()] = emit_name;
         manual_task_id_map_by_key_[TaskIdHoistKey(rv.get())] = emit_name;
+        NoteLiveManualTaskIdEmitName(emit_name);
       } else {
         EmitIndentedLine(cpp_type + " " + emit_name + ";");
       }
@@ -1602,6 +1627,15 @@ class OrchestrationStmtCodegen : public CodegenBase {
         continue;
       }
       const auto& rv = current_return_vars_[i];
+      // A carry may be declared outside the loop/branch while its yielded
+      // producer was local to a nested scope that has already closed.
+      if (auto stale_tid = FindClosedScopeTaskId(yield_stmt->value_[i])) {
+        CHECK_SPAN(false, yield_stmt->span_)
+            << "Task id '" << stale_tid->name_hint_
+            << "' is yielded after the `pl.scope()` that produced it has closed, so the yield "
+               "has no runtime value to name. Publish the task id into an array declared outside "
+               "that scope before it closes, then yield a read of that array element.";
+      }
       // ArrayType IfStmt phi: record the backing array this branch yields; the
       // enclosing IfStmt binds it once both branches are emitted. Nothing is
       // emitted — the branch already mutated that array in place.
@@ -4202,28 +4236,37 @@ class OrchestrationStmtCodegen : public CodegenBase {
     emit_name_map_[assign->var_.get()] = target_name;
   }
 
-  /// Reject an ``arr[i] = tid`` whose TaskId was produced in a scope that has
-  /// already closed.
-  ///
-  /// The slot write is emitted in place, but the value names a C++ local
-  /// declared inside the ``SIMPLER_SCOPE { }`` that produced it. Writing it
-  /// after that block closes compiles here and is then rejected by the host
-  /// compiler with ``'<tid>' was not declared in this scope`` — a failure the
-  /// user cannot trace back to their source, and one ``--compile-only`` never
-  /// reaches. Diagnose it at the DSL level instead.
+  /// Return the TaskId producer local if ``value`` names one from a closed
+  /// scope. Both array stores and yields must reject these reads before the
+  /// host compiler encounters an out-of-scope C++ identifier.
   ///
   /// A stale value is identified positively: ``emit_name_map_`` still holds the
   /// name it was bound to (never scope-restored), while ``manual_task_id_map_``
   /// does not (restored at each closing brace — see
-  /// ``VisitStmt_(RuntimeScopeStmtPtr)``). A TaskId this codegen never bound to
-  /// a local has no entry in either and is left alone.
-  void CheckTaskIdSlotValueInScope(const CallPtr& call, const std::string& array_name) {
-    auto value_var = AsVarLike(call->args_[2]);
-    if (!value_var) return;
+  /// ``VisitStmt_(RuntimeScopeStmtPtr)``). Function ``Scalar[TASK_ID]``
+  /// parameters are registered at construction (``RegisterFunctionTaskIdParams``)
+  /// so yielding / storing them is not mistaken for a closed-scope producer. A
+  /// TaskId this codegen never bound to a local has no entry in either map and
+  /// is left alone.
+  VarPtr FindClosedScopeTaskId(const ExprPtr& value) const {
+    auto value_var = AsVarLike(value);
+    if (!value_var) return nullptr;
     auto scalar_ty = As<ScalarType>(value_var->GetType());
-    if (!scalar_ty || scalar_ty->dtype_ != DataType::TASK_ID) return;
-    if (manual_task_id_map_.count(value_var.get())) return;
-    if (!emit_name_map_.count(value_var.get())) return;
+    if (!scalar_ty || scalar_ty->dtype_ != DataType::TASK_ID) return nullptr;
+    // Resolve through pointer and UniqueId maps (both scope-restored together).
+    // A live sequential / phi carry or function parameter stays registered; a
+    // producer local from a closed scope does not (issue #2677 / #2659).
+    if (ResolveManualTaskIdBinding(value_var.get())) return nullptr;
+    auto emit_it = emit_name_map_.find(value_var.get());
+    if (emit_it == emit_name_map_.end()) return nullptr;
+    // Emit-name alias of a still-registered live carry (SSA rename after inline).
+    if (live_manual_task_id_emit_names_.count(emit_it->second)) return nullptr;
+    return value_var;
+  }
+
+  void CheckTaskIdSlotValueInScope(const CallPtr& call, const std::string& array_name) {
+    auto value_var = FindClosedScopeTaskId(call->args_[2]);
+    if (!value_var) return;
     CHECK_SPAN(false, call->span_)
         << "Task id '" << value_var->name_hint_ << "' is stored into array '" << array_name
         << "' after the `pl.scope()` that produced it has closed, so the store has no runtime "
@@ -4348,13 +4391,47 @@ class OrchestrationStmtCodegen : public CodegenBase {
   template <typename IsScopeLocal>
   void PreserveEnclosingArrayCarries(std::unordered_map<const Var*, ArrayCarryEntry>* saved_array_carry,
                                      std::unordered_map<const Var*, ManualTaskIdBinding>* saved_map,
+                                     std::unordered_map<uint64_t, ManualTaskIdBinding>* saved_map_by_key,
                                      const IsScopeLocal& is_scope_local) {
     for (const auto& [var, entry] : array_carry_vars_) {
       if (saved_array_carry->count(var)) continue;     // outer entry — keep outer value
       if (is_scope_local(entry.array_name)) continue;  // scope-local storage — drop
       (*saved_array_carry)[var] = entry;               // enclosing-valid carry — preserve
       auto tid_it = manual_task_id_map_.find(var);     // keep its per-slot dep names in sync
-      if (tid_it != manual_task_id_map_.end()) (*saved_map)[var] = tid_it->second;
+      if (tid_it != manual_task_id_map_.end()) {
+        (*saved_map)[var] = tid_it->second;
+        (*saved_map_by_key)[TaskIdHoistKey(var)] = tid_it->second;
+      }
+    }
+  }
+
+  /// Rebuild the O(1) reverse index of live scalar TaskId emit names from the
+  /// current pointer / UniqueId maps (call after every scope restore).
+  void RebuildLiveManualTaskIdEmitNames() {
+    live_manual_task_id_emit_names_.clear();
+    auto note = [&](const ManualTaskIdBinding& binding) {
+      if (const auto* name = std::get_if<std::string>(&binding)) {
+        live_manual_task_id_emit_names_.insert(*name);
+      }
+    };
+    for (const auto& [_, binding] : manual_task_id_map_) note(binding);
+    for (const auto& [_, binding] : manual_task_id_map_by_key_) note(binding);
+  }
+
+  /// Note a scalar TaskId emit name as live (kept in sync with map inserts).
+  void NoteLiveManualTaskIdEmitName(const std::string& name) { live_manual_task_id_emit_names_.insert(name); }
+
+  /// Bind every ``Scalar[TASK_ID]`` already present in ``emit_name_map_`` (function
+  /// parameters and their lineage aliases seeded before construction) as a live
+  /// TaskId for the whole orchestration / Graph body.
+  void RegisterFunctionTaskIdParams() {
+    for (const auto& [var, emit_name] : emit_name_map_) {
+      if (!var) continue;
+      auto scalar_ty = As<ScalarType>(var->GetType());
+      if (!scalar_ty || scalar_ty->dtype_ != DataType::TASK_ID) continue;
+      manual_task_id_map_[var] = emit_name;
+      manual_task_id_map_by_key_[TaskIdHoistKey(var)] = emit_name;
+      NoteLiveManualTaskIdEmitName(emit_name);
     }
   }
 
@@ -4417,6 +4494,11 @@ class OrchestrationStmtCodegen : public CodegenBase {
   /// inner block — are discarded once the manual scope exits.
   std::unordered_map<const Var*, ManualTaskIdBinding> manual_task_id_map_;
   std::unordered_map<uint64_t, ManualTaskIdBinding> manual_task_id_map_by_key_;
+  /// Reverse index of scalar ``TaskId`` emit names currently present in
+  /// ``manual_task_id_map_`` / ``manual_task_id_map_by_key_``. Kept in sync on
+  /// registration and rebuilt after every scope restore so
+  /// ``CheckTaskIdSlotValueInScope`` can test emit-name aliases in O(1).
+  std::unordered_set<std::string> live_manual_task_id_emit_names_;
   /// Records the C++ array allocation backing a TaskId carry that holds an
   /// array of task ids (not a scalar). Used by ``YieldStmt`` to decide how
   /// to write into the carry:

--- a/tests/ut/codegen/test_array_codegen.py
+++ b/tests/ut/codegen/test_array_codegen.py
@@ -22,7 +22,9 @@ import pytest
 from _orchestration_codegen_common import _finalize_handbuilt_for_codegen
 from _pto_loc_common import strip_loc
 from pypto import codegen, passes
+from pypto.jit.decorator import jit
 from pypto.pypto_core import DataType, ir
+from pypto.runtime import RunConfig
 
 
 def _generate_orch(src: str) -> str:
@@ -1087,6 +1089,114 @@ def test_orch_task_id_phi_from_if_is_publishable_to_array():
     assert phi, code
     # ...and the publish after the branches close resolves to that same local.
     assert f"tids[branch] = {phi.group(1)};" in code or f"tids[branch] = {phi.group(1)}" in code, code
+
+
+@pytest.mark.parametrize(
+    "control_flow",
+    ["for i in pl.range(2)", "for i in pl.parallel(2)", "if flag > 0"],
+    ids=["sequential", "parallel", "if_phi"],
+)
+def test_orch_task_id_yield_after_nested_scope_closed_is_rejected(control_flow):
+    """A live carry cannot be assigned a producer local from a closed scope."""
+    prog = pl.parse_program(f"""
+@pl.program
+class P:
+    @pl.function(type=pl.FunctionType.Orchestration, auto_scope=False)
+    def main(
+        self, x: pl.Tensor[[64], pl.FP32], flag: pl.Scalar[pl.INT64]
+    ) -> pl.Tensor[[64], pl.FP32]:
+        tids = pl.array.create(1, pl.TASK_ID)
+        dep = pl.system.task_invalid()
+        {control_flow}:
+            with pl.scope():
+                dep = pl.system.task_dummy(deps=[])
+            # Keep the implicit yield outside the producer's scope.
+            _fence = pl.system.task_dummy(deps=[])
+        tids[0] = dep
+        return x
+""")
+
+    with pytest.raises(ValueError, match="is yielded after") as excinfo:
+        _compile_orch(prog)
+
+    msg = str(excinfo.value)
+    assert "dep" in msg, msg
+    assert "after the `pl.scope()` that produced it has closed" in msg, msg
+    assert "array declared outside" in msg, msg
+    assert "Internal error" not in msg, msg
+
+
+def test_orch_branch_yield_of_task_id_parameter_is_accepted():
+    """A ``pl.Scalar[TASK_ID]`` function parameter stays live across branch yields.
+
+    Parameters are seeded into ``emit_name_map_`` at codegen construction but are
+    not producer locals of a nested ``pl.scope()``. Yielding one into an ``if``
+    phi must not trip ``FindClosedScopeTaskId`` — the parameter is valid for the
+    whole function body.
+    """
+    prog = pl.parse_program("""
+@pl.program
+class P:
+    @pl.function(type=pl.FunctionType.Orchestration, auto_scope=False)
+    def main(
+        self,
+        x: pl.Tensor[[64], pl.FP32],
+        seed: pl.Scalar[pl.TASK_ID],
+        flag: pl.Scalar[pl.INT64],
+    ) -> pl.Tensor[[64], pl.FP32]:
+        dep = seed
+        if flag > 0:
+            dep = seed
+        else:
+            dep = seed
+        _ = pl.system.task_dummy(deps=[dep])
+        return x
+""")
+
+    code = _compile_orch(prog)
+    # Both arms yield the parameter into the phi; the dep edge must name that
+    # live id (parameter or phi), never raise the closed-scope diagnostic.
+    assert "TaskId::invalid()" in code, code
+    assert "task_dummy" in code or "set_dependencies" in code, code
+
+
+def test_orch_loop_carried_task_id_republished_via_inline_callee():
+    """Loop-carried TaskId returned from an inlined callee may re-enter a slot.
+
+    Regression for issue #2677: a TaskId produced inside a nested ``pl.scope()``,
+    returned from ``@pl.jit.inline``, and carried across a caller ``pl.range``
+    must stay nameable when the next iteration stores it into a ``pl.array`` at
+    the callee entry. The closed-scope diagnostic must not false-positive on
+    that legal carry — two iterations are the minimum that crosses a closed
+    scope.
+    """
+    torch = pytest.importorskip("torch")
+
+    rows, cols = 16, 128
+
+    @jit.inline(auto_scope=False)
+    def stage(out: pl.Tensor[[rows, cols], pl.FP32], incoming: pl.Scalar[pl.TASK_ID]):
+        carry = pl.array.create(1, pl.TASK_ID)
+        carry[0] = incoming
+        with pl.scope():
+            with pl.spmd(rows, name_hint="stage_body", deps=[carry[0]]) as body_tid:
+                row = pl.tile.get_block_idx()
+                out[row : row + 1, 0:cols] = pl.full([1, cols], dtype=pl.FP32, value=1.0)
+            carry[0] = body_tid
+        return carry[0]
+
+    # Entry must also be auto_scope=False: after InlineFunctions splices the
+    # callee, the hand-placed ``pl.scope()`` lives in the orchestration body.
+    @jit(auto_scope=False)
+    def prog(out: pl.Tensor[[rows, cols], pl.FP32]):
+        dep = pl.system.task_dummy(deps=[])
+        for _ in pl.range(2):
+            dep = stage(out, dep)
+        return out
+
+    # Compile-only: the bug fires in orchestration codegen before any runtime.
+    out = torch.empty(rows, cols, dtype=torch.float32)
+    prog.compile(out, config=RunConfig(platform="a2a3sim"))
 
 
 if __name__ == "__main__":

--- a/tests/ut/codegen/test_orchestration_task_deps.py
+++ b/tests/ut/codegen/test_orchestration_task_deps.py
@@ -876,15 +876,15 @@ def test_mixed_in_and_out_of_scope_deps_reports_user_error():
     assert "Internal error" not in msg, msg
 
 
-def test_user_dep_edge_out_of_compiler_inserted_loop_scope_is_rejected():
-    """The boundary need not be user-written to swallow a ``deps=[...]`` edge.
+def test_user_dep_edge_on_loop_carried_task_id_after_range_is_honored():
+    """A loop-carried TaskId remains usable in ``deps=[...]`` after ``pl.range``.
 
     ``MaterializeRuntimeScopes`` wraps every ``ForStmt`` body in its own AUTO
-    ``SIMPLER_SCOPE``, so a TaskId produced in the loop body and depended on after
-    the loop crosses a closed scope even though the source names no scope at
-    all. The loop-carry machinery does hoist a valid C++ ``TaskId`` to the
-    outer level, but the dep binding is not visible there, so the edge would be
-    dropped — reject instead.
+    ``SIMPLER_SCOPE``. The sequential TaskId carry is declared outside that
+    body, so depending on it after the loop names a live C++ local — the same
+    registration that keeps issue #2677's inline republish legal. Previously
+    the carry was only registered under ``manual_scope``, so this edge was
+    rejected even though the hoist already existed.
     """
 
     @pl.program
@@ -909,9 +909,14 @@ def test_user_dep_edge_out_of_compiler_inserted_loop_scope_is_rejected():
             b, _ = pl.submit(self.k2, x, deps=[loop_tid])
             return b
 
-    msg = _assert_dep_edge_rejected(P, "loop_tid")
-    # The message points at loop bodies / branches as scope openers.
-    assert "pl.range" in msg, msg
+    code = _generate_orch_full_pipeline(P, allow_relaxed_verification=True)
+
+    # Live sequential carry outside the per-iteration AUTO scope.
+    assert re.search(r"TaskId\s+loop_tid\w*\s*=\s*TaskId::invalid\(\);", code), code
+    # Post-loop consumer still wires the carried id into set_dependencies.
+    assert ".set_dependencies(" in code, code
+    assert re.search(r"if \(loop_tid\w*\.is_valid\(\)\)", code), code
+    assert re.search(r"\] = loop_tid\w*;", code), code
 
 
 def test_spmd_grid_tid_dep_across_manual_scope_boundary_is_rejected():


### PR DESCRIPTION
## Summary
- Fixes [#2677](https://github.com/hw-native-sys/pypto/issues/2677): `CheckTaskIdSlotValueInScope` false-positived when a TaskId returned from an `@pl.jit.inline` callee was carried across a caller `pl.range` and re-stored into a `pl.array` at the next iteration.
- Always register sequential TaskId loop carries in `manual_task_id_map_` (including `by_key`), not only under `manual_scope`; resolve live carries via `ResolveManualTaskIdBinding` / emit-name alias before rejecting closed-scope stores.
- Adds a compile-only regression UT matching the issue's minimal repro.

## Test plan
- [x] `tests/ut/codegen/test_array_codegen.py::test_orch_loop_carried_task_id_republished_via_inline_callee` (a2a3sim, compile-only)
- [x] `test_orch_task_id_array_store_after_nested_scope_closed_is_rejected` still rejects illegal stores
- [x] `test_orch_task_id_phi_from_if_is_publishable_to_array` / `test_orch_task_id_array_store_from_nested_scope` still pass
- [x] A/B: reverting the registration gate reproduces the #2677 diagnostic on the new test