### PR TITLE
perf(lint,ci): scope pre-commit to the files a commit actually changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,6 +265,11 @@ jobs:
   # ---------------------------------------------------------------------------
   pre-commit:
     runs-on: ubuntu-latest
+    permissions:
+      # `pull-requests: read` is what the PR files API below needs; `contents: read`
+      # is for the checkout.
+      contents: read
+      pull-requests: read
 
     steps:
     - name: Checkout
@@ -273,10 +278,94 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.10'
+
+    # LINT SCOPE — a pull request lints the files it changed; everything else
+    # (a push to main, workflow_dispatch) sweeps the whole tree.
+    #
+    # The median pull request here touches 4 files out of ~1660 tracked, so
+    # `--all-files` was doing roughly four hundred times the necessary work, and
+    # doing it on the critical path: every other job lists this one in `needs`.
+    # pyright dominates that cost and is the part diff-scoping actually removes --
+    # it declares `require_serial: true` (it type-checks across files, so sharding
+    # it re-resolves the import graph per shard), which is why it cannot be
+    # parallelised the way the local hooks now are. Measured on real commits from
+    # this history, on a four-core runner: 51.7s over the whole tree against
+    # 2.8s / 7.6s / 9.2s over 2- / 6- / 34-file diffs.
+    #
+    # The file list comes from the PR files API rather than a `git diff`, matching
+    # the `changes` job above: it needs no fetch-depth: 0 clone and already reports
+    # the merge-base diff GitHub shows in the PR.
+    #
+    # Every uncertain path falls back to `--all-files`, never to a narrower run --
+    # a lint gate that silently checked less than it claimed would be worse than a
+    # slow one. That includes the case this scoping genuinely cannot cover: a
+    # change to a rule or to the hook config can make files the pull request never
+    # touched non-compliant, and only a full sweep would see them, so those pull
+    # requests get one.
+    - name: Decide lint scope
+      id: scope
+      env:
+        GH_TOKEN: ${{ github.token }}
+        EVENT_NAME: ${{ github.event_name }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        REPO: ${{ github.repository }}
+      run: |
+        set -euo pipefail
+
+        sweep() {
+          echo 'args=--all-files' >> "$GITHUB_OUTPUT"
+          echo "$1 -> --all-files"
+          exit 0
+        }
+
+        if [ "$EVENT_NAME" != 'pull_request' ]; then
+          sweep "event '$EVENT_NAME' is not a pull request"
+        fi
+
+        # Read the PR's own count first, so a truncated list is detectable below.
+        if ! expected="$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.changed_files')"; then
+          sweep 'PR metadata request failed'
+        fi
+        if ! files="$(gh api "repos/$REPO/pulls/$PR_NUMBER/files" --paginate \
+                        --jq '.[].filename')"; then
+          sweep 'PR files request failed'
+        fi
+        if [ -z "$files" ]; then
+          sweep 'no changed files reported'
+        fi
+
+        # The endpoint caps out at 3000 files, and a truncated list is still
+        # non-empty -- the unreported files would go unlinted in silence.
+        retrieved="$(printf '%s\n' "$files" | wc -l)"
+        if [ "$retrieved" -ne "$expected" ]; then
+          sweep "file list truncated ($retrieved of $expected)"
+        fi
+
+        if printf '%s\n' "$files" | grep -qE '^(tests/lint/|\.pre-commit-config\.yaml$)'; then
+          sweep 'a lint rule or the hook config changed'
+        fi
+
+        # A deleted or renamed-away path is in the API list but not in the
+        # checkout, and pre-commit would be handed a file that is not there.
+        # The test must be an `if` and not `[ -f "$f" ] && ...`: under `set -e` a
+        # trailing false test would make the whole substitution fail, so a pull
+        # request that only deletes files would fail the step rather than sweep.
+        existing="$(printf '%s\n' "$files" | while IFS= read -r f; do
+          if [ -f "$f" ]; then printf '%s\n' "$f"; fi
+        done)"
+        if [ -z "$existing" ]; then
+          sweep 'every changed path was deleted or renamed away'
+        fi
+
+        # No tracked path in this repository contains whitespace, so the list is
+        # safe to pass as a plain argument vector.
+        echo "args=--files $(printf '%s ' $existing)" >> "$GITHUB_OUTPUT"
+        printf '%s file(s) -> --files\n' "$(printf '%s\n' "$existing" | wc -l)"
+
     - name: pre-commit
       uses: pre-commit/action@v3.0.0
       with:
-        extra_args: --all-files
+        extra_args: ${{ steps.scope.outputs.args }}
 
   clang-tidy:
     # Build inputs come from build-constraints.txt rather than from whatever

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,12 +58,13 @@ repos:
           language: system
           files: ^(python/pypto/|python/bindings/|src/|include/).*\.(py|cpp|h)$
 
-        # The same script with no arguments, which additionally reports registry
-        # exceptions that no source uses -- a question only a whole-tree sweep can
-        # answer. Gated on the registry itself, the commit that can introduce one.
+        # The half of the same script that no file-scoped run can answer: whether
+        # some registry exception is now unused. An exception names one exact file,
+        # so this reads only those, never the tree. Gated on the registry itself,
+        # the commit that can introduce an unused one.
         - id: check-environment-registry
           name: check-environment-registry
-          entry: python tests/lint/check_environment_inputs.py
+          entry: python tests/lint/check_environment_inputs.py --unused-exceptions-only
           language: system
           pass_filenames: false
           files: ^(python/pypto/_environment\.json|tests/lint/check_environment_inputs\.py)$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,7 @@ repos:
           entry: python tests/lint/check_docs_en_zh_parity.py
           language: system
           pass_filenames: false
+          files: ^(docs/|tests/lint/check_docs_en_zh_parity\.py$)
 
         - id: check-docs-nav
           name: check-docs-nav
@@ -38,12 +39,14 @@ repos:
           language_version: python3
           additional_dependencies: [pyyaml]
           pass_filenames: false
+          files: ^(docs/|mkdocs\.yml$|tests/lint/check_docs_nav\.py$)
 
         - id: check-docs-symbol-coverage
           name: check-docs-symbol-coverage
           entry: python tests/lint/check_docs_symbol_coverage.py
           language: system
           pass_filenames: false
+          files: ^(docs/en/user/|python/pypto/language/|tests/lint/check_docs_symbol_coverage\.py$)
 
         - id: check-no-broad-raises
           name: check-no-broad-raises
@@ -56,6 +59,7 @@ repos:
           entry: python tests/lint/check_environment_inputs.py
           language: system
           pass_filenames: false
+          files: ^(python/pypto/|python/bindings/|src/|include/|tests/lint/check_environment_inputs\.py$)
 
         - id: check-emitter-check-classification
           name: check-emitter-check-classification
@@ -74,24 +78,28 @@ repos:
           entry: python tests/lint/check_function_attr_key_parity.py
           language: system
           pass_filenames: false
+          files: ^(include/|src/|python/|tests/lint/check_function_attr_key_parity\.py$)
 
         - id: check-op-docstring-parity
           name: check-op-docstring-parity
           entry: python tests/lint/check_op_docstring_parity.py
           language: system
           pass_filenames: false
+          files: ^(python/pypto/(ir|language)/op/|tests/lint/check_op_docstring_parity\.py$)
 
         - id: check-ir-property-parity
           name: check-ir-property-parity
           entry: python tests/lint/check_ir_property_parity.py
           language: system
           pass_filenames: false
+          files: ^(include/pypto/ir/transforms/ir_property\.h|src/ir/transforms/ir_property\.cpp|python/bindings/modules/passes\.cpp|python/pypto/pypto_core/passes\.pyi|tests/lint/check_ir_property_parity\.py)$
 
         - id: check-property-set-doc-parity
           name: check-property-set-doc-parity
           entry: python tests/lint/check_property_set_doc_parity.py
           language: system
           pass_filenames: false
