### PR TITLE
fix(ir): preserve GM tensor writes across tile conversion

### DIFF
--- a/docs/en/dev/passes/11-convert_tensor_to_tile_ops.md
+++ b/docs/en/dev/passes/11-convert_tensor_to_tile_ops.md
@@ -41,15 +41,44 @@ For each `FunctionType::InCore` function:
 
 1. **Pre-scan consumer memory demand** (`ConsumerSpaceCollector`): Collect, for every variable, the memory space its downstream consumers need, driven by the `input_reqs` declared in `OpConversionRegistry`. A `tensor.slice` feeding `tensor.matmul` is the motivating case — it needs a Mat `tile.load` (natural, plus a zero-copy `tile.transpose_view` when transposed) rather than landing in Vec and being moved out again — but the mechanism is general, not matmul-specific.
 
-2. **Insert tile.load (entry loads)**: For each `TensorType` parameter directly consumed by a converted op, insert `tile.load(param, zeros, shape, shape, target_memory=Vec)` at function entry. Parameters only referenced by self-loading ops (`tensor.slice`, `tensor.matmul`, `tensor.read`, `tensor.write`, `tensor.assemble`) are skipped — they manage their own loads.
+2. **Analyze writes and share read-only loads**: Before conversion, trace writes through GM aliases and control flow using operator argument effects. A parameter used by a default tile-input converter may share an entry `tile.load` only when it is not written in the function. Writes to local values derived from a parameter also conservatively disable sharing for that parameter. Calls with opaque effects disable entry-load sharing. The loaded tile lives in a separate operand cache; the GM parameter retains its identity and type. Load space follows consumer demand, or remains unset for `InferTileMemorySpace` to determine.
 
-3. **Convert body via TensorToTileMutator**: Walk the function body and convert each `tensor.*` call to its `tile.*` equivalent using `OpConversionRegistry`. The mutator propagates type changes through control flow (IterArgs, ForStmt/WhileStmt return_vars, IfStmt return_vars).
+3. **Convert body via TensorToTileMutator**: Convert each registered call using `OpConversionRegistry`. `BridgeInputSpaces` supplies tile operands at the consuming statement, reusing read-only entry loads for default inputs or loading mutable GM operands at each use. Memory converters retain their GM operands and perform their own loading/storing. Local computed results still map to tiles. A value-flow analysis identifies tile-valued loop/branch results: GM handles carried through writes remain GM, while computed carries receive tile seeds and compatible yields.
 
 4. **Insert tile.store (exit stores)**: For each return value converted from `TensorType` to `TileType`, add an `Out` parameter and insert `tile.store(tile, zeros, out_param)`. If the return value comes from a `tile.assemble` loop, the loop is rewritten to use `tile.store` directly (conversion-time assemble-loop rewrite; distinct from `OptimizeOrchTensors` Pattern 3 which handles cross-function optimization).
 
 5. **Upgrade written param directions**: An alias-origin analysis (`AnalyzeCallAccess`) attributes every read/write back to the parameter it originates from, then upgrades each `In` param that is written to `Out` (write-only) or `InOut` (read and written). Which argument an operator writes is **not** decided here — it is read from that operator's registry declaration (`set_arg_effect`, see [Operators](../ir/05-operators.md#argument-effects)), so `tile.store`, `tile.mscatter`, `tensor.write`, `tensor.assemble`, `tensor.expand_clone`, the `pld.tile.*` / `pld.tensor.*` push and pull family, `pld.system.notify`, `system.syncall` and the composite collectives all reach the same analysis through one table. An argument declared `Write` is not counted as a read: a store landing on a sub-region never reads the untouched remainder. Kwarg-dependent effects resolve per call, so an atomic store or an `AtomicAdd` notify marks its destination read+write while the plain forms do not. Params the user already declared `Out` / `InOut` are left as-is.
 
    An operator that never declared its effects still counts as reading every argument. That default is now confined to operators the registry has nothing to say about — most of them functional — rather than being the fallback for a hand-maintained list that a new write operator silently escaped.
+
+### GM Identity and Read/Write Ordering
+
+Loading a GM tensor for computation creates a tile value, not an alias that can
+replace every use of the tensor. For example, this kernel computes from `x` and
+then changes one GM element:
+
+```python
+@pl.jit.incore
+def kernel(
+    x: pl.InOut[pl.Tensor[[16, 32], pl.FP32]],
+    out: pl.Out[pl.Tensor[[16, 1], pl.FP32]],
+):
+    r = pl.row_max(x)
+    out[0:16, 0:1] = r
+    pl.tensor.write(x, [0, 0], pl.const(1.0, pl.FP32))
+    return out
+```
+
+The reduction receives a `tile.load(x, ...)` result. The final write remains
+`tensor.write(x, ...)`, emitted as a GM `pto.store_scalar`; it does not become a
+`tile.write` into the reduction's input tile. The same rule applies to
+`pld.DistributedTensor` parameters, scalar reads, and returned GM aliases.
+
+When a later computation reads `x` after a GM write, it loads the updated value
+at that statement. Mutable GM loads are not shared across writes, branches, or
+loop iterations. Returning another tensor, or returning nothing, does not
+discard the GM write. `InOut` describes argument effects; it does not request an
+unconditional whole-tensor store at function exit.
 
 ### GM Store Coherence Restriction
 

--- a/docs/zh/dev/passes/11-convert_tensor_to_tile_ops.md
+++ b/docs/zh/dev/passes/11-convert_tensor_to_tile_ops.md
@@ -41,15 +41,41 @@ program_tiled = convert_pass(program)
 
 1. **预扫描消费端内存需求**（`ConsumerSpaceCollector`）：由 `OpConversionRegistry` 中声明的 `input_reqs` 驱动，为每个变量收集其下游消费者所需的 memory space。典型场景是 `tensor.slice` 喂给 `tensor.matmul`——它需要生成 Mat 空间的 `tile.load`（自然 load，转置时再叠加零拷贝 `tile.transpose_view`），而不是先落到 Vec 再搬出去——但该机制是通用的，并非 matmul 专用。
 
-2. **插入 tile.load（入口加载）**：为每个被转换 op 直接使用的 `TensorType` 参数，在函数入口插入 `tile.load(param, zeros, shape, shape, target_memory=Vec)`。仅被自加载 op（`tensor.slice`、`tensor.matmul`、`tensor.read`、`tensor.write`、`tensor.assemble`）引用的参数不会生成额外加载。
+2. **分析写入并共享只读加载**：转换前，根据算子参数效应，跨 GM 别名和控制流追踪写入。使用默认 tile 输入转换的参数，仅在函数中不会被写入时，才可共享入口 `tile.load`。对参数派生的局部值执行写入，也会保守地禁用该参数的加载共享。含有不透明副作用的调用会禁用入口加载共享。加载出的 tile 保存在独立的操作数缓存中，GM 参数保留原有身份和类型。加载空间遵循消费端需求；没有需求时保持未设置，由 `InferTileMemorySpace` 决定。
 
