### PR TITLE
fix(distributed): bound InCore collective staging tiles

### DIFF
--- a/docs/en/dev/passes/13-lower_composite_ops.md
+++ b/docs/en/dev/passes/13-lower_composite_ops.md
@@ -1,6 +1,6 @@
 # LowerCompositeOps Pass
 
-Decomposes composite tile / distributed ops into primitive operations so codegen does not need to emit their high-level forms. Today the pass handles `tile.sin` / `tile.cos` (FP32 Cody-Waite + Horner), packed `tile.tquant_mx`, and `pld.tensor.*` distributed collectives (`allreduce` (mesh and ring), `allgather`, `reduce_scatter`, `broadcast`, `barrier`). Mesh and ring allreduce may also create a metadata-preserving `tensor.view` so tile load/remote/store operate on a 2D flattened target window.
+Decomposes composite tile / distributed ops into primitive operations so codegen does not need to emit their high-level forms. Today the pass handles `tile.sin` / `tile.cos` (FP32 Cody-Waite + Horner), packed `tile.tquant_mx`, and `pld.tensor.*` distributed collectives (`allreduce` (mesh and ring), `allgather`, `reduce_scatter`, `broadcast`, `barrier`, `all_to_all`, `all_to_all_v`). Mesh and ring allreduce may also create a metadata-preserving `tensor.view` so tile load/remote/store operate on a 2D flattened target window.
 
 ## Overview
 
@@ -229,9 +229,9 @@ Mesh and ring lowering support FP16 and FP32 with `ReduceOp::kSum`, `kMax`,
 
 ### `pld.tensor.allgather`
 
-Signature: `allgather(local_data, target, signal)`. `local_data` is this rank's chunk (`Tensor` or `Tile` `[1, SIZE]`), `target` is a window-bound `DistributedTensor[NR, SIZE]` staging area that also serves as the result, and `signal` is the INT32 barrier. Push-based decomposition:
+Signature: `allgather(local_data, target, signal)`. `local_data` is this rank's chunk (plain `Tensor` `[1, SIZE]` on the InCore path), `target` is a window-bound `DistributedTensor[NR, SIZE]` staging area that also serves as the result, and `signal` is the INT32 barrier. Push-based decomposition:
 
-- ``tile.create([1, SIZE], dtype=..., target_memory=Vec)`` — allocate a VEC staging tile for ``pld.tile.put`` auto-chunking.  ``pld.tile.put`` reads directly from the ``local_data`` Tensor (or Tile) source — no explicit ``tile.load`` is emitted.
+- ``tile.create([1, stage_cols], dtype=..., target_memory=Vec)`` — allocate a VEC staging tile for ``pld.tile.put`` auto-chunking. For a static extent, ``stage_cols`` is ``min(SIZE, chunk_elements)`` floored to a 32-byte row boundary when it is below one full chunk; for example, FP32 ``SIZE=17`` produces ``stage_cols=16``, not 17. A transfer shorter than one alignment unit (8 FP32 elements, 64 packed-FP4 elements) has no positive stage width that is both aligned and no larger than the transfer, and remains unsupported. Symbolic extents use the full chunk bound — the same static-UB contract as `MakeTputStageShape` / `chunk_cols`, so a runtime width of 17 still allocates 4096 FP32 elements. The geometry uses physical storage bits, so a 16-KiB stage holds 4096 FP32 or 32768 packed-FP4 logical elements. The stage is a bounded bounce buffer, **not** a copy of the transfer: pto-isa reads the full extent from the partition views and 2-D-slides the transfer through it, so sizing the stage from ``SIZE`` would only waste UB (a ``[1, 65537]`` FP32 stage is 256 KiB and overflows the VEC budget). ``pld.tile.put`` reads directly from the ``local_data`` Tensor source — no explicit ``tile.load`` is emitted.
 - Phase 1: for `peer` in `0..NR-1`, `pld.tile.put(target, peer, local_data, put_stage, [my_rank, 0], [0, 0], [1, SIZE])` — push this rank's chunk into every peer's window at row `my_rank`. Self-store (`peer == my_rank`) uses HCCL identity mapping. `pld.tile.put` auto-chunks when SIZE exceeds the staging-tile capacity
 - Phase 2: barrier (generation 1) + epilogue (subtract 1 from every non-self cell)
 - Return `target` — the window IS the gathered `[NR, SIZE]` result (window-as-result, `DistributedTensor`)
@@ -256,10 +256,19 @@ All four `ReduceOp`s are supported — `kSum`, `kMax`, `kMin`, and `kProd` — r
 
 Decomposes into a 3-phase recipe:
 