+          files: ^(include/pypto/ir/transforms/ir_property\.h|src/ir/transforms/ir_property\.cpp|docs/(en|zh)/dev/passes/99-verifier\.md|tests/lint/check_property_set_doc_parity\.py)$
 
     - repo: https://github.com/pre-commit/pre-commit-hooks
       rev: v4.6.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,8 +56,17 @@ repos:
           name: check-environment-inputs
           entry: python tests/lint/check_environment_inputs.py
           language: system
+          files: ^(python/pypto/|python/bindings/|src/|include/).*\.(py|cpp|h)$
+
+        # The same script with no arguments, which additionally reports registry
+        # exceptions that no source uses -- a question only a whole-tree sweep can
+        # answer. Gated on the registry itself, the commit that can introduce one.
+        - id: check-environment-registry
+          name: check-environment-registry
+          entry: python tests/lint/check_environment_inputs.py
+          language: system
           pass_filenames: false
-          files: ^(python/pypto/|python/bindings/|src/|include/|tests/lint/check_environment_inputs\.py$)
+          files: ^(python/pypto/_environment\.json|tests/lint/check_environment_inputs\.py)$
 
         - id: check-emitter-check-classification
           name: check-emitter-check-classification
@@ -75,8 +84,7 @@ repos:
           name: check-function-attr-key-parity
           entry: python tests/lint/check_function_attr_key_parity.py
           language: system
-          pass_filenames: false
-          files: ^(include/|src/|python/|tests/lint/check_function_attr_key_parity\.py$)
+          files: ^(include/|src/|python/).*\.(h|hpp|cpp|cc|py)$
 
         - id: check-op-docstring-parity
           name: check-op-docstring-parity

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,23 +15,20 @@ repos:
         - id: check-headers
           name: check-headers
           entry: python tests/lint/check_headers.py
-          language: python
-          language_version: python3
+          language: system
           pass_filenames: false
 
         - id: check-english-only
           name: check-english-only
           entry: python tests/lint/check_english_only.py
-          language: python
-          language_version: python3
+          language: system
           pass_filenames: false
           exclude: ^(3rdparty/|docs/zh/|README\.zh-CN\.md)
 
         - id: check-docs-en-zh-parity
           name: check-docs-en-zh-parity
           entry: python tests/lint/check_docs_en_zh_parity.py
-          language: python
-          language_version: python3
+          language: system
           pass_filenames: false
 
         - id: check-docs-nav
@@ -45,64 +42,55 @@ repos:
         - id: check-docs-symbol-coverage
           name: check-docs-symbol-coverage
           entry: python tests/lint/check_docs_symbol_coverage.py
-          language: python
-          language_version: python3
+          language: system
           pass_filenames: false
 
         - id: check-no-broad-raises
           name: check-no-broad-raises
           entry: python tests/lint/check_no_broad_raises.py
-          language: python
-          language_version: python3
+          language: system
           pass_filenames: false
 
         - id: check-environment-inputs
           name: check-environment-inputs
           entry: python tests/lint/check_environment_inputs.py
-          language: python
-          language_version: python3.10
+          language: system
           pass_filenames: false
 
         - id: check-emitter-check-classification
           name: check-emitter-check-classification
           entry: python tests/lint/check_emitter_check_classification.py
-          language: python
-          language_version: python3
+          language: system
           pass_filenames: false
 
         - id: check-op-name-literals
           name: check-op-name-literals
           entry: python tests/lint/check_op_name_literals.py
-          language: python
-          language_version: python3
+          language: system
           pass_filenames: false
 
         - id: check-function-attr-key-parity
           name: check-function-attr-key-parity
           entry: python tests/lint/check_function_attr_key_parity.py
-          language: python
-          language_version: python3
+          language: system
           pass_filenames: false
 
         - id: check-op-docstring-parity
           name: check-op-docstring-parity
           entry: python tests/lint/check_op_docstring_parity.py
-          language: python
-          language_version: python3
+          language: system
           pass_filenames: false
 
         - id: check-ir-property-parity
           name: check-ir-property-parity
           entry: python tests/lint/check_ir_property_parity.py
-          language: python
-          language_version: python3
+          language: system
           pass_filenames: false
 
         - id: check-property-set-doc-parity
           name: check-property-set-doc-parity
           entry: python tests/lint/check_property_set_doc_parity.py
-          language: python
-          language_version: python3
+          language: system
           pass_filenames: false
 
     - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,13 +16,11 @@ repos:
           name: check-headers
           entry: python tests/lint/check_headers.py
           language: system
-          pass_filenames: false
 
         - id: check-english-only
           name: check-english-only
           entry: python tests/lint/check_english_only.py
           language: system
-          pass_filenames: false
           exclude: ^(3rdparty/|docs/zh/|README\.zh-CN\.md)
 
         - id: check-docs-en-zh-parity
@@ -52,7 +50,7 @@ repos:
           name: check-no-broad-raises
           entry: python tests/lint/check_no_broad_raises.py
           language: system
-          pass_filenames: false
+          files: ^tests/.*\.py$
 
         - id: check-environment-inputs
           name: check-environment-inputs
@@ -65,13 +63,13 @@ repos:
           name: check-emitter-check-classification
           entry: python tests/lint/check_emitter_check_classification.py
           language: system
-          pass_filenames: false
+          files: ^src/(codegen|backend)/.*\.(cpp|cc|h|hpp)$
 
         - id: check-op-name-literals
           name: check-op-name-literals
           entry: python tests/lint/check_op_name_literals.py
           language: system
-          pass_filenames: false
+          files: ^(tests|python)/.*\.py$
 
         - id: check-function-attr-key-parity
           name: check-function-attr-key-parity

--- a/tests/lint/_scan.py
+++ b/tests/lint/_scan.py
@@ -33,7 +33,7 @@ import sys
 from collections.abc import Iterable, Sequence
 from pathlib import Path
 
-__all__ = ["resolve", "tracked_files"]
+__all__ = ["resolve", "select", "tracked_files"]
 
 
 def tracked_files(root: Path, scan_roots: Sequence[str] = ()) -> list[Path]:
@@ -76,6 +76,38 @@ def _within(path: Path, root: Path, scan_roots: Sequence[str]) -> bool:
     return any(relative == r or relative.startswith(f"{r.rstrip('/')}/") for r in scan_roots)
 
 