-3. **通过 TensorToTileMutator 转换函数体**：遍历函数体，使用 `OpConversionRegistry` 将每个 `tensor.*` 调用转换为对应的 `tile.*` 调用。Mutator 通过控制流传播类型变更（IterArgs、ForStmt/WhileStmt return_vars、IfStmt return_vars）。
+3. **通过 TensorToTileMutator 转换函数体**：使用 `OpConversionRegistry` 转换已注册的调用。`BridgeInputSpaces` 在消费语句处提供 tile 操作数：默认输入可复用只读入口加载，可变 GM 操作数则在每次使用时加载。内存操作转换器保留 GM 操作数，并自行执行加载和存储。局部计算结果仍映射到 tile。值流分析（value-flow analysis）识别循环和分支中变为 tile 的结果：通过写操作传递的 GM 句柄保持 GM 类型，计算型循环携带值则获得 tile 初值和类型一致的 yield。
 
 4. **插入 tile.store（出口存储）**：对每个从 `TensorType` 转换为 `TileType` 的返回值，添加 `Out` 参数并插入 `tile.store(tile, zeros, out_param)`。如果返回值来自 `tile.assemble` 循环，则将循环重写为直接使用 `tile.store`（转换时 assemble-loop 重写；与 `OptimizeOrchTensors` 模式 3 不同，该模式处理跨函数优化）。
 
 5. **升级被写入参数的方向（direction）**：通过别名溯源分析（`AnalyzeCallAccess`）把每次读/写归属到其来源参数，再把被写入的 `In` 参数升级为 `Out`（只写）或 `InOut`（既读又写）。**某个算子写哪个实参不再由本 pass 判定**，而是读取该算子在注册表上的声明（`set_arg_effect`，参见 [算子](../ir/05-operators.md#参数效应argument-effects)）；因此 `tile.store`、`tile.mscatter`、`tensor.write`、`tensor.assemble`、`tensor.expand_clone`、`pld.tile.*` / `pld.tensor.*` 推送与拉取家族、`pld.system.notify`、`system.syncall` 以及复合集合通信都经由同一张表进入本分析。被声明为 `Write` 的实参不计为读：只写入子区域的 store 从不读取未触及的部分。由 kwarg 决定的效应按调用逐个解析，因此原子 store 或 `AtomicAdd` 形式的 notify 会把目的操作数标记为读+写，而普通形式不会。用户已显式声明为 `Out` / `InOut` 的参数保持不变。
 
    从未声明效应的算子仍然按"读取全部实参"处理。该默认值如今只覆盖注册表无话可说的算子（其中绝大多数是纯函数式的），而不再是一张手工维护清单的兜底——新增的写类算子曾经可以悄无声息地从这张清单里漏掉。
+
+### GM 身份与读写顺序
+
+为计算加载 GM 张量会创建一个 tile 值，不能用它替换该张量的所有引用。
+例如，下面的 kernel 先读取 `x` 进行计算，再修改一个 GM 元素：
+
+```python
+@pl.jit.incore
+def kernel(
+    x: pl.InOut[pl.Tensor[[16, 32], pl.FP32]],
+    out: pl.Out[pl.Tensor[[16, 1], pl.FP32]],
+):
+    r = pl.row_max(x)
+    out[0:16, 0:1] = r
+    pl.tensor.write(x, [0, 0], pl.const(1.0, pl.FP32))
+    return out
+```
+
+归约接收 `tile.load(x, ...)` 的结果。最后的写入保留为
+`tensor.write(x, ...)`，生成 GM `pto.store_scalar`；它不会变成针对归约输入
+tile 的 `tile.write`。同样的规则适用于 `pld.DistributedTensor` 参数、标量读取
+以及返回的 GM 别名。
+
+如果后续计算在 GM 写入之后再次读取 `x`，它会在该语句处加载更新后的值。
+可变 GM 加载不会跨写入、分支或循环迭代共享。返回其他张量或者不返回值，都不会
+丢弃 GM 写入。`InOut` 描述参数效应，不表示在函数退出时无条件存储整个张量。
 
 ### GM 存储一致性限制
 

--- a/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
+++ b/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
@@ -414,11 +414,15 @@ class TensorArgsInConvertedOpsCollector : public IRVisitor {
    *
    * When an IterArg is in used_ (consumed by a converted op), its initValue_ may be a
    * function parameter eligible for a shared entry load. Follow each newly
-   * discovered seed once, including chains of nested IterArgs, in O(N).
+   * discovered seed once, including chains of nested IterArgs, in O(N). Only
+   * tile-valued carries consume such a preload; GM carries load their current
+   * value at the computation, which may differ from their initializer.
    */
-  void TraceIterArgInitValues() {
+  template <typename IsTileValue>
+  void TraceIterArgInitValues(IsTileValue is_tile_value) {
     std::vector<const Var*> worklist(used_.begin(), used_.end());
     for (size_t i = 0; i < worklist.size(); ++i) {
+      if (!is_tile_value(worklist[i])) continue;
       auto it = iter_arg_to_init_.find(worklist[i]);
       if (it == iter_arg_to_init_.end()) continue;
       if (auto var = AsVarLike(it->second);
@@ -713,19 +717,29 @@ class TensorConversionAnalysis : public IRVisitor {
   explicit TensorConversionAnalysis(const OpConversionRegistry& registry) : registry_(registry) {}
 
   void Propagate() {
-    for (size_t i = 0; i < worklist_.size(); ++i) {
-      auto it = users_.find(worklist_[i]);
+    // Yield edges can precede the tuple definitions in their branch/body.
+    // Resolve projections only after the complete definition index exists.
+    for (const auto& [source, target] : projection_flows_) {
+      if (auto var = AsVarLike(ResolveFlowSource(source))) AddFlow(var, target);
+    }
+    while (!worklist_.empty()) {
+      const auto* value = worklist_.back();
+      worklist_.pop_back();
+      auto it = users_.find(value);
       if (it == users_.end()) continue;
       for (const auto* user : it->second) MarkTile(user);
     }
-    for (size_t i = 0; i < write_worklist_.size(); ++i) {
-      auto it = sources_.find(write_worklist_[i]);
+    while (!write_worklist_.empty()) {
+      const auto* value = write_worklist_.back();
+      write_worklist_.pop_back();
+      auto it = sources_.find(value);
       if (it == sources_.end()) continue;
       for (const auto* source : it->second) MarkWritten(source);
     }
   }
 
-  [[nodiscard]] bool IsTile(const VarPtr& var) const { return tiles_.count(var.get()) != 0; }
+  [[nodiscard]] bool IsTile(const Var* var) const { return tiles_.count(var) != 0; }
+  [[nodiscard]] bool IsTile(const VarPtr& var) const { return IsTile(var.get()); }
   [[nodiscard]] bool HasOpaqueCalls() const { return has_opaque_calls_; }
   [[nodiscard]] bool MayWriteSource(const VarPtr& var) const {
     return written_sources_.count(var.get()) != 0;
@@ -757,11 +771,12 @@ class TensorConversionAnalysis : public IRVisitor {
     var_collectors::VarDefUseCollector refs;
     refs.VisitExpr(op->value_);
     sources_[op->var_.get()] = std::move(refs.var_uses_ordered);
+    if (As<TupleType>(op->var_->GetType())) tuple_definitions_[op->var_.get()] = op->value_;
     if (As<TileType>(op->var_->GetType())) {
       MarkTile(op->var_.get());
     } else if (AsTensorTypeLike(op->var_->GetType())) {
-      if (auto source = AsVarLike(op->value_)) {
-        AddFlow(source, op->var_);
+      if (AsVarLike(op->value_) || As<TupleGetItemExpr>(op->value_)) {
+        AddFlow(op->value_, op->var_);
       } else if (auto call = As<Call>(op->value_); call && registry_.Lookup(call->op_->name_)) {
         if (IsOp(call, "tensor.write") || IsOp(call, "tensor.assemble")) {
           AddFlow(call->args_[0], op->var_);
@@ -800,7 +815,38 @@ class TensorConversionAnalysis : public IRVisitor {
     if (written_sources_.insert(var).second) write_worklist_.push_back(var);
   }
 
+  /// Reuse immutable MakeTuple nodes as shared descriptors. Aliases select
+  /// the same descriptor, and projections select only their indexed element.
+  /// Memoization visits each alias/projection once without copying wide tuples.
+  /// Tensor leaves remain Var/IterArg nodes so their phi cycles use the worklist.
+  ExprPtr ResolveFlowSource(const ExprPtr& source) {
+    auto cached = resolved_flow_sources_.find(source.get());
+    if (cached != resolved_flow_sources_.end()) return cached->second;
+
+    ExprPtr resolved;
+    if (auto var = AsVarLike(source)) {
+      if (!As<TupleType>(var->GetType())) {
+        resolved = var;
+      } else if (auto definition = tuple_definitions_.find(var.get());
+                 definition != tuple_definitions_.end()) {
+        resolved = ResolveFlowSource(definition->second);
+      }
+    } else if (As<MakeTuple>(source)) {
+      resolved = source;
+    } else if (auto projection = As<TupleGetItemExpr>(source)) {
+      if (auto tuple = As<MakeTuple>(ResolveFlowSource(projection->tuple_))) {
+        resolved = ResolveFlowSource(tuple->elements_[projection->index_]);
+      }
+    }
+    resolved_flow_sources_.emplace(source.get(), resolved);
+    return resolved;
+  }
+
   void AddFlow(const ExprPtr& source, const VarPtr& target) {
+    if (As<TupleGetItemExpr>(source)) {
+      projection_flows_.emplace_back(source, target);
+      return;
+    }
     auto var = AsVarLike(source);
     if (!var) return;
     users_[var.get()].push_back(target.get());
@@ -829,6 +875,9 @@ class TensorConversionAnalysis : public IRVisitor {
   }
 
   const OpConversionRegistry& registry_;
+  std::unordered_map<const Var*, ExprPtr> tuple_definitions_;
+  std::unordered_map<const Expr*, ExprPtr> resolved_flow_sources_;
+  std::vector<std::pair<ExprPtr, VarPtr>> projection_flows_;
   std::unordered_map<const Var*, std::vector<const Var*>> users_;
   std::unordered_set<const Var*> tiles_;
   std::vector<const Var*> worklist_;
@@ -2555,7 +2604,7 @@ IncoreTransformResult TransformIncoreFunction(const FunctionPtr& func) {
   // tiles are kept in a separate cache, never installed in the SSA var map.
   TensorArgsInConvertedOpsCollector collector(conv_registry);
   collector.VisitStmt(canonical_body);
-  collector.TraceIterArgInitValues();
+  collector.TraceIterArgInitValues([&tile_values](const Var* var) { return tile_values.IsTile(var); });
   const auto& params_used_by_converted_ops = collector.GetUsed();
   for (const auto& var : func->params_) {
     if (!AsTensorTypeLike(var->GetType()) || tile_values.MayWriteSource(var) ||

--- a/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
+++ b/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
@@ -376,8 +376,19 @@ void CheckReinterpretViewIncoreLayout(const CallPtr& call) {
          "yet be preserved by tensor-to-tile lowering";
 }
 
+/// Converters without explicit input_reqs consume ordinary tensor operands as
+/// tiles. Memory operations and distributed transfers manage GM operands
+/// themselves; loading their operands would erase the destination identity.
+bool UsesDefaultTileInputs(const CallPtr& call) {
+  if (!call || call->op_->name_.rfind("tensor.", 0) != 0) return false;
+  return !(IsOp(call, "tensor.slice") || IsOp(call, "tensor.assemble") || IsOp(call, "tensor.read") ||
+           IsOp(call, "tensor.write") || IsOp(call, "tensor.expand_clone") || IsOp(call, "tensor.gather") ||
+           IsOp(call, "tensor.paged_gather") || IsOp(call, "tensor.create_l1") ||
+           IsOp(call, "tensor.gather_row"));
+}
+
 /**
- * @brief Visitor that collects tensor-typed variable names used directly by converted ops.
+ * @brief Visitor that collects tensor-typed variables used directly by converted ops.
  *
  * Traverses the IR tree via IRVisitor and records the name of every Var/IterArg argument
  * whose type is TensorType and that appears in a call to an op registered in
@@ -402,20 +413,17 @@ class TensorArgsInConvertedOpsCollector : public IRVisitor {
    * @brief Trace from collected IterArgs to their ForStmt/WhileStmt initValue_ expressions.
    *
    * When an IterArg is in used_ (consumed by a converted op), its initValue_ may be a
-   * function parameter that also needs a Phase-1 tile.load.  This fixpoint loop propagates
-   * through chains of IterArgs (e.g. nested loops) until no new entries are added.
+   * function parameter eligible for a shared entry load. Follow each newly
+   * discovered seed once, including chains of nested IterArgs, in O(N).
    */
   void TraceIterArgInitValues() {
-    bool changed = true;
-    while (changed) {
-      changed = false;
-      for (const auto& [iter_arg_ptr, init_expr] : iter_arg_to_init_) {
-        if (used_.count(iter_arg_ptr) == 0) continue;
-        if (auto var = As<Var>(init_expr)) {
-          if (AsTensorTypeLike(var->GetType()) && used_.insert(var.get()).second) {
-            changed = true;
-          }
-        }
+    std::vector<const Var*> worklist(used_.begin(), used_.end());
+    for (size_t i = 0; i < worklist.size(); ++i) {
+      auto it = iter_arg_to_init_.find(worklist[i]);
+      if (it == iter_arg_to_init_.end()) continue;
+      if (auto var = AsVarLike(it->second);
+          var && AsTensorTypeLike(var->GetType()) && used_.insert(var.get()).second) {
+        worklist.push_back(var.get());
       }
     }
   }
@@ -431,11 +439,7 @@ class TensorArgsInConvertedOpsCollector : public IRVisitor {
       // Skip ops whose inputs are handled by their own converter (self-loading):
       // they create loads with specific offsets/spaces, so Phase-1 default Vec loads
       // would be redundant or wrong.
-      static const std::unordered_set<std::string> kSelfLoadingOps = {
-          "tensor.slice",        "tensor.assemble",     "tensor.read",
-          "tensor.write",        "tensor.expand_clone", "tensor.gather",
-          "tensor.paged_gather", "tensor.create_l1",    "tensor.gather_row"};
-      if (kSelfLoadingOps.count(call->op_->name_)) {
+      if (!UsesDefaultTileInputs(call)) {
         IRVisitor::VisitStmt_(op);
         return;
       }
@@ -698,6 +702,142 @@ class ConsumerSpaceCollector : public IRVisitor {
   std::vector<std::pair<const Var*, const Var*>> propagation_edges_;
 };
 
+/// Predict which SSA values become tiles, including phi values. A GM handle
+/// carried through a write remains GM; a carry updated by a computation needs
+/// a tile seed. Propagate along value-flow edges, not every operand use. Each
+/// edge and marked value is processed once, including cyclic loop carries.
+/// A separate backward dependency walk conservatively excludes parameters
+/// whose GM storage or loaded tile values may be modified from load sharing.
+class TensorConversionAnalysis : public IRVisitor {
+ public:
+  explicit TensorConversionAnalysis(const OpConversionRegistry& registry) : registry_(registry) {}
+
+  void Propagate() {
+    for (size_t i = 0; i < worklist_.size(); ++i) {
+      auto it = users_.find(worklist_[i]);
+      if (it == users_.end()) continue;
+      for (const auto* user : it->second) MarkTile(user);
+    }
+    for (size_t i = 0; i < write_worklist_.size(); ++i) {
+      auto it = sources_.find(write_worklist_[i]);
+      if (it == sources_.end()) continue;
+      for (const auto* source : it->second) MarkWritten(source);
+    }
+  }
+
+  [[nodiscard]] bool IsTile(const VarPtr& var) const { return tiles_.count(var.get()) != 0; }
+  [[nodiscard]] bool HasOpaqueCalls() const { return has_opaque_calls_; }
+  [[nodiscard]] bool MayWriteSource(const VarPtr& var) const {
+    return written_sources_.count(var.get()) != 0;
+  }
+
+ protected:
+  void VisitExpr_(const CallPtr& op) override {
+    if (std::dynamic_pointer_cast<const GlobalVar>(op->op_)) has_opaque_calls_ = true;
+    if (const auto* entry = LookupOpEntry(op->op_)) {
+      for (size_t i = 0; i < op->args_.size(); ++i) {
+        if (!ArgEffectWrites(entry->GetArgEffect(i, op->kwargs_))) continue;
+        var_collectors::VarDefUseCollector refs;
+        refs.VisitExpr(op->args_[i]);
+        for (const auto* var : refs.var_uses_ordered) MarkWritten(var);
+      }
+    }
+    IRVisitor::VisitExpr_(op);
+  }
+
+  void VisitExpr_(const SubmitPtr& op) override {
+    has_opaque_calls_ = true;
+    IRVisitor::VisitExpr_(op);
+  }
+
+  void VisitStmt_(const AssignStmtPtr& op) override {
+    // Include tuple packing/projection and other expression-valued aliases,
+    // not just direct Call operands. Each assignment's expression is visited
+    // once and the collector stops at Var/IterArg references.
+    var_collectors::VarDefUseCollector refs;
+    refs.VisitExpr(op->value_);
+    sources_[op->var_.get()] = std::move(refs.var_uses_ordered);
+    if (As<TileType>(op->var_->GetType())) {
+      MarkTile(op->var_.get());
+    } else if (AsTensorTypeLike(op->var_->GetType())) {
+      if (auto source = AsVarLike(op->value_)) {
+        AddFlow(source, op->var_);
+      } else if (auto call = As<Call>(op->value_); call && registry_.Lookup(call->op_->name_)) {
+        if (IsOp(call, "tensor.write") || IsOp(call, "tensor.assemble")) {
+          AddFlow(call->args_[0], op->var_);
+        } else if (IsOp(call, "tensor.expand_clone")) {
+          AddFlow(call->args_[1], op->var_);
+        } else {
+          MarkTile(op->var_.get());
+        }
+      }
+    }
+    IRVisitor::VisitStmt_(op);
+  }
+
+  void VisitStmt_(const ForStmtPtr& op) override {
+    AddLoopFlows(op->body_, op->iter_args_, op->return_vars_);
+    IRVisitor::VisitStmt_(op);
+  }
+
+  void VisitStmt_(const WhileStmtPtr& op) override {
+    AddLoopFlows(op->body_, op->iter_args_, op->return_vars_);
+    IRVisitor::VisitStmt_(op);
+  }
+
+  void VisitStmt_(const IfStmtPtr& op) override {
+    AddYieldFlows(op->then_body_, op->return_vars_);
+    if (op->else_body_) AddYieldFlows(*op->else_body_, op->return_vars_);
+    IRVisitor::VisitStmt_(op);
+  }
+
+ private:
+  void MarkTile(const Var* var) {
+    if (tiles_.insert(var).second) worklist_.push_back(var);
+  }
+
+  void MarkWritten(const Var* var) {
+    if (written_sources_.insert(var).second) write_worklist_.push_back(var);
+  }
+
+  void AddFlow(const ExprPtr& source, const VarPtr& target) {
+    auto var = AsVarLike(source);
+    if (!var) return;
+    users_[var.get()].push_back(target.get());
+    sources_[target.get()].push_back(var.get());
+    if (As<TileType>(var->GetType())) MarkTile(var.get());
+  }
+
+  void AddYieldFlows(const StmtPtr& body, const std::vector<VarPtr>& targets) {
+    auto yield = transform_utils::GetLastYieldStmt(body);
+    if (!yield) return;
+    for (size_t i = 0; i < targets.size() && i < yield->value_.size(); ++i) {
+      AddFlow(yield->value_[i], targets[i]);
+    }
+  }
+
+  void AddLoopFlows(const StmtPtr& body, const std::vector<IterArgPtr>& iter_args,
+                    const std::vector<VarPtr>& returns) {
+    std::vector<VarPtr> targets;
+    targets.reserve(iter_args.size());
+    for (size_t i = 0; i < iter_args.size(); ++i) {
+      AddFlow(iter_args[i]->initValue_, iter_args[i]);
+      if (i < returns.size()) AddFlow(iter_args[i], returns[i]);
+      targets.push_back(iter_args[i]);
+    }
+    AddYieldFlows(body, targets);
+  }
+
+  const OpConversionRegistry& registry_;
+  std::unordered_map<const Var*, std::vector<const Var*>> users_;
+  std::unordered_set<const Var*> tiles_;
+  std::vector<const Var*> worklist_;
+  std::unordered_map<const Var*, std::vector<const Var*>> sources_;
+  std::unordered_set<const Var*> written_sources_;
+  std::vector<const Var*> write_worklist_;
+  bool has_opaque_calls_ = false;
+};
+
 // ============================================================================
 // TypePropagatingMutator: base class that extends IRMutator with type
 // propagation through control flow (IterArg types, ForStmt/WhileStmt
@@ -709,10 +849,6 @@ class ConsumerSpaceCollector : public IRVisitor {
 // ============================================================================
 
 class TypePropagatingMutator : public IRMutator {
- public:
-  /// Add a mapping from an old variable to a new one (populates var_remap_).
-  void AddMapping(const Expr* old_ptr, const ExprPtr& new_expr) { var_remap_[old_ptr] = new_expr; }
-
  protected:
   /// Override IterArg to propagate type from initValue_ when it changes.
   /// The base IRMutator preserves the original type; we want the new type
@@ -878,21 +1014,64 @@ class TypePropagatingMutator : public IRMutator {
 
 // ============================================================================
 // TensorToTileMutator: converts tensor ops to tile ops in InCore function
-// bodies.  Overrides AssignStmt/EvalStmt to run converters from
-// OpConversionRegistry; everything else (control flow recursion, variable
-// substitution, IterArg/return_var type propagation) comes from the base.
+// bodies. Materializes compute operands and tile-valued control-flow seeds,
+// then runs converters from OpConversionRegistry. The base handles SSA
+// substitution and propagation of the resulting types.
 // ============================================================================
 
 class TensorToTileMutator : public TypePropagatingMutator {
  public:
   TensorToTileMutator(const OpConversionRegistry& conv_registry, const OpRegistry& op_registry,
-                      const ConsumerSpaceCollector& consumer_collector, CachePolicyByParam cache_policies)
+                      const ConsumerSpaceCollector& consumer_collector,
+                      const TensorConversionAnalysis& tile_values, CachePolicyByParam cache_policies)
       : conv_registry_(conv_registry),
         op_registry_(op_registry),
         consumer_collector_(consumer_collector),
+        tile_values_(tile_values),
         cache_policies_(std::move(cache_policies)) {}
 
+  /// A cached load is a compute operand, never an SSA replacement for its GM
+  /// source. Only parameters proven unwritten throughout the function enter
+  /// this map; all other GM operands load at the consuming statement.
+  StmtPtr PreloadReadOnlyParam(const VarPtr& var) {
+    std::vector<StmtPtr> stmts;
+    auto tile = LoadTensorOperand(var, var->span_, stmts);
+    preloaded_tiles_[var.get()] = tile;
+    INTERNAL_CHECK_SPAN(stmts.size() == 1, var->span_) << "Internal error: parameter already preloaded";
+    return stmts.front();
+  }
+
  protected:
+  StmtPtr VisitStmt_(const ForStmtPtr& op) override { return ConvertLoop(op); }
+
+  StmtPtr VisitStmt_(const WhileStmtPtr& op) override { return ConvertLoop(op); }
+
+  StmtPtr VisitStmt_(const IfStmtPtr& op) override {
+    auto saved_targets = std::move(yield_tile_targets_);
+    SetYieldTileTargets(op->return_vars_);
+    auto result = TypePropagatingMutator::VisitStmt_(op);
+    yield_tile_targets_ = std::move(saved_targets);
+    return result;
+  }
+
+  StmtPtr VisitStmt_(const YieldStmtPtr& op) override {
+    auto result = As<YieldStmt>(IRMutator::VisitStmt_(op));
+    auto values = result->value_;
+    std::vector<StmtPtr> stmts;
+    for (size_t i = 0; i < values.size() && i < yield_tile_targets_.size(); ++i) {
+      if (yield_tile_targets_[i] && AsTensorTypeLike(values[i]->GetType())) {
+        values[i] = LoadTensorOperand(values[i], op->span_, stmts);
+      }
+    }
+    if (values != result->value_) {
+      auto copy = MutableCopy(result);
+      copy->value_ = std::move(values);
+      result = std::move(copy);
+    }
+    stmts.push_back(result);
+    return SeqStmts::Flatten(std::move(stmts), op->span_);
+  }
+
   /// Honour a ``pl.set_cache_policy`` declaration on a ``tile.load`` that was
   /// already in the body (user-written, or produced by an earlier pass) rather
   /// than synthesised here. Hooked on the generic Call visit so the loads a
@@ -916,7 +1095,13 @@ class TensorToTileMutator : public TypePropagatingMutator {
     auto call = As<Call>(new_value);
 
     // Non-call values: propagate type change
-    if (!call) return HandlePassThroughAssign(op, new_value);
+    if (!call) {
+      // Sharing a read-only operand through a plain SSA alias must preserve
+      // the alias's GM type while making its already-loaded value reusable.
+      auto cached = preloaded_tiles_.find(new_value.get());
+      if (cached != preloaded_tiles_.end()) preloaded_tiles_[op->var_.get()] = cached->second;
+      return HandlePassThroughAssign(op, new_value);
+    }
 
     // Function calls (GlobalVar) pass through — only process op calls
     if (std::dynamic_pointer_cast<const GlobalVar>(call->op_)) {
@@ -1026,6 +1211,66 @@ class TensorToTileMutator : public TypePropagatingMutator {
   }
 
  private:
+  void SetYieldTileTargets(const std::vector<VarPtr>& vars) {
+    yield_tile_targets_.clear();
+    for (const auto& var : vars) yield_tile_targets_.push_back(tile_values_.IsTile(var));
+  }
+
+  template <typename LoopPtr>
+  StmtPtr ConvertLoop(const LoopPtr& op) {
+    std::vector<StmtPtr> stmts;
+    auto loop = MutableCopy(op);
+    auto saved_targets = std::move(yield_tile_targets_);
+    SetYieldTileTargets(op->return_vars_);
+    for (size_t i = 0; i < op->iter_args_.size(); ++i) {
+      const auto& iter = op->iter_args_[i];
+      auto init = VisitExpr(iter->initValue_);
+      if (tile_values_.IsTile(iter) && AsTensorTypeLike(init->GetType())) {
+        init = LoadTensorOperand(init, iter->span_, stmts);
+      }
+      if (init != iter->initValue_) {
+        auto new_iter = std::make_shared<IterArg>(iter->name_hint_, init->GetType(), init, iter->span_);
+        RetainVar(new_iter);
+        var_remap_[iter.get()] = new_iter;
+        loop->iter_args_[i] = std::move(new_iter);
+      }
+    }
+    stmts.push_back(TypePropagatingMutator::VisitStmt_(LoopPtr(loop)));
+    for (const auto& iter : op->iter_args_) var_remap_.erase(iter.get());
+    yield_tile_targets_ = std::move(saved_targets);
+    return SeqStmts::Flatten(std::move(stmts), op->span_);
+  }
+
+  ExprPtr LoadTensorOperand(const ExprPtr& source, const Span& span, std::vector<StmtPtr>& stmts) {
+    auto cached = preloaded_tiles_.find(source.get());
+    if (cached != preloaded_tiles_.end()) return cached->second;
+
+    auto tensor_type = AsTensorTypeLike(source->GetType());
+    INTERNAL_CHECK_SPAN(tensor_type, span) << "Internal error: expected a GM tensor operand";
+    auto offsets = MakeZeroOffsets(tensor_type->shape_.size(), span);
+    auto valid = MakeShapeTuple(tensor_type->shape_, span);
+    auto var = AsVarLike(source);
+    auto req = var ? consumer_collector_.GetConsumerReq(var.get()) : std::nullopt;
+    // There is no GM -> Acc load. Keep the natural load so memory inference
+    // reports the unsupported accumulator input at its consumer.
+    if (req && req->space == MemorySpace::Acc) req.reset();
+    std::vector<std::pair<std::string, std::any>> kwargs;
+    if (req) kwargs.emplace_back("target_memory", req->space);
+    AppendCachePolicyKwarg(source, cache_policies_, &kwargs);
+    ExprPtr shapes = valid;
+    if (req && req->cube_m_align > 0) {
+      auto boxed = BoxCubeMAxis(tensor_type->shape_, req->cube_m_align, req->cube_m_axis, span);
+      if (!AreExprVectorsEqual(boxed, tensor_type->shape_)) shapes = MakeShapeTuple(boxed, span);
+    }
+    auto load = MarkCompilerMatBridge(
+        op_registry_.Create("tile.load", {source, offsets, shapes, valid}, kwargs, span),
+        req ? req->space : MemorySpace::Vec);
+    auto tile =
+        std::make_shared<Var>(MakeTileValueName(var ? var->name_hint_ : "operand"), load->GetType(), span);
+    stmts.push_back(std::make_shared<AssignStmt>(tile, load, span));
+    return tile;
+  }
+
   /// Handle a `tensor.create` that seeds a cube accumulator: allocate whole NZ
   /// fractal boxes on the row axis and declare the requested rectangle as
   /// `valid_shape`.
@@ -1178,10 +1423,22 @@ class TensorToTileMutator : public TypePropagatingMutator {
   /// Returns the (possibly modified) args and any load statements to prepend.
   std::pair<std::vector<ExprPtr>, std::vector<StmtPtr>> BridgeInputSpaces(
       const CallPtr& call, const std::unordered_map<size_t, InputSpaceReq>& input_reqs) {
-    if (input_reqs.empty()) return {call->args_, {}};
-
     auto args = call->args_;
     std::vector<StmtPtr> stmts;
+
+    // The default requirements are the same ones used to select read-only
+    // entry loads. Apply them only to this call's operands. GM memory ops keep
+    // their source/destination handles even if another consumer loaded them.
+    if (UsesDefaultTileInputs(call)) {
+      std::unordered_map<const Expr*, ExprPtr> loaded_args;
+      for (size_t i = 0; i < args.size(); ++i) {
+        if (input_reqs.count(i) || !AsTensorTypeLike(args[i]->GetType())) continue;
+        auto [it, inserted] = loaded_args.try_emplace(args[i].get());
+        if (inserted) it->second = LoadTensorOperand(args[i], call->span_, stmts);
+        args[i] = it->second;
+      }
+    }
+    if (input_reqs.empty()) return {std::move(args), std::move(stmts)};
 
     // An operand of rank > 2 means this matmul lowers to tile.batch_matmul, not
     // tile.matmul (see the rank dispatch in op_conversion_registry.cpp).
@@ -1303,6 +1560,9 @@ class TensorToTileMutator : public TypePropagatingMutator {
   const OpConversionRegistry& conv_registry_;
   const OpRegistry& op_registry_;
   const ConsumerSpaceCollector& consumer_collector_;
+  const TensorConversionAnalysis& tile_values_;
+  std::unordered_map<const Expr*, ExprPtr> preloaded_tiles_;
+  std::vector<bool> yield_tile_targets_;
   /// Declared GM cache policies of this function's params (empty when the
   /// function carries no ``pl.set_cache_policy`` declaration).
   const CachePolicyByParam cache_policies_;
@@ -2282,76 +2542,29 @@ IncoreTransformResult TransformIncoreFunction(const FunctionPtr& func) {
   // erased when the transformed function is rebuilt.
   auto cache_policies = BuildCachePolicyByParam(func);
 
-  // Create the body mutator
-  TensorToTileMutator mutator(conv_registry, op_registry, consumer_collector, cache_policies);
+  TensorConversionAnalysis tile_values(conv_registry);
+  tile_values.VisitStmt(canonical_body);
+  tile_values.Propagate();
+
+  TensorToTileMutator mutator(conv_registry, op_registry, consumer_collector, tile_values, cache_policies);
 
   // New body statements (prefix tile.loads + mutated body)
   std::vector<StmtPtr> new_stmts;
 
-  // Phase 1: Insert tile.load for each TensorType parameter that is directly consumed
-  // by a converted tensor op.  Parameters that are only referenced by non-converted ops
-  // (e.g. tile.load, tile.move) already manage their own tile representation and must
-  // NOT get an additional load inserted here.
+  // Phase 1: Share entry loads for read-only default compute operands. These
+  // tiles are kept in a separate cache, never installed in the SSA var map.
   TensorArgsInConvertedOpsCollector collector(conv_registry);
   collector.VisitStmt(canonical_body);
   collector.TraceIterArgInitValues();
   const auto& params_used_by_converted_ops = collector.GetUsed();
-
   for (const auto& var : func->params_) {
-    // ``AsTensorTypeLike`` covers ``DistributedTensorType`` window params too --
-    // the entry load reads this rank's local GM, same as for a plain tensor.
-    auto tensor_type = AsTensorTypeLike(var->GetType());
-    if (!tensor_type) continue;
-
-    if (params_used_by_converted_ops.find(var.get()) == params_used_by_converted_ops.end()) continue;
-
-    // Attribute the entry load to the parameter declaration it loads, not to `def`.
-    const auto& load_span = var->span_;
-    auto offsets = MakeZeroOffsets(tensor_type->shape_.size(), load_span);
-    auto valid = MakeShapeTuple(tensor_type->shape_, load_span);
-
-    // Honour the same consumer demand the mutator honours for the loads it
-    // creates (see BridgeInputSpaces): a parameter feeding a matmul goes
-    // straight to Mat rather than landing in Vec and being moved out again.
-    //
-    // With no demand recorded, leave `target_memory` *absent*. It used to be
-    // hard-coded to Vec, which is a guess this pass is not equipped to make --
-    // it sees only the ops it converts, while InferTileMemorySpace (pass 20)
-    // sees the whole function and places the tile from actual consumer demand.
-    // An unset space is the IR's "not decided yet", so stating Vec here would
-    // overwrite a real answer with a default and make pass 20 honour it (it
-    // never overrides a present kwarg).
-    auto entry_req = consumer_collector.GetConsumerReq(var.get());
-    // An Acc demand is not a load target either (see BridgeInputSpaces): a
-    // parameter cannot be loaded into L0C, so the entry load stays natural and
-    // the accumulator constraint is reported where it actually holds.
-    if (entry_req.has_value() && entry_req->space == MemorySpace::Acc) entry_req.reset();
-    std::vector<std::pair<std::string, std::any>> load_kwargs;
-    if (entry_req.has_value()) {
-      load_kwargs.emplace_back("target_memory", entry_req->space);
+    if (!AsTensorTypeLike(var->GetType()) || tile_values.MayWriteSource(var) ||
+        tile_values.HasOpaqueCalls()) {
+      continue;
     }
-    AppendCachePolicyKwarg(var, cache_policies, &load_kwargs);
-    // A parameter that reaches a matmul directly, or through an inherit-input
-    // chain such as tensor.set_validshape, is loaded here rather than by
-    // BridgeInputSpaces / HandleConsumerDrivenLoad -- so the same row boxing has
-    // to apply, or the cube operand keeps its unaligned physical row count.
-    ExprPtr shapes = valid;
-    if (entry_req.has_value() && entry_req->cube_m_align > 0) {
-      auto boxed =
-          BoxCubeMAxis(tensor_type->shape_, entry_req->cube_m_align, entry_req->cube_m_axis, load_span);
-      if (!AreExprVectorsEqual(boxed, tensor_type->shape_)) {
-        shapes = MakeShapeTuple(boxed, load_span);
-      }
+    if (params_used_by_converted_ops.count(var.get())) {
+      new_stmts.push_back(mutator.PreloadReadOnlyParam(var));
     }
-    auto load_call = MarkCompilerMatBridge(
-        op_registry.Create("tile.load", {var, offsets, shapes, valid}, load_kwargs, load_span),
-        entry_req.has_value() ? entry_req->space : MemorySpace::Vec);
-
-    std::string tile_name = MakeTileValueName(var->name_hint_);
-    auto tile_var = std::make_shared<Var>(tile_name, load_call->GetType(), load_span);
-
-    new_stmts.push_back(std::make_shared<AssignStmt>(tile_var, load_call, load_span));
-    mutator.AddMapping(var.get(), tile_var);
   }
 
   // Phase 2: Transform body via mutator (handles control flow recursion + op conversion)

--- a/tests/ut/codegen/test_pto_codegen.py
+++ b/tests/ut/codegen/test_pto_codegen.py
@@ -151,6 +151,36 @@ def _single_line(lines: list[str], token: str, *, startswith: bool = False) -> s
     return matched[0]
 
 
+def test_gm_scalar_write_between_converted_ops_keeps_store_and_reload():
+    """The GM side effect survives the full pipeline, between its two loads."""
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            x: pl.InOut[pl.Tensor[[16, 32], pl.FP32]],
+            first: pl.Out[pl.Tensor[[16, 1], pl.FP32]],
+            second: pl.Out[pl.Tensor[[16, 32], pl.FP32]],
+        ):
+            r = pl.row_max(x)
+            first[0:16, 0:1] = r
+            pl.tensor.write(x, [0, 0], pl.const(1.0, pl.FP32))
+            y = pl.add(x, 2.0)
+            second[0:16, 0:32] = y
+            return  # noqa: PLR1711 (DSL return terminator)
+
+    mlir = _generate_default_mlir(Before)
+    lines = _get_mlir_lines(mlir)
+    scalar_store = _single_line(lines, "pto.store_scalar")
+    assert ", %arg0[" in scalar_store, "the scalar store must target the original x pointer"
+    assert "pto.tsetval" not in mlir, "a GM write must not be redirected into a UB tile"
+    loads = [line for line in lines if "pto.tload " in line]
+    assert len(loads) == 2, "the second computation must reload x after its GM write"
+    assert lines.index(loads[0]) < lines.index(scalar_store) < lines.index(loads[1])
+    assert mlir.count("pto.tstore ") == 2, "only the two output tensors need bulk stores"
+
+
 SAMPLE_PTOAS_OUTPUT = """\
 #include "pto/pto-inst.hpp"
 using namespace pto;

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -3225,6 +3225,86 @@ class TestNestedControlFlow:
         with pytest.raises(pypto.InternalError, match="has no registered tile conversion"):
             passes.convert_tensor_to_tile_ops()(prog)
 
+    def test_gm_for_carry_loads_current_value_without_unused_seed_load(self):
+        """A GM carry may switch tensors, so its initializer cache cannot serve its uses."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.Tensor[[16, 32], pl.FP32],
+                y: pl.Tensor[[16, 32], pl.FP32],
+                out: pl.Out[pl.Tensor[[2], pl.FP32]],
+            ) -> pl.Tensor[[16, 32], pl.FP32]:
+                for i, (carried,) in pl.range(2, init_values=(x,)):
+                    r = pl.row_max(carried)
+                    scalar = pl.tensor.read(r, [0, 0])
+                    pl.tensor.write(out, [i], scalar)
+                    result = pl.yield_(y)
+                return result
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.Tensor[[16, 32], pl.FP32],
+                y: pl.Tensor[[16, 32], pl.FP32],
+                out: pl.Out[pl.Tensor[[2], pl.FP32]],
+            ) -> pl.Tensor[[16, 32], pl.FP32]:
+                for i, (carried,) in pl.range(2, init_values=(x,)):
+                    current = pl.load(carried, [0, 0], [16, 32])
+                    tmp = pl.tile.create([16, 128], dtype=pl.FP32, target_memory=pl.Mem.Vec)
+                    r = pl.tile.row_max(current, tmp)
+                    scalar = pl.tile.read(r, [0, 0])
+                    pl.tensor.write(out, [i], scalar)
+                    result = pl.yield_(y)
+                return result
+
+        _assert_convert_equal(Before, Expected)
+
+    def test_gm_while_carry_loads_current_value_without_unused_seed_load(self):
+        """While carries retain GM identity without allocating an unused entry tile."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.Tensor[[16, 32], pl.FP32],
+                y: pl.Tensor[[16, 32], pl.FP32],
+                out: pl.Out[pl.Tensor[[2], pl.FP32]],
+            ) -> pl.Tensor[[16, 32], pl.FP32]:
+                for i, carried in pl.while_(init_values=(0, x)):
+                    pl.cond(i < 2)
+                    r = pl.row_max(carried)
+                    scalar = pl.tensor.read(r, [0, 0])
+                    pl.tensor.write(out, [i], scalar)
+                    _last_i, result = pl.yield_(i + 1, y)
+                return result
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.Tensor[[16, 32], pl.FP32],
+                y: pl.Tensor[[16, 32], pl.FP32],
+                out: pl.Out[pl.Tensor[[2], pl.FP32]],
+            ) -> pl.Tensor[[16, 32], pl.FP32]:
+                for i, carried in pl.while_(init_values=(0, x)):
+                    pl.cond(i < 2)
+                    current = pl.load(carried, [0, 0], [16, 32])
+                    tmp = pl.tile.create([16, 128], dtype=pl.FP32, target_memory=pl.Mem.Vec)
+                    r = pl.tile.row_max(current, tmp)
+                    scalar = pl.tile.read(r, [0, 0])
+                    pl.tensor.write(out, [i], scalar)
+                    _last_i, result = pl.yield_(i + 1, y)
+                return result
+
+        _assert_convert_equal(Before, Expected)
+
     def test_iter_arg_init_from_tensor_param_gets_preloaded(self):
         """Tensor parameter used only as ForStmt iter_arg initValue must be pre-loaded.
 
@@ -3951,6 +4031,183 @@ class TestGmLocalTensorConversion:
                 r = pl.tile.row_max(second, tmp)
                 stored = pl.store(r, [0, 0], out)
                 return stored
+
+        _assert_convert_equal(Before, Expected)
+
+    def test_tuple_alias_chain_projection_loads_the_gm_branch_yield(self):
+        """A projected computed tensor makes its branch result tile-valued."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.Tensor[[16, 32], pl.FP32],
+                y: pl.Tensor[[16, 32], pl.FP32],
+                flag: pl.Scalar[pl.BOOL],
+                out: pl.Out[pl.Tensor[[16, 32], pl.FP32]],
+            ):
+                local = pl.add(x, 1.0)
+                pair = (local, y)
+                alias = pair
+                inner = alias
+                projected = inner[0]
+                if flag:
+                    value = pl.yield_(projected)
+                else:
+                    value = pl.yield_(y)
+                out[0:16, 0:32] = value
+                return  # noqa: PLR1711 (DSL return terminator)
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.Tensor[[16, 32], pl.FP32],
+                y: pl.Tensor[[16, 32], pl.FP32],
+                flag: pl.Scalar[pl.BOOL],
+                out: pl.Out[pl.Tensor[[16, 32], pl.FP32]],
+            ):
+                xt = pl.load(x, [0, 0], [16, 32])
+                local = pl.tile.adds(xt, 1.0)
+                pair = (local, y)
+                alias = pair
+                inner = alias
+                projected = inner[0]
+                if flag:
+                    value = pl.yield_(projected)
+                else:
+                    yt = pl.load(y, [0, 0], [16, 32])
+                    value = pl.yield_(yt)
+                _stored = pl.store(value, [0, 0], out)
+                return  # noqa: PLR1711 (DSL return terminator)
+
+        _assert_convert_equal(Before, Expected)
+
+    def test_tuple_alias_chain_gm_projection_keeps_branch_yields_gm(self):
+        """A computed sibling must not turn the selected GM element into a tile."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.Tensor[[16, 32], pl.FP32],
+                y: pl.InOut[pl.Tensor[[16, 32], pl.FP32]],
+                flag: pl.Scalar[pl.BOOL],
+            ):
+                local = pl.add(x, 1.0)
+                pair = (local, y)
+                alias = pair
+                inner = alias
+                projected = inner[1]
+                if flag:
+                    value = pl.yield_(projected)
+                else:
+                    value = pl.yield_(y)
+                pl.tensor.write(value, [0, 0], pl.const(2.0, pl.FP32))
+                return  # noqa: PLR1711 (DSL return terminator)
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.Tensor[[16, 32], pl.FP32],
+                y: pl.InOut[pl.Tensor[[16, 32], pl.FP32]],
+                flag: pl.Scalar[pl.BOOL],
+            ):
+                xt = pl.load(x, [0, 0], [16, 32])
+                local = pl.tile.adds(xt, 1.0)
+                pair = (local, y)
+                alias = pair
+                inner = alias
+                projected = inner[1]
+                if flag:
+                    value = pl.yield_(projected)
+                else:
+                    value = pl.yield_(y)
+                pl.tensor.write(value, [0, 0], pl.const(2.0, pl.FP32))
+                return  # noqa: PLR1711 (DSL return terminator)
+
+        _assert_convert_equal(Before, Expected)
+
+    def test_tuple_projection_yield_converts_for_carry_to_tile(self):
+        """Resolve a direct projection after indexing its loop-local tuple."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.Tensor[[16, 32], pl.FP32],
+                y: pl.Tensor[[16, 32], pl.FP32],
+                out: pl.Out[pl.Tensor[[16, 32], pl.FP32]],
+            ):
+                for _i, (carried,) in pl.range(2, init_values=(x,)):
+                    local = pl.add(carried, 1.0)
+                    pair = (local, y)
+                    result = pl.yield_(pair[0])
+                out[0:16, 0:32] = result
+                return  # noqa: PLR1711 (DSL return terminator)
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.Tensor[[16, 32], pl.FP32],
+                y: pl.Tensor[[16, 32], pl.FP32],
+                out: pl.Out[pl.Tensor[[16, 32], pl.FP32]],
+            ):
+                xt = pl.load(x, [0, 0], [16, 32])
+                for _i, (carried,) in pl.range(2, init_values=(xt,)):
+                    local = pl.tile.adds(carried, 1.0)
+                    pair = (local, y)
+                    result = pl.yield_(pair[0])
+                _stored = pl.store(result, [0, 0], out)
+                return  # noqa: PLR1711 (DSL return terminator)
+
+        _assert_convert_equal(Before, Expected)
+
+    def test_tuple_projection_yield_converts_while_carry_to_tile(self):
+        """A projected tensor leaf propagates through a while carry and result."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.Tensor[[16, 32], pl.FP32],
+                y: pl.Tensor[[16, 32], pl.FP32],
+                out: pl.Out[pl.Tensor[[16, 32], pl.FP32]],
+            ):
+                for i, carried in pl.while_(init_values=(0, x)):
+                    pl.cond(i < 2)
+                    local = pl.add(carried, 1.0)
+                    pair = (local, y)
+                    _last_i, result = pl.yield_(i + 1, pair[0])
+                out[0:16, 0:32] = result
+                return  # noqa: PLR1711 (DSL return terminator)
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.Tensor[[16, 32], pl.FP32],
+                y: pl.Tensor[[16, 32], pl.FP32],
+                out: pl.Out[pl.Tensor[[16, 32], pl.FP32]],
+            ):
+                xt = pl.load(x, [0, 0], [16, 32])
+                for i, carried in pl.while_(init_values=(0, xt)):
+                    pl.cond(i < 2)
+                    local = pl.tile.adds(carried, 1.0)
+                    pair = (local, y)
+                    _last_i, result = pl.yield_(i + 1, pair[0])
+                _stored = pl.store(result, [0, 0], out)
+                return  # noqa: PLR1711 (DSL return terminator)
 
         _assert_convert_equal(Before, Expected)
 

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -3341,9 +3341,9 @@ class TestNestedControlFlow:
                 a__tile = pl.load(a, [0], [64])
                 b__tile = pl.load(b, [0], [64])
                 if n == 0:
-                    ra: pl.Tile[[64], pl.FP32] = a__tile
-                    rb: pl.Tile[[64], pl.FP32] = b__tile
-                    phi_a, phi_b = pl.yield_(ra, rb)
+                    _ra: pl.Tensor[[64], pl.FP32] = a
+                    _rb: pl.Tensor[[64], pl.FP32] = b
+                    phi_a, phi_b = pl.yield_(a__tile, b__tile)
                 else:
                     ra__tile = pl.tile.add(a__tile, b__tile)
                     rb__tile = pl.tile.mul(a__tile, b__tile)
@@ -3668,6 +3668,329 @@ class TestGmLocalTensorConversion:
         After = passes.convert_tensor_to_tile_ops()(Before)
         ir.assert_structural_equal(After, Expected)
 
+    def test_gm_write_after_reduction_preserves_destination(self):
+        """Loading a compute operand must not redirect its GM side effects."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.InOut[pl.Tensor[[16, 32], pl.FP32]],
+                out: pl.Out[pl.Tensor[[16, 1], pl.FP32]],
+            ) -> pl.Tensor[[16, 1], pl.FP32]:
+                r = pl.row_max(x)
+                out[0:16, 0:1] = r
+                pl.tensor.write(x, [0, 0], pl.const(1.0, pl.FP32))
+                return out
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.InOut[pl.Tensor[[16, 32], pl.FP32]],
+                out: pl.Out[pl.Tensor[[16, 1], pl.FP32]],
+            ) -> pl.Tensor[[16, 1], pl.FP32]:
+                xt = pl.load(x, [0, 0], [16, 32])
+                tmp = pl.tile.create([16, 128], dtype=pl.FP32, target_memory=pl.Mem.Vec)
+                r = pl.tile.row_max(xt, tmp)
+                stored = pl.store(r, [0, 0], out)
+                pl.tensor.write(x, [0, 0], pl.const(1.0, pl.FP32))
+                return stored
+
+        _assert_convert_equal(Before, Expected)
+
+    def test_gm_write_between_computations_reloads_at_each_use(self):
+        """An intervening GM write invalidates the value loaded for computation."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.InOut[pl.Tensor[[16, 32], pl.FP32]],
+                first: pl.Out[pl.Tensor[[16, 1], pl.FP32]],
+                second: pl.Out[pl.Tensor[[16, 32], pl.FP32]],
+            ):
+                r = pl.row_max(x)
+                first[0:16, 0:1] = r
+                pl.tensor.write(x, [0, 0], pl.const(1.0, pl.FP32))
+                y = pl.add(x, 2.0)
+                second[0:16, 0:32] = y
+                return  # noqa: PLR1711 (DSL return terminator)
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.InOut[pl.Tensor[[16, 32], pl.FP32]],
+                first: pl.Out[pl.Tensor[[16, 1], pl.FP32]],
+                second: pl.Out[pl.Tensor[[16, 32], pl.FP32]],
+            ):
+                before = pl.load(x, [0, 0], [16, 32])
+                tmp = pl.tile.create([16, 128], dtype=pl.FP32, target_memory=pl.Mem.Vec)
+                r = pl.tile.row_max(before, tmp)
+                _stored_first = pl.store(r, [0, 0], first)
+                pl.tensor.write(x, [0, 0], pl.const(1.0, pl.FP32))
+                after = pl.load(x, [0, 0], [16, 32])
+                y = pl.tile.adds(after, 2.0)
+                _stored_second = pl.store(y, [0, 0], second)
+                return  # noqa: PLR1711 (DSL return terminator)
+
+        _assert_convert_equal(Before, Expected)
+
+    def test_gm_write_before_computation_is_not_preloaded(self):
+        """A write's returned alias stays GM and is loaded after the write."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.InOut[pl.Tensor[[16, 32], pl.FP32]],
+                out: pl.Out[pl.Tensor[[16, 32], pl.FP32]],
+            ):
+                updated: pl.Tensor[[16, 32], pl.FP32] = pl.tensor.write(x, [0, 0], pl.const(1.0, pl.FP32))
+                y = pl.add(updated, x)
+                out[0:16, 0:32] = y
+                return  # noqa: PLR1711 (DSL return terminator)
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.InOut[pl.Tensor[[16, 32], pl.FP32]],
+                out: pl.Out[pl.Tensor[[16, 32], pl.FP32]],
+            ):
+                updated: pl.Tensor[[16, 32], pl.FP32] = pl.tensor.write(x, [0, 0], pl.const(1.0, pl.FP32))
+                lhs = pl.load(updated, [0, 0], [16, 32])
+                rhs = pl.load(x, [0, 0], [16, 32])
+                y = pl.tile.add(lhs, rhs)
+                _stored = pl.store(y, [0, 0], out)
+                return  # noqa: PLR1711 (DSL return terminator)
+
+        _assert_convert_equal(Before, Expected)
+
+    def test_gm_compute_and_scalar_read_preserve_param_return(self):
+        """A read-only tile cache must not change GM scalar reads or return aliases."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self, x: pl.Tensor[[16, 32], pl.FP32], out: pl.Out[pl.Tensor[[16, 1], pl.FP32]]
+            ) -> pl.Tensor[[16, 32], pl.FP32]:
+                r = pl.row_max(x)
+                value = pl.tensor.read(x, [0, 0])
+                y = pl.add(r, value)
+                out[0:16, 0:1] = y
+                return x
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self, x: pl.Tensor[[16, 32], pl.FP32], out: pl.Out[pl.Tensor[[16, 1], pl.FP32]]
+            ) -> pl.Tensor[[16, 32], pl.FP32]:
+                xt = pl.load(x, [0, 0], [16, 32])
+                tmp = pl.tile.create([16, 128], dtype=pl.FP32, target_memory=pl.Mem.Vec)
+                r = pl.tile.row_max(xt, tmp)
+                value = pl.tensor.read(x, [0, 0])
+                y = pl.tile.adds(r, value)
+                _stored = pl.store(y, [0, 0], out)
+                return x
+
+        _assert_convert_equal(Before, Expected)
+
+    def test_window_gm_write_after_reduction_preserves_destination(self):
+        """DistributedTensor GM handles obey the same conversion boundary."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.InOut[pld.DistributedTensor[[16, 32], pl.FP32]],
+                out: pl.Out[pl.Tensor[[16, 1], pl.FP32]],
+            ):
+                r = pl.row_max(x)
+                out[0:16, 0:1] = r
+                pl.tensor.write(x, [0, 0], pl.const(1.0, pl.FP32))
+                return  # noqa: PLR1711 (DSL return terminator)
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.InOut[pld.DistributedTensor[[16, 32], pl.FP32]],
+                out: pl.Out[pl.Tensor[[16, 1], pl.FP32]],
+            ):
+                xt = pl.load(x, [0, 0], [16, 32])
+                tmp = pl.tile.create([16, 128], dtype=pl.FP32, target_memory=pl.Mem.Vec)
+                r = pl.tile.row_max(xt, tmp)
+                _stored = pl.store(r, [0, 0], out)
+                pl.tensor.write(x, [0, 0], pl.const(1.0, pl.FP32))
+                return  # noqa: PLR1711 (DSL return terminator)
+
+        _assert_convert_equal(Before, Expected)
+
+    def test_gm_loop_carry_used_by_compute_stays_gm(self):
+        """A GM handle yielded through a write must not become a tile carry."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.InOut[pl.Tensor[[16, 32], pl.FP32]],
+                out: pl.Out[pl.Tensor[[16, 1], pl.FP32]],
+            ) -> pl.Tensor[[16, 32], pl.FP32]:
+                for i, (carried,) in pl.range(2, init_values=(x,)):
+                    r = pl.row_max(carried)
+                    out[0:16, 0:1] = r
+                    updated: pl.Tensor[[16, 32], pl.FP32] = pl.tensor.write(
+                        carried, [0, 0], pl.cast(i, pl.FP32)
+                    )
+                    result = pl.yield_(updated)
+                return result
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.InOut[pl.Tensor[[16, 32], pl.FP32]],
+                out: pl.Out[pl.Tensor[[16, 1], pl.FP32]],
+            ) -> pl.Tensor[[16, 32], pl.FP32]:
+                for i, (carried,) in pl.range(2, init_values=(x,)):
+                    xt = pl.load(carried, [0, 0], [16, 32])
+                    tmp = pl.tile.create([16, 128], dtype=pl.FP32, target_memory=pl.Mem.Vec)
+                    r = pl.tile.row_max(xt, tmp)
+                    _stored = pl.store(r, [0, 0], out)
+                    updated: pl.Tensor[[16, 32], pl.FP32] = pl.tensor.write(
+                        carried, [0, 0], pl.cast(i, pl.FP32)
+                    )
+                    result = pl.yield_(updated)
+                return result
+
+        _assert_convert_equal(Before, Expected)
+
+    def test_gm_while_carry_and_branch_write_reload_inside_loop(self):
+        """Neither the loop nor a conditional write may hoist a mutable GM load."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.InOut[pl.Tensor[[16, 32], pl.FP32]],
+                out: pl.Out[pl.Tensor[[16, 1], pl.FP32]],
+            ) -> pl.Tensor[[16, 32], pl.FP32]:
+                for i, carried in pl.while_(init_values=(0, x)):
+                    pl.cond(i < 2)
+                    if i == 0:
+                        alias = carried
+                        pl.tensor.write(alias, [0, 0], pl.const(1.0, pl.FP32))
+                    r = pl.row_max(carried)
+                    out[0:16, 0:1] = r
+                    _last_i, result = pl.yield_(i + 1, carried)
+                return result
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.InOut[pl.Tensor[[16, 32], pl.FP32]],
+                out: pl.Out[pl.Tensor[[16, 1], pl.FP32]],
+            ) -> pl.Tensor[[16, 32], pl.FP32]:
+                for i, carried in pl.while_(init_values=(0, x)):
+                    pl.cond(i < 2)
+                    if i == 0:
+                        alias = carried
+                        pl.tensor.write(alias, [0, 0], pl.const(1.0, pl.FP32))
+                    xt = pl.load(carried, [0, 0], [16, 32])
+                    tmp = pl.tile.create([16, 128], dtype=pl.FP32, target_memory=pl.Mem.Vec)
+                    r = pl.tile.row_max(xt, tmp)
+                    _stored = pl.store(r, [0, 0], out)
+                    _last_i, result = pl.yield_(i + 1, carried)
+                return result
+
+        _assert_convert_equal(Before, Expected)
+
+    def test_local_view_write_does_not_modify_a_later_gm_compute_operand(self):
+        """A mutated local snapshot cannot serve as a cache of the GM source."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self, x: pl.Tensor[[16, 32], pl.FP32], out: pl.Out[pl.Tensor[[16, 1], pl.FP32]]
+            ) -> pl.Tensor[[16, 1], pl.FP32]:
+                snapshot = pl.reshape(x, [32, 16])
+                pl.tensor.write(snapshot, [0, 0], pl.const(1.0, pl.FP32))
+                r = pl.row_max(x)
+                out[0:16, 0:1] = r
+                return out
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self, x: pl.Tensor[[16, 32], pl.FP32], out: pl.Out[pl.Tensor[[16, 1], pl.FP32]]
+            ) -> pl.Tensor[[16, 1], pl.FP32]:
+                first = pl.load(x, [0, 0], [16, 32])
+                snapshot = pl.tile.reshape(first, [32, 16])
+                pl.tile.write(snapshot, [0, 0], pl.const(1.0, pl.FP32))
+                second = pl.load(x, [0, 0], [16, 32])
+                tmp = pl.tile.create([16, 128], dtype=pl.FP32, target_memory=pl.Mem.Vec)
+                r = pl.tile.row_max(second, tmp)
+                stored = pl.store(r, [0, 0], out)
+                return stored
+
+        _assert_convert_equal(Before, Expected)
+
+    def test_gm_write_through_tuple_alias_precedes_compute_load(self):
+        """Packing a GM handle into a tuple must not hide its write dependency."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.InOut[pl.Tensor[[16, 32], pl.FP32]],
+                out: pl.Out[pl.Tensor[[16, 1], pl.FP32]],
+            ) -> pl.Tensor[[16, 1], pl.FP32]:
+                pair = (x, x)
+                alias = pair[0]
+                pl.tensor.write(alias, [0, 0], pl.const(1.0, pl.FP32))
+                r = pl.row_max(x)
+                out[0:16, 0:1] = r
+                return out
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.InOut[pl.Tensor[[16, 32], pl.FP32]],
+                out: pl.Out[pl.Tensor[[16, 1], pl.FP32]],
+            ) -> pl.Tensor[[16, 1], pl.FP32]:
+                pair = (x, x)
+                alias = pair[0]
+                pl.tensor.write(alias, [0, 0], pl.const(1.0, pl.FP32))
+                xt = pl.load(x, [0, 0], [16, 32])
+                tmp = pl.tile.create([16, 128], dtype=pl.FP32, target_memory=pl.Mem.Vec)
+                r = pl.tile.row_max(xt, tmp)
+                stored = pl.store(r, [0, 0], out)
+                return stored
+
+        _assert_convert_equal(Before, Expected)
+
     def test_mixed_tile_and_scalar_store_to_same_gm_tensor_rejected(self):
         """DMA and scalar stores to one GM tensor have no coherence guarantee."""
 
@@ -3917,7 +4240,7 @@ class TestGmLocalTensorConversion:
                 a_tile = pl.load(a, [0], [4])
                 b_tile = pl.load(b, [0], [4])
                 t_tile = pl.tile.add(a_tile, b_tile)
-                val = pl.tile.read(a_tile, [0])
+                val = pl.tensor.read(a, [0])
                 pl.tile.write(t_tile, [0], val)
                 v = pl.tile.read(t_tile, [0])
                 pl.tensor.write(out, [0], v)


### PR DESCRIPTION
## Summary
A GM parameter that feeds a tensor computation and is later modified with `tensor.write` could have its scalar update redirected into a loaded UB tile and never reach GM. Preserve the GM handle across tile conversion so the scalar write reaches its original destination and later computations reload the updated data. Existing kernel syntax stays valid.

## Changes
- Separate read-only tile-load sharing from SSA variable replacement and materialize mutable GM inputs at their consumers.
- Track mutation dependencies through aliases and control flow; distinguish GM loop carries from local tile-valued seeds and yields.
- Add sixteen regression tests for write ordering, scalar reads, aliases, loops, distributed parameters, local snapshots, and generated PTO code, and update the English and Chinese lowering documentation.

## Verification
- `cmake --build build --parallel "$PYPTO_BUILD_JOBS"` (20 jobs): passed.
- `python -m pytest tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py tests/ut/codegen/test_pto_codegen.py -n "$PYPTO_TEST_JOBS" -q` (8 workers): passed.
- `python -m pytest tests/ut/ -n "$PYPTO_TEST_JOBS" -q` (8 workers): 11,838 passed, 5 skipped, 1 xfailed.
- `python tests/lint/clang_tidy.py --strict-version --jobs="$PYPTO_BUILD_JOBS" --diff-base=upstream/main --build-dir build`: passed with clang-tidy 21.1.0.
- `pre-commit run --all-files`: all hooks passed, including Pyright.

Compile-only A2/A3 checks also passed PTOAS for the original reproducer, a write between computations, and a loop-carried GM alias. No local device or simulator numerical execution was performed; system suites are left to CI.