-- Phase 2: barrier (generation 1) + epilogue (subtract 1 from every non-self cell)
-- Phase 3: `tile.create` (VEC staging tile) + `pld.tile.get(target, peer=root, target, stage)` on every rank — each rank reads root's slice into its own `target`. For `peer == root` the HCCL identity mapping makes the get a local no-op, so root keeps its own data while non-root ranks receive root's.
+- Phase 2: barrier (generation 1)
+- Phase 3: `tile.create` (VEC staging tile, capped at one 16-KiB chunk like allgather's) + `pld.tile.get(target, peer=root, target, stage)` on every rank — each rank reads root's slice into its own `target`. For `peer == root` the HCCL identity mapping makes the get a local no-op, so root keeps its own data while non-root ranks receive root's. Because the stage no longer derives from the target's extent, a **dynamic** target shape is accepted — the dynamic dim simply takes the chunk bound.
+- Epilogue: subtract 1 from every non-self cell
 
 `root` is a static `int` kwarg known at compile time.
+
+### `pld.tensor.all_to_all`
+
+Symmetric push: each rank writes `input[dest, :]` into every peer window at row `my_rank` via `pld.tile.put`, then barriers. The shared VEC stage is the same capped `[stage_rows, stage_cols]` bounce buffer as allgather.
+
+### `pld.tensor.all_to_all_v`
+
+Variable-size push (`MPI_Alltoallv` pattern). Each destination transfers `clamp(send_counts[dest], 0, MAX_RECV)` rows through the same capped 2-D stage; `target.shape[0] % NR == 0` stays load-bearing so the receiver can index sender `s` at row `s * MAX_RECV`. The runtime row count is a dynamic partition-view dim; the stage itself stays a static chunk bound.
 
 ### `pld.tensor.barrier`
 

--- a/docs/zh/dev/passes/13-lower_composite_ops.md
+++ b/docs/zh/dev/passes/13-lower_composite_ops.md
@@ -1,6 +1,6 @@
 # LowerCompositeOps Pass
 
-把组合 (composite) tile / distributed 算子降级 (lower) 为基础操作，使代码生成 (codegen) 不再需要发射其高层形式。当前支持 `tile.sin` / `tile.cos`（FP32 Cody-Waite + Horner）、packed `tile.tquant_mx`，以及 `pld.tensor.*` 分布式集合通信算子（`allreduce`（mesh 与 ring）、`allgather`、`reduce_scatter`、`broadcast`、`barrier`）。mesh 和 ring allreduce 还可能创建保留元数据的 `tensor.view`，让 tile load/remote/store 操作一个 2D 展平目标窗口。
+把组合 (composite) tile / distributed 算子降级 (lower) 为基础操作，使代码生成 (codegen) 不再需要发射其高层形式。当前支持 `tile.sin` / `tile.cos`（FP32 Cody-Waite + Horner）、packed `tile.tquant_mx`，以及 `pld.tensor.*` 分布式集合通信算子（`allreduce`（mesh 与 ring）、`allgather`、`reduce_scatter`、`broadcast`、`barrier`、`all_to_all`、`all_to_all_v`）。mesh 和 ring allreduce 还可能创建保留元数据的 `tensor.view`，让 tile load/remote/store 操作一个 2D 展平目标窗口。
 
 ## 概览 (Overview)
 
@@ -281,13 +281,11 @@ mesh 和 ring 降级均支持 FP16、FP32，以及任意正元素数量下的
 
 ### `pld.tensor.allgather`
 
-签名：`allgather(local_data, target, signal)`。`local_data` 是本 rank 的 chunk（`Tensor` 或 `Tile` `[1, SIZE]`），`target` 是窗口绑定的 `DistributedTensor[NR, SIZE]` 暂存区同时又是结果，`signal` 是 INT32 屏障。基于推送 (push-based) 的展开：
+签名：`allgather(local_data, target, signal)`。`local_data` 是本 rank 的 chunk（InCore 路径上为普通 `Tensor` `[1, SIZE]`），`target` 是窗口绑定的 `DistributedTensor[NR, SIZE]` 暂存区同时又是结果，`signal` 是 INT32 屏障。基于推送 (push-based) 的展开：
 
-- ``tile.create([1, SIZE], dtype=..., target_memory=Vec)`` — 分配一个 VEC staging tile 供 ``pld.tile.put`` 自动分块使用。``pld.tile.put`` 直接从 ``local_data`` Tensor（或 Tile）源读取 — 不发射显式的 ``tile.load``。
+- ``tile.create([1, stage_cols], dtype=..., target_memory=Vec)`` — 分配一个 VEC staging tile 供 ``pld.tile.put`` 自动分块使用。对于静态 extent，``stage_cols`` 先取 ``min(SIZE, chunk_elements)``，在小于完整 chunk 时再向下取整到 32-byte 行边界；例如 FP32 ``SIZE=17`` 得到 ``stage_cols=16``，而不是 17。短于一个对齐单元（FP32 为 8 个元素，packed-FP4 为 64 个元素）的传输，不存在既对齐又不大于传输的正 stage 宽度，因此仍不受支持。符号 extent 使用完整 chunk 上界 — 与 `MakeTputStageShape` / `chunk_cols` 相同的静态 UB 约定，因此运行时宽度 17 仍会分配 4096 个 FP32 元素。几何计算采用物理存储 bit 宽度，因此一个 16-KiB stage 可容纳 4096 个 FP32 或 32768 个 packed-FP4 逻辑元素。该 stage 是有界中转缓冲，**不是**传输的副本：pto-isa 从 partition view 读取完整 extent 并把传输在 stage 上做二维滑动，因此按 ``SIZE`` 来分配 stage 只会浪费 UB（``[1, 65537]`` 的 FP32 stage 为 256 KiB，会超出 VEC 预算）。``pld.tile.put`` 直接从 ``local_data`` Tensor 源读取 — 不发射显式的 ``tile.load``。
 - Phase 1：对 `peer` 从 `0` 到 `NR-1`，`pld.tile.put(target, peer, local_data, put_stage, [my_rank, 0], [0, 0], [1, SIZE])` — 将本 rank 的 chunk 推送到每个 peer 窗口的第 `my_rank` 行。自推送 (`peer == my_rank`) 通过 HCCL 恒等映射实现。`pld.tile.put` 在 SIZE 超过 staging tile 容量时自动分块
-- Phase 2a：notify-all（`AtomicAdd 1`）
-- Phase 2b：wait-all（`Ge 1`）
-- 尾调用：`EmitEpilogueReset`（自清理信用屏障）
+- Phase 2：屏障（generation 1）+ 尾声（从每个非 self cell 减去 1）
 - 返回 `target` — 窗口本身就是汇聚后的 `[NR, SIZE]` 结果（窗口即结果，`DistributedTensor`）
 
 与原始基于拉取 (pull-based) 的 allgather（4 参数带独立 `out` 张量）相比，该推送版本去掉了 `out` 参数和每 peer 的 `pld.tile.get` 汇聚循环。总 HBM 从 `(NR+1)×SIZE` 降至 `NR×SIZE`，代价是窗口在调用方消费结果之前一直处于占用状态。
@@ -312,26 +310,31 @@ mesh 和 ring 降级均支持 FP16、FP32，以及任意正元素数量下的
 
 展开为 3 阶段序列：
 
-- Phase 2a：notify-all（`AtomicAdd 1`）
-- Phase 2b：wait-all（`Ge 1`）
-- 尾调用：`EmitEpilogueReset`（自清理信用屏障）
-- Phase 3：每个 rank 都发射 `tile.create`（VEC staging tile）+ `pld.tile.get(target, peer=root, target, stage)`，把 root 的切片读进自己的 `target`。`peer == root` 时 HCCL 恒等映射让该 get 成为本地空操作，因此 root 保留自己的数据，非 root rank 收到 root 的数据
+- Phase 2：屏障（generation 1）
+- Phase 3：每个 rank 都发射 `tile.create`（VEC staging tile，与 allgather 一样上限为一个 16-KiB chunk）+ `pld.tile.get(target, peer=root, target, stage)`，把 root 的切片读进自己的 `target`。`peer == root` 时 HCCL 恒等映射让该 get 成为本地空操作，因此 root 保留自己的数据，非 root rank 收到 root 的数据。由于 stage 不再由 target 的 extent 推导，**动态** target shape 现已被接受 — 动态维度直接取 chunk 上限
+- 尾声：从每个非 self cell 减去 1
 
 `root` 是编译时已知的静态 `int` kwarg。
 
+### `pld.tensor.all_to_all`
+
+对称推送：每个 rank 通过 `pld.tile.put` 把 `input[dest, :]` 写入每个 peer 窗口的第 `my_rank` 行，然后做屏障。共享 VEC stage 与 allgather 相同，是有界的 `[stage_rows, stage_cols]` 中转缓冲。
+
+### `pld.tensor.all_to_all_v`
+
+可变大小推送（`MPI_Alltoallv` 模式）。每个目的地通过同一个有界 2-D stage 传输 `clamp(send_counts[dest], 0, MAX_RECV)` 行；`target.shape[0] % NR == 0` 仍是负载约束，以便接收方按行 `s * MAX_RECV` 定位发送方 `s`。运行时行数是动态 partition-view 维，stage 本身仍是静态 chunk 上界。
+
 ### `pld.tensor.barrier`
 
-纯同步，无数据搬运。展开为 2 阶段序列：
+纯同步，无数据搬运。展开为屏障（generation 1）加上其尾声（从每个非 self cell 减去 1）。
 
-- Phase 2a：notify-all（`AtomicAdd 1`）
-- Phase 2b：wait-all（`Ge 1`）
-- 尾调用：`EmitEpilogueReset`（自清理信用屏障）
-
-返回表达式就是同一个 `signal` 张量，支持 `signal = pld.tensor.barrier(signal)` 的 rebind 写法。
+返回表达式就是同一个 `signal` 张量，支持 `signal = pld.tensor.barrier(signal)` 的 rebind 写法。在自清理协议下，每次调用都从 generation 1 重新开始，因此 rebind 不再需要链到任何先前状态。
 
 ### Signal buffer 约定
 
-所有分布式规则在 wait 谓词上都使用 `kGe` 而非 `kEq`。单次调用内 cell 单调递增，但慢的 rank 第一次轮询时，如果快的 peer 已经完成 Phase 3 的数据搬运并开始下一轮 notify，cell 可能已经超过阈值。此时 `kEq` 会死锁，`kGe` 不会。可自重置的写法（调用结束时 set-to-zero / `Eq 0`）受 PTOAS issue #797 阻塞，后续运行时修复落地后才能切换。
+每次调用发出 `N` 次屏障 — 向每个 peer cell 做 `AtomicAdd(1)`，再 `Wait(>= g)`，其中 `g` **只在该次调用内**递增（每次新调用经 `EmitBarrier` 的调用局部 `barrier_count_` 从 1 重新开始）。主体结束后，尾声（`EmitEpilogueReset`）用一次 `AtomicAdd(-N)` 从每个非 self cell 减去本次调用的总信用 `N`。原子加与减可交换，因此一旦每个 rank 完成尾声，signal 可证明再次全零 — 没有跨调用状态，下一次在同一 signal 上的调用也从 generation 1 开始。
+
+所有分布式规则在 wait 谓词上都使用 `kGe` 而非 `kEq`。快的 peer 可能在慢 rank 第一次轮询前就把 cell 推进到超过阈值，此时 `kEq` 会死锁，`kGe` 不会。同理，`kSet` 绝不能与 `kAtomicAdd` 混用在同一组 cell 上。
 
 ## 实现要点 (Implementation Notes)
 

--- a/src/ir/op/distributed/comm_op_utils.h
+++ b/src/ir/op/distributed/comm_op_utils.h
@@ -31,6 +31,7 @@
 #include <any>
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <string>
 #include <utility>
 #include <vector>
@@ -138,7 +139,11 @@ inline void ValidateStageFitsTransfer(const std::vector<ExprPtr>& stage_shape,
       cols_static = static_cast<bool>(d);
       if (d) transfer_cols = d->value_;
     } else if (d) {
-      transfer_rows *= d->value_;
+      if (d->value_ > 0 && transfer_rows > std::numeric_limits<int64_t>::max() / d->value_) {
+        transfer_rows = std::numeric_limits<int64_t>::max();
+      } else {
+        transfer_rows *= d->value_;
+      }
     } else {
       rows_static = false;
     }

--- a/src/ir/transforms/lower_composite_ops_pass.cpp
+++ b/src/ir/transforms/lower_composite_ops_pass.cpp
@@ -33,6 +33,7 @@
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/span.h"
 #include "pypto/ir/stmt.h"
+#include "pypto/ir/storage_size.h"
 #include "pypto/ir/transforms/base/mutator.h"
 #include "pypto/ir/transforms/pass_properties.h"
 #include "pypto/ir/transforms/passes.h"
@@ -225,6 +226,132 @@ void ValidateMeshSignalShape(const DistributedTensorTypePtr& signal_type, const 
         << " — a signal shaped for mode=\"ring\" allreduce ([2*(NR-1), NR]) cannot be shared with "
            "this collective; give it its own [NR, 1] signal window";
   }
+}
+
+/// Per-dtype UB chunking constants shared by every InCore collective lowering.
+/// ``storage_bits`` is the physical width of one logical element.
+/// ``chunk_elements`` is the widest logical-element count that fits one
+/// ``kAllReduceChunkBytes`` tile; ``alignment_elements`` is the logical-element
+/// count spanning one ``kPTOTileAlignmentBytes`` PTO tile row.
+struct CollectiveChunkGeometry {
+  int64_t storage_bits = 0;
+  int64_t chunk_elements = 0;
+  int64_t alignment_elements = 0;
+  ExprPtr alignment_elements_idx;
+  ExprPtr alignment_minus_one_idx;
+  ExprPtr max_chunk_cols;
+};
+
+/// Derives the chunk geometry for ``dtype``. ``op_name`` is woven into the
+/// diagnostics so a caller-specific message survives the extraction.
+CollectiveChunkGeometry MakeChunkGeometry(const DataType& dtype, const Span& span, const char* op_name) {
+  CollectiveChunkGeometry geo;
+  geo.storage_bits = static_cast<int64_t>(storage_size::GetStorageBitWidth(dtype));
+  INTERNAL_CHECK_SPAN(geo.storage_bits > 0, span)
+      << op_name << " target dtype has no storage width: " << dtype.ToString();
+  constexpr int64_t kBitsPerByte = 8;
+  const int64_t chunk_bits = kAllReduceChunkBytes * kBitsPerByte;
+  const int64_t alignment_bits = kPTOTileAlignmentBytes * kBitsPerByte;
+  INTERNAL_CHECK_SPAN(chunk_bits % geo.storage_bits == 0, span)
+      << op_name << " dtype storage width must divide the chunk bit budget";
+  geo.chunk_elements = chunk_bits / geo.storage_bits;
+  INTERNAL_CHECK_SPAN(geo.chunk_elements > 0, span)
+      << op_name << " dtype is wider than the chunk byte budget";
+  INTERNAL_CHECK_SPAN(alignment_bits % geo.storage_bits == 0, span)
+      << op_name << " dtype storage width must divide the tile-alignment bit budget";
+  geo.alignment_elements = alignment_bits / geo.storage_bits;
+  geo.alignment_elements_idx = std::make_shared<ConstInt>(geo.alignment_elements, DataType::INDEX, span);
+  geo.alignment_minus_one_idx = std::make_shared<ConstInt>(geo.alignment_elements - 1, DataType::INDEX, span);
+  geo.max_chunk_cols = std::make_shared<ConstInt>(geo.chunk_elements, DataType::INDEX, span);
+  return geo;
+}
+
+/// Picks the physical chunk width for a chunked collective. A statically known
+/// ``logical_extent`` smaller than one full chunk is rounded up to the nearest
+/// 32-byte-aligned element count, so a short collective does not reserve a full
+/// ``kAllReduceChunkBytes`` tile and the caller keeps its remaining VEC UB
+/// budget. Anything else — including a symbolic extent — uses the full chunk.
+ExprPtr SelectStaticChunkCols(const CollectiveChunkGeometry& geo, const ExprPtr& logical_extent,
+                              const Span& span) {
+  if (auto extent = As<ConstInt>(logical_extent);
+      extent && extent->value_ > 0 && extent->value_ < geo.chunk_elements) {
+    const int64_t aligned_extent =
+        ((extent->value_ - 1) / geo.alignment_elements + 1) * geo.alignment_elements;
+    return std::make_shared<ConstInt>(aligned_extent, DataType::INDEX, span);
+  }
+  return geo.max_chunk_cols;
+}
+
+/// Sizes the 2D VEC staging tile that a ``pld.tile.put`` / ``pld.tile.get``
+/// transfer slides through.
+///
+/// pto-isa TPUT/TGET read the full extent from the partition views and 2D-slide
+/// the transfer through the stage, so the stage only has to *fit within* the
+/// flattened transfer rather than equal it (see comm_op::ValidateStageFitsTransfer).
+/// Sizing the stage from the whole transfer therefore buys nothing and costs
+/// everything: a [1, 65537] FP32 transfer would reserve 256 KiB of VEC and fail
+/// in AllocateMemoryAddr. Cap it to one ``kAllReduceChunkBytes`` tile instead.
+///
+/// ``transfer_shape`` is flattened to [rows = prod(leading dims), cols = innermost].
+/// A dynamic dim contributes the chunk bound directly, matching MakeTputStageShape's
+/// contract for pld.tensor.put / pld.tensor.get: the stage is a static UB
+/// allocation, and pto-isa reads the runtime extent from the partition views.
+/// ``ValidateStageFitsTransfer`` therefore compares only statically known dims
+/// (``!cols_static || stage_cols <= transfer_cols``). A symbolic SIZE of runtime
+/// 17 still gets a 4096-element FP32 stage — that is the same bound a user-level
+/// ``chunk_cols`` would supply, not a stage-fits-transfer violation. The result
+/// never exceeds a *statically known* transfer dim.
+ExprPtr MakeCollectiveStageShape(const std::vector<ExprPtr>& transfer_shape,
+                                 const CollectiveChunkGeometry& geo, const Span& span, const char* op_name) {
+  INTERNAL_CHECK_SPAN(!transfer_shape.empty(), span) << op_name << " transfer shape must have rank >= 1";
+
+  int64_t cols_val = geo.chunk_elements;
+  if (auto cols_c = As<ConstInt>(transfer_shape.back()); cols_c && cols_c->value_ > 0) {
+    cols_val = std::min(cols_c->value_, geo.chunk_elements);
+    // Unlike SelectStaticChunkCols (allreduce's own accumulator scratch,
+    // decoupled from the transfer shape), this stage is the literal bounce
+    // buffer pld.tile.put/get slides the transfer through, so it can never
+    // exceed the transfer (comm_op::ValidateStageFitsTransfer,
+    // "!cols_static || stage_cols <= transfer_cols"). A short, non-tile-aligned
+    // length (e.g. 17 elements of FP32) must therefore round its column width
+    // DOWN to the nearest kPTOTileAlignmentBytes-aligned width rather than up
+    // — pto.alloc_tile requires the row byte size aligned, and the remainder
+    // (17 - 16 = 1 element here) rides the same auto-chunked partial last
+    // slide that already handles a transfer wider than one full chunk. Sizes
+    // below one alignment unit (< 8 elements of FP32) have no valid aligned
+    // width that still fits within the transfer; leave those unrounded — a
+    // pre-existing, narrower gap this cap fix does not claim to close.
+    if (cols_val >= geo.alignment_elements && cols_val < geo.chunk_elements) {
+      cols_val = (cols_val / geo.alignment_elements) * geo.alignment_elements;
+    }
+  }
+
+  // Keep a 2D stage (e.g. all_to_all_v's [MAX_RECV, SIZE]) inside the same
+  // byte budget by trading rows against the chosen column width.
+  const int64_t rows_budget = std::max<int64_t>(1, geo.chunk_elements / cols_val);
+  int64_t rows_prod = 1;
+  bool rows_static = true;
+  for (size_t d = 0; d + 1 < transfer_shape.size(); ++d) {
+    auto dim_c = As<ConstInt>(transfer_shape[d]);
+    if (!dim_c || dim_c->value_ <= 0) {
+      rows_static = false;
+      break;
+    }
+    // Only min(product, rows_budget) is observable. Saturate before
+    // multiplication so an otherwise-valid very large static shape cannot
+    // overflow int64_t while computing the bounded stage geometry.
+    if (rows_prod >= rows_budget || dim_c->value_ > rows_budget / rows_prod) {
+      rows_prod = rows_budget;
+    } else {
+      rows_prod *= dim_c->value_;
+    }
+  }
+  const int64_t rows_val = rows_static ? std::min(rows_prod, rows_budget) : 1;
+
+  return std::make_shared<MakeTuple>(
+      std::vector<ExprPtr>{std::make_shared<ConstInt>(rows_val, DataType::INDEX, span),
+                           std::make_shared<ConstInt>(cols_val, DataType::INDEX, span)},
+      span);
 }
 
 // ============================================================================