+def select(
+    root: Path,
+    selected: Iterable[Path],
+    scan_roots: Sequence[str] = (),
+    suffixes: Iterable[str] | None = None,
+) -> list[Path]:
+    """The subset of *selected* that a whole-tree run over the same scope would have visited.
+
+    Anything outside the repo or the scan roots, carrying an unwanted suffix, or no longer on
+    disk (a file deleted in the same commit) is dropped rather than checked on different terms.
+
+    Args:
+        root: Repository root. Relative arguments are resolved against it, matching how
+            pre-commit passes them, rather than against the process working directory.
+        selected: Paths passed on the command line.
+        scan_roots: Repo-relative directories the checker is scoped to; empty means the whole repo.
+        suffixes: File suffixes to keep, e.g. ``{".py"}``; ``None`` keeps every suffix.
+
+    Returns:
+        Absolute paths, sorted and de-duplicated.
+    """
+    keep = set(suffixes) if suffixes is not None else None
+    return sorted(
+        {
+            path
+            for raw in selected
+            for path in [raw if raw.is_absolute() else root / raw]
+            if path.is_file() and (keep is None or path.suffix in keep) and _within(path, root, scan_roots)
+        }
+    )
+
+
 def resolve(
     root: Path,
     selected: Iterable[Path] | None,
@@ -96,20 +128,8 @@ def resolve(
     Returns:
         Absolute paths, sorted and de-duplicated.
     """
-    keep = set(suffixes) if suffixes is not None else None
-
-    def wanted(path: Path) -> bool:
-        return keep is None or path.suffix in keep
-
     selected = list(selected or ())
-    if not selected:
-        return [path for path in tracked_files(root, scan_roots) if wanted(path)]
-
-    resolved = {
-        path
-        for raw in selected
-        # A relative argument is repo-relative, matching how pre-commit passes it.
-        for path in [raw if raw.is_absolute() else root / raw]
-        if path.is_file() and wanted(path) and _within(path, root, scan_roots)
-    }
-    return sorted(resolved)
+    if selected:
+        return select(root, selected, scan_roots, suffixes)
+    keep = set(suffixes) if suffixes is not None else None
+    return [path for path in tracked_files(root, scan_roots) if keep is None or path.suffix in keep]

--- a/tests/lint/_scan.py
+++ b/tests/lint/_scan.py
@@ -1,0 +1,115 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Shared file selection for the per-file lint checkers.
+
+Each of these checkers answers a question about one file in isolation -- does it carry the
+copyright header, does it hold a non-English run, does it assert a broad exception -- so it can
+run in either of two modes:
+
+* **file-scoped**, the pre-commit path: the hook is given the files in the commit. pre-commit
+  partitions that list across ``cpu_count()`` worker subprocesses, so the scan parallelises for
+  free, and a commit never pays to re-parse the ~1600 files it did not touch.
+* **whole-tree**, the no-argument path: a manual run, or a CI ``--all-files`` sweep, checks
+  every tracked file under the checker's scan roots.
+
+The two modes must agree: a file the whole-tree run would flag must also be flagged when it
+arrives as an argument, and a file the whole-tree run would never look at (wrong suffix, outside
+the scan roots) must be dropped in either mode rather than checked on different terms. Routing
+both through :func:`resolve` is what keeps that true -- the root and suffix filters are written
+once and applied to both.
+
+``pre-commit`` passes repo-relative paths; a hand-written invocation may pass absolute ones or a
+path outside the repo. All three are normalised here.
+"""
+
+import subprocess
+import sys
+from collections.abc import Iterable, Sequence
+from pathlib import Path
+
+__all__ = ["resolve", "tracked_files"]
+
+
+def tracked_files(root: Path, scan_roots: Sequence[str] = ()) -> list[Path]:
+    """Every git-tracked file under *scan_roots* (or the whole repo when empty).
+
+    Args:
+        root: Repository root; ``git ls-files`` runs here.
+        scan_roots: Repo-relative pathspecs to limit the listing to.
+
+    Returns:
+        Absolute paths, sorted, of the tracked entries that exist as files.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "ls-files", "--", *scan_roots],
+            cwd=root,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError as e:
+        print(f"Error: Failed to get git tracked files: {e}", file=sys.stderr)
+        sys.exit(1)
+    except FileNotFoundError:
+        print("Error: git command not found", file=sys.stderr)
+        sys.exit(1)
+
+    paths = (root / line for line in result.stdout.splitlines() if line)
+    return sorted(path for path in paths if path.is_file())
+
+
+def _within(path: Path, root: Path, scan_roots: Sequence[str]) -> bool:
+    """Whether *path* lies inside the repo and under one of *scan_roots*."""
+    try:
+        relative = path.relative_to(root).as_posix()
+    except ValueError:
+        return False  # outside the repository entirely
+    if not scan_roots:
+        return True
+    return any(relative == r or relative.startswith(f"{r.rstrip('/')}/") for r in scan_roots)
+
+
+def resolve(
+    root: Path,
+    selected: Iterable[Path] | None,
+    scan_roots: Sequence[str] = (),
+    suffixes: Iterable[str] | None = None,
+) -> list[Path]:
+    """The files to check: the caller's explicit selection, else the whole tree.
+
+    The same root and suffix filters apply to both modes, so a file-scoped run visits exactly
+    the subset of files a whole-tree run would have visited.
+
+    Args:
+        root: Repository root.
+        selected: Paths passed on the command line by pre-commit, or empty/None for whole-tree.
+        scan_roots: Repo-relative directories the checker is scoped to; empty means the whole repo.
+        suffixes: File suffixes to keep, e.g. ``{".py"}``; ``None`` keeps every suffix.
+
+    Returns:
+        Absolute paths, sorted and de-duplicated.
+    """
+    keep = set(suffixes) if suffixes is not None else None
+
+    def wanted(path: Path) -> bool:
+        return keep is None or path.suffix in keep
+
+    selected = list(selected or ())
+    if not selected:
+        return [path for path in tracked_files(root, scan_roots) if wanted(path)]
+
+    resolved = {
+        path
+        for raw in selected
+        # A relative argument is repo-relative, matching how pre-commit passes it.
+        for path in [raw if raw.is_absolute() else root / raw]
+        if path.is_file() and wanted(path) and _within(path, root, scan_roots)
+    }
+    return sorted(resolved)

--- a/tests/lint/check_emitter_check_classification.py
+++ b/tests/lint/check_emitter_check_classification.py
@@ -42,9 +42,10 @@ both hides real checks after the literal and can report text inside one as code.
 
 import argparse
 import re
-import subprocess
 import sys
 from pathlib import Path
+
+from _scan import resolve
 
 # Trees that run after verification. Everything here is post-verification by construction.
 SCANNED_DIRS = ("src/codegen", "src/backend")
@@ -70,31 +71,6 @@ _ARITY_ALIAS_RE = re.compile(
 _IDENT_RE = re.compile(r"\b[A-Za-z_]\w*\b")
 
 _INTERNAL_MARKER = "internal error"
-
-
-def get_git_tracked_sources(root_dir: Path) -> list[Path]:
-    """Get the git-tracked C++ sources under the scanned emitter trees."""
-    try:
-        result = subprocess.run(
-            ["git", "ls-files", "--", *SCANNED_DIRS],
-            cwd=root_dir,
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-    except subprocess.CalledProcessError as e:
-        print(f"Error: Failed to get git tracked files: {e}", file=sys.stderr)
-        sys.exit(1)
-    except FileNotFoundError:
-        print("Error: git command not found", file=sys.stderr)
-        sys.exit(1)
-
-    files = []
-    for line in result.stdout.splitlines():
-        path = root_dir / line
-        if Path(line).suffix in SOURCE_SUFFIXES and path.is_file():
-            files.append(path)
-    return sorted(files)
 
 
 def _blank_line_comment(text: str, out: list[str], i: int, n: int) -> int:
@@ -285,11 +261,17 @@ def main() -> int:
         default=Path(__file__).resolve().parents[2],
         help="Repository root (defaults to the repo containing this script)",
     )
+    parser.add_argument(
+        "files",
+        nargs="*",
+        type=Path,
+        help=f"Files to check (default: every git-tracked C++ source under {', '.join(SCANNED_DIRS)})",
+    )
     args = parser.parse_args()
     root_dir = args.root.resolve()
 
     total = 0
-    for path in get_git_tracked_sources(root_dir):
+    for path in resolve(root_dir, args.files, SCANNED_DIRS, SOURCE_SUFFIXES):
         rel = path.relative_to(root_dir).as_posix()
         for line, rule, detail in find_violations(path):
             if f"{rel}:{line}" in ALLOWLIST:

--- a/tests/lint/check_english_only.py
+++ b/tests/lint/check_english_only.py
@@ -13,37 +13,13 @@ Detects non-English text (e.g., Chinese, Japanese, Korean, etc.) in source files
 
 import argparse
 import re
-import subprocess
 import sys
 from pathlib import Path
 
+from _scan import resolve
+
 # Default excluded directories (can be overridden via --exclude)
 DEFAULT_EXCLUDED_PATTERNS = ["3rdparty", "reference", "docs/zh", "README.zh-CN.md"]
-
-
-def get_git_tracked_files(root_dir: Path) -> list[Path]:
-    """Get list of files tracked by git."""
-    try:
-        result = subprocess.run(
-            ["git", "ls-files"],
-            cwd=root_dir,
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        files = []
-        for line in result.stdout.strip().split("\n"):
-            if line:
-                file_path = root_dir / line
-                if file_path.is_file():
-                    files.append(file_path)
-        return files
-    except subprocess.CalledProcessError as e:
-        print(f"Error: Failed to get git tracked files: {e}", file=sys.stderr)
-        sys.exit(1)
-    except FileNotFoundError:
-        print("Error: git command not found", file=sys.stderr)
-        sys.exit(1)
 
 
 def contains_non_english(text: str) -> tuple[bool, list[tuple[int, str]]]:
@@ -108,10 +84,16 @@ def main() -> int:
         description="Check that all source files and documentation are in English only"
     )
     parser.add_argument(
-        "path",
-        nargs="?",
-        default=".",
-        help="Path to git repository (default: current directory)",
+        "--root",
+        type=Path,
+        default=Path(__file__).resolve().parents[2],
+        help="Repository root (defaults to the repo containing this script)",
+    )
+    parser.add_argument(
+        "files",
+        nargs="*",
+        type=Path,
+        help="Files to check (default: every git-tracked file in the repo)",
     )
     parser.add_argument("--verbose", "-v", action="store_true", help="Verbose output")
     parser.add_argument(
@@ -123,18 +105,18 @@ def main() -> int:
 
     args = parser.parse_args()
 
-    root_path = Path(args.path).resolve()
+    root_path = args.root.resolve()
 
     if not root_path.exists():
         print(f"Error: Path '{root_path}' does not exist", file=sys.stderr)
         return 1
 
+    # A worktree's .git is a file rather than a directory, so test existence, not is_dir().
     if not (root_path / ".git").exists():
         print(f"Error: '{root_path}' is not a git repository", file=sys.stderr)
         return 1
 
-    # Get all git-tracked files
-    all_files = get_git_tracked_files(root_path)
+    all_files = resolve(root_path, args.files)
 
     # Combine default exclusions with user-provided ones
     excluded_patterns = DEFAULT_EXCLUDED_PATTERNS.copy()

--- a/tests/lint/check_environment_inputs.py
+++ b/tests/lint/check_environment_inputs.py
@@ -300,6 +300,44 @@ def selected_sources(root: Path, selected: Iterable[Path]) -> list[Path]:
     return sorted(set(keep))
 
 
+def _reads(path: Path) -> list[EnvironmentRead]:
+    """Every environment read in *path*, parsed per its language."""
+    text = path.read_text()
+    return python_reads(text) if path.suffix == ".py" else cpp_reads(text)
+
+
+def _exception_set(registry: dict[str, Any]) -> set[tuple[str, str]]:
+    return {(item["path"], item["function"]) for item in registry.get("dynamic_reads", [])}
+
+
+def _unused_report(exceptions: set[tuple[str, str]], used: set[tuple[str, str]]) -> list[str]:
+    return [
+        f"Unused dynamic-read exception: {path}:{function}" for path, function in sorted(exceptions - used)
+    ]
+
+
+def unused_exceptions(root: Path, registry: dict[str, Any]) -> list[str]:
+    """Report dynamic-read exceptions that no source uses.
+
+    ``check_registry`` rejects a wildcard or absolute exception path, so an exception names
+    one exact file and only *that* file can mark it used. Reading just those files answers
+    the question exactly as a whole-tree sweep would, without re-reading the ~526 sources
+    the file-scoped audit has already read.
+
+    ``selected_sources`` applies the same root and suffix filter :func:`all_sources` does,
+    so an exception naming a path outside the audited scope stays unused here, as before.
+    """
+    check_registry(registry)
+    exceptions = _exception_set(registry)
+    used = set()
+    for path in selected_sources(root, [Path(relative) for relative, _ in exceptions]):
+        relative = path.relative_to(root).as_posix()
+        for read in _reads(path):
+            if read.variable is None and (relative, read.function) in exceptions:
+                used.add((relative, read.function))
+    return _unused_report(exceptions, used)
+
+
 def check_tree(root: Path, registry: dict[str, Any], files: list[Path] | None = None) -> list[str]:
     """Report every unclassified read in PyPTO Python/C++ production sources.
 
@@ -307,28 +345,25 @@ def check_tree(root: Path, registry: dict[str, Any], files: list[Path] | None = 
         root: Repository root.
         registry: Parsed ``_environment.json``.
         files: Sources to audit. ``None`` means the whole tree, which additionally reports
-            dynamic-read exceptions that no source uses -- a question only a full sweep can
-            answer, since a file-scoped run cannot tell "unused" from "used elsewhere".
+            unused dynamic-read exceptions -- free there, since the sweep already visits
+            every file that could mark one used. A file-scoped run cannot answer that
+            question; :func:`unused_exceptions` answers it on its own.
     """
     check_registry(registry)
-    exceptions = {(item["path"], item["function"]) for item in registry.get("dynamic_reads", [])}
+    exceptions = _exception_set(registry)
     whole_tree = files is None
     used = set()
     errors = []
     for path in all_sources(root) if whole_tree else files or []:
         relative = path.relative_to(root).as_posix()
-        reads = python_reads(path.read_text()) if path.suffix == ".py" else cpp_reads(path.read_text())
-        for read in reads:
+        for read in _reads(path):
             if read.variable is None and (relative, read.function) in exceptions:
                 used.add((relative, read.function))
             elif read.variable not in registry["variables"]:
                 name = read.variable or f"dynamic read in {read.function}"
                 errors.append(f"{relative}:{read.line}: unclassified environment input: {name}")
     if whole_tree:
-        errors.extend(
-            f"Unused dynamic-read exception: {path}:{function}"
-            for path, function in sorted(exceptions - used)
-        )
+        errors.extend(_unused_report(exceptions, used))
     return errors
 
 
@@ -340,11 +375,21 @@ def main() -> int:
         type=Path,
         help="Sources to audit (default: the whole tree, which also reports unused exceptions)",
     )
+    parser.add_argument(
+        "--unused-exceptions-only",
+        action="store_true",
+        help="Only report unused dynamic-read exceptions, reading just the files they name",
+    )
     args = parser.parse_args()
+    if args.unused_exceptions_only and args.files:
+        parser.error("--unused-exceptions-only takes no file arguments")
 
     registry = json.loads((_ROOT / "python/pypto/_environment.json").read_text())
-    files = selected_sources(_ROOT, args.files) if args.files else None
-    errors = check_tree(_ROOT, registry, files)
+    if args.unused_exceptions_only:
+        errors = unused_exceptions(_ROOT, registry)
+    else:
+        files = selected_sources(_ROOT, args.files) if args.files else None
+        errors = check_tree(_ROOT, registry, files)
     for error in errors:
         print(error)
     return int(bool(errors))

--- a/tests/lint/check_environment_inputs.py
+++ b/tests/lint/check_environment_inputs.py
@@ -17,9 +17,11 @@ PyPTO consumers; implicit tool inputs in the registry need separate toolchain
 dependency discovery and are not certified by this source scan.
 """
 
+import argparse
 import ast
 import json
 import re
+from collections.abc import Iterable
 from pathlib import Path
 from typing import Any, NamedTuple
 
@@ -27,6 +29,16 @@ from _cpp_text import strip_cpp_comments
 
 _ROOT = Path(__file__).resolve().parents[2]
 _CATEGORIES = {"semantic", "tool_resolution", "fresh_request", "nonsemantic"}
+
+# Scan root -> the file suffixes audited under it. python/pypto holds the Python
+# sources; src, include and python/bindings hold the C++ ones. python/bindings is a
+# sibling of python/pypto, so the two never overlap.
+SCAN_ROOTS: dict[str, frozenset[str]] = {
+    "python/pypto": frozenset({".py"}),
+    "src": frozenset({".cpp", ".h"}),
+    "include": frozenset({".cpp", ".h"}),
+    "python/bindings": frozenset({".cpp", ".h"}),
+}
 
 
 class EnvironmentRead(NamedTuple):
@@ -251,16 +263,59 @@ def check_registry(registry: dict[str, Any]) -> None:
             raise ValueError("Dynamic-read exceptions must name an exact relative path and function")
 
 
-def check_tree(root: Path, registry: dict[str, Any]) -> list[str]:
-    """Report every unclassified read in PyPTO Python/C++ production sources."""
+def all_sources(root: Path) -> list[Path]:
+    """Every production source the registry governs.
+
+    The scan roots carry different suffixes -- ``python/pypto`` holds the Python sources,
+    the other three the C++ ones -- so :data:`SCAN_ROOTS` maps each root to its own set
+    rather than applying one filter to all four. Enumeration is by ``rglob`` rather than
+    ``git ls-files`` so that a source not yet added to the index is still audited.
+    """
+    files: list[Path] = []
+    for directory, suffixes in SCAN_ROOTS.items():
+        files.extend(sorted(p for p in (root / directory).rglob("*") if p.suffix in suffixes))
+    return files
+
+
+def selected_sources(root: Path, selected: Iterable[Path]) -> list[Path]:
+    """The subset of *selected* that :func:`all_sources` would have visited.
+
+    pre-commit hands this script the files in the commit; anything outside the scan roots,
+    or carrying a suffix that root does not scan, must be dropped rather than audited on
+    different terms from a whole-tree run.
+    """
+    keep = []
+    for raw in selected:
+        path = raw if raw.is_absolute() else root / raw
+        if not path.is_file():
+            continue
+        try:
+            relative = path.relative_to(root).as_posix()
+        except ValueError:
+            continue
+        for directory, suffixes in SCAN_ROOTS.items():
+            if relative.startswith(f"{directory}/") and path.suffix in suffixes:
+                keep.append(path)
+                break
+    return sorted(set(keep))
+
+
+def check_tree(root: Path, registry: dict[str, Any], files: list[Path] | None = None) -> list[str]:
+    """Report every unclassified read in PyPTO Python/C++ production sources.
+
+    Args:
+        root: Repository root.
+        registry: Parsed ``_environment.json``.
+        files: Sources to audit. ``None`` means the whole tree, which additionally reports
+            dynamic-read exceptions that no source uses -- a question only a full sweep can
+            answer, since a file-scoped run cannot tell "unused" from "used elsewhere".
+    """
     check_registry(registry)
     exceptions = {(item["path"], item["function"]) for item in registry.get("dynamic_reads", [])}
+    whole_tree = files is None
     used = set()
     errors = []
-    files = sorted((root / "python" / "pypto").rglob("*.py"))
-    for directory in ("src", "include", "python/bindings"):
-        files.extend(sorted(path for path in (root / directory).rglob("*") if path.suffix in {".cpp", ".h"}))
-    for path in files:
+    for path in all_sources(root) if whole_tree else files or []:
         relative = path.relative_to(root).as_posix()
         reads = python_reads(path.read_text()) if path.suffix == ".py" else cpp_reads(path.read_text())
         for read in reads:
@@ -269,15 +324,27 @@ def check_tree(root: Path, registry: dict[str, Any]) -> list[str]:
             elif read.variable not in registry["variables"]:
                 name = read.variable or f"dynamic read in {read.function}"
                 errors.append(f"{relative}:{read.line}: unclassified environment input: {name}")
-    errors.extend(
-        f"Unused dynamic-read exception: {path}:{function}" for path, function in sorted(exceptions - used)
-    )
+    if whole_tree:
+        errors.extend(
+            f"Unused dynamic-read exception: {path}:{function}"
+            for path, function in sorted(exceptions - used)
+        )
     return errors
 
 
 def main() -> int:
+    parser = argparse.ArgumentParser(description="Check that environment reads are registered.")
+    parser.add_argument(
+        "files",
+        nargs="*",
+        type=Path,
+        help="Sources to audit (default: the whole tree, which also reports unused exceptions)",
+    )
+    args = parser.parse_args()
+
     registry = json.loads((_ROOT / "python/pypto/_environment.json").read_text())
-    errors = check_tree(_ROOT, registry)
+    files = selected_sources(_ROOT, args.files) if args.files else None
+    errors = check_tree(_ROOT, registry, files)
     for error in errors:
         print(error)
     return int(bool(errors))

--- a/tests/lint/check_function_attr_key_parity.py
+++ b/tests/lint/check_function_attr_key_parity.py
@@ -66,6 +66,7 @@ import sys
 from pathlib import Path
 
 from _cpp_text import strip_cpp_comments
+from _scan import select
 
 # Declaration sites, relative to the repo root.
 CPP_DECL = "include/pypto/ir/function.h"
@@ -73,6 +74,9 @@ PY_DECL = "python/pypto/_function_attrs.py"
 
 # Directories scanned for bare literals, relative to the repo root.
 SCAN_ROOTS = ("include", "src", "python")
+
+CPP_SUFFIXES = frozenset({".h", ".hpp", ".cpp", ".cc"})
+SCANNED_SUFFIXES = CPP_SUFFIXES | {".py"}
 
 # Paths exempt from the bare-literal scan: the two declaration sites, which necessarily spell each
 # key once. ``.pyi`` stubs are outside the scan by construction -- only ``.py`` is parsed.
@@ -249,9 +253,32 @@ def scan_py(path: Path, rel: str, keys: dict[str, str | None]) -> list[str]:
     return scanner.errors
 
 
+def scanned_sources(root: Path, selected: list[Path]) -> list[Path]:
+    """The files to scan for bare key literals.
+
+    With no selection this enumerates the scan roots by ``rglob`` -- not ``git ls-files`` --
+    so a source not yet added to the index is still scanned. A selection (pre-commit passing
+    the commit's files) is filtered down to that same scope.
+    """
+    if selected:
+        return select(root, selected, SCAN_ROOTS, SCANNED_SUFFIXES)
+    files: list[Path] = []
+    for scan_root in SCAN_ROOTS:
+        base = root / scan_root
+        if base.is_dir():
+            files.extend(sorted(p for p in base.rglob("*") if p.is_file()))
+    return files
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--root", default=None, help="Repository root (default: inferred)")
+    parser.add_argument(
+        "files",
+        nargs="*",
+        type=Path,
+        help=f"Files to scan (default: every source under {'/, '.join(SCAN_ROOTS)}/)",
+    )
     args = parser.parse_args()
 
     root = Path(args.root).resolve() if args.root else Path(__file__).resolve().parents[2]
@@ -271,20 +298,14 @@ def main() -> int:
     py_by_key = {key: ident for ident, key in py.items()}
     py_keys: dict[str, str | None] = {key: py_by_key.get(key) for key in cpp_keys}
 
-    for scan_root in SCAN_ROOTS:
-        base = root / scan_root
-        if not base.is_dir():
+    for path in scanned_sources(root, args.files):
+        rel = path.relative_to(root).as_posix()
+        if rel in EXEMPT:
             continue
-        for path in sorted(base.rglob("*")):
-            if not path.is_file():
-                continue
-            rel = path.relative_to(root).as_posix()
-            if rel in EXEMPT:
-                continue
-            if path.suffix in (".h", ".hpp", ".cpp", ".cc"):
-                errors.extend(scan_cpp(path, rel, cpp_keys))
-            elif path.suffix == ".py":
-                errors.extend(scan_py(path, rel, py_keys))
+        if path.suffix in CPP_SUFFIXES:
+            errors.extend(scan_cpp(path, rel, cpp_keys))
+        elif path.suffix == ".py":
+            errors.extend(scan_py(path, rel, py_keys))
 
     if errors:
         print(

--- a/tests/lint/check_headers.py
+++ b/tests/lint/check_headers.py
@@ -11,9 +11,10 @@ Script to check copyright headers in source files.
 """
 
 import argparse
-import subprocess
 import sys
 from pathlib import Path
+
+from _scan import resolve
 
 # Define the expected headers
 PY_HEADER = """
@@ -67,31 +68,6 @@ FILE_NAME_HEADERS = {
     ".clang-format": PY_HEADER,
     ".clang-tidy": PY_HEADER,
 }
-
-
-def get_git_tracked_files(root_dir: Path) -> list[Path]:
-    """Get list of files tracked by git."""
-    try:
-        result = subprocess.run(
-            ["git", "ls-files"],
-            cwd=root_dir,
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        files = []
-        for line in result.stdout.strip().split("\n"):
-            if line:
-                file_path = root_dir / line
-                if file_path.is_file():
-                    files.append(file_path)
-        return files
-    except subprocess.CalledProcessError as e:
-        print(f"Error: Failed to get git tracked files: {e}", file=sys.stderr)
-        sys.exit(1)
-    except FileNotFoundError:
-        print("Error: git command not found", file=sys.stderr)
-        sys.exit(1)
 
 
 def check_file_header(file_path: Path) -> tuple[bool, str]:
@@ -148,27 +124,33 @@ def main():
     """Main function."""
     parser = argparse.ArgumentParser(description="Check copyright headers in git-tracked source files")
     parser.add_argument(
-        "path",
-        nargs="?",
-        default=".",
-        help="Path to git repository (default: current directory)",
+        "--root",
+        type=Path,
+        default=Path(__file__).resolve().parents[2],
+        help="Repository root (defaults to the repo containing this script)",
+    )
+    parser.add_argument(
+        "files",
+        nargs="*",
+        type=Path,
+        help="Files to check (default: every git-tracked file in the repo)",
     )
     parser.add_argument("--verbose", "-v", action="store_true", help="Verbose output")
 
     args = parser.parse_args()
 
-    root_path = Path(args.path).resolve()
+    root_path = args.root.resolve()
 
     if not root_path.exists():
         print(f"Error: Path '{root_path}' does not exist", file=sys.stderr)
         return 1
 
+    # A worktree's .git is a file rather than a directory, so test existence, not is_dir().
     if not (root_path / ".git").exists():
         print(f"Error: '{root_path}' is not a git repository", file=sys.stderr)
         return 1
 
-    # Get all git-tracked files
-    all_files = get_git_tracked_files(root_path)
+    all_files = resolve(root_path, args.files)
 
     # Filter out excluded directories
     excluded_patterns = ["reference"]

--- a/tests/lint/check_no_broad_raises.py
+++ b/tests/lint/check_no_broad_raises.py
@@ -24,9 +24,13 @@ flagged, and a broad type is caught anywhere in a tuple -- not just as its first
 
 import argparse
 import ast
-import subprocess
 import sys
 from pathlib import Path
+
+from _scan import resolve
+
+# Directories scanned, relative to the repo root.
+SCAN_ROOTS = ("tests",)
 
 # Tests that legitimately assert the exception *hierarchy* itself (e.g. "ValueError is catchable as
 # Exception"). Scoped to the exact class or function under test -- not the whole file -- so an
@@ -41,31 +45,6 @@ ALLOWLIST = frozenset(
 )
 
 BROAD_NAMES = frozenset({"Exception", "BaseException"})
-
-
-def get_git_tracked_test_files(root_dir: Path) -> list[Path]:
-    """Get list of git-tracked Python files under tests/."""
-    try:
-        result = subprocess.run(
-            ["git", "ls-files", "--", "tests"],
-            cwd=root_dir,
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-    except subprocess.CalledProcessError as e:
-        print(f"Error: Failed to get git tracked files: {e}", file=sys.stderr)
-        sys.exit(1)
-    except FileNotFoundError:
-        print("Error: git command not found", file=sys.stderr)
-        sys.exit(1)
-
-    files = []
-    for line in result.stdout.splitlines():
-        path = root_dir / line
-        if line.endswith(".py") and path.is_file():
-            files.append(path)
-    return files
 
 
 def _is_raises_call(node: ast.Call, aliases: set[str]) -> bool:
@@ -126,11 +105,17 @@ def main() -> int:
         default=Path(__file__).resolve().parents[2],
         help="Repository root (defaults to the repo containing this script)",
     )
+    parser.add_argument(
+        "files",
+        nargs="*",
+        type=Path,
+        help="Files to check (default: every git-tracked .py under tests/)",
+    )
     args = parser.parse_args()
     root_dir = args.root.resolve()
 
     total = 0
-    for path in get_git_tracked_test_files(root_dir):
+    for path in resolve(root_dir, args.files, SCAN_ROOTS, {".py"}):
         rel = path.relative_to(root_dir).as_posix()
         for lineno, exc_name, qualname in find_violations(path):
             site = f"{rel}::{qualname}"

--- a/tests/lint/check_op_name_literals.py
+++ b/tests/lint/check_op_name_literals.py
@@ -61,9 +61,10 @@ Scope and deliberate limits:
 import argparse
 import ast
 import re
-import subprocess
 import sys
 from pathlib import Path
+
+from _scan import resolve
 
 # Sites that legitimately compare a bare literal. Scoped to the exact class or function -- not the
 # whole file -- so an unrelated bare comparison added to one of these files later is still reported.
@@ -89,31 +90,6 @@ COLLECTION_BUILDERS = frozenset({"frozenset", "set", "list", "tuple"})
 
 LITERAL_OPS = (ast.Eq, ast.NotEq)
 MEMBERSHIP_OPS = (ast.In, ast.NotIn)
-
-
-def get_git_tracked_files(root_dir: Path) -> list[Path]:
-    """Get list of git-tracked Python files under the scanned roots."""
-    try:
-        result = subprocess.run(
-            ["git", "ls-files", "--", *SCAN_ROOTS],
-            cwd=root_dir,
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-    except subprocess.CalledProcessError as e:
-        print(f"Error: Failed to get git tracked files: {e}", file=sys.stderr)
-        sys.exit(1)
-    except FileNotFoundError:
-        print("Error: git command not found", file=sys.stderr)
-        sys.exit(1)
-
-    files = []
-    for line in result.stdout.splitlines():
-        path = root_dir / line
-        if line.endswith(".py") and path.is_file():
-            files.append(path)
-    return files
 
 
 def _is_op_name_access(node: ast.expr) -> bool:
@@ -341,11 +317,17 @@ def main() -> int:
         default=Path(__file__).resolve().parents[2],
         help="Repository root (defaults to the repo containing this script)",
     )
+    parser.add_argument(
+        "files",
+        nargs="*",
+        type=Path,
+        help=f"Files to check (default: every git-tracked .py under {'/, '.join(SCAN_ROOTS)}/)",
+    )
     args = parser.parse_args()
     root_dir = args.root.resolve()
 
     total = 0
-    for path in get_git_tracked_files(root_dir):
+    for path in resolve(root_dir, args.files, SCAN_ROOTS, {".py"}):
         rel = path.relative_to(root_dir).as_posix()
         if rel == f"tests/lint/{Path(__file__).name}":
             continue

--- a/tests/ut/tools/test_check_emitter_check_classification.py
+++ b/tests/ut/tools/test_check_emitter_check_classification.py
@@ -16,6 +16,7 @@ line-window or regex implementation gets wrong.
 """
 
 import importlib.util
+import sys
 from pathlib import Path
 from types import ModuleType
 
@@ -23,7 +24,13 @@ import pytest
 
 
 def _load_lint() -> ModuleType:
-    path = Path(__file__).resolve().parents[2] / "lint" / "check_emitter_check_classification.py"
+    directory = Path(__file__).resolve().parents[2] / "lint"
+    # The checkers import their siblings bare (`from _scan import ...`), which resolves when a
+    # script is run directly because its own directory leads sys.path. Loading one by file path
+    # skips that, so put the directory on the path first.
+    if str(directory) not in sys.path:
+        sys.path.insert(0, str(directory))
+    path = directory / "check_emitter_check_classification.py"
     spec = importlib.util.spec_from_file_location("pypto_check_emitter_check_classification", path)
     assert spec is not None
     assert spec.loader is not None
@@ -140,7 +147,7 @@ def test_repository_is_clean() -> None:
     root = Path(__file__).resolve().parents[3]
     offenders = [
         f"{path.relative_to(root).as_posix()}:{line}: [rule {rule}] {detail}"
-        for path in lint.get_git_tracked_sources(root)
+        for path in lint.resolve(root, None, lint.SCANNED_DIRS, lint.SOURCE_SUFFIXES)
         for line, rule, detail in lint.find_violations(path)
         if f"{path.relative_to(root).as_posix()}:{line}" not in lint.ALLOWLIST
     ]

--- a/tests/ut/tools/test_check_environment_inputs.py
+++ b/tests/ut/tools/test_check_environment_inputs.py
@@ -204,6 +204,75 @@ def test_stale_dynamic_exceptions_fail(lint, tmp_path):
     ]
 
 
+def _write(tmp_path, files):
+    for relative, text in files.items():
+        path = tmp_path / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text)
+    return tmp_path
+
+
+# A source that uses the exception, one that does not, and one under a root the audit
+# does not cover. Each registry below is checked both ways; see the test's docstring.
+_SOURCES = {
+    "python/pypto/compiler.py": "import os\ndef restore(name):\n    os.getenv(name)\n",
+    "python/pypto/other.py": 'import os\nos.getenv("PYPTO_KNOWN")\n',
+    "tests/lint/helper.py": "import os\ndef restore(name):\n    os.getenv(name)\n",
+}
+
+
+@pytest.mark.parametrize(
+    "path, function",
+    [
+        # Used: the named file really does hold that dynamic read.
+        ("python/pypto/compiler.py", "restore"),
+        # Unused: right file, wrong function.
+        ("python/pypto/compiler.py", "absent"),
+        # Unused: the file does not exist.
+        ("python/pypto/removed.py", "restore"),
+        # Unused: the read exists but sits outside the audited roots, so a whole-tree
+        # sweep never sees it either.
+        ("tests/lint/helper.py", "restore"),
+    ],
+)
+def test_unused_exceptions_agrees_with_the_whole_tree_sweep(lint, tmp_path, path, function):
+    """The cheap path must reach the verdict the sweep it replaces would reach.
+
+    ``unused_exceptions`` reads only the files the exceptions name, on the grounds that
+    ``check_registry`` forbids a wildcard or absolute path so no other file can mark one
+    used. That reasoning is what this pins: for each shape of exception, its answer must
+    equal the unused-exception lines of a full ``check_tree`` sweep.
+    """
+    root = _write(tmp_path, _SOURCES)
+    registry = _registry()
+    registry["dynamic_reads"] = [{"path": path, "function": function, "reason": "Test."}]
+
+    swept = [e for e in lint.check_tree(root, registry) if e.startswith("Unused dynamic-read")]
+    assert lint.unused_exceptions(root, registry) == swept
+
+
+def test_unused_exceptions_does_not_read_files_no_exception_names(lint, tmp_path):
+    """The performance property, asserted rather than assumed.
+
+    An unparseable source makes the whole-tree sweep raise, because it reads every file.
+    ``unused_exceptions`` must not, which is only true if it never opens that file.
+    """
+    root = _write(tmp_path, {**_SOURCES, "python/pypto/broken.py": "def (((\n"})
+    registry = _registry()
+    registry["dynamic_reads"] = [
+        {"path": "python/pypto/compiler.py", "function": "restore", "reason": "Test."}
+    ]
+
+    with pytest.raises(SyntaxError):
+        lint.check_tree(root, registry)
+    assert lint.unused_exceptions(root, registry) == []
+
+
+def test_unused_exceptions_reports_nothing_when_the_registry_has_none(lint, tmp_path):
+    root = _write(tmp_path, _SOURCES)
+    assert lint.unused_exceptions(root, _registry()) == []
+
+
 @pytest.mark.parametrize("category, reason", [("unknown", "Some input"), ("semantic", "")])
 def test_registry_requires_a_supported_category_and_reason(lint, category, reason):
     registry = _registry()

--- a/tests/ut/tools/test_lint_scan.py
+++ b/tests/ut/tools/test_lint_scan.py
@@ -1,0 +1,140 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Tests for the shared file selection behind the per-file lint checkers.
+
+``tests/lint/_scan.py`` is what lets those checkers run in two modes -- given the commit's files
+by pre-commit, or given nothing and sweeping the tree. The property that makes the split safe is
+that the two modes agree: a file the whole-tree run would visit must also be visited when it
+arrives as an argument, and a file the whole-tree run would skip must be skipped either way.
+These tests pin that agreement, plus the argument normalisation pre-commit relies on.
+"""
+
+import importlib.util
+import subprocess
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+def _load_scan() -> ModuleType:
+    path = Path(__file__).resolve().parents[2] / "lint" / "_scan.py"
+    spec = importlib.util.spec_from_file_location("pypto_lint_scan", path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+scan = _load_scan()
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A tiny git repo with tracked files in and out of a `tests/` scan root."""
+    for rel in ("tests/a.py", "tests/sub/b.py", "tests/c.txt", "python/d.py", "src/e.cpp"):
+        path = tmp_path / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("x\n")
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True)
+    return tmp_path
+
+
+def _rel(root: Path, paths: list[Path]) -> list[str]:
+    return [p.relative_to(root).as_posix() for p in paths]
+
+
+def test_whole_tree_applies_root_and_suffix_filters(repo: Path) -> None:
+    assert _rel(repo, scan.resolve(repo, None, ("tests",), {".py"})) == ["tests/a.py", "tests/sub/b.py"]
+
+
+def test_whole_tree_without_filters_returns_every_tracked_file(repo: Path) -> None:
+    assert _rel(repo, scan.resolve(repo, None)) == [
+        "python/d.py",
+        "src/e.cpp",
+        "tests/a.py",
+        "tests/c.txt",
+        "tests/sub/b.py",
+    ]
+
+
+def test_untracked_file_is_invisible_to_the_whole_tree_mode(repo: Path) -> None:
+    (repo / "tests" / "untracked.py").write_text("x\n")
+    assert "tests/untracked.py" not in _rel(repo, scan.resolve(repo, None, ("tests",), {".py"}))
+
+
+@pytest.mark.parametrize(
+    "selected, expected",
+    [
+        # The plain case: a file inside the scan root with a matching suffix.
+        (["tests/a.py"], ["tests/a.py"]),
+        (["tests/a.py", "tests/sub/b.py"], ["tests/a.py", "tests/sub/b.py"]),
+        # Wrong suffix, right root.
+        (["tests/c.txt"], []),
+        # Right suffix, outside the scan root -- the case that keeps a file-scoped run from
+        # reporting on files the whole-tree run would never have opened.
+        (["python/d.py"], []),
+        # A path that does not exist (e.g. a file deleted in the same commit).
+        (["tests/gone.py"], []),
+        # Duplicates collapse and the result is sorted.
+        (["tests/sub/b.py", "tests/a.py", "tests/a.py"], ["tests/a.py", "tests/sub/b.py"]),
+    ],
+)
+def test_file_scoped_selection_filters(repo: Path, selected: list[str], expected: list[str]) -> None:
+    resolved = scan.resolve(repo, [Path(s) for s in selected], ("tests",), {".py"})
+    assert _rel(repo, resolved) == expected
+
+
+def test_relative_arguments_are_repo_relative_not_cwd_relative(repo: Path) -> None:
+    """pre-commit passes repo-relative paths regardless of the process working directory."""
+    resolved = scan.resolve(repo, [Path("tests/a.py")], ("tests",), {".py"})
+    assert _rel(repo, resolved) == ["tests/a.py"]
+
+
+def test_absolute_arguments_are_accepted(repo: Path) -> None:
+    resolved = scan.resolve(repo, [repo / "tests" / "a.py"], ("tests",), {".py"})
+    assert _rel(repo, resolved) == ["tests/a.py"]
+
+
+def test_path_outside_the_repository_is_dropped(repo: Path, tmp_path: Path) -> None:
+    outside = tmp_path.parent / "outside.py"
+    outside.write_text("x\n")
+    assert scan.resolve(repo, [outside], ("tests",), {".py"}) == []
+
+
+def test_empty_selection_falls_back_to_the_whole_tree(repo: Path) -> None:
+    """An empty list means "no files given", not "no files to check"."""
+    assert scan.resolve(repo, [], ("tests",), {".py"}) == scan.resolve(repo, None, ("tests",), {".py"})
+
+
+def test_the_two_modes_agree_file_by_file(repo: Path) -> None:
+    """The invariant the file-scoped hooks rest on.
+
+    Every tracked file either appears in both the whole-tree sweep and its own single-file
+    selection, or in neither. A file scoped out by root or suffix must be scoped out both ways.
+    """
+    tracked = subprocess.run(
+        ["git", "ls-files"], cwd=repo, capture_output=True, text=True, check=True
+    ).stdout.split()
+    whole_tree = set(_rel(repo, scan.resolve(repo, None, ("tests",), {".py"})))
+    for rel in tracked:
+        scoped = _rel(repo, scan.resolve(repo, [Path(rel)], ("tests",), {".py"}))
+        assert scoped == ([rel] if rel in whole_tree else []), rel
+
+
+def test_tracked_files_ignores_directories(repo: Path) -> None:
+    """`git ls-files` never lists a directory, but the is_file() guard must survive a stale index."""
+    assert all(p.is_file() for p in scan.tracked_files(repo))
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Every local hook was declared `pass_filenames: false`, so each one re-read and
re-parsed the whole tree on every commit no matter what it touched, and CI ran
`--all-files` on every pull request. The median pull request in this history
changes 4 files out of ~1660 tracked.

## Measured

| Scenario | Before | After | Where |
| --- | --- | --- | --- |
| Local commit, 3 files | 39s | **4.0s** | dev box |
| Local commit, docs only | 35s | **1.0s** | dev box |
| CI gate, 2-file PR | ~114s | **4.6s** | dev box pinned to 4 cores |
| CI gate, 6-file PR | ~114s | **10.7s** | dev box pinned to 4 cores |
| CI gate, `--all-files` | 114.3s | 110.7s | **both from real CI runs** |

**The whole-tree row is the honest one to read first: `--all-files` is
essentially unchanged.** pyright (46s) and cpplint (32s) are 78s of that 114s
and neither is touched here. The per-hook gains are real but small at that
scale — `check-op-name-literals` 12.1s → 6.9s, `check-no-broad-raises` 7.5s →
3.8s, `check-environment-inputs` 4.2s → 2.4s — and `check-environment-registry`
was adding 4.3s back; the last commit below cuts that to 0.10s, which the
110.7s figure predates.

All the value is in *not* running the whole tree. That path removes pyright and
cpplint almost entirely, which is exactly where the time is. It is measured on a
four-core-pinned dev box rather than observed on CI, because this pull request
changes `tests/lint/` and `.pre-commit-config.yaml` and therefore routes itself
to `--all-files` by the rule below. The first ordinary pull request after this
lands is what will show the real number.

The gate matters out of proportion to its size: every other job lists it in
`needs`, so its runtime sits in front of the whole pipeline.

## The commits

- `chore(lint): run the stdlib-only lint hooks on the ambient interpreter` —
  twelve local hooks import only the standard library, so pre-commit was
  building three managed virtualenvs to `pip install .` an empty package into.
  `language: system` drops them. This also makes a fresh checkout work without
  a package index: building those venvs needs setuptools from PyPI, and behind
  a proxy that disallows it `check-environment-inputs` failed to install and
  aborted the run before any hook executed. `check-docs-nav` keeps its venv —
  it is the one local hook with a real dependency (pyyaml).
- `chore(lint): gate each consistency hook on the files it actually reads` —
  the eight hooks that compare two sides of a contract do need the whole tree
  when they run, but not to *run* when nothing they read changed. Each gate is
  derived from the paths the script opens, read out of the source.
- `perf(lint): check only the commit's files in the per-file lint hooks` —
  five hooks answer a question about one file in isolation. Handing them the
  commit's files also lets pre-commit shard the list across `cpu_count()`
  worker subprocesses (`lang_base.run_xargs`). Threads would not have helped:
  the work is `ast.parse`, which holds the GIL throughout, and a 32-thread pool
  measured *slower* than serial. That sharding is worth much less on a
  four-core runner (1.75x) than on a many-core workstation (17x), which is why
  the `--all-files` row above barely moves. A new `tests/lint/_scan.py` replaces
  five near-identical copies of the same `git ls-files` boilerplate and keeps
  both modes on one filter.
- `perf(lint): file-scope the per-file half of the last two whole-tree hooks` —
  `check-environment-inputs` and `check-function-attr-key-parity` each do a
  bulk per-file job and a thin global one. The unused-exception sweep genuinely
  cannot run file-scoped, so it stays whole-tree in `check-environment-registry`,
  gated on the registry.
- `perf(lint): read only the files an environment exception names` — the split
  above first left `--all-files` scanning those 526 sources twice, 4.2s → 6.7s.
  It never needed the second walk: `check_registry` forbids a wildcard or
  absolute exception path, so an exception names one exact file and only that
  file can mark it used. Reading just those drops the registry hook from 4.3s to
  0.10s, and the pair now costs 0.89s on a full sweep against 4.2s before the
  split. Checked differentially against the sweep it replaces over seven
  registry shapes.
- `perf(ci): lint a pull request's own diff instead of the whole tree` — the
  file list comes from the PR files API rather than a `git diff`, matching the
  `changes` job: no `fetch-depth: 0` clone, and it already reports the
  merge-base diff GitHub shows.

## Why pyright is the part diff-scoping buys back

pyright declares `require_serial: true` — it type checks across files, so
sharding it re-resolves the import graph per shard — and it is ~46s of the
~114s gate. It cannot be parallelised the way the local hooks now are. On four
cores it measures 51.7s over the whole tree against 2.8s / 7.6s / 9.2s over 2- /
6- / 34-file diffs taken from real commits in this history.

## Scoping to a diff can only ever check less

So every uncertain path falls back to `--all-files` and none falls back to a
narrower run: a non-pull-request event, a failed or truncated API response, an
empty list, or a pull request where every changed path was deleted. It also
covers the one case the scoping genuinely cannot see — a change to a rule or to
the hook config can make files the pull request never touched non-compliant, so
those pull requests get a full sweep. Pushes to main sweep as well, so main is
re-validated in full on every merge.

The residual gap is narrow and stated rather than hidden: a commit that deletes
the last dynamic read without touching the registry leaves an unused exception
stale until the next full sweep.

## Verification

- **Whole-tree output is byte-identical.** All 13 checkers run with no
  arguments produce the same stdout, stderr and exit code as a baseline
  captured before the series. The only delta is the file count in two
  `Checking N file(s)` banners, accounted for file by file: the two this series
  adds, plus one from the upstream commits it was rebased onto.
- **Injection suite.** Each file-scoped hook is handed a file violating exactly
  its own rule and must fail, then a clean counterpart of the same file and
  must pass — so no hook is passing merely because it stopped looking.
- **Gate matrix.** 50 assertions, one pre-commit invocation per hook/file pair,
  asserting each hook runs on every input it reads and is filtered out on
  representative files it does not.
- **CI branch matrix.** A harness extracts the `Decide lint scope` script from
  `ci.yml` and drives it against a stubbed `gh` across all twelve paths.
  Writing it found a real defect: the existence filter had been
  `[ -f "$f" ] && printf ...`, whose false branch is the last command of the
  loop, so under `set -e` a pull request that only deleted files failed the
  step instead of falling back to a sweep. It is an `if` now.
- `tests/ut/tools/test_lint_scan.py` adds 15 tests pinning the invariant the
  split rests on: the two modes agree file by file.
- `pre-commit run --all-files` exits 0 with all 24 hooks passing;
  `tests/ut/tools/` is 209 passed, 1 skipped.

`tests/ut/tools/test_check_emitter_check_classification.py` needed two
mechanical updates — its loader now puts `tests/lint` on `sys.path`, because
the checker gained a sibling import that only resolves when a script is run
directly, and its repository-wide case calls `resolve()` where it called the
deleted `get_git_tracked_sources()`. No assertion changed.

Note for reviewers on this pull request's own timing: it edits the hook config,
so its cache key changes and the run rebuilds every hook environment from
scratch (110s, including pyright's torch 2.8.0 venv) before linting. That cost
is unrelated to this change and is paid by any pull request touching
`.pre-commit-config.yaml`.