@@ -1092,18 +1219,10 @@ ExprPtr LowerTensorAllReduceRule(const CallPtr& call, const std::vector<ExprPtr>
   auto zero_idx = std::make_shared<ConstInt>(0, DataType::INDEX, span);
   auto one_idx = std::make_shared<ConstInt>(1, DataType::INDEX, span);
   auto one_i32 = std::make_shared<ConstInt>(1, DataType::INT32, span);
-  const int64_t element_bytes = static_cast<int64_t>(target_type->dtype_.GetByte());
-  INTERNAL_CHECK_SPAN(element_bytes > 0, span)
-      << "pld.tensor.allreduce target dtype has no storage width: " << target_type->dtype_.ToString();
-  const int64_t chunk_elements = kAllReduceChunkBytes / element_bytes;
-  INTERNAL_CHECK_SPAN(chunk_elements > 0, span)
-      << "pld.tensor.allreduce dtype is wider than the mesh chunk byte budget";
-  INTERNAL_CHECK_SPAN(kPTOTileAlignmentBytes % element_bytes == 0, span)
-      << "pld.tensor.allreduce dtype width must divide the tile alignment";
-  const int64_t alignment_elements = kPTOTileAlignmentBytes / element_bytes;
-  auto alignment_elements_idx = std::make_shared<ConstInt>(alignment_elements, DataType::INDEX, span);
-  auto alignment_minus_one_idx = std::make_shared<ConstInt>(alignment_elements - 1, DataType::INDEX, span);
-  auto max_chunk_cols = std::make_shared<ConstInt>(chunk_elements, DataType::INDEX, span);
+  const auto chunk_geometry = MakeChunkGeometry(target_type->dtype_, span, "pld.tensor.allreduce");
+  auto alignment_elements_idx = chunk_geometry.alignment_elements_idx;
+  auto alignment_minus_one_idx = chunk_geometry.alignment_minus_one_idx;
+  auto max_chunk_cols = chunk_geometry.max_chunk_cols;
 
   const auto* partial_valid_shape = GetPartialValidShape(target_type, span);
   // A fully-valid packed tensor is one logical 1D stream. Keep the view
@@ -1138,14 +1257,8 @@ ExprPtr LowerTensorAllReduceRule(const CallPtr& call, const std::vector<ExprPtr>
         << "pld.tensor.allreduce partial valid_shape must fit within one " << kAllReduceChunkBytes
         << "-byte mesh chunk using a statically bounded tile; chunking a partial rectangle with row gaps "
            "is not supported";
-  } else if (auto flat_extent = As<ConstInt>(flat_valid_shape[1]);
-             flat_extent && flat_extent->value_ > 0 && flat_extent->value_ < chunk_elements) {
-    // Do not reserve a full 16-KiB tile for a statically small allreduce. PTO
-    // tiles require a 32-byte-aligned row, so use the smallest legal physical
-    // width that covers the logical extent. Every chunk-local tile inherits
-    // this width, preserving the caller's remaining VEC UB budget.
-    const int64_t aligned_extent = ((flat_extent->value_ - 1) / alignment_elements + 1) * alignment_elements;
-    chunk_cols = std::make_shared<ConstInt>(aligned_extent, DataType::INDEX, span);
+  } else {
+    chunk_cols = SelectStaticChunkCols(chunk_geometry, flat_valid_shape[1], span);
   }
   auto flat_target = b.Bind(
       "target_2d", CreateAllReduceTargetView(target, flat_shape, flat_valid_shape, partial_valid_shape, span),
@@ -1398,18 +1511,10 @@ ExprPtr LowerTensorRingAllReduceRule(const CallPtr& call, const std::vector<Expr
   auto size_const = As<ConstInt>(size_expr);
   auto nr_const = As<ConstInt>(nr_expr);
 
-  const int64_t element_bytes = static_cast<int64_t>(target_type->dtype_.GetByte());
-  INTERNAL_CHECK_SPAN(element_bytes > 0, span)
-      << "pld.tensor.allreduce mode=ring target dtype has no storage width: "
-      << target_type->dtype_.ToString();
-  const int64_t max_chunk_elements = kAllReduceChunkBytes / element_bytes;
-  INTERNAL_CHECK_SPAN(max_chunk_elements > 0, span)
-      << "pld.tensor.allreduce mode=ring dtype is wider than the chunk byte budget";
-  INTERNAL_CHECK_SPAN(kPTOTileAlignmentBytes % element_bytes == 0, span)
-      << "pld.tensor.allreduce mode=ring dtype width must divide the tile alignment";
-  const int64_t alignment_elements = kPTOTileAlignmentBytes / element_bytes;
-  auto alignment_elements_idx = std::make_shared<ConstInt>(alignment_elements, DataType::INDEX, span);
-  auto alignment_minus_one_idx = std::make_shared<ConstInt>(alignment_elements - 1, DataType::INDEX, span);
+  const auto chunk_geometry = MakeChunkGeometry(target_type->dtype_, span, "pld.tensor.allreduce mode=ring");
+  const int64_t alignment_elements = chunk_geometry.alignment_elements;
+  auto alignment_elements_idx = chunk_geometry.alignment_elements_idx;
+  auto alignment_minus_one_idx = chunk_geometry.alignment_minus_one_idx;
 
   // FP32 keeps balanced floor(i * SIZE / NR) boundaries. FP16 rounds each
   // interior boundary up to a 32-byte position so every non-empty segment
@@ -1429,13 +1534,7 @@ ExprPtr LowerTensorRingAllReduceRule(const CallPtr& call, const std::vector<Expr
     }
   }
 
-  ExprPtr chunk_cols = std::make_shared<ConstInt>(max_chunk_elements, DataType::INDEX, span);
-  if (auto segment_const = As<ConstInt>(max_segment_cols);
-      segment_const && segment_const->value_ > 0 && segment_const->value_ < max_chunk_elements) {
-    const int64_t aligned_segment =
-        ((segment_const->value_ - 1) / alignment_elements + 1) * alignment_elements;
-    chunk_cols = std::make_shared<ConstInt>(aligned_segment, DataType::INDEX, span);
-  }
+  ExprPtr chunk_cols = SelectStaticChunkCols(chunk_geometry, max_segment_cols, span);
   auto chunk_shape = tile_conversion_utils::MakeShapeTuple({one_idx, chunk_cols}, span);
   // Own a single explicit linear ND view for every subchunk. Besides making
   // the [1, 1] column-vector exception unambiguous, this keeps the remote-load,
@@ -1843,19 +1942,12 @@ ExprPtr LowerTensorBroadcastRule(const CallPtr& call, const std::vector<ExprPtr>
   // Build a 2D VEC staging tile [rows, cols] where rows = prod(dims[:-1]),
   // cols = dims[-1], mirroring ConvertTensorToTileOps's lowering of
   // pld.tensor.get.
-  int64_t rows_val = 1;
-  for (size_t d = 0; d + 1 < target_type->shape_.size(); ++d) {
-    auto dim_c = As<ConstInt>(target_type->shape_[d]);
-    INTERNAL_CHECK_SPAN(dim_c, span) << "broadcast target shape must be static";
-    rows_val *= dim_c->value_;
-  }
-  auto last_dim_c = As<ConstInt>(target_type->shape_.back());
-  INTERNAL_CHECK_SPAN(last_dim_c, span) << "broadcast target shape must be static";
-  int64_t cols_val = last_dim_c->value_;
-
-  auto rows_expr = std::make_shared<ConstInt>(rows_val, DataType::INDEX, span);
-  auto cols_expr = std::make_shared<ConstInt>(cols_val, DataType::INDEX, span);
-  auto stage_shape_tuple = std::make_shared<MakeTuple>(std::vector<ExprPtr>{rows_expr, cols_expr}, span);
+  // The stage is a bounded bounce buffer, not a copy of the transfer, so the
+  // target shape no longer has to be static: a dynamic extent simply takes the
+  // chunk bound. pld.tile.get slides the full extent through it.
+  const auto chunk_geometry = MakeChunkGeometry(target_type->dtype_, span, "pld.tensor.broadcast");
+  auto stage_shape_tuple =
+      MakeCollectiveStageShape(target_type->shape_, chunk_geometry, span, "pld.tensor.broadcast");
 
   auto stage_tile =
       b.Bind("bcast_stage",
@@ -1886,7 +1978,9 @@ ExprPtr LowerTensorBroadcastRule(const CallPtr& call, const std::vector<ExprPtr>
 //   arg[2] = signal      — DistributedTensor INT32, cross-rank barrier
 //
 // Phases:
-//   0.  tile.create [1, SIZE] VEC — staging tile for auto-chunking
+//   0.  tile.create [stage_rows, stage_cols] VEC — bounded staging tile for
+//       auto-chunking; rows * cols fits one 16-KiB chunk and each row is
+//       32-byte aligned whenever the transfer is at least one alignment unit
 //   1.  for peer in 0..NR-1:
 //         pld.tile.put(target, peer, local_data, put_stage,
 //                      [my_rank, 0], [0, 0], [1, SIZE])
@@ -1949,11 +2043,17 @@ ExprPtr LowerTensorAllGatherRule(const CallPtr& call, const std::vector<ExprPtr>
   // Each peer receives this rank's chunk at target[my_rank, 0:SIZE].
   // Self-store (peer == my_rank) uses HCCL identity mapping — the same trust
   // model as the pld.tile.get self-path in the original pull-based allgather.
-  // pld.tile.put auto-chunks when SIZE exceeds the staging-tile capacity, so a
-  // single [1, SIZE] VEC staging tile suffices regardless of SIZE.
+  // pld.tile.put auto-chunks when SIZE exceeds the staging-tile capacity, so the
+  // stage is capped to one chunk rather than sized from SIZE — a [1, SIZE] stage
+  // would reserve SIZE * dtype bytes of VEC and overflow UB for a large SIZE.
+  // chunk_shape stays the *transfer* extent handed to pld.tile.put below.
+  const auto chunk_geometry = MakeChunkGeometry(target_type->dtype_, span, "pld.tensor.allgather");
+  auto stage_shape =
+      MakeCollectiveStageShape({std::make_shared<ConstInt>(1, DataType::INDEX, span), size_expr},
+                               chunk_geometry, span, "pld.tensor.allgather");
   auto put_stage =
       b.Bind("ag_stage",
-             reg.Create("tile.create", {chunk_shape},
+             reg.Create("tile.create", {stage_shape},
                         {{"dtype", target_type->dtype_}, {"target_memory", MemorySpace::Vec}}, span),
              span);
 
@@ -2188,11 +2288,16 @@ ExprPtr LowerTensorAllToAllRule(const CallPtr& call, const std::vector<ExprPtr>&
   //      larger than the stage is auto-chunked. The self-rank case (peer ==
   //      my_rank) falls out of the same path via HCCL identity mapping.
   //
-  // One shared [1, SIZE] VEC staging tile is reused across all destinations,
-  // mirroring allgather's per-peer pld.tile.get.
+  // One shared VEC staging tile is reused across all destinations, mirroring
+  // allgather's. It is capped to one chunk rather than sized from SIZE: the
+  // stage is a bounce buffer the transfer slides through, so a [1, SIZE] stage
+  // would only waste UB. chunk_shape stays the transfer extent.
+  const auto chunk_geometry = MakeChunkGeometry(target_type->dtype_, span, "pld.tensor.all_to_all");
+  auto stage_shape =
+      MakeCollectiveStageShape({one_idx, size_expr}, chunk_geometry, span, "pld.tensor.all_to_all");
   auto put_stage =
       b.Bind("aa_stage",
-             reg.Create("tile.create", {chunk_shape},
+             reg.Create("tile.create", {stage_shape},
                         {{"dtype", target_type->dtype_}, {"target_memory", MemorySpace::Vec}}, span),
              span);
 
@@ -2229,13 +2334,11 @@ ExprPtr LowerTensorAllToAllRule(const CallPtr& call, const std::vector<ExprPtr>&
 // ============================================================================
 // LowerTensorAllToAllVRule — pld.tensor.all_to_all_v (variable-size all-to-all)
 //
-// Variable-size all-to-all (MPI_Alltoallv pattern).  Each rank pushes a full
-// MAX_RECV-row capacity block to every peer via a single static-shape
-// pld.tile.put per destination; only ``min(send_counts[dest], MAX_RECV)`` of
-// those rows are logically valid.  ``send_counts[dest]`` is a *runtime*,
-// data-dependent count read from device data during the exchange, but it
-// does not change the transfer size (PTOAS requires static partition-view
-// dims for pto.comm.tput).  The 5-arg API signature (input, target, signal,
+// Variable-size all-to-all (MPI_Alltoallv pattern). Each rank pushes a
+// runtime-sized block to every peer via one pld.tile.put per destination.
+// ``send_counts[dest]`` is read from device data and clamped to
+// ``[0, MAX_RECV]``; that clamped value becomes the dynamic transfer row count.
+// The 5-arg API signature (input, target, signal,
 // send_counts, recv_counts) extends the symmetric all_to_all's
 // window-as-result pattern: the intrinsic returns target, and the caller
 // reads back from the window with tile.load.  During the push phase each
@@ -2256,8 +2359,9 @@ ExprPtr LowerTensorAllToAllRule(const CallPtr& call, const std::vector<ExprPtr>&
 //       // Single pld.tile.put per destination: contiguous [rows, SIZE] block
 //       // at input[dest*MAX_RECV, :] → target[my_rank*MAX_RECV, :]. The
 //       // transfer shape is the runtime [rows, SIZE] (PTOAS accepts dynamic
-//       // partition-view dims on pto.comm.tput).  A [1, SIZE] staging tile
-//       // feeds the TPUT engine, which 2-D-slides the transfer through it.
+//       // partition-view dims on pto.comm.tput). A bounded
+//       // [stage_rows, stage_cols] tile feeds the TPUT engine, which
+//       // 2-D-slides the transfer through it.
 //
 //   Phase 2: self-clearing credit barrier
 //     EmitBarrier() — AtomicAdd(+1) on every peer cell, then Wait(Ge 1)
@@ -2332,28 +2436,40 @@ ExprPtr LowerTensorAllToAllVRule(const CallPtr& call, const std::vector<ExprPtr>
   // MAX_RECV = target[0] / NR.  NR is extracted from signal[0]
   // (deducer-enforced compile-time constant).  Signal is required to be 2D
   // [NR, 1] so MakeSignalOffsets(rank) → [rank, 0] matches notify/wait.
+  // These three validate the caller's declared window/signal shapes, so a
+  // violation is a user error, not a compiler invariant — report it as such.
   auto total_rows_c = As<ConstInt>(target_type->shape_[0]);
-  INTERNAL_CHECK_SPAN(total_rows_c, span) << "target dim 0 must be a compile-time constant";
+  CHECK_SPAN(total_rows_c, span)
+      << "pld.tensor.all_to_all_v target dim 0 must be a compile-time constant (it is split as "
+         "NR * MAX_RECV to give every sender a fixed-capacity slot)";
   auto signal_type = As<DistributedTensorType>(signal->GetType());
   INTERNAL_CHECK_SPAN(signal_type, span) << "signal must be DistributedTensorType";
   ValidateMeshSignalShape(signal_type, "pld.tensor.all_to_all_v", span);
   auto nr_c = As<ConstInt>(signal_type->shape_[0]);
-  INTERNAL_CHECK_SPAN(nr_c, span) << "signal dim 0 (NR) must be a compile-time constant";
+  CHECK_SPAN(nr_c, span) << "pld.tensor.all_to_all_v signal dim 0 (NR) must be a compile-time constant";
   int64_t max_recv_value = total_rows_c->value_ / nr_c->value_;
-  INTERNAL_CHECK_SPAN(max_recv_value * nr_c->value_ == total_rows_c->value_, span)
-      << "target dim 0 (" << total_rows_c->value_ << ") must be divisible by NR (" << nr_c->value_ << ")";
+  // Divisibility is load-bearing, not incidental: the receiver locates sender
+  // s's block at row s * MAX_RECV without knowing s's count, so every sender
+  // needs an equal-capacity slot. This is deliberately not relaxed.
+  CHECK_SPAN(max_recv_value * nr_c->value_ == total_rows_c->value_, span)
+      << "pld.tensor.all_to_all_v target dim 0 (" << total_rows_c->value_ << ") must be divisible by NR ("
+      << nr_c->value_
+      << "): the receiver locates sender s's block at row s * MAX_RECV without knowing s's count, so "
+         "every sender needs an equal-capacity slot. Round the window's row count up to a multiple of NR";
   auto max_recv_expr = std::make_shared<ConstInt>(max_recv_value, DataType::INDEX, span);
 
-  // Per-destination staging tile: static [1, SIZE] — pto-isa auto-chunks the
-  // transfer through it. The stage stays static (UB is allocated statically)
-  // even though the transfer extent is dynamic.
-  auto stage_shape = std::make_shared<MakeTuple>(std::vector<ExprPtr>{one_idx, size_expr}, span);
+  // Per-destination staging tile, capped to one chunk — pto-isa slides the
+  // static [MAX_RECV, SIZE] transfer through it, so the stage need not (and
+  // should not) be sized from SIZE.
+  const auto chunk_geometry = MakeChunkGeometry(target_type->dtype_, span, "pld.tensor.all_to_all_v");
+  auto stage_shape =
+      MakeCollectiveStageShape({max_recv_expr, size_expr}, chunk_geometry, span, "pld.tensor.all_to_all_v");
 
   // ---- Phase 1: push per-destination blocks to peer windows ----
-  // One shared [1, SIZE] VEC staging tile reused across all destinations;
-  // a single pld.tile.put per destination transfers [rows, SIZE], where rows is
-  // the runtime send count clamped to [0, MAX_RECV] — so only the payload
-  // crosses the wire, not the full capacity block.
+  // One shared bounded [stage_rows, stage_cols] VEC tile is reused across all
+  // destinations. A single pld.tile.put transfers [rows, SIZE], where rows is
+  // the runtime count clamped to [0, MAX_RECV], and 2-D-slides that transfer
+  // through the stage — so only the payload crosses the wire.
   // Flat row-index arithmetic:
   // source[dest*MAX_RECV, :] → target[my_rank*MAX_RECV, :].
   auto put_stage =
@@ -2408,8 +2524,8 @@ ExprPtr LowerTensorAllToAllVRule(const CallPtr& call, const std::vector<ExprPtr>
                   span);
 
         // Single pld.tile.put per destination transferring exactly the rows
-        // being sent. The [1, SIZE] VEC staging tile feeds the TPUT engine,
-        // which 2-D-slides the larger transfer through it.
+        // being sent. The bounded [stage_rows, stage_cols] VEC tile feeds the
+        // TPUT engine, which 2-D-slides the larger transfer through it.
         // 2D source offsets: input[dest * MAX_RECV, :]
         auto src_offsets = std::make_shared<MakeTuple>(
             std::vector<ExprPtr>{dest_base, std::make_shared<ConstInt>(0, DataType::INDEX, span)}, span);
@@ -2421,7 +2537,7 @@ ExprPtr LowerTensorAllToAllVRule(const CallPtr& call, const std::vector<ExprPtr>
         // PTOAS accepts dynamic partition-view dims on pto.comm.tput
         // (TPutOp::verify passes CommGlobalShapePolicy::AllowDynamicPartitionView),
         // and pld.tile.put needs no chunk_rows attr: it takes an explicit
-        // [1, SIZE] staging tile, and ValidateStageFitsTransfer skips dynamic
+        // bounded 2-D staging tile, and ValidateStageFitsTransfer skips dynamic
         // dims because the runtime extent bounds them.
         auto transfer_shape = std::make_shared<MakeTuple>(std::vector<ExprPtr>{rows, size_expr}, span);
         // Skip the push entirely for a destination getting no rows — a

--- a/tests/st/distributed/collectives/test_l3_tensor_all_to_all_intrinsic.py
+++ b/tests/st/distributed/collectives/test_l3_tensor_all_to_all_intrinsic.py
@@ -28,78 +28,80 @@ import pypto.language as pl
 import pypto.language.distributed as pld
 import pytest
 import torch
-from pypto import ir
 from pypto.ir import DistributedConfig
+from pypto.runtime import RunConfig
 
-SIZE = 64
+STAGE_CHUNK = 4096
 
 
-def _expected_all_to_all(inputs: torch.Tensor) -> torch.Tensor:
+def _expected_all_to_all(inputs: torch.Tensor, size: int) -> torch.Tensor:
     """Golden matching simpler: output[rank, src, j] = src*1000 + rank*100 + j."""
     nranks = inputs.shape[0]
     src_idx = torch.arange(nranks, dtype=torch.float32).view(1, -1, 1)
     rank_idx = torch.arange(nranks, dtype=torch.float32).view(-1, 1, 1)
-    j = torch.arange(SIZE, dtype=torch.float32).view(1, 1, -1)
+    j = torch.arange(size, dtype=torch.float32).view(1, 1, -1)
     return src_idx * 1000 + rank_idx * 100 + j
 
 
-def _make_rank_inputs(n_ranks: int) -> torch.Tensor:
+def _make_rank_inputs(n_ranks: int, size: int) -> torch.Tensor:
     """Each rank r fills input[r, d, j] = r*1000 + d*100 + j (chunk for dest d)."""
     r = torch.arange(n_ranks, dtype=torch.float32).view(-1, 1, 1)
     d = torch.arange(n_ranks, dtype=torch.float32).view(1, -1, 1)
-    j = torch.arange(SIZE, dtype=torch.float32).view(1, 1, -1)
+    j = torch.arange(size, dtype=torch.float32).view(1, 1, -1)
     return r * 1000 + d * 100 + j
 
 
-def _build_all_to_all_program(n_ranks: int):
+def _build_all_to_all_program(n_ranks: int, size: int):
     """Build an N-rank all-to-all program at call time using the intrinsic."""
     nr = n_ranks
+    SIZE = size
 
-    @pl.program
-    class AllToAllIntrinsicNRank:
-        @pl.function(type=pl.FunctionType.InCore)
-        def exchange_step(
-            self,
-            inp: pl.Tensor[[nr, SIZE], pl.FP32],
-            out: pl.Out[pl.Tensor[[nr, SIZE], pl.FP32]],
-            data: pl.InOut[pld.DistributedTensor[[nr, SIZE], pl.FP32]],
-            signal: pl.InOut[pld.DistributedTensor[[nr, 1], pl.INT32]],
-        ) -> pl.Tensor[[nr, SIZE], pl.FP32]:
-            # Push-based all_to_all — intrinsic pushes chunks to peers and
-            # returns data in-place (window-as-result).
-            result = pld.tensor.all_to_all(inp, data, signal)
-            # Read back from the window into out for host-side verification.
-            for src in pl.range(nr):
-                chunk = pl.load(result, [src, 0], [1, SIZE])
-                pl.store(chunk, [src, 0], out)
-            return out
+    @pl.jit.incore
+    def exchange_step(
+        inp: pl.Tensor[[nr, SIZE], pl.FP32],
+        out: pl.Out[pl.Tensor[[nr, SIZE], pl.FP32]],
+        data: pl.InOut[pld.DistributedTensor[[nr, SIZE], pl.FP32]],
+        signal: pl.InOut[pld.DistributedTensor[[nr, 1], pl.INT32]],
+    ) -> pl.Tensor[[nr, SIZE], pl.FP32]:
+        # Push-based all_to_all — intrinsic pushes chunks to peers and
+        # returns data in-place (window-as-result).
+        result = pld.tensor.all_to_all(inp, data, signal)
+        # Read back from the window into out for host-side verification,
+        # chunked through a fixed-width on-chip tile so a non-tile-aligned
+        # or larger-than-UB SIZE never reserves an oversized or misaligned
+        # tile (STAGE_CHUNK is a compile-time constant, always 32-byte
+        # aligned; valid_shape masks the logical width actually read).
+        for src in pl.range(nr):
+            for col in pl.range(0, SIZE, STAGE_CHUNK):
+                valid = pl.min(STAGE_CHUNK, SIZE - col)
+                chunk = pl.load(result, [src, col], [1, STAGE_CHUNK], valid_shape=[1, valid])
+                pl.store(chunk, [src, col], out)
+        return out
 
-        @pl.function(type=pl.FunctionType.Orchestration)
-        def chip_orch(
-            self,
-            inp: pl.Tensor[[nr, SIZE], pl.FP32],
-            out: pl.Out[pl.Tensor[[nr, SIZE], pl.FP32]],
-            data: pl.InOut[pld.DistributedTensor[[nr, SIZE], pl.FP32]],
-            signal: pl.InOut[pld.DistributedTensor[[nr, 1], pl.INT32]],
-        ) -> pl.Tensor[[nr, SIZE], pl.FP32]:
-            return self.exchange_step(inp, out, data, signal)
+    @pl.jit
+    def chip_orch(
+        inp: pl.Tensor[[nr, SIZE], pl.FP32],
+        out: pl.Out[pl.Tensor[[nr, SIZE], pl.FP32]],
+        data: pl.InOut[pld.DistributedTensor[[nr, SIZE], pl.FP32]],
+        signal: pl.InOut[pld.DistributedTensor[[nr, 1], pl.INT32]],
+    ) -> pl.Tensor[[nr, SIZE], pl.FP32]:
+        return exchange_step(inp, out, data, signal)
 
-        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
-        def host_orch(
-            self,
-            inputs: pl.Tensor[[nr, nr, SIZE], pl.FP32],
-            outputs: pl.Out[pl.Tensor[[nr, nr, SIZE], pl.FP32]],
-        ) -> pl.Tensor[[nr, nr, SIZE], pl.FP32]:
-            data_buf = pld.alloc_window_buffer(nr * SIZE * pl.FP32.get_byte())
-            signal_buf = pld.alloc_window_buffer(nr * pl.INT32.get_byte())
+    @pl.jit.host
+    def host_orch(
+        inputs: pl.Tensor[[nr, nr, SIZE], pl.FP32],
+        outputs: pl.Out[pl.Tensor[[nr, nr, SIZE], pl.FP32]],
+    ) -> pl.Tensor[[nr, nr, SIZE], pl.FP32]:
+        data_buf = pld.alloc_window_buffer(nr * SIZE * pl.FP32.get_byte())
+        signal_buf = pld.alloc_window_buffer(nr * pl.INT32.get_byte())
 
-            for r in pl.range(pld.world_size()):
-                data = pld.window(data_buf, [nr, SIZE], dtype=pl.FP32)
-                sig = pld.window(signal_buf, [nr, 1], dtype=pl.INT32)
-                self.chip_orch(inputs[r], outputs[r], data, sig, device=r)
-            return outputs
+        for r in pl.range(pld.world_size()):
+            data = pld.window(data_buf, [nr, SIZE], dtype=pl.FP32)
+            sig = pld.window(signal_buf, [nr, 1], dtype=pl.INT32)
+            chip_orch(inputs[r], outputs[r], data, sig, device=r)
+        return outputs
 
-    return AllToAllIntrinsicNRank
+    return host_orch
 
 
 class TestL3TensorAllToAllIntrinsic:
@@ -109,28 +111,47 @@ class TestL3TensorAllToAllIntrinsic:
     rank-ordered personalized exchange.
     """
 
+    @pytest.mark.parametrize("size", [17, 4097, 65537])
     @pytest.mark.parametrize("n_ranks", [2, 4])
-    def test_all_to_all_intrinsic(self, test_config, device_ids, n_ranks):
-        """Compile and run mesh all-to-all for P=2 or P=4; skip when devices are scarce."""
+    def test_all_to_all_intrinsic(self, test_config, device_ids, n_ranks, size):
+        """Compile and run mesh all-to-all for P=2 or P=4; skip when devices are scarce.
+
+        SIZE values cover the InCore staging-tile-cap fix: 17 (unaligned,
+        exercises the floor-to-32-byte-aligned-width path — round DOWN, not
+        up, since the stage tile can never exceed the transfer it slides
+        through) and 4097 (one element past the 4096-element/16 KiB
+        chunk-budget boundary for FP32). SIZE=1 is not covered here: below one
+        32-byte alignment unit (8 FP32 elements) there is no stage width that
+        both satisfies pto.alloc_tile's alignment rule and still fits within
+        the transfer, a pre-existing gap this fix does not close. 65537 (the
+        original bug repro size — a [1, 65537] FP32 stage would reserve 256
+        KiB and overflow UB before this fix) requires running WITHOUT
+        --forked: with --forked, this case hangs (blocked in
+        futex_wait_queue, not an error) — this is a pre-existing `--forked`
+        + sim fork()-thread-lock deadlock, unrelated to this fix. Without
+        --forked, all three sizes pass cleanly for every composite in this
+        file.
+        """
         if len(device_ids) < n_ranks:
             pytest.skip(f"all-to-all P={n_ranks} needs {n_ranks} devices, got {device_ids}")
 
-        program = _build_all_to_all_program(n_ranks)
-        compiled = ir.compile(
-            program,
-            platform=test_config.platform,
-            distributed_config=DistributedConfig(
-                device_ids=device_ids[:n_ranks],
-                num_sub_workers=0,
+        program = _build_all_to_all_program(n_ranks, size)
+        inputs = _make_rank_inputs(n_ranks, size)
+        outputs = torch.zeros((n_ranks, n_ranks, size), dtype=torch.float32)
+        compiled = program.compile(
+            inputs,
+            outputs,
+            config=RunConfig(
+                platform=test_config.platform,
+                distributed_config=DistributedConfig(
+                    device_ids=device_ids[:n_ranks],
+                    num_sub_workers=0,
+                ),
             ),
         )
+        compiled(inputs, outputs, config=RunConfig(platform=test_config.platform))
 
-        inputs = _make_rank_inputs(n_ranks)
-        outputs = torch.zeros((n_ranks, n_ranks, SIZE), dtype=torch.float32)
-
-        compiled(inputs, outputs)
-
-        expected = _expected_all_to_all(inputs)
+        expected = _expected_all_to_all(inputs, size)
         assert torch.allclose(outputs, expected), (
             f"all-to-all intrinsic P={n_ranks} mismatch: max diff = {(outputs - expected).abs().max().item()}"
         )

--- a/tests/st/distributed/collectives/test_l3_tensor_all_to_all_v_intrinsic.py
+++ b/tests/st/distributed/collectives/test_l3_tensor_all_to_all_v_intrinsic.py
@@ -30,12 +30,17 @@ reads back with ``pl.load`` — exactly the same pattern as the symmetric
 
 The TPUT engine transfers exactly the rows being sent — the transfer shape is
 [rows, SIZE], where ``rows = clamp(send_counts[dest], 0, MAX_RECV)`` is read at
-runtime — using a compact [1, SIZE] staging tile that it auto-chunks through.
+runtime — using a bounded 2-D staging tile that it auto-chunks through.
 PTOAS accepts dynamic partition-view dims on ``pto.comm.tput``, so the padding
 up to MAX_RECV never crosses the interconnect. The receiver uses the published
 recv_counts to identify valid rows and skip unwritten window holes.
 
-ST coverage: **P=2** (default CI / 2-device hosts) and **P=4** (any four devices).
+The shared staging tile is a bounded ``[stage_rows, stage_cols]`` tile whose
+area fits one 16-KiB chunk; TPUT 2-D-slides larger transfers through it.
+
+ST coverage: **P=2** (default CI / 2-device hosts) and **P=4** (any four
+devices), with widths 17, 4097, and 65537 plus count boundaries 0, 1, and
+``MAX_RECV``.
 """
 
 import sys
@@ -44,133 +49,110 @@ import pypto.language as pl
 import pypto.language.distributed as pld
 import pytest
 import torch
-from pypto import ir
 from pypto.ir import DistributedConfig
+from pypto.runtime import RunConfig
 
 SIZE = 64
+STAGE_CHUNK = 4096
 MAX_RECV = 4
 
 
-def _build_all_to_all_v_program(n_ranks: int, max_recv: int):
+def _build_all_to_all_v_program(n_ranks: int, max_recv: int, size: int = SIZE):
     """Build an N-rank variable-size all-to-all program."""
     nr = n_ranks
     mr = max_recv
+    SIZE = size
     total = nr * mr
 
-    @pl.program
-    class AllToAllVIntrinsicNRank:
-        """N-rank variable-size all-to-all program with window-as-result pattern."""
+    @pl.jit.incore
+    def exchange_step(
+        inp: pl.Tensor[[total, SIZE], pl.FP32],
+        counts: pl.Tensor[[nr, 1], pl.INT32],
+        out: pl.Out[pl.Tensor[[total, SIZE], pl.FP32]],
+        recv_out: pl.Out[pl.Tensor[[nr, 1], pl.INT32]],
+        data: pl.InOut[pld.DistributedTensor[[total, SIZE], pl.FP32]],
+        signal: pl.InOut[pld.DistributedTensor[[nr, 1], pl.INT32]],
+        recv_counts: pl.InOut[pld.DistributedTensor[[nr, 1], pl.INT32]],
+    ) -> tuple[pl.Tensor[[total, SIZE], pl.FP32], pl.Tensor[[nr, 1], pl.INT32]]:
+        """Push variable rows per peer, then read the window via published counts."""
+        result = pld.tensor.all_to_all_v(inp, data, signal, counts, recv_counts)
+        # Copy the complete receive window through a bounded, aligned tile. The
+        # valid and tail row ranges partition each sender's slot, preserving the
+        # bounded-transfer assertion while supporting arbitrary SIZE.
+        for src in pl.range(nr):
+            n_rows_i32 = pl.read(recv_counts, [src, 0])
+            pl.write(recv_out, [src, 0], n_rows_i32)
+            n_rows = pl.cast(n_rows_i32, pl.INDEX)
+            base = src * mr
+            for r in pl.range(n_rows):
+                flat_row = base + r
+                for col in pl.range(0, SIZE, STAGE_CHUNK):
+                    valid = pl.min(STAGE_CHUNK, SIZE - col)
+                    chunk = pl.load(result, [flat_row, col], [1, STAGE_CHUNK], valid_shape=[1, valid])
+                    pl.store(chunk, [flat_row, col], out)
+            for r in pl.range(n_rows, mr):
+                flat_row = base + r
+                for col in pl.range(0, SIZE, STAGE_CHUNK):
+                    valid = pl.min(STAGE_CHUNK, SIZE - col)
+                    chunk = pl.load(result, [flat_row, col], [1, STAGE_CHUNK], valid_shape=[1, valid])
+                    pl.store(chunk, [flat_row, col], out)
+        return out, recv_out
 
-        @pl.function(type=pl.FunctionType.InCore)
-        def exchange_step(
-            self,
-            inp: pl.Tensor[[total, SIZE], pl.FP32],
-            counts: pl.Tensor[[nr, 1], pl.INT32],
-            out: pl.Out[pl.Tensor[[total, SIZE], pl.FP32]],
-            recv_out: pl.Out[pl.Tensor[[nr, 1], pl.INT32]],
-            data: pl.InOut[pld.DistributedTensor[[total, SIZE], pl.FP32]],
-            signal: pl.InOut[pld.DistributedTensor[[nr, 1], pl.INT32]],
-            recv_counts: pl.InOut[pld.DistributedTensor[[nr, 1], pl.INT32]],
-        ) -> tuple[pl.Tensor[[total, SIZE], pl.FP32], pl.Tensor[[nr, 1], pl.INT32]]:
-            """InCore kernel: push variable rows per peer, barrier, read back via recv_counts."""
-            # Push-based all_to_all_v — intrinsic pushes counts[dest] rows to
-            # each peer, publishes counts into recv_counts, and returns data
-            # in-place (window-as-result).
-            result = pld.tensor.all_to_all_v(inp, data, signal, counts, recv_counts)
-            # Read back valid rows from the window for host-side verification.
-            # Loop bounded by published recv_counts[src] (not a hardcoded formula
-            # / MAX_RECV). The TPUT transfer shape is the runtime [rows, SIZE]
-            # (PTOAS accepts dynamic partition-view dims on pto.comm.tput); a
-            # [1, SIZE] staging tile feeds the engine. The receiver uses
-            # recv_counts to skip unwritten window holes.
-            # Both loops target `out`, and their row ranges partition each
-            # sender's slot, so every row of the window is copied exactly once
-            # and `out` ends up FULLY written. That last part matters: a
-            # `pl.Out` tensor is write-only on the device (the host buffer is
-            # never uploaded), so any row the kernel skipped would come back as
-            # undefined memory rather than as window content.
-            #   [base, base + recv_counts[src])       valid -- checked vs golden
-            #   [base + recv_counts[src], base + mr)  tail  -- bounded-transfer check
-            # Keeping the valid-row loop bounded by the published recv_counts
-            # (not a hardcoded formula / MAX_RECV) exercises the intended
-            # device-side consumer pattern; the tail loop is what makes the
-            # bounded-transfer assertion non-vacuous — a padded full-capacity
-            # transfer would deposit the sender's surplus there.
-            for src in pl.range(nr):
-                n_rows_i32 = pl.read(recv_counts, [src, 0])
-                # Scalar read/write — a [1,1] INT32 tile.load fails ptoas
-                # 32-byte row alignment (4 bytes).
-                pl.write(recv_out, [src, 0], n_rows_i32)
-                n_rows = pl.cast(n_rows_i32, pl.INDEX)
-                base = src * mr
-                for r in pl.range(n_rows):
-                    flat_row = base + r
-                    chunk = pl.load(result, [flat_row, 0], [1, SIZE])
-                    pl.store(chunk, [flat_row, 0], out)
-                for r in pl.range(n_rows, mr):
-                    flat_row = base + r
-                    chunk = pl.load(result, [flat_row, 0], [1, SIZE])
-                    pl.store(chunk, [flat_row, 0], out)
-            return out, recv_out
+    @pl.jit
+    def chip_orch(
+        inp: pl.Tensor[[total, SIZE], pl.FP32],
+        counts: pl.Tensor[[nr, 1], pl.INT32],
+        out: pl.Out[pl.Tensor[[total, SIZE], pl.FP32]],
+        recv_out: pl.Out[pl.Tensor[[nr, 1], pl.INT32]],
+        data: pl.InOut[pld.DistributedTensor[[total, SIZE], pl.FP32]],
+        signal: pl.InOut[pld.DistributedTensor[[nr, 1], pl.INT32]],
+        recv_counts: pl.InOut[pld.DistributedTensor[[nr, 1], pl.INT32]],
+    ) -> tuple[pl.Tensor[[total, SIZE], pl.FP32], pl.Tensor[[nr, 1], pl.INT32]]:
+        return exchange_step(inp, counts, out, recv_out, data, signal, recv_counts)
 
-        @pl.function(type=pl.FunctionType.Orchestration)
-        def chip_orch(
-            self,
-            inp: pl.Tensor[[total, SIZE], pl.FP32],
-            counts: pl.Tensor[[nr, 1], pl.INT32],
-            out: pl.Out[pl.Tensor[[total, SIZE], pl.FP32]],
-            recv_out: pl.Out[pl.Tensor[[nr, 1], pl.INT32]],
-            data: pl.InOut[pld.DistributedTensor[[total, SIZE], pl.FP32]],
-            signal: pl.InOut[pld.DistributedTensor[[nr, 1], pl.INT32]],
-            recv_counts: pl.InOut[pld.DistributedTensor[[nr, 1], pl.INT32]],
-        ) -> tuple[pl.Tensor[[total, SIZE], pl.FP32], pl.Tensor[[nr, 1], pl.INT32]]:
-            """Chip orchestration: dispatch to exchange_step with bound windows."""
-            return self.exchange_step(inp, counts, out, recv_out, data, signal, recv_counts)
+    @pl.jit.host
+    def host_orch(
+        inputs: pl.Tensor[[nr, total, SIZE], pl.FP32],
+        send_counts: pl.Tensor[[nr, nr, 1], pl.INT32],
+        outputs: pl.Out[pl.Tensor[[nr, total, SIZE], pl.FP32]],
+        recv_outputs: pl.Out[pl.Tensor[[nr, nr, 1], pl.INT32]],
+    ) -> tuple[pl.Tensor[[nr, total, SIZE], pl.FP32], pl.Tensor[[nr, nr, 1], pl.INT32]]:
+        data_buf = pld.alloc_window_buffer(total * SIZE * pl.FP32.get_byte())
+        signal_buf = pld.alloc_window_buffer(nr * pl.INT32.get_byte())
+        recv_buf = pld.alloc_window_buffer(nr * pl.INT32.get_byte())
 
-        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
-        def host_orch(
-            self,
-            inputs: pl.Tensor[[nr, total, SIZE], pl.FP32],
-            send_counts: pl.Tensor[[nr, nr, 1], pl.INT32],
-            outputs: pl.Out[pl.Tensor[[nr, total, SIZE], pl.FP32]],
-            recv_outputs: pl.Out[pl.Tensor[[nr, nr, 1], pl.INT32]],
-        ) -> tuple[pl.Tensor[[nr, total, SIZE], pl.FP32], pl.Tensor[[nr, nr, 1], pl.INT32]]:
-            """HOST orchestrator: allocate windows once, loop over ranks calling chip_orch."""
-            data_buf = pld.alloc_window_buffer(total * SIZE * pl.FP32.get_byte())
-            signal_buf = pld.alloc_window_buffer(nr * pl.INT32.get_byte())
-            recv_buf = pld.alloc_window_buffer(nr * pl.INT32.get_byte())
+        for r in pl.range(pld.world_size()):
+            data = pld.window(data_buf, [total, SIZE], dtype=pl.FP32)
+            sig = pld.window(signal_buf, [nr, 1], dtype=pl.INT32)
+            recv = pld.window(recv_buf, [nr, 1], dtype=pl.INT32)
+            chip_orch(
+                inputs[r],
+                send_counts[r],
+                outputs[r],
+                recv_outputs[r],
+                data,
+                sig,
+                recv,
+                device=r,
+            )
+        return outputs, recv_outputs
 
-            for r in pl.range(pld.world_size()):
-                data = pld.window(data_buf, [total, SIZE], dtype=pl.FP32)
-                sig = pld.window(signal_buf, [nr, 1], dtype=pl.INT32)
-                recv = pld.window(recv_buf, [nr, 1], dtype=pl.INT32)
-                self.chip_orch(
-                    inputs[r],
-                    send_counts[r],
-                    outputs[r],
-                    recv_outputs[r],
-                    data,
-                    sig,
-                    recv,
-                    device=r,
-                )
-            return outputs, recv_outputs
-
-    return AllToAllVIntrinsicNRank
+    return host_orch
 
 
 class TestL3TensorAllToAllVIntrinsic:
     """L3 distributed runtime: variable-size all-to-all via ``pld.tensor.all_to_all_v``."""
 
+    @pytest.mark.parametrize("size", [17, 4097, 65537])
     @pytest.mark.parametrize("n_ranks", [2, 4])
-    def test_all_to_all_v_intrinsic(self, test_config, device_ids, n_ranks):
+    def test_all_to_all_v_intrinsic(self, test_config, device_ids, n_ranks, size):
         """Compile and run variable-size all-to-all for P=2 or P=4.
 
         Each rank sends ``n_ranks - dest`` rows to each peer (variable counts).
         MAX_RECV=4 is the compile-time capacity, actual sends ≤ MAX_RECV.
-        The test validates that the push-based decomposition produces the
-        correct per-src per-dest exchange, and that ``recv_counts`` publishes
-        the receive-side counts (no hardcoded ``n_rows = nr - rank`` on device).
+        SIZE covers the alignment-floor path (17), one element beyond the
+        16-KiB FP32 chunk (4097), and the original UB-overflow scale (65537).
+        The count set retains 1-row and MAX_RECV boundaries.
         """
         if len(device_ids) < n_ranks:
             pytest.skip(f"all_to_all_v P={n_ranks} needs {n_ranks} devices, got {device_ids}")
@@ -179,37 +161,47 @@ class TestL3TensorAllToAllVIntrinsic:
         mr = MAX_RECV
         total = nr * mr
 
-        program = _build_all_to_all_v_program(nr, mr)
-        compiled = ir.compile(
-            program,
-            platform=test_config.platform,
-            distributed_config=DistributedConfig(
-                device_ids=device_ids[:nr],
-                num_sub_workers=0,
-            ),
-        )
-
-        # Build inputs: 3D host view [nr, total, SIZE] = per-rank flat 2D
+        # Build inputs: 3D host view [nr, total, size] = per-rank flat 2D
         # Rank r sends to dest d: rows dest*mr+k for k=0..n_rows-1
         # Value = r*1000 + d*100 + k*10 + j%10
         # The TPUT transfers only [n_rows, SIZE] — rows beyond n_rows are not
         # pushed at all.  The receiver uses recv_counts to identify the valid
         # rows; the rest of its capacity slot is simply never written.
-        inputs = torch.zeros((nr, total, SIZE), dtype=torch.float32)
+        inputs = torch.zeros((nr, total, size), dtype=torch.float32)
         send_counts = torch.zeros((nr, nr, 1), dtype=torch.int32)
+        columns = torch.arange(size, dtype=torch.float32) % 10
         for r in range(nr):
             for d in range(nr):
                 n_rows = nr - d  # variable send count
                 send_counts[r, d, 0] = n_rows
                 base = d * mr
                 for k in range(n_rows):
-                    for j in range(SIZE):
-                        inputs[r, base + k, j] = float(r * 1000 + d * 100 + k * 10 + j % 10)
+                    inputs[r, base + k, :] = float(r * 1000 + d * 100 + k * 10) + columns
 
-        outputs = torch.zeros((nr, total, SIZE), dtype=torch.float32)
+        outputs = torch.zeros((nr, total, size), dtype=torch.float32)
         recv_outputs = torch.zeros((nr, nr, 1), dtype=torch.int32)
 
-        compiled(inputs, send_counts, outputs, recv_outputs)
+        program = _build_all_to_all_v_program(nr, mr, size)
+        compiled = program.compile(
+            inputs,
+            send_counts,
+            outputs,
+            recv_outputs,
+            config=RunConfig(
+                platform=test_config.platform,
+                distributed_config=DistributedConfig(
+                    device_ids=device_ids[:nr],
+                    num_sub_workers=0,
+                ),
+            ),
+        )
+        compiled(
+            inputs,
+            send_counts,
+            outputs,
+            recv_outputs,
+            config=RunConfig(platform=test_config.platform),
+        )
 
         # Golden validation:
         # Rank rank receives from src the chunk that src sent to dest=rank.
@@ -288,12 +280,6 @@ class TestL3TensorAllToAllVSkew:
         total = nr * mr
         raw = _SKEW_CASES[case](nr, mr)
 
-        compiled = ir.compile(
-            _build_all_to_all_v_program(nr, mr),
-            platform=test_config.platform,
-            distributed_config=DistributedConfig(device_ids=device_ids[:nr], num_sub_workers=0),
-        )
-
         # Fill the FULL capacity slot of every destination, not just the rows
         # being sent, so an over-send would deposit recognisable data in the
         # padding rows and the assertion below would catch it.
@@ -316,7 +302,24 @@ class TestL3TensorAllToAllVSkew:
 
         outputs = torch.zeros((nr, total, SIZE), dtype=torch.float32)
         recv_outputs = torch.zeros((nr, nr, 1), dtype=torch.int32)
-        compiled(inputs, send_counts, outputs, recv_outputs)
+        program = _build_all_to_all_v_program(nr, mr)
+        compiled = program.compile(
+            inputs,
+            send_counts,
+            outputs,
+            recv_outputs,
+            config=RunConfig(
+                platform=test_config.platform,
+                distributed_config=DistributedConfig(device_ids=device_ids[:nr], num_sub_workers=0),
+            ),
+        )
+        compiled(
+            inputs,
+            send_counts,
+            outputs,
+            recv_outputs,
+            config=RunConfig(platform=test_config.platform),
+        )
 
         for rank in range(nr):
             for src in range(nr):

--- a/tests/st/distributed/collectives/test_l3_tensor_allgather_intrinsic.py
+++ b/tests/st/distributed/collectives/test_l3_tensor_allgather_intrinsic.py
@@ -29,10 +29,10 @@ import pypto.language as pl
 import pypto.language.distributed as pld
 import pytest
 import torch
-from pypto import ir
 from pypto.ir import DistributedConfig
+from pypto.runtime import RunConfig
 
-SIZE = 64
+STAGE_CHUNK = 4096
 
 
 def _expected_allgather(inputs: torch.Tensor) -> torch.Tensor:
@@ -41,67 +41,69 @@ def _expected_allgather(inputs: torch.Tensor) -> torch.Tensor:
     return torch.stack([gathered] * inputs.shape[0]).unsqueeze(1)
 
 
-def _make_rank_inputs(n_ranks: int) -> torch.Tensor:
+def _make_rank_inputs(n_ranks: int, size: int) -> torch.Tensor:
     """Distinct per-rank tensors so the golden concat is non-trivial."""
     rows = [
-        torch.arange(r * 100.0, r * 100.0 + SIZE, dtype=torch.float32).reshape(1, SIZE)
+        torch.arange(r * 100.0, r * 100.0 + size, dtype=torch.float32).reshape(1, size)
         for r in range(n_ranks)
     ]
     return torch.stack(rows)
 
 
-def _build_allgather_program(n_ranks: int):
+def _build_allgather_program(n_ranks: int, size: int):
     """Build an N-rank allgather program at call time using the intrinsic.
 
     Deferred construction lets this file collect even if the embedded body
     is rejected by the parser.
     """
     nr = n_ranks
+    SIZE = size
 
-    @pl.program
-    class AllGatherIntrinsicNRank:
-        @pl.function(type=pl.FunctionType.InCore)
-        def gather_step(
-            self,
-            inp: pl.Tensor[[1, SIZE], pl.FP32],
-            out: pl.Out[pl.Tensor[[1, nr * SIZE], pl.FP32]],
-            data: pl.InOut[pld.DistributedTensor[[nr, SIZE], pl.FP32]],
-            signal: pl.InOut[pld.DistributedTensor[[nr, 1], pl.INT32]],
-        ) -> pl.Tensor[[1, nr * SIZE], pl.FP32]:
-            # Push-based allgather: window becomes the gathered [NR, SIZE] result.
-            data = pld.tensor.allgather(inp, data, signal)
-            # Stage-out: read from the gathered window into the output tensor.
-            for r in pl.range(nr):
-                chunk = pl.load(data, [r, 0], [1, SIZE])
-                pl.store(chunk, [0, r * SIZE], out)
-            return out
+    @pl.jit.incore
+    def gather_step(
+        inp: pl.Tensor[[1, SIZE], pl.FP32],
+        out: pl.Out[pl.Tensor[[1, nr * SIZE], pl.FP32]],
+        data: pl.InOut[pld.DistributedTensor[[nr, SIZE], pl.FP32]],
+        signal: pl.InOut[pld.DistributedTensor[[nr, 1], pl.INT32]],
+    ) -> pl.Tensor[[1, nr * SIZE], pl.FP32]:
+        # Push-based allgather: window becomes the gathered [NR, SIZE] result.
+        data = pld.tensor.allgather(inp, data, signal)
+        # Stage-out: read from the gathered window into the output tensor,
+        # chunked through a fixed-width on-chip tile so a non-tile-aligned
+        # or larger-than-UB SIZE never reserves an oversized or misaligned
+        # tile (STAGE_CHUNK is a compile-time constant, always 32-byte
+        # aligned; valid_shape masks the logical width actually read).
+        for r in pl.range(nr):
+            for col in pl.range(0, SIZE, STAGE_CHUNK):
+                valid = pl.min(STAGE_CHUNK, SIZE - col)
+                chunk = pl.load(data, [r, col], [1, STAGE_CHUNK], valid_shape=[1, valid])
+                pl.store(chunk, [0, r * SIZE + col], out)
+        return out
 
-        @pl.function(type=pl.FunctionType.Orchestration)
-        def chip_orch(
-            self,
-            inp: pl.Tensor[[1, SIZE], pl.FP32],
-            out: pl.Out[pl.Tensor[[1, nr * SIZE], pl.FP32]],
-            data: pl.InOut[pld.DistributedTensor[[nr, SIZE], pl.FP32]],
-            signal: pl.InOut[pld.DistributedTensor[[nr, 1], pl.INT32]],
-        ) -> pl.Tensor[[1, nr * SIZE], pl.FP32]:
-            return self.gather_step(inp, out, data, signal)
+    @pl.jit
+    def chip_orch(
+        inp: pl.Tensor[[1, SIZE], pl.FP32],
+        out: pl.Out[pl.Tensor[[1, nr * SIZE], pl.FP32]],
+        data: pl.InOut[pld.DistributedTensor[[nr, SIZE], pl.FP32]],
+        signal: pl.InOut[pld.DistributedTensor[[nr, 1], pl.INT32]],
+    ) -> pl.Tensor[[1, nr * SIZE], pl.FP32]:
+        return gather_step(inp, out, data, signal)
 
-        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
-        def host_orch(
-            self,
-            inputs: pl.Tensor[[nr, 1, SIZE], pl.FP32],
-            outputs: pl.Out[pl.Tensor[[nr, 1, nr * SIZE], pl.FP32]],
-        ) -> pl.Tensor[[nr, 1, nr * SIZE], pl.FP32]:
-            data_buf = pld.alloc_window_buffer(nr * SIZE * pl.FP32.get_byte())
-            signal_buf = pld.alloc_window_buffer(nr * pl.INT32.get_byte())
+    @pl.jit.host
+    def host_orch(
+        inputs: pl.Tensor[[nr, 1, SIZE], pl.FP32],
+        outputs: pl.Out[pl.Tensor[[nr, 1, nr * SIZE], pl.FP32]],
+    ) -> pl.Tensor[[nr, 1, nr * SIZE], pl.FP32]:
+        data_buf = pld.alloc_window_buffer(nr * SIZE * pl.FP32.get_byte())
+        signal_buf = pld.alloc_window_buffer(nr * pl.INT32.get_byte())
 
-            for r in pl.range(pld.world_size()):
-                data = pld.window(data_buf, [nr, SIZE], dtype=pl.FP32)
-                sig = pld.window(signal_buf, [nr, 1], dtype=pl.INT32)
-                self.chip_orch(inputs[r], outputs[r], data, sig, device=r)
-            return outputs
+        for r in pl.range(pld.world_size()):
+            data = pld.window(data_buf, [nr, SIZE], dtype=pl.FP32)
+            sig = pld.window(signal_buf, [nr, 1], dtype=pl.INT32)
+            chip_orch(inputs[r], outputs[r], data, sig, device=r)
+        return outputs
 
-    return AllGatherIntrinsicNRank
+    return host_orch
 
 
 class TestL3TensorAllGatherIntrinsic:
@@ -111,26 +113,47 @@ class TestL3TensorAllGatherIntrinsic:
     bit-identical to the hand-written ``test_l3_allgather.py`` reference.
     """
 
+    @pytest.mark.parametrize("size", [17, 4097, 65537])
     @pytest.mark.parametrize("n_ranks", [2, 4])
-    def test_allgather_intrinsic(self, test_config, device_ids, n_ranks):
-        """Compile and run mesh allgather for P=2 or P=4; skip when devices are scarce."""
+    def test_allgather_intrinsic(self, test_config, device_ids, n_ranks, size):
+        """Compile and run mesh allgather for P=2 or P=4; skip when devices are scarce.
+
+        SIZE values cover the InCore staging-tile-cap fix: 17 (unaligned,
+        exercises the floor-to-32-byte-aligned-width path — round DOWN, not
+        up, since the stage tile can never exceed the transfer it slides
+        through) and 4097 (one element past the 4096-element/16 KiB
+        chunk-budget boundary for FP32 — the sharpest check that a >1-chunk
+        transfer still slides correctly through the capped stage). SIZE=1 is
+        not covered here: below one 32-byte alignment unit (8 FP32 elements)
+        there is no stage width that both satisfies pto.alloc_tile's
+        alignment rule and still fits within the transfer, a pre-existing gap
+        this fix does not close. 65537 (the original bug repro size — a
+        [1, 65537] FP32 stage would reserve 256 KiB and overflow UB before
+        this fix) requires running WITHOUT --forked: with --forked, this case
+        hangs (blocked in futex_wait_queue, not an error) — this is a
+        pre-existing `--forked` + sim fork()-thread-lock deadlock, unrelated
+        to this fix. Without --forked, all three sizes pass cleanly for every
+        composite in this file.
+        """
         if len(device_ids) < n_ranks:
             pytest.skip(f"allgather P={n_ranks} needs {n_ranks} devices, got {device_ids}")
 
-        program = _build_allgather_program(n_ranks)
-        compiled = ir.compile(
-            program,
-            platform=test_config.platform,
-            distributed_config=DistributedConfig(
-                device_ids=device_ids[:n_ranks],
-                num_sub_workers=0,
+        program = _build_allgather_program(n_ranks, size)
+        inputs = _make_rank_inputs(n_ranks, size)
+        outputs = torch.zeros((n_ranks, 1, n_ranks * size), dtype=torch.float32)
+        compiled = program.compile(
+            inputs,
+            outputs,
+            config=RunConfig(
+                platform=test_config.platform,
+                distributed_config=DistributedConfig(
+                    device_ids=device_ids[:n_ranks],
+                    num_sub_workers=0,
+                ),
             ),
         )
 
-        inputs = _make_rank_inputs(n_ranks)
-        outputs = torch.zeros((n_ranks, 1, n_ranks * SIZE), dtype=torch.float32)
-
-        compiled(inputs, outputs)
+        compiled(inputs, outputs, config=RunConfig(platform=test_config.platform))
 
         expected = _expected_allgather(inputs)
         assert torch.allclose(outputs, expected), (

--- a/tests/st/distributed/collectives/test_l3_tensor_broadcast_intrinsic.py
+++ b/tests/st/distributed/collectives/test_l3_tensor_broadcast_intrinsic.py
@@ -25,11 +25,13 @@ import pypto.language as pl
 import pypto.language.distributed as pld
 import pytest
 import torch
-from pypto import ir
 from pypto.ir import DistributedConfig
+from pypto.runtime import RunConfig
 
-SIZE = 64
 ROOT_RANK = 0
+STAGE_CHUNK = 4096
+DYNAMIC_NRANKS = 2
+BROADCAST_RUNTIME_SIZE = pl.dynamic("BROADCAST_RUNTIME_SIZE")
 
 
 def _expected_broadcast(inputs: torch.Tensor, root: int = ROOT_RANK) -> torch.Tensor:
@@ -38,73 +40,126 @@ def _expected_broadcast(inputs: torch.Tensor, root: int = ROOT_RANK) -> torch.Te
     return torch.stack([root_row] * inputs.shape[0]).unsqueeze(1)
 
 
-def _make_rank_inputs(n_ranks: int) -> torch.Tensor:
+def _make_rank_inputs(n_ranks: int, size: int) -> torch.Tensor:
     """Distinct per-rank tensors so root-only broadcast is non-trivial."""
     rows = [
-        torch.arange(r * 100.0, r * 100.0 + SIZE, dtype=torch.float32).reshape(1, SIZE)
+        torch.arange(r * 100.0, r * 100.0 + size, dtype=torch.float32).reshape(1, size)
         for r in range(n_ranks)
     ]
     return torch.stack(rows)
 
 
-def _build_broadcast_program(n_ranks: int):
+def _build_broadcast_program(n_ranks: int, size: int):
     """Build an N-rank broadcast program at call time using the intrinsic.
 
     Deferred construction lets this file collect even if the embedded body
     is rejected by the parser.
     """
     nr = n_ranks
+    SIZE = size
 
-    @pl.program
-    class BroadcastIntrinsicNRank:
-        @pl.function(type=pl.FunctionType.InCore)
-        def broadcast_step(
-            self,
-            inp: pl.Tensor[[1, SIZE], pl.FP32],
-            out: pl.Out[pl.Tensor[[1, SIZE], pl.FP32]],
-            data: pl.InOut[pld.DistributedTensor[[1, SIZE], pl.FP32]],
-            signal: pl.InOut[pld.DistributedTensor[[nr, 1], pl.INT32]],
-            my_rank: pl.Scalar[pl.INT32],
-        ) -> pl.Tensor[[1, SIZE], pl.FP32]:
-            # Phase 1: root only stages data.
-            if my_rank == ROOT_RANK:
-                local = pl.load(inp, [0, 0], [1, SIZE])
-                pl.store(local, [0, 0], data)
+    @pl.jit.incore
+    def broadcast_step(
+        inp: pl.Tensor[[1, SIZE], pl.FP32],
+        out: pl.Out[pl.Tensor[[1, SIZE], pl.FP32]],
+        data: pl.InOut[pld.DistributedTensor[[1, SIZE], pl.FP32]],
+        signal: pl.InOut[pld.DistributedTensor[[nr, 1], pl.INT32]],
+        my_rank: pl.Scalar[pl.INT32],
+    ) -> pl.Tensor[[1, SIZE], pl.FP32]:
+        # Phase 1: root only stages data, chunked through a fixed-width
+        # on-chip tile so a non-tile-aligned or larger-than-UB SIZE never
+        # reserves an oversized or misaligned tile (STAGE_CHUNK is a
+        # compile-time constant, always 32-byte aligned; valid_shape masks
+        # the logical width actually transferred).
+        if my_rank == ROOT_RANK:
+            for col in pl.range(0, SIZE, STAGE_CHUNK):
+                valid = pl.min(STAGE_CHUNK, SIZE - col)
+                local = pl.load(inp, [0, col], [1, STAGE_CHUNK], valid_shape=[1, valid])
+                pl.store(local, [0, col], data)
 
-            # Phases 2-3: barrier + broadcast — one call.
-            data = pld.tensor.broadcast(data, signal, root=ROOT_RANK)
+        # Phases 2-3: barrier + broadcast — one call.
+        data = pld.tensor.broadcast(data, signal, root=ROOT_RANK)
 
-            # Stage-out: every rank reads root's data.
-            acc = pl.load(data, [0, 0], [1, SIZE])
-            return pl.store(acc, [0, 0], out)
+        # Stage-out: every rank reads root's data, same chunking as above.
+        for col in pl.range(0, SIZE, STAGE_CHUNK):
+            valid = pl.min(STAGE_CHUNK, SIZE - col)
+            acc = pl.load(data, [0, col], [1, STAGE_CHUNK], valid_shape=[1, valid])
+            pl.store(acc, [0, col], out)
+        return out
 
-        @pl.function(type=pl.FunctionType.Orchestration)
-        def chip_orch(
-            self,
-            inp: pl.Tensor[[1, SIZE], pl.FP32],
-            out: pl.Out[pl.Tensor[[1, SIZE], pl.FP32]],
-            data: pl.InOut[pld.DistributedTensor[[1, SIZE], pl.FP32]],
-            signal: pl.InOut[pld.DistributedTensor[[nr, 1], pl.INT32]],
-            my_rank: pl.Scalar[pl.INT32],
-        ) -> pl.Tensor[[1, SIZE], pl.FP32]:
-            return self.broadcast_step(inp, out, data, signal, my_rank)
+    @pl.jit
+    def chip_orch(
+        inp: pl.Tensor[[1, SIZE], pl.FP32],
+        out: pl.Out[pl.Tensor[[1, SIZE], pl.FP32]],
+        data: pl.InOut[pld.DistributedTensor[[1, SIZE], pl.FP32]],
+        signal: pl.InOut[pld.DistributedTensor[[nr, 1], pl.INT32]],
+        my_rank: pl.Scalar[pl.INT32],
+    ) -> pl.Tensor[[1, SIZE], pl.FP32]:
+        return broadcast_step(inp, out, data, signal, my_rank)
 
-        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
-        def host_orch(
-            self,
-            inputs: pl.Tensor[[nr, 1, SIZE], pl.FP32],
-            outputs: pl.Out[pl.Tensor[[nr, 1, SIZE], pl.FP32]],
-        ) -> pl.Tensor[[nr, 1, SIZE], pl.FP32]:
-            data_buf = pld.alloc_window_buffer(SIZE * pl.FP32.get_byte())
-            signal_buf = pld.alloc_window_buffer(nr * pl.INT32.get_byte())
+    @pl.jit.host
+    def host_orch(
+        inputs: pl.Tensor[[nr, 1, SIZE], pl.FP32],
+        outputs: pl.Out[pl.Tensor[[nr, 1, SIZE], pl.FP32]],
+    ) -> pl.Tensor[[nr, 1, SIZE], pl.FP32]:
+        data_buf = pld.alloc_window_buffer(SIZE * pl.FP32.get_byte())
+        signal_buf = pld.alloc_window_buffer(nr * pl.INT32.get_byte())
 
-            for r in pl.range(pld.world_size()):
-                data = pld.window(data_buf, [1, SIZE], dtype=pl.FP32)
-                sig = pld.window(signal_buf, [nr, 1], dtype=pl.INT32)
-                self.chip_orch(inputs[r], outputs[r], data, sig, r, device=r)
-            return outputs
+        for r in pl.range(pld.world_size()):
+            data = pld.window(data_buf, [1, SIZE], dtype=pl.FP32)
+            sig = pld.window(signal_buf, [nr, 1], dtype=pl.INT32)
+            chip_orch(inputs[r], outputs[r], data, sig, r, device=r)
+        return outputs
 
-    return BroadcastIntrinsicNRank
+    return host_orch
+
+
+@pl.jit.incore
+def _dynamic_broadcast_step(
+    inp: pl.Tensor[[1, BROADCAST_RUNTIME_SIZE], pl.FP32],
+    out: pl.Out[pl.Tensor[[1, BROADCAST_RUNTIME_SIZE], pl.FP32]],
+    data: pl.InOut[pld.DistributedTensor[[1, BROADCAST_RUNTIME_SIZE], pl.FP32]],
+    signal: pl.InOut[pld.DistributedTensor[[DYNAMIC_NRANKS, 1], pl.INT32]],
+    my_rank: pl.Scalar[pl.INT32],
+) -> pl.Tensor[[1, BROADCAST_RUNTIME_SIZE], pl.FP32]:
+    BROADCAST_RUNTIME_SIZE = pl.dynamic("BROADCAST_RUNTIME_SIZE")
+    if my_rank == ROOT_RANK:
+        for col in pl.range(0, BROADCAST_RUNTIME_SIZE, STAGE_CHUNK):
+            valid = pl.min(STAGE_CHUNK, BROADCAST_RUNTIME_SIZE - col)
+            local = pl.load(inp, [0, col], [1, STAGE_CHUNK], valid_shape=[1, valid])
+            pl.store(local, [0, col], data)
+    data = pld.tensor.broadcast(data, signal, root=ROOT_RANK)
+    for col in pl.range(0, BROADCAST_RUNTIME_SIZE, STAGE_CHUNK):
+        valid = pl.min(STAGE_CHUNK, BROADCAST_RUNTIME_SIZE - col)
+        acc = pl.load(data, [0, col], [1, STAGE_CHUNK], valid_shape=[1, valid])
+        pl.store(acc, [0, col], out)
+    return out
+
+
+@pl.jit
+def _dynamic_broadcast_chip(
+    inp: pl.Tensor[[1, BROADCAST_RUNTIME_SIZE], pl.FP32],
+    out: pl.Out[pl.Tensor[[1, BROADCAST_RUNTIME_SIZE], pl.FP32]],
+    data: pl.InOut[pld.DistributedTensor[[1, BROADCAST_RUNTIME_SIZE], pl.FP32]],
+    signal: pl.InOut[pld.DistributedTensor[[DYNAMIC_NRANKS, 1], pl.INT32]],
+    my_rank: pl.Scalar[pl.INT32],
+) -> pl.Tensor[[1, BROADCAST_RUNTIME_SIZE], pl.FP32]:
+    return _dynamic_broadcast_step(inp, out, data, signal, my_rank)
+
+
+@pl.jit.host
+def _dynamic_broadcast_host(
+    inputs: pl.Tensor[[DYNAMIC_NRANKS, 1, BROADCAST_RUNTIME_SIZE], pl.FP32],
+    outputs: pl.Out[pl.Tensor[[DYNAMIC_NRANKS, 1, BROADCAST_RUNTIME_SIZE], pl.FP32]],
+) -> pl.Tensor[[DYNAMIC_NRANKS, 1, BROADCAST_RUNTIME_SIZE], pl.FP32]:
+    BROADCAST_RUNTIME_SIZE = pl.dynamic("BROADCAST_RUNTIME_SIZE")
+    data_buf = pld.alloc_window_buffer(BROADCAST_RUNTIME_SIZE * pl.FP32.get_byte())
+    signal_buf = pld.alloc_window_buffer(DYNAMIC_NRANKS * pl.INT32.get_byte())
+    for r in pl.range(pld.world_size()):
+        data = pld.window(data_buf, [1, BROADCAST_RUNTIME_SIZE], dtype=pl.FP32)
+        sig = pld.window(signal_buf, [DYNAMIC_NRANKS, 1], dtype=pl.INT32)
+        _dynamic_broadcast_chip(inputs[r], outputs[r], data, sig, r, device=r)
+    return outputs
 
 
 class TestL3TensorBroadcastIntrinsic:
@@ -114,30 +169,76 @@ class TestL3TensorBroadcastIntrinsic:
     bit-identical to the hand-written ``test_l3_broadcast.py`` reference.
     """
 
+    @pytest.mark.parametrize("size", [17, 4097, 65537])
     @pytest.mark.parametrize("n_ranks", [2, 4])
-    def test_broadcast_intrinsic(self, test_config, device_ids, n_ranks):
-        """Compile and run mesh broadcast for P=2 or P=4; skip when devices are scarce."""
+    def test_broadcast_intrinsic(self, test_config, device_ids, n_ranks, size):
+        """Compile and run mesh broadcast for P=2 or P=4; skip when devices are scarce.
+
+        SIZE values cover the InCore staging-tile-cap fix: 17 (unaligned,
+        exercises the floor-to-32-byte-aligned-width path — round DOWN, not
+        up, since the stage tile can never exceed the transfer it slides
+        through) and 4097 (one element past the 4096-element/16 KiB
+        chunk-budget boundary for FP32). SIZE=1 is not covered here: below one
+        32-byte alignment unit (8 FP32 elements) there is no stage width that
+        both satisfies pto.alloc_tile's alignment rule and still fits within
+        the transfer, a pre-existing gap this fix does not close. 65537 (the
+        original bug repro size — a [1, 65537] FP32 stage would reserve 256
+        KiB and overflow UB before this fix) requires running WITHOUT
+        --forked: with --forked, this case hangs (blocked in
+        futex_wait_queue, not an error) — this is a pre-existing `--forked`
+        + sim fork()-thread-lock deadlock, unrelated to this fix. Without
+        --forked, all three sizes pass cleanly for every composite in this
+        file.
+        """
         if len(device_ids) < n_ranks:
             pytest.skip(f"broadcast P={n_ranks} needs {n_ranks} devices, got {device_ids}")
 
-        program = _build_broadcast_program(n_ranks)
-        compiled = ir.compile(
-            program,
-            platform=test_config.platform,
-            distributed_config=DistributedConfig(
-                device_ids=device_ids[:n_ranks],
-                num_sub_workers=0,
+        program = _build_broadcast_program(n_ranks, size)
+        inputs = _make_rank_inputs(n_ranks, size)
+        outputs = torch.zeros((n_ranks, 1, size), dtype=torch.float32)
+        compiled = program.compile(
+            inputs,
+            outputs,
+            config=RunConfig(
+                platform=test_config.platform,
+                distributed_config=DistributedConfig(
+                    device_ids=device_ids[:n_ranks],
+                    num_sub_workers=0,
+                ),
             ),
         )
-
-        inputs = _make_rank_inputs(n_ranks)
-        outputs = torch.zeros((n_ranks, 1, SIZE), dtype=torch.float32)
-
-        compiled(inputs, outputs)
+        compiled(inputs, outputs, config=RunConfig(platform=test_config.platform))
 
         expected = _expected_broadcast(inputs)
         assert torch.allclose(outputs, expected), (
             f"broadcast intrinsic P={n_ranks} mismatch: max diff = {(outputs - expected).abs().max().item()}"
+        )
+
+    def test_broadcast_dynamic_target_shape_runtime(self, test_config, device_ids):
+        """Compile and execute a target whose trailing extent is runtime-bound."""
+        n_ranks = 2
+        size = 17
+        if len(device_ids) < n_ranks:
+            pytest.skip(f"dynamic broadcast P=2 needs 2 devices, got {device_ids}")
+
+        inputs = _make_rank_inputs(n_ranks, size)
+        outputs = torch.zeros_like(inputs)
+        compiled = _dynamic_broadcast_host.compile(
+            inputs,
+            outputs,
+            config=RunConfig(
+                platform=test_config.platform,
+                distributed_config=DistributedConfig(
+                    device_ids=device_ids[:n_ranks],
+                    num_sub_workers=0,
+                ),
+            ),
+        )
+        compiled(inputs, outputs, config=RunConfig(platform=test_config.platform))
+
+        expected = _expected_broadcast(inputs)
+        assert torch.allclose(outputs, expected), (
+            f"dynamic broadcast mismatch: max diff = {(outputs - expected).abs().max().item()}"
         )
 
 

--- a/tests/ut/ir/transforms/test_lower_composite_ops.py
+++ b/tests/ut/ir/transforms/test_lower_composite_ops.py
@@ -27,6 +27,7 @@ import pypto.language.distributed as pld
 import pytest
 from pypto import ir, passes
 from pypto.language.parser.diagnostics.exceptions import ParserError
+from pypto.pypto_core import ir as _ir_core
 
 _OP_PLD_TILE_REMOTE_LOAD = ir.get_op("pld.tile.remote_load").name
 _OP_TILE_LOAD = ir.get_op("tile.load").name
@@ -758,9 +759,9 @@ _AAV_MAX_RECV = 2
 _AAV_TOTAL = _AAV_NRANKS * _AAV_MAX_RECV
 
 
-def _build_all_to_all_v_before():
+def _build_all_to_all_v_before(size: int = _AAV_SIZE):
     """InCore program calling ``pld.tensor.all_to_all_v`` with runtime counts."""
-    SIZE = _AAV_SIZE
+    SIZE = size
     nr = _AAV_NRANKS
     total = _AAV_TOTAL
 
@@ -3357,6 +3358,210 @@ def test_ring_allreduce_epilogue_resets_every_row():
         offsets = notify.args[2]
         assert isinstance(offsets, ir.MakeTuple)
         assert len(offsets.elements) == 2
+
+
+class _StageShapeCollector(ir.IRVisitor):
+    """Record the static shape of every ``tile.create`` Call encountered."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.shapes: list[tuple[int, ...]] = []
+
+    def visit_call(self, op: ir.Call) -> None:
+        if op.op.name == _ir_core.get_op("tile.create").name and op.args:
+            shape = op.args[0]
+            if isinstance(shape, ir.MakeTuple):
+                dims = [d.value for d in shape.elements if isinstance(d, ir.ConstInt)]
+                if len(dims) == len(shape.elements):
+                    self.shapes.append(tuple(dims))
+        super().visit_call(op)
+
+
+def _stage_tile_shapes(prog) -> list[tuple[int, ...]]:
+    collector = _StageShapeCollector()
+    collector.visit_program(prog)
+    return collector.shapes
+
+
+def _expected_chunk_cols(size: int, chunk_elements: int = 4096, alignment: int = 8) -> int:
+    """Mirrors ``MakeCollectiveStageShape``'s column pick: a short extent
+    rounds DOWN to the nearest ``alignment``-element width — the stage is a
+    literal pld.tile.put/get bounce buffer and can never exceed the transfer
+    (ValidateStageFitsTransfer), so alignment can only come from shrinking it,
+    never padding past ``size`` — while anything at or past the chunk budget
+    takes the full chunk width. Only meaningful for ``size >= alignment``; a
+    shorter transfer has no valid aligned width that still fits within it.
+    """
+    if size >= chunk_elements:
+        return chunk_elements
+    if size >= alignment:
+        return (size // alignment) * alignment
+    return size
+
+
+@pytest.mark.parametrize("size", [17, 64, 65537])
+def test_broadcast_stage_tile_is_capped_to_one_chunk(size):
+    """The broadcast staging tile is a bounded bounce buffer, not a copy of the
+    transfer: pld.tile.get slides the full extent through it, so a large SIZE
+    must not scale the tile (a [1, 65537] FP32 stage is 256 KiB and overflows UB).
+    A short, non-tile-aligned SIZE (17) must round DOWN to a 32-byte-aligned
+    column width (never up -- the stage can never exceed the transfer) instead
+    of reserving that exact odd byte count.
+    """
+    nr = 2
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore)
+        def broadcast_step(
+            self,
+            data: pl.InOut[pld.DistributedTensor[[1, size], pl.FP32]],
+            signal: pl.InOut[pld.DistributedTensor[[nr, 1], pl.INT32]],
+        ) -> pld.DistributedTensor[[1, size], pl.FP32]:
+            data = pld.tensor.broadcast(data, signal, root=0)
+            return data
+
+    After = passes.lower_composite_ops()(Before)
+    # 16 KiB budget / 4 B per FP32 = 4096 elements.
+    assert (1, _expected_chunk_cols(size)) in _stage_tile_shapes(After)
+
+
+def test_broadcast_accepts_dynamic_target_shape():
+    """The stage no longer derives from the target's static extent, so a dynamic
+    trailing dim lowers instead of tripping "broadcast target shape must be static".
+    """
+    nr = 2
+    n = pl.dynamic("BROADCAST_DYNAMIC_N")
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore)
+        def broadcast_step(
+            self,
+            data: pl.InOut[pld.DistributedTensor[[1, n], pl.FP32]],
+            signal: pl.InOut[pld.DistributedTensor[[nr, 1], pl.INT32]],
+        ) -> pld.DistributedTensor[[1, n], pl.FP32]:
+            data = pld.tensor.broadcast(data, signal, root=0)
+            return data
+
+    # A dynamic dimension that appears only on DistributedTensor is not yet
+    # self-contained in Python printer roundtrips. Keep pass verification, but
+    # skip the unrelated RoundtripInstrument limitation (same workaround as
+    # test_allreduce_dynamic_mesh_lowering_reaches_pto_codegen).
+    from pypto.pypto_core import passes as _core_passes  # noqa: PLC0415
+
+    ctx = _core_passes.PassContext(
+        [_core_passes.VerificationInstrument(_core_passes.VerificationMode.BEFORE_AND_AFTER)]
+    )
+    with ctx:
+        After = passes.lower_composite_ops()(Before)
+
+    assert "pld.tensor.broadcast" not in set(_collect_op_names(After))
+    # A dynamic extent takes the full chunk bound.
+    assert (1, 4096) in _stage_tile_shapes(After)
+
+
+def test_broadcast_stage_row_product_saturates_without_overflow():
+    """Huge static leading dimensions saturate at the row budget safely."""
+    nr = 2
+    huge = 1 << 62
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore)
+        def broadcast_step(
+            self,
+            data: pl.InOut[pld.DistributedTensor[[huge, 4, 64], pl.FP32]],
+            signal: pl.InOut[pld.DistributedTensor[[nr, 1], pl.INT32]],
+        ) -> pld.DistributedTensor[[huge, 4, 64], pl.FP32]:
+            return pld.tensor.broadcast(data, signal, root=0)
+
+    After = passes.lower_composite_ops()(Before)
+    # 4096 FP32 elements / 64 columns = 64 stage rows.
+    assert (64, 64) in _stage_tile_shapes(After)
+
+
+@pytest.mark.parametrize("size", [17, 64, 65537])
+def test_allgather_stage_tile_is_capped_to_one_chunk(size):
+    """Same cap on the allgather push stage; chunk_shape stays the transfer extent.
+    A short, non-tile-aligned SIZE (17) must round DOWN to a 32-byte-aligned
+    column width (never up -- the stage can never exceed the transfer) instead
+    of reserving that exact odd byte count.
+    """
+    nr = 2
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore)
+        def gather_step(
+            self,
+            inp: pl.Tensor[[1, size], pl.FP32],
+            data: pl.InOut[pld.DistributedTensor[[nr, size], pl.FP32]],
+            signal: pl.InOut[pld.DistributedTensor[[nr, 1], pl.INT32]],
+        ) -> pld.DistributedTensor[[nr, size], pl.FP32]:
+            result = pld.tensor.allgather(inp, data, signal)
+            return result
+
+    After = passes.lower_composite_ops()(Before)
+    assert (1, _expected_chunk_cols(size)) in _stage_tile_shapes(After)
+
+
+@pytest.mark.parametrize(
+    "size,expected_cols",
+    [
+        (34, 34),  # even, below one 64-element packed row: documented unrounded gap
+        (66, 64),  # even, just past one packed 32-byte row: floor, never round up
+        (65536, 32768),  # full 16-KiB packed-FP4 chunk, not the GetByte() ceiling
+    ],
+)
+def test_allgather_fp4_stage_uses_physical_storage_width(size, expected_cols):
+    """Packed FP4 geometry uses 4 physical bits per logical element.
+
+    A 16-KiB stage therefore holds 32768 FP4 elements, not 16384 as
+    ``DataType.get_byte()``'s byte-ceiling would imply. Packed last
+    dimensions must be even; 66 is the short aligned-floor case (64), and
+    34 is below one 32-byte packed row so it stays unrounded.
+    """
+    nr = 2
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore)
+        def gather_step(
+            self,
+            inp: pl.Tensor[[1, size], pl.FP4],
+            data: pl.InOut[pld.DistributedTensor[[nr, size], pl.FP4]],
+            signal: pl.InOut[pld.DistributedTensor[[nr, 1], pl.INT32]],
+        ) -> pld.DistributedTensor[[nr, size], pl.FP4]:
+            return pld.tensor.allgather(inp, data, signal)
+
+    After = passes.lower_composite_ops()(Before)
+    assert (1, expected_cols) in _stage_tile_shapes(After)
+
+
+@pytest.mark.parametrize("size", [17, 64, 65537])
+def test_all_to_all_v_stage_tile_is_capped_to_one_chunk(size):
+    """Same cap on the all_to_all_v per-destination push stage — a 2D budget
+    trade-off, unlike the ``[1, SIZE]`` stage the other siblings use: rows
+    (MAX_RECV) shrink once the chosen column width alone saturates the chunk
+    byte budget (``MakeCollectiveStageShape``'s ``rows_budget = chunk_elements
+    // cols_val``). A short, non-tile-aligned SIZE (17) must also round its
+    column width DOWN to a 32-byte-aligned count, same as the other siblings.
+
+    all_to_all_v's own divisibility constraint stays a compile-time
+    ``[MAX_RECV, SIZE]`` (deliberately not relaxed — see Correction 3), but it
+    shares the same per-destination staging-tile bug as allgather/broadcast/
+    all_to_all: before this fix the stage was sized directly from ``SIZE``, so
+    a ``[MAX_RECV, 65537]`` FP32 stage still reserved 256 KiB and overflowed UB.
+    """
+    # 16 KiB budget / 4 B per FP32 = 4096 elements — mirrors MakeCollectiveStageShape's
+    # row/col trade-off exactly, rather than assuming rows stays fixed at MAX_RECV.
+    chunk_elements = 4096
+    cols = _expected_chunk_cols(size, chunk_elements=chunk_elements)
+    rows = min(_AAV_MAX_RECV, max(1, chunk_elements // cols))
+
+    After = passes.lower_composite_ops()(_build_all_to_all_v_before(size=size))
+    assert (rows, cols) in _stage_tile_shapes(After)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Bounds the shared **VEC (UB) staging tile** that InCore `pld.tensor.allgather`, `broadcast`, `all_to_all`, and `all_to_all_v` lower into for `pld.tile.put` / `pld.tile.get`.

This is a **correctness / on-chip capacity** fix, not a throughput or HBM savings change. TPUT/TGET already slide a transfer through a stage that may be smaller than the transfer (`ValidateStageFitsTransfer`). The composite rules previously sized that stage from the full logical extent, so large transfers reserved transfer-sized Unified Buffer and failed `AllocateMemoryAddr` before the kernel could run.

- Cap each shared VEC staging tile to the existing 16-KiB collective chunk budget (`kAllReduceChunkBytes`).
- Floor short static column widths to a 32-byte row boundary without allowing the stage to exceed the transfer.
- Keep the documented sub-alignment gap where no positive width can satisfy both constraints (e.g. FP32 `SIZE=1`).
- Derive chunk and alignment geometry from physical storage bits (packed FP4: 32768 logical elems / 16 KiB; 64 / 32-byte row).
- Saturate large static leading-dimension products in stage sizing and TPUT/TGET stage-fit validation.
- Keep a static UB bound for symbolic transfer dims; add real-hardware coverage for a runtime-bound broadcast extent.

## Why

The previous lowering treated the stage as a copy of the transfer. Example: FP32 `[1, 65537]` requested ~256 KiB of VEC and exceeded the ~184 KiB UB budget used by this pass's allreduce chunking assumptions.

That failure is an **allocator reject**, not a slow path. Payload size, HCCL window footprint, and wire bytes are unchanged. For transfers that already fitted in one chunk (e.g. FP32 `SIZE ≤ 4096`), stage sizing is essentially unchanged. For transfers larger than one chunk, the ISA may issue more slides through the bounded bounce buffer; the win is that those transfers become **runnable**.

A second boundary bug: FP32 `SIZE=17` cannot use a 17-column row (`pto.alloc_tile` requires 32-byte-aligned row bytes). The stage must floor to 16 columns—not ceil—because a static stage may not exceed the transfer. The leftover element rides the same partial last slide used for multi-chunk transfers.

## Relation to #1189

#1189 tracks compiler support for TP/EP collectives. This PR does **not** close that issue.

It fixes one concrete blocker on the **InCore** `pld.tensor.*` path: allgather / broadcast / all_to_all / all_to_all_v could not run transfers larger than VEC UB because their shared staging tile was sized from the full transfer. With the stage capped to one 16-KiB chunk (matching the existing allreduce chunk budget), those ops accept the same large / unaligned extents the InCore allreduce path already aimed at.

Still out of scope for #1189 (and not changed here): HOST-rail dtype widening beyond what is already supported, and HOST `reduce_scatter` remaining Sum-only.

## Implementation

`MakeCollectiveStageShape` flattens the transfer to `[rows, cols]`, selects an aligned bounded column width, and trades rows against columns while keeping `rows * cols` inside one chunk. Dynamic dims take the static chunk bound (same contract as `MakeTputStageShape` / user `chunk_cols`).

Geometry uses `storage_size::GetStorageBitWidth()` rather than byte-ceiling `DataType::GetByte()`.

`all_to_all_v` keeps `target.shape[0] % NR == 0` and runtime-clamped row counts; wire protocol unchanged.

## Tests

Affected STs use `@pl.jit` and the public JIT compile entry.

- allgather / broadcast / all_to_all: `SIZE={17,4097,65537}`
- all_to_all_v: same widths plus count boundaries `0`, `1`, `MAX_RECV`, negative, over-capacity
- broadcast: additional runtime-bound dynamic target-width execution
- lowering UTs: FP4 physical geometry and overflow-safe row-product coverage

Run the large-SIZE intrinsic cases **without** `--forked` (pre-existing sim fork/thread-lock hang under `--forked`, unrelated to this fix).

## Verification

Measured on the review branch before the final squash (historical heads `3be7668f` / `7f6653eb`); current PR tip is the single squashed commit on this branch.

- editable C++ build: PASS
- `tests/ut/ir/transforms/test_lower_composite_ops.py`: **142 passed**
- configured pre-commit on the changed files: **PASS**
- real a2a3, no `--forked`, P=2: **17 passed / 16 expected P=4 skips** on the four affected intrinsic files
- real a2a3, four cards: **33 passed** on those files
- earlier full real-a2a3 `tests/st/distributed/collectives` at `3be7668f`: **111/111 unique cases** across timeout-safe shards

Hardware was run in the native system container (`task-submit` unavailable here). No test expectations were weakened.

## Deliberate non-goals

- Sub-alignment widths (no stage width both 32-byte-aligned and ≤ transfer)
- HOST-rail dtype widening
- HOST `reduce_scatter` non-Sum residual
- Changing `all_to_all_v` capacity divisibility
- Throughput / HBM / network bandwidth improvements
