### PR TITLE
feat(ir): define internal buffer operator contracts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,8 @@ set(PYPTO_SOURCES
     src/ir/type.cpp
 
     # IR - Operators
+    src/ir/op/buffer_ops/elementwise.cpp
+    src/ir/op/buffer_ops/memory.cpp
     src/ir/op/tile_ops/batch_matmul.cpp
     src/ir/op/tile_ops/broadcast.cpp
     src/ir/op/tile_ops/elementwise.cpp

--- a/docs/en/dev/ir/02-types.md
+++ b/docs/en/dev/ir/02-types.md
@@ -54,10 +54,75 @@ rule at construction, including when attributes are attached with
 
 These types support construction, structural comparison, and binary serialization.
 Buffer type dumps use native `pypto.ir.BufferType(...)` constructors and preserve
-the complete descriptors. Buffer operators, representation verification, and
-PTO emission will be integrated separately. Automatic tile-to-buffer lowering
-is not enabled; the public Tile DSL and default pipeline still use `TileType`.
-Reparsing complete buffer-program dumps through the DSL parser is not supported.
+the complete descriptors. Internal buffer operators use the contracts below.
+Representation verification and PTO emission will be integrated separately.
+Automatic tile-to-buffer lowering is not enabled; the public Tile DSL and default
+pipeline still use `TileType`. Reparsing complete buffer-program dumps through
+the DSL parser is not supported.
+
+#### Buffer operator contracts
+
+Registrations default to `OpIRStage::Functional`. Internal buffer operators
+explicitly select `OpIRStage::Buffer` and `set_internal_only()`. Their output
+arity is declared: zero requires `VoidType`, one a native result, and multiple
+results a matching `TupleType`. Functional registrations still require at least
+one result under the existing contract.
+
+Every buffer operand declares data and metadata access separately with
+`set_buffer_arg_effect(i, data, metadata)`; scalar operands use
+`set_buffer_non_memory_arg(i)`. Both access dimensions use `BufferAccess`
+(`None`, `Read`, `Write`, `ReadWrite`). No declaration defaults to read access.
+`set_buffer_result_behavior(...)` classifies results as allocation, alias,
+borrowed handle, or native value; void calls declare `None`. Alias and borrowed
+results name their source operand. `Allocate` declares a root handle; an explicit
+address may overlap other roots. It does not prove freshness or initialization.
+Descriptor and memory-space legality remain part of each operator's type
+deduction or explicit result validation.
+
+`buffer.alloc` uses `f_validate_explicit_type(...)` instead of a deducer: its
+physical descriptor exists only in `Call.type`. These mutually exclusive modes
+prevent a second copy of the descriptor in kwargs. The private IR builder
+accepts the result type before the span:
+
+```python
+from pypto.pypto_core import ir as _ir
+
+span = ir.Span.unknown()
+valid_rows = ir.Var("valid_rows", ir.ScalarType(DataType.INDEX), span)
+descriptor = ir.BufferType([32, 64], DataType.FP32, ir.Mem.Vec, valid_shape=[-1, 64])
+allocation = _ir._create_internal_op_call(
+    "buffer.alloc", [ir.MakeTuple([valid_rows], span)], {}, descriptor, span
+)
+```
+
+The first operand is always a `MakeTuple` containing just the runtime valid
+extents, in the order of the descriptor's `-1` dimensions. Static descriptors
+use an empty tuple. The optional second operand is the final effective byte
+address, with no additional base or offset. An omitted address requests fresh
+storage; an explicit zero is a valid addressed allocation. Negative constant
+addresses, including `-1`, are rejected. Both operands are non-memory values.
+Runtime values must be integer or `INDEX` scalars. Constant valid extents must
+lie between zero and their physical extent; runtime bounds and address
+nonnegativity are preconditions when they cannot be checked statically.
+
+`buffer.set_validshape(buffer, valid_extents)` returns `VoidType` and writes
+metadata only. Its `MakeTuple` operand includes **all** dimensions. Dimensions
+marked `-1` may change within their physical bounds; static valid dimensions
+must be supplied as matching constants. The operation changes neither the
+immutable type nor buffer identity. Lowering must select a dynamic descriptor
+in advance for any valid dimension that changes over a handle's lifetime.
+
+`OpRegistry::ValidateBufferCall` validates an existing call against the same
+schema as creation, including its original result type and kwargs. Storage
+lifetime, overlap, and initialization proofs belong to subsequent verification.
+
+The initial `buffer.copy(src, dst)` and `buffer.mul(lhs, rhs, dst)` operations
+write their explicit destination and return `VoidType`. They currently require
+matching Vec buffer descriptors. A write effect does not imply that all bytes
+are initialized. Exact input/destination aliases are allowed; equality of
+runtime valid extents and legalization of partially overlapping views are
+preconditions for constructing these calls. Existing Functional-stage `ArgEffect` queries deliberately
+reject buffer operators; buffer consumers must use `GetBufferArgEffect`.
 
 ### TensorType
 

--- a/docs/zh/dev/ir/02-types.md
+++ b/docs/zh/dev/ir/02-types.md
@@ -49,10 +49,66 @@ Void call 应放在 `EvalStmt` 中，不能绑定变量、用作操作数、放�
 在构造时即进行校验，通过 `ir.set_call_attrs` 附加属性时也会校验。
 
 这些类型支持构造、结构比较和二进制序列化。Buffer 类型 dump 使用原生
-`pypto.ir.BufferType(...)` 构造表达式，并保留完整描述符。Buffer 算子、
-表示验证和 PTO 代码生成将分别集成。自动 tile-to-buffer lowering 尚未启用，
-公开 Tile DSL 和默认流水线仍使用 `TileType`。目前不支持通过 DSL parser
-重新解析完整的 buffer 程序 dump。
+`pypto.ir.BufferType(...)` 构造表达式，并保留完整描述符。内部 buffer 算子
+使用下文契约；表示验证和 PTO 代码生成将分别集成。自动 tile-to-buffer
+lowering 尚未启用，公开 Tile DSL 和默认流水线仍使用 `TileType`。
+目前不支持通过 DSL parser 重新解析完整的 buffer 程序 dump。
+
+#### Buffer 算子契约
+
+算子注册默认为 `OpIRStage::Functional`。内部 buffer 算子显式选择
+`OpIRStage::Buffer` 并调用 `set_internal_only()`。结果数量必须声明：
+零结果要求 `VoidType`，单结果使用原生类型，多结果使用数量匹配的
+`TupleType`。Functional 注册仍按现有契约要求至少一个结果。
+
+每个 buffer 操作数通过 `set_buffer_arg_effect(i, data, metadata)`
+分别声明数据与元数据访问；标量操作数使用 `set_buffer_non_memory_arg(i)`。
+两个访问维度都使用 `BufferAccess`（`None`、`Read`、`Write`、`ReadWrite`），
+缺少声明不会默认视为读取。`set_buffer_result_behavior(...)` 将结果分类为
+分配、别名、借用句柄或原生值，void call 声明 `None`。别名和借用结果
+需要指定来源操作数。`Allocate` 声明 root 句柄；指定地址的 root 可以相互
+重叠，因此它不证明存储独立或已初始化。描述符及内存空间合法性由各算子的
+类型推导或显式结果验证检查。
+
+`buffer.alloc` 使用 `f_validate_explicit_type(...)`，不使用类型推导器：
+物理描述符只存在于 `Call.type` 中。两种模式互斥，避免在 kwargs 中重复
+存储描述符。私有 IR 构造器在 span 前接收结果类型：
+
+```python
+from pypto.pypto_core import ir as _ir
+
+span = ir.Span.unknown()
+valid_rows = ir.Var("valid_rows", ir.ScalarType(DataType.INDEX), span)
+descriptor = ir.BufferType([32, 64], DataType.FP32, ir.Mem.Vec, valid_shape=[-1, 64])
+allocation = _ir._create_internal_op_call(
+    "buffer.alloc", [ir.MakeTuple([valid_rows], span)], {}, descriptor, span
+)
+```
+
+第一个操作数始终是 `MakeTuple`，只包含描述符中 `-1` 维度对应的运行时
+valid extent，按维度顺序排列。静态描述符使用空 tuple。可选的第二个操作数
+是最终有效字节地址，不再叠加 base 或 offset。省略地址表示请求独立存储；
+显式零地址是合法的指定地址分配。负常量地址（包括 `-1`）会被拒绝。
+两个操作数都属于非内存值，运行时值必须是整数或 `INDEX` 标量。
+常量 valid extent 必须介于零和对应物理维度之间；无法静态检查时，运行时
+extent 的边界及地址非负性属于构造调用的前置条件。
+
+`buffer.set_validshape(buffer, valid_extents)` 返回 `VoidType`，只写入元数据。
+其 `MakeTuple` 操作数包含**所有**维度。标记为 `-1` 的维度可在物理边界内
+变化；静态 valid 维度必须传入与描述符一致的常量。该操作不改变不可变类型
+或 buffer 身份。对于句柄生命周期内会变化的 valid 维度，lowering 必须提前
+选择动态描述符。
+
+`OpRegistry::ValidateBufferCall` 按创建调用时的同一 schema 检查已有 call，
+包括其原始结果类型和 kwargs。存储生命周期、重叠和初始化证明属于后续验证。
+
+首批 `buffer.copy(src, dst)` 和 `buffer.mul(lhs, rhs, dst)` 写入显式
+destination 并返回 `VoidType`，目前要求所有参数的 Vec buffer 描述符
+相同。写效应并不表示所有字节都已初始化。允许输入和 destination 是同一
+句柄；构造调用前需要保证运行时 valid extent 一致，并完成部分重叠 view
+的合法化。现有 Functional 阶段的
+`ArgEffect` 查询会显式拒绝 buffer 算子，buffer 消费方必须使用
+`GetBufferArgEffect`。
 
 ### TensorType
 

--- a/include/pypto/ir/op_registry.h
+++ b/include/pypto/ir/op_registry.h
@@ -53,6 +53,30 @@ namespace ir {
 class Call;
 using CallPtr = std::shared_ptr<const Call>;
 
+/// The representation an operator consumes and produces. Existing operators
+/// keep their functional SSA contract; buffer operators name mutable storage.
+enum class OpIRStage : uint8_t { Functional, Buffer };
+
+/// Access to buffer data or descriptor metadata. None is explicit: an
+/// unclassified buffer argument must never silently become a read-only one.
+enum class BufferAccess : uint8_t { None, Read, Write, ReadWrite };
+
+struct BufferArgEffect {
+  BufferAccess data;
+  BufferAccess metadata;
+  bool non_memory;
+};
+
+/// Ownership of each actual SSA result. Allocate defines a storage root without
+/// initializing data or promising disjoint storage: explicitly addressed roots
+/// may overlap. Alias and Borrow reference storage named by an ordinary operand.
+enum class BufferResultBehavior : uint8_t { None, Allocate, Alias, Borrow, Value };
+
+struct BufferResultSpec {
+  BufferResultBehavior behavior;
+  std::optional<size_t> alias_arg;
+};
+
 /// Full memory space specification for one operator.
 struct OpMemorySpaceSpec {
   /// Required memory spaces per input arg index.
@@ -360,7 +384,7 @@ class OpRegistryEntry {
    * - description: Must be set via set_description()
    * - op_category: Must be set via set_op_category()
    * - arguments: Must be set via add_argument() or no_argument()
-   * - deduce_type: Must be set via f_deduce_type()
+   * - Result typing: f_deduce_type(), or f_validate_explicit_type() for internal Buffer ops
    *
    * @return Const reference to the operator pointer
    * @throws ValueError if any required field is not set
@@ -382,10 +406,11 @@ class OpRegistryEntry {
         << "Operator '" + name_ +
                "' has no argument definition. Use .add_argument() or .no_argument() to define arguments.";
 
-    // Check deduce_type is set
-    CHECK(deduce_type_.has_value())
-        << "Operator '" + name_ + "' has no type deduction function. Use .f_deduce_type() to provide one.";
+    CHECK(deduce_type_.has_value() || validate_explicit_type_.has_value())
+        << "Operator '" + name_ + "' has no type deduction function or explicit type validator. "
+        << "Use .f_deduce_type(), or .f_validate_explicit_type() for an internal Buffer operator.";
 
+    ValidateIRStage();
     return op_;
   }
 
@@ -432,6 +457,9 @@ class OpRegistryEntry {
     CHECK(deduce_type_.has_value()) << "Operator '" + name_ + "' has no type deduction function";
     return *deduce_type_;
   }
+
+  /// Whether this operator's result descriptor must be supplied by its creator.
+  [[nodiscard]] bool RequiresExplicitType() const { return validate_explicit_type_.has_value(); }
 
   /**
    * @brief Set the operator description
@@ -520,8 +548,30 @@ class OpRegistryEntry {
       std::function<TypePtr(const std::vector<ExprPtr>&,
                             const std::vector<std::pair<std::string, std::any>>&)>
           dt) {
+    CHECK(!validate_explicit_type_.has_value())
+        << "Operator '" << name_ << "' cannot combine type deduction with explicit type validation";
     CHECK(!deduce_type_.has_value()) << "Operator '" + name_ + "' type deduction function is already set";
     deduce_type_ = std::move(dt);
+    return *this;
+  }
+
+  /**
+   * @brief Validate a creator-supplied result descriptor for an internal Buffer operator.
+   *
+   * Mutually exclusive with f_deduce_type(). The descriptor lives only in
+   * Call::type_; addresses and runtime extents remain ordinary operands.
+   * The callback must validate operand types and their relation to the result.
+   */
+  inline OpRegistryEntry& f_validate_explicit_type(
+      std::function<void(const std::vector<ExprPtr>&, const std::vector<std::pair<std::string, std::any>>&,
+                         const TypePtr&)>
+          validator) {
+    CHECK(!deduce_type_.has_value()) << "Operator '" << name_
+                                     << "' cannot combine type deduction with explicit type validation";
+    CHECK(!validate_explicit_type_.has_value())
+        << "Operator '" << name_ << "' explicit type validator is already set";
+    CHECK(validator) << "Operator '" << name_ << "' explicit type validator must not be empty";
+    validate_explicit_type_ = std::move(validator);
     return *this;
   }
 
@@ -880,11 +930,44 @@ class OpRegistryEntry {
   /// output: destination tiles must NOT appear in `add_argument()`, because a
   /// caller cannot pre-allocate a buffer that `InitMemRef` owns. Default 1.
   inline OpRegistryEntry& set_output_arity(size_t arity) {
-    CHECK(arity >= 1) << "Operator '" << name_ << "' declared output arity " << arity
-                      << "; every operator produces at least one value";
+    CHECK(arity >= 1 || ir_stage_ == OpIRStage::Buffer)
+        << "Operator '" << name_ << "' declared output arity " << arity
+        << "; functional operators produce at least one value. Select Buffer stage before declaring zero";
     output_arity_ = arity;
+    output_arity_declared_ = true;
     return *this;
   }
+
+  inline OpRegistryEntry& set_ir_stage(OpIRStage stage) {
+    CHECK(stage == OpIRStage::Buffer || output_arity_ > 0)
+        << "Operator '" << name_ << "' cannot give a zero-result operator Functional stage";
+    ir_stage_ = stage;
+    return *this;
+  }
+
+  [[nodiscard]] OpIRStage GetIRStage() const { return ir_stage_; }
+
+  /// Classify both data and metadata explicitly, including a view that only
+  /// reads metadata or an allocation address that names no buffer at all.
+  OpRegistryEntry& set_buffer_arg_effect(size_t arg_index, BufferAccess data, BufferAccess metadata);
+  OpRegistryEntry& set_buffer_non_memory_arg(size_t arg_index);
+
+  /// Declare one result's storage behavior. The shorthand names result zero;
+  /// a zero-result operator explicitly declares None at that position.
+  OpRegistryEntry& set_buffer_result_behavior(BufferResultBehavior behavior,
+                                              std::optional<size_t> alias_arg = std::nullopt) {
+    return set_buffer_result_behavior(0, behavior, alias_arg);
+  }
+  OpRegistryEntry& set_buffer_result_behavior(size_t result_index, BufferResultBehavior behavior,
+                                              std::optional<size_t> alias_arg = std::nullopt);
+
+  [[nodiscard]] const BufferArgEffect& GetBufferArgEffect(size_t arg_index) const;
+  [[nodiscard]] const BufferResultSpec& GetBufferResultSpec(size_t result_index = 0) const;
+
+  /// Validate registrations separately from call types. Both are public so
+  /// tools can inspect a contract without mutating the global registry.
+  void ValidateIRStage() const;
+  void ValidateCall(const std::vector<ExprPtr>& args, const TypePtr& result_type, const Span& span) const;
 
   /// Declare argument `arg_index` to be compiler-supplied scratch: the hardware
   /// writes it, but it carries no result the caller reads. This is what
@@ -917,6 +1000,8 @@ class OpRegistryEntry {
   /// `Read` for any argument the operator did not name.
   [[nodiscard]] ArgEffect GetArgEffect(size_t arg_index,
                                        const std::vector<std::pair<std::string, std::any>>& kwargs) const {
+    CHECK(ir_stage_ == OpIRStage::Functional)
+        << "Operator '" << name_ << "' requires GetBufferArgEffect to inspect data and metadata effects";
     if (!arg_effects_.has_value()) return ArgEffect::Read;
     auto resolver = arg_effects_->kwarg_dependent.find(arg_index);
     if (resolver != arg_effects_->kwarg_dependent.end()) return resolver->second(kwargs);
@@ -947,6 +1032,8 @@ class OpRegistryEntry {
   /// to run a kwarg-dependent resolver against — a resolver is entitled to
   /// reject kwargs no real call would carry.
   [[nodiscard]] bool MayWriteArg(size_t arg_index) const {
+    CHECK(ir_stage_ == OpIRStage::Functional)
+        << "Operator '" << name_ << "' requires GetBufferArgEffect to inspect data and metadata effects";
     if (!arg_effects_.has_value()) return false;
     if (arg_effects_->kwarg_dependent.count(arg_index) > 0) return true;
     if (arg_index >= arg_effects_->per_arg.size()) return false;
@@ -956,6 +1043,8 @@ class OpRegistryEntry {
   /// True when this operator writes through at least one argument under some
   /// kwargs. Cheap pre-filter for analyses that only care about writers.
   [[nodiscard]] bool WritesAnyArg() const {
+    CHECK(ir_stage_ == OpIRStage::Functional)
+        << "Operator '" << name_ << "' requires GetBufferArgEffect to inspect data and metadata effects";
     if (!arg_effects_.has_value()) return false;
     if (!arg_effects_->kwarg_dependent.empty()) return true;
     return std::any_of(arg_effects_->per_arg.begin(), arg_effects_->per_arg.end(), ArgEffectWrites);
@@ -1047,7 +1136,11 @@ class OpRegistryEntry {
       arguments_;  ///< Argument specifications (name, description)
   std::optional<std::function<TypePtr(const std::vector<ExprPtr>&,
                                       const std::vector<std::pair<std::string, std::any>>&)>>
-      deduce_type_;                               ///< Type deduction function
+      deduce_type_;  ///< Type deduction function
+  std::optional<
+      std::function<void(const std::vector<ExprPtr>&, const std::vector<std::pair<std::string, std::any>>&,
+                         const TypePtr&)>>
+      validate_explicit_type_;  ///< Validation for an explicit internal Buffer result descriptor
   std::optional<OpMemorySpaceSpec> memory_spec_;  ///< Memory space specification
   std::optional<OpArgEffectSpec> arg_effects_;    ///< Per-argument execution effects; nullopt = unclassified
   std::optional<OpLaneInvariantArgSpec>
@@ -1057,10 +1150,14 @@ class OpRegistryEntry {
   std::set<size_t> forbid_output_alias_args_;  ///< Input args whose buffer the output must not reuse
   std::optional<core_affinity::CoreAffinity> core_affinity_;     ///< Explicit core-affinity override
   std::optional<core_affinity::CrossCoreRole> cross_core_role_;  ///< Cross-core role (for predicates)
-  bool no_duplicate_{false};         ///< True when the op must not run on a second core (set_no_duplicate)
-  bool internal_only_{false};        ///< True for compiler-created ops only.
-  size_t output_arity_{1};           ///< Values produced; > 1 means a TupleType result
-  std::set<size_t> workspace_args_;  ///< Args written as scratch rather than as results
+  bool no_duplicate_{false};   ///< True when the op must not run on a second core (set_no_duplicate)
+  bool internal_only_{false};  ///< True for compiler-created ops only.
+  size_t output_arity_{1};     ///< Values produced; > 1 means a TupleType result
+  OpIRStage ir_stage_{OpIRStage::Functional};
+  bool output_arity_declared_{false};
+  std::map<size_t, BufferArgEffect> buffer_arg_effects_;
+  std::map<size_t, BufferResultSpec> buffer_results_;
+  std::set<size_t> workspace_args_;          ///< Args written as scratch rather than as results
   std::optional<std::string> template_dir_;  ///< Package resource for builtin templates.
 };
 
@@ -1165,6 +1262,11 @@ class OpRegistry {
                                        const std::vector<std::pair<std::string, std::any>>& kwargs,
                                        Span span) const;
 
+  /// Create an internal Buffer call whose registered schema requires an explicit result descriptor.
+  [[nodiscard]] CallPtr CreateInternal(const std::string& op_name, const std::vector<ExprPtr>& args,
+                                       const std::vector<std::pair<std::string, std::any>>& kwargs,
+                                       const TypePtr& result_type, Span span) const;
+
   /**
    * @brief Check if an operator is registered
    *
@@ -1248,13 +1350,25 @@ class OpRegistry {
    */
   void ValidateMultiOutputOps() const;
 
+  /// Buffer-stage registrations must declare complete effects and ownership.
+  void ValidateBufferOps() const;
+
+  /// Validate the original Buffer call, including its stored type, without rebuilding it.
+  /// This also checks calls produced by deserialization or direct Call construction.
+  void ValidateBufferCall(const CallPtr& call) const;
+
  private:
   OpRegistry() = default;
   ~OpRegistry() = default;
 
   [[nodiscard]] CallPtr CreateImpl(const std::string& op_name, const std::vector<ExprPtr>& args,
                                    const std::vector<std::pair<std::string, std::any>>& kwargs, Span span,
-                                   bool allow_internal) const;
+                                   bool allow_internal, const TypePtr& explicit_type = nullptr) const;
+
+  [[nodiscard]] TypePtr ResolveAndValidateCallType(
+      const OpRegistryEntry& entry, const std::vector<ExprPtr>& args,
+      const std::vector<std::pair<std::string, std::any>>& kwargs, const TypePtr& explicit_type,
+      const Span& span) const;
 
   std::unordered_map<std::string, OpRegistryEntry> registry_;
 };

--- a/python/bindings/bindings.cpp
+++ b/python/bindings/bindings.cpp
@@ -80,4 +80,7 @@ NB_MODULE(pypto_core, m) {
   // a destination tile in the argument list makes the caller pre-allocate a
   // buffer InitMemRef owns, and hides the write from direction inference
   pypto::ir::OpRegistry::GetInstance().ValidateMultiOutputOps();
+
+  // Buffer ops carry explicit data/metadata effects and result ownership.
+  pypto::ir::OpRegistry::GetInstance().ValidateBufferOps();
 }

--- a/python/bindings/modules/ir.cpp
+++ b/python/bindings/modules/ir.cpp
@@ -837,6 +837,43 @@ void BindIR(nb::module_& m) {
   comm_layout_mod.attr("COMM_CTX_SIZE") = pypto::codegen::distributed::comm_layout::kCommCtxSize;
 
   // OpRegistry
+  nb::enum_<OpIRStage>(ir, "OpIRStage", "Representation consumed and produced by an operator")
+      .value("Functional", OpIRStage::Functional)
+      .value("Buffer", OpIRStage::Buffer);
+  nb::enum_<BufferAccess>(ir, "BufferAccess", "Access to buffer data or descriptor metadata")
+      .value("None_", BufferAccess::None)
+      .value("Read", BufferAccess::Read)
+      .value("Write", BufferAccess::Write)
+      .value("ReadWrite", BufferAccess::ReadWrite);
+  nb::enum_<BufferResultBehavior>(ir, "BufferResultBehavior", "Storage ownership of an actual SSA result")
+      .value("None_", BufferResultBehavior::None)
+      .value("Allocate", BufferResultBehavior::Allocate)
+      .value("Alias", BufferResultBehavior::Alias)
+      .value("Borrow", BufferResultBehavior::Borrow)
+      .value("Value", BufferResultBehavior::Value);
+  nb::class_<BufferArgEffect>(ir, "BufferArgEffect", "Explicit data and metadata effects of one operand")
+      .def_ro("data", &BufferArgEffect::data)
+      .def_ro("metadata", &BufferArgEffect::metadata)
+      .def_ro("non_memory", &BufferArgEffect::non_memory);
+  nb::class_<BufferResultSpec>(ir, "BufferResultSpec", "Ownership and alias source of one SSA result")
+      .def_ro("behavior", &BufferResultSpec::behavior)
+      .def_ro("alias_arg", &BufferResultSpec::alias_arg);
+  ir.def(
+      "get_op_ir_stage",
+      [](const std::string& op_name) { return OpRegistry::GetInstance().GetEntry(op_name).GetIRStage(); },
+      nb::arg("op_name"), "Get the operator's explicitly declared IR stage");
+  ir.def(
+      "get_op_buffer_arg_effect",
+      [](const std::string& op_name, size_t arg_index) {
+        return OpRegistry::GetInstance().GetEntry(op_name).GetBufferArgEffect(arg_index);
+      },
+      nb::arg("op_name"), nb::arg("arg_index"), "Get explicit data and metadata effects of a buffer operand");
+  ir.def(
+      "get_op_buffer_result_spec",
+      [](const std::string& op_name, size_t result_index) {
+        return OpRegistry::GetInstance().GetEntry(op_name).GetBufferResultSpec(result_index);
+      },
+      nb::arg("op_name"), nb::arg("result_index") = 0, "Get ownership and alias source of one buffer result");
   ir.def(
       "create_op_call",
       [](const std::string& op_name, const std::vector<ExprPtr>& args, const Span& span) {
@@ -864,7 +901,8 @@ void BindIR(nb::module_& m) {
   // re-checks the invariants the printer stamps before calling in, so the
   // guard `internal_only` provides is enforced at the user-facing surface
   // rather than dropped. `create_op_call` still routes through
-  // `CreateUserFacing` and is unaffected.
+  // `CreateUserFacing` and is unaffected. Buffer lowering additionally supplies
+  // an explicit result descriptor for allocation and view operators.
   ir.def(
       "_create_internal_op_call",
       [](const std::string& op_name, const std::vector<ExprPtr>& args, const nb::dict& kwargs_dict,
@@ -874,6 +912,16 @@ void BindIR(nb::module_& m) {
       },
       nb::arg("op_name"), nb::arg("args"), nb::arg("kwargs"), nb::arg("span"),
       "Create a Call expression for a compiler-internal operator (round-trip parser only)");
+
+  ir.def(
+      "_create_internal_op_call",
+      [](const std::string& op_name, const std::vector<ExprPtr>& args, const nb::dict& kwargs_dict,
+         const TypePtr& result_type, const Span& span) {
+        auto kwargs = ConvertKwargsDict(kwargs_dict);
+        return OpRegistry::GetInstance().CreateInternal(op_name, args, kwargs, result_type, span);
+      },
+      nb::arg("op_name"), nb::arg("args"), nb::arg("kwargs"), nb::arg("type"), nb::arg("span"),
+      "Create an internal Buffer call with a validated explicit result descriptor");
 
   ir.def(
       "set_call_attrs",
@@ -902,7 +950,7 @@ void BindIR(nb::module_& m) {
   ir.def(
       "get_op_output_arity",
       [](const std::string& op_name) { return OpRegistry::GetInstance().GetEntry(op_name).GetOutputArity(); },
-      nb::arg("op_name"), "Number of values an operator produces (>1 means a TupleType result)");
+      nb::arg("op_name"), "Number of SSA results (0 means VoidType, >1 means TupleType)");
 
   ir.def(
       "op_arg_is_workspace",

--- a/python/bindings/modules/testing.cpp
+++ b/python/bindings/modules/testing.cpp
@@ -18,12 +18,20 @@
  */
 
 #include <nanobind/nanobind.h>
+#include <nanobind/stl/optional.h>
 #include <nanobind/stl/shared_ptr.h>  // NOLINT(misc-include-cleaner) -- registers shared_ptr casters
 #include <nanobind/stl/string.h>      // NOLINT(misc-include-cleaner) -- registers std::string casters
+#include <nanobind/stl/tuple.h>
+#include <nanobind/stl/vector.h>
 
+#include <any>
 #include <cassert>
+#include <cstddef>
+#include <optional>
 #include <string>
+#include <tuple>
 #include <utility>
+#include <vector>
 
 #include "../module.h"
 #include "pypto/backend/common/backend.h"
@@ -31,17 +39,72 @@
 #include "pypto/core/error.h"
 #include "pypto/core/logging.h"
 #include "pypto/ir/core_affinity_kind.h"
+#include "pypto/ir/expr.h"
 #include "pypto/ir/function.h"
 #include "pypto/ir/op_registry.h"
 #include "pypto/ir/span.h"
 #include "pypto/ir/transforms/dsa/allocation_plan.h"
 #include "pypto/ir/transforms/dsa/reuse_penalty_recognizer.h"
 #include "pypto/ir/transforms/utils/core_affinity.h"
+#include "pypto/ir/type.h"
 
 namespace nb = nanobind;
 
 namespace pypto {
 namespace python {
+
+/// Validate malformed registrations without installing them in the singleton.
+/// This exercises the exact checks used by registry creation and import.
+void ValidateBufferOpContractForTesting(
+    ir::OpIRStage stage, std::optional<size_t> arity, const std::vector<ir::ExprPtr>& args,
+    const ir::TypePtr& result_type,
+    const std::vector<std::tuple<size_t, bool, ir::BufferAccess, ir::BufferAccess>>& effects,
+    const std::vector<std::tuple<size_t, ir::BufferResultBehavior, std::optional<size_t>>>& results,
+    bool internal_only) {
+  ir::OpRegistryEntry entry;
+  entry.set_ir_stage(stage).set_internal_only(internal_only).no_argument();
+  if (arity.has_value()) entry.set_output_arity(*arity);
+  for (size_t i = 0; i < args.size(); ++i) entry.add_argument(std::to_string(i), "Test argument");
+  for (const auto& [index, non_memory, data, metadata] : effects) {
+    if (non_memory) {
+      CHECK(data == ir::BufferAccess::None && metadata == ir::BufferAccess::None)
+          << "A non-memory operand cannot declare memory effects";
+      entry.set_buffer_non_memory_arg(index);
+    } else {
+      entry.set_buffer_arg_effect(index, data, metadata);
+    }
+  }
+  for (const auto& [index, behavior, alias_arg] : results) {
+    entry.set_buffer_result_behavior(index, behavior, alias_arg);
+  }
+  entry.ValidateIRStage();
+  entry.ValidateCall(args, result_type, ir::Span::unknown());
+}
+
+/// Exercise typing-mode registration failures without modifying the singleton.
+void ValidateOpTypeRegistrationForTesting(ir::OpIRStage stage, bool internal_only,
+                                          const std::vector<std::string>& typing_modes) {
+  ir::OpRegistryEntry entry;
+  entry.set_ir_stage(stage).set_internal_only(internal_only).no_argument();
+  if (stage == ir::OpIRStage::Buffer) {
+    entry.set_output_arity(0).set_buffer_result_behavior(ir::BufferResultBehavior::None);
+  }
+  for (const auto& mode : typing_modes) {
+    if (mode == "deduced") {
+      entry.f_deduce_type(
+          [](const std::vector<ir::ExprPtr>&, const std::vector<std::pair<std::string, std::any>>&) {
+            return ir::GetVoidType();
+          });
+    } else if (mode == "explicit") {
+      entry.f_validate_explicit_type([](const std::vector<ir::ExprPtr>&,
+                                        const std::vector<std::pair<std::string, std::any>>&,
+                                        const ir::TypePtr&) {});
+    } else {
+      CHECK(false) << "Unknown test typing mode '" << mode << "'";
+    }
+  }
+  entry.ValidateIRStage();
+}
 
 // ============================================================================
 // Helper functions to demonstrate error raising from C++
@@ -261,6 +324,18 @@ void BindTesting(nb::module_& m) {
   // Create a protected submodule for testing utilities
   // This will be accessible as pypto.testing in Python
   nb::module_ testing = m.def_submodule("testing", "Internal testing utilities (do not use in production)");
+
+  testing.def("validate_buffer_op_contract", &ValidateBufferOpContractForTesting, nb::arg("stage"),
+              nb::arg("arity").none(), nb::arg("args"), nb::arg("result_type"), nb::arg("effects"),
+              nb::arg("results"), nb::arg("internal_only") = true,
+              "Validate a local operator contract without changing the global registry");
+  testing.def("validate_op_type_registration", &ValidateOpTypeRegistrationForTesting, nb::arg("stage"),
+              nb::arg("internal_only"), nb::arg("typing_modes"),
+              "Validate local operator typing modes without changing the global registry");
+  testing.def(
+      "validate_buffer_call",
+      [](const ir::CallPtr& call) { ir::OpRegistry::GetInstance().ValidateBufferCall(call); },
+      nb::arg("call"), "Validate a stored Buffer call against its registered schema");
 
   // Register error-raising helper functions
   testing.def("raise_value_error", &raise_value_error, nb::arg("message"),

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -3176,6 +3176,7 @@ def create_op_call(
         Exception: If operator is not registered, is internal-only, or type deduction fails
     """
 
+@overload
 def _create_internal_op_call(
     op_name: str,
     args: Sequence[Expr],
@@ -3205,6 +3206,20 @@ def _create_internal_op_call(
 
     Raises:
         Exception: If operator is not registered or type deduction fails
+    """
+
+@overload
+def _create_internal_op_call(
+    op_name: str,
+    args: Sequence[Expr],
+    kwargs: Mapping[str, int | bool | str | float | DataType | MemorySpace | PadValue],
+    type: Type,
+    span: Span,
+) -> Call:
+    """Create an internal Buffer call with a validated explicit result descriptor.
+
+    Only operators registered with explicit type validation accept this form.
+    The descriptor is stored in the result type; runtime values stay in args.
     """
 
 def set_call_attrs(call: Call, attrs: Mapping[str, object]) -> Call:
@@ -3304,6 +3319,61 @@ def get_op_memory_spec(op_name: str) -> dict[str, Any] | None:
           consumer demand (e.g. `tile.load`, `tile.create`).
         * ``None`` — no resolver registered for this op.
     """
+
+class OpIRStage(enum.Enum):
+    """Representation consumed and produced by an operator."""
+
+    Functional = ...
+    Buffer = ...
+
+class BufferAccess(enum.Enum):
+    """Access to buffer data or descriptor metadata; absence is explicit."""
+
+    None_ = ...
+    Read = ...
+    Write = ...
+    ReadWrite = ...
+
+class BufferResultBehavior(enum.Enum):
+    """Storage ownership of each actual SSA result."""
+
+    None_ = ...
+    Allocate = ...
+    Alias = ...
+    Borrow = ...
+    Value = ...
+
+class BufferArgEffect:
+    """Explicit data and metadata effects of one buffer-stage operand."""
+
+    @property
+    def data(self) -> BufferAccess:
+        """Access to lane data; Write does not imply full coverage."""
+    @property
+    def metadata(self) -> BufferAccess:
+        """Access to descriptor state, including dynamic valid extents."""
+    @property
+    def non_memory(self) -> bool:
+        """Whether the operand contains only non-memory scalar values."""
+
+class BufferResultSpec:
+    """Storage ownership and alias source of one actual SSA result."""
+
+    @property
+    def behavior(self) -> BufferResultBehavior:
+        """The declared ownership behavior."""
+    @property
+    def alias_arg(self) -> int | None:
+        """Source operand for Alias/Borrow, absent for other behaviors."""
+
+def get_op_ir_stage(op_name: str) -> OpIRStage:
+    """Get the operator's typed representation stage."""
+
+def get_op_buffer_arg_effect(op_name: str, arg_index: int) -> BufferArgEffect:
+    """Get declared buffer data/metadata effects; fail on missing classification."""
+
+def get_op_buffer_result_spec(op_name: str, result_index: int = 0) -> BufferResultSpec:
+    """Get one buffer result's ownership; zero-result ops declare None_ at index 0."""
 
 class ArgEffect(enum.Enum):
     """What executing an operator does to the buffer one argument names."""
@@ -3426,7 +3496,8 @@ def get_op_lane_invariant_arg(op_name: str, arg_index: int) -> LaneInvariantArg 
 def get_op_output_arity(op_name: str) -> int:
     """Number of values an operator produces.
 
-    1 for an ordinary operator; N > 1 for a multi-output operator, whose deduced
+    0 for a buffer operator returning ``VoidType``; 1 for an ordinary operator;
+    N > 1 for a multi-output operator, whose deduced
     result is a ``TupleType`` of exactly N elements. Codegen reads the arity from
     here rather than restating it per emitter.
 
@@ -3443,7 +3514,7 @@ def get_op_output_arity(op_name: str) -> int:
 def op_arg_is_workspace(op_name: str, arg_index: int) -> bool:
     """Whether an argument is compiler-supplied scratch rather than a result.
 
-    A multi-output operator may write through an argument only when that
+    A Functional-stage multi-output operator may write through an argument only when that
     argument is declared a workspace; an undeclared written argument is a
     destination tile leaked into the argument list.
 

--- a/python/pypto/pypto_core/testing.pyi
+++ b/python/pypto/pypto_core/testing.pyi
@@ -15,7 +15,31 @@ Internal testing utilities (do not use in production)
 
 from typing import Literal, NoReturn, TypedDict
 
-from .ir import Call, Function
+from .ir import BufferAccess, BufferResultBehavior, Call, Expr, Function, OpIRStage, Type
+
+def validate_buffer_op_contract(
+    stage: OpIRStage,
+    arity: int | None,
+    args: list[Expr],
+    result_type: Type,
+    effects: list[tuple[int, bool, BufferAccess, BufferAccess]],
+    results: list[tuple[int, BufferResultBehavior, int | None]],
+    internal_only: bool = True,
+) -> None:
+    """Check a local registration and call without mutating the global registry.
+
+    Effect entries give argument index, non-memory classification, data access,
+    and metadata access. Result entries give result index, ownership behavior,
+    and optional alias source argument. ``arity=None`` omits the declaration.
+    """
+
+def validate_op_type_registration(
+    stage: OpIRStage, internal_only: bool, typing_modes: list[Literal["deduced", "explicit"]]
+) -> None:
+    """Check ordered typing-mode declarations without changing the global registry."""
+
+def validate_buffer_call(call: Call) -> None:
+    """Validate a stored Buffer call without changing its arguments or result type."""
 
 class DsaReusePenaltyEdge(TypedDict):
     """One internal pre-solver DSA-RP recognizer result."""

--- a/src/ir/op/buffer_ops/elementwise.cpp
+++ b/src/ir/op/buffer_ops/elementwise.cpp
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <any>
+#include <cstddef>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "pypto/core/logging.h"
+#include "pypto/ir/expr.h"
+#include "pypto/ir/kind_traits.h"
+#include "pypto/ir/memory_space.h"
+#include "pypto/ir/op_registry.h"
+#include "pypto/ir/transforms/structural_comparison.h"
+#include "pypto/ir/type.h"
+
+namespace pypto {
+namespace ir {
+
+namespace {
+
+TypePtr DeduceVecBufferWrite(const std::vector<ExprPtr>& args, size_t argument_count,
+                             const std::string& op_name) {
+  CHECK(args.size() == argument_count)
+      << op_name << " requires " << argument_count << " buffer operands, got " << args.size();
+  BufferTypePtr descriptor;
+  for (size_t i = 0; i < args.size(); ++i) {
+    CHECK(args[i]) << op_name << " argument " << i << " must not be null";
+    auto buffer = As<BufferType>(args[i]->GetType());
+    CHECK(buffer) << op_name << " argument " << i << " must have BufferType";
+    CHECK(buffer->memory_space_ == MemorySpace::Vec)
+        << op_name << " argument " << i << " must be in Vec memory";
+    if (!descriptor) {
+      descriptor = buffer;
+    } else {
+      CHECK(structural_equal(descriptor, buffer))
+          << op_name << " requires identical physical descriptors, including valid shape, layout and padding";
+    }
+  }
+  return GetVoidType();
+}
+
+}  // namespace
+
+// These initial internal operators require equal physical descriptors. An
+// exact input/destination alias is legal; partially overlapping views must be
+// legalized before these calls are constructed. Write concerns the active data
+// region, not whole-allocation initialization. Runtime valid extents are read
+// from each handle's metadata, and must agree when the descriptor is dynamic.
+// ExecutionMemoryAccessEvidence remains Unknown: its Functional classification
+// describes Tile SSA results and cannot represent destination-passing writes.
+REGISTER_OP("buffer.copy")
+    .set_description("Copy active buffer data into an explicit destination with the same descriptor")
+    .set_op_category("BufferOp")
+    .set_ir_stage(OpIRStage::Buffer)
+    .set_internal_only()
+    .add_argument("src", "Source buffer")
+    .add_argument("dst", "Destination buffer")
+    .set_output_arity(0)
+    .set_buffer_arg_effect(0, BufferAccess::Read, BufferAccess::Read)
+    .set_buffer_arg_effect(1, BufferAccess::Write, BufferAccess::Read)
+    .set_buffer_result_behavior(BufferResultBehavior::None)
+    .f_deduce_type([](const std::vector<ExprPtr>& args,
+                      const std::vector<std::pair<std::string, std::any>>&) {
+      return DeduceVecBufferWrite(args, 2, "buffer.copy");
+    });
+
+REGISTER_OP("buffer.mul")
+    .set_description("Multiply active buffer data into an explicit destination with the same descriptor")
+    .set_op_category("BufferOp")
+    .set_ir_stage(OpIRStage::Buffer)
+    .set_internal_only()
+    .add_argument("lhs", "Left input buffer")
+    .add_argument("rhs", "Right input buffer")
+    .add_argument("dst", "Destination buffer")
+    .set_output_arity(0)
+    .set_buffer_arg_effect(0, BufferAccess::Read, BufferAccess::Read)
+    .set_buffer_arg_effect(1, BufferAccess::Read, BufferAccess::Read)
+    .set_buffer_arg_effect(2, BufferAccess::Write, BufferAccess::Read)
+    .set_buffer_result_behavior(BufferResultBehavior::None)
+    .f_deduce_type([](const std::vector<ExprPtr>& args,
+                      const std::vector<std::pair<std::string, std::any>>&) {
+      return DeduceVecBufferWrite(args, 3, "buffer.mul");
+    });
+
+}  // namespace ir
+}  // namespace pypto

--- a/src/ir/op/buffer_ops/memory.cpp
+++ b/src/ir/op/buffer_ops/memory.cpp
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <algorithm>
+#include <any>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "pypto/core/dtype.h"
+#include "pypto/core/logging.h"
+#include "pypto/ir/expr.h"
+#include "pypto/ir/kind_traits.h"
+#include "pypto/ir/op_registry.h"
+#include "pypto/ir/scalar_expr.h"
+#include "pypto/ir/type.h"
+
+namespace pypto {
+namespace ir {
+
+namespace {
+
+void CheckIntegerOperand(const ExprPtr& value, const std::string& context) {
+  CHECK(value) << context << " must not be null";
+  auto scalar = As<ScalarType>(value->GetType());
+  CHECK_SPAN(scalar && (scalar->dtype_.IsInt() || scalar->dtype_ == DataType::INDEX), value->span_)
+      << context << " must be an integer or INDEX scalar";
+}
+
+void CheckValidExtent(const ExprPtr& extent, int64_t physical_extent, size_t axis,
+                      const std::string& op_name) {
+  CheckIntegerOperand(extent, op_name + " runtime valid extent");
+  if (auto constant = As<ConstInt>(extent)) {
+    CHECK_SPAN(constant->value_ >= 0 && constant->value_ <= physical_extent, extent->span_)
+        << op_name << " valid extent for dimension " << axis << " must be between 0 and " << physical_extent
+        << ", got " << constant->value_;
+  }
+}
+
+void ValidateBufferAlloc(const std::vector<ExprPtr>& args, const TypePtr& result_type) {
+  CHECK(args.size() == 1 || args.size() == 2)
+      << "buffer.alloc requires a runtime-valid tuple and an optional effective address";
+  auto buffer = As<BufferType>(result_type);
+  CHECK(buffer) << "buffer.alloc result must have BufferType";
+  CHECK(args[0]) << "buffer.alloc runtime valid extents must not be null";
+  auto valid = As<MakeTuple>(args[0]);
+  CHECK_SPAN(valid, args[0]->span_) << "buffer.alloc runtime valid extents must be a MakeTuple";
+  const auto dynamic_count =
+      static_cast<size_t>(std::count(buffer->valid_shape_.begin(), buffer->valid_shape_.end(), int64_t{-1}));
+  CHECK_SPAN(valid->elements_.size() == dynamic_count, valid->span_)
+      << "buffer.alloc requires " << dynamic_count
+      << " runtime valid extent(s), one per dynamic descriptor dimension, got " << valid->elements_.size();
+
+  size_t operand_index = 0;
+  for (size_t axis = 0; axis < buffer->valid_shape_.size(); ++axis) {
+    if (buffer->valid_shape_[axis] != -1) continue;
+    const auto& extent = valid->elements_[operand_index++];
+    CheckValidExtent(extent, buffer->shape_[axis], axis, "buffer.alloc");
+  }
+
+  if (args.size() == 2) {
+    CheckIntegerOperand(args[1], "buffer.alloc effective address");
+    if (auto address = As<ConstInt>(args[1])) {
+      CHECK_SPAN(address->value_ >= 0, address->span_)
+          << "buffer.alloc effective address must be nonnegative; omit the operand for addressless "
+             "allocation";
+    }
+  }
+}
+
+TypePtr DeduceSetValidShape(const std::vector<ExprPtr>& args) {
+  CHECK(args.size() == 2) << "buffer.set_validshape requires a buffer and a tuple of all valid extents";
+  CHECK(args[0] && args[1]) << "buffer.set_validshape operands must not be null";
+  auto buffer = As<BufferType>(args[0]->GetType());
+  CHECK_SPAN(buffer, args[0]->span_) << "buffer.set_validshape requires a BufferType operand";
+  auto valid = As<MakeTuple>(args[1]);
+  CHECK_SPAN(valid, args[1]->span_) << "buffer.set_validshape valid extents must be a MakeTuple";
+  CHECK_SPAN(valid->elements_.size() == buffer->shape_.size(), valid->span_)
+      << "buffer.set_validshape requires one valid extent per physical dimension";
+  for (size_t axis = 0; axis < buffer->shape_.size(); ++axis) {
+    const auto& extent = valid->elements_[axis];
+    CheckValidExtent(extent, buffer->shape_[axis], axis, "buffer.set_validshape");
+    if (buffer->valid_shape_[axis] != -1) {
+      auto constant = As<ConstInt>(extent);
+      CHECK_SPAN(constant && constant->value_ == buffer->valid_shape_[axis], extent->span_)
+          << "buffer.set_validshape cannot change static valid dimension " << axis << " ("
+          << buffer->valid_shape_[axis] << "); its descriptor must already mark changing dimensions dynamic";
+    }
+  }
+  return GetVoidType();
+}
+
+}  // namespace
+
+// The immutable physical descriptor is Call::type_, never a duplicate kwarg.
+// Only dynamic valid extents occur in arg 0, ordered by their descriptor axes.
+// Arg 1, when present, is the final effective byte address: zero is valid and
+// no base/offset is added here. Addressless roots request fresh storage;
+// addressed roots can overlap. Allocate does not imply initialized data or
+// disjoint storage. Runtime extent bounds and address nonnegativity remain
+// preconditions when they cannot be checked statically.
+REGISTER_OP("buffer.alloc")
+    .set_description("Declare a buffer with explicit runtime valid extents and an optional effective address")
+    .set_op_category("BufferOp")
+    .set_ir_stage(OpIRStage::Buffer)
+    .set_internal_only()
+    .add_argument("valid_extents", "Tuple of runtime valid extents for dynamic descriptor dimensions")
+    .add_argument("address", "Optional final effective byte address; omission requests fresh storage")
+    .set_output_arity(1)
+    .set_buffer_non_memory_arg(0)
+    .set_buffer_non_memory_arg(1)
+    .set_buffer_result_behavior(BufferResultBehavior::Allocate)
+    .f_validate_explicit_type([](const std::vector<ExprPtr>& args,
+                                 const std::vector<std::pair<std::string, std::any>>&,
+                                 const TypePtr& result_type) { ValidateBufferAlloc(args, result_type); });
+
+// Runtime valid state belongs to the handle. Updating it does not create a
+// second handle or write data, and must not change immutable descriptor fields.
+REGISTER_OP("buffer.set_validshape")
+    .set_description("Update runtime valid extents without changing the buffer descriptor or data")
+    .set_op_category("BufferOp")
+    .set_ir_stage(OpIRStage::Buffer)
+    .set_internal_only()
+    .add_argument("buffer", "Buffer whose runtime valid metadata is updated")
+    .add_argument("valid_extents", "Tuple of all valid extents; static descriptor dimensions must agree")
+    .set_output_arity(0)
+    .set_buffer_arg_effect(0, BufferAccess::None, BufferAccess::Write)
+    .set_buffer_non_memory_arg(1)
+    .set_buffer_result_behavior(BufferResultBehavior::None)
+    .f_deduce_type([](const std::vector<ExprPtr>& args,
+                      const std::vector<std::pair<std::string, std::any>>&) {
+      return DeduceSetValidShape(args);
+    });
+
+}  // namespace ir
+}  // namespace pypto

--- a/src/ir/op_registry.cpp
+++ b/src/ir/op_registry.cpp
@@ -30,6 +30,7 @@
 #include "pypto/ir/kind_traits.h"
 #include "pypto/ir/memory_space.h"
 #include "pypto/ir/span.h"
+#include "pypto/ir/transforms/structural_comparison.h"
 #include "pypto/ir/type.h"
 
 namespace pypto {
@@ -41,6 +42,16 @@ namespace {
 ///
 /// Kept out of line so `Span::to_string()` is only paid on the error path.
 std::string LocationSuffix(const Span& span) { return span.is_valid() ? " at " + span.to_string() : ""; }
+
+bool IsBufferHandle(const TypePtr& type) { return As<BufferType>(type) || As<MultiBufferType>(type); }
+
+bool IsNonMemoryBufferOperand(const TypePtr& type) {
+  if (As<ScalarType>(type)) return true;
+  if (auto tuple = As<TupleType>(type)) {
+    return std::all_of(tuple->types_.begin(), tuple->types_.end(), IsNonMemoryBufferOperand);
+  }
+  return false;
+}
 
 /// Render an allowed-space list as "Acc" / "Vec or Acc" / "Vec, Mat or Acc".
 std::string FormatAllowedSpaces(const std::vector<MemorySpace>& allowed) {
@@ -147,6 +158,140 @@ void CheckOperandMemorySpaceReachable(const OpMemorySpaceSpec& spec, const std::
 
 }  // namespace
 
+OpRegistryEntry& OpRegistryEntry::set_buffer_arg_effect(size_t arg_index, BufferAccess data,
+                                                        BufferAccess metadata) {
+  CHECK(ir_stage_ == OpIRStage::Buffer)
+      << "Operator '" << name_ << "' must select Buffer stage before declaring buffer effects";
+  CHECK(buffer_arg_effects_.emplace(arg_index, BufferArgEffect{data, metadata, false}).second)
+      << "Operator '" << name_ << "' already classified buffer argument " << arg_index;
+  return *this;
+}
+
+OpRegistryEntry& OpRegistryEntry::set_buffer_non_memory_arg(size_t arg_index) {
+  set_buffer_arg_effect(arg_index, BufferAccess::None, BufferAccess::None);
+  buffer_arg_effects_.at(arg_index).non_memory = true;
+  return *this;
+}
+
+OpRegistryEntry& OpRegistryEntry::set_buffer_result_behavior(size_t result_index,
+                                                             BufferResultBehavior behavior,
+                                                             std::optional<size_t> alias_arg) {
+  CHECK(ir_stage_ == OpIRStage::Buffer)
+      << "Operator '" << name_ << "' must select Buffer stage before declaring buffer results";
+  CHECK(buffer_results_.emplace(result_index, BufferResultSpec{behavior, alias_arg}).second)
+      << "Operator '" << name_ << "' already classified result " << result_index;
+  return *this;
+}
+
+const BufferArgEffect& OpRegistryEntry::GetBufferArgEffect(size_t arg_index) const {
+  CHECK(ir_stage_ == OpIRStage::Buffer) << "Operator '" << name_ << "' is not a buffer operator";
+  auto it = buffer_arg_effects_.find(arg_index);
+  CHECK(it != buffer_arg_effects_.end())
+      << "Operator '" << name_ << "' has no buffer effect for argument " << arg_index;
+  return it->second;
+}
+
+const BufferResultSpec& OpRegistryEntry::GetBufferResultSpec(size_t result_index) const {
+  CHECK(ir_stage_ == OpIRStage::Buffer) << "Operator '" << name_ << "' is not a buffer operator";
+  auto it = buffer_results_.find(result_index);
+  CHECK(it != buffer_results_.end()) << "Operator '" << name_ << "' has no buffer result behavior for result "
+                                     << result_index;
+  return it->second;
+}
+
+void OpRegistryEntry::ValidateIRStage() const {
+  CHECK(!validate_explicit_type_.has_value() || (ir_stage_ == OpIRStage::Buffer && internal_only_))
+      << "Operator '" << name_ << "' explicit type validation requires an internal-only Buffer operator";
+  if (ir_stage_ == OpIRStage::Functional) {
+    CHECK(output_arity_ > 0) << "Functional operator '" << name_ << "' must produce at least one value";
+    CHECK(buffer_arg_effects_.empty() && buffer_results_.empty())
+        << "Functional operator '" << name_ << "' cannot carry buffer contracts";
+    return;
+  }
+  CHECK(internal_only_) << "Buffer operator '" << name_ << "' must be internal-only";
+  CHECK(output_arity_declared_) << "Buffer operator '" << name_ << "' must explicitly declare output arity";
+  CHECK(!arg_effects_.has_value()) << "Buffer operator '" << name_
+                                   << "' must use buffer data and metadata effects, not ArgEffect";
+  CHECK(arguments_.has_value()) << "Buffer operator '" << name_ << "' must declare its arguments";
+  for (size_t i = 0; i < GetArgumentCount(); ++i) {
+    CHECK(buffer_arg_effects_.count(i) > 0)
+        << "Buffer operator '" << name_ << "' has no buffer effect for argument " << i;
+  }
+  CHECK(buffer_arg_effects_.size() == GetArgumentCount())
+      << "Buffer operator '" << name_ << "' declares an effect for an argument outside its schema";
+  const size_t result_count = std::max(size_t{1}, output_arity_);
+  for (size_t i = 0; i < result_count; ++i) {
+    const auto& result = GetBufferResultSpec(i);
+    CHECK((result.behavior == BufferResultBehavior::None) == (output_arity_ == 0))
+        << "Buffer operator '" << name_ << "' must declare None behavior exactly for zero results";
+    const bool aliases =
+        result.behavior == BufferResultBehavior::Alias || result.behavior == BufferResultBehavior::Borrow;
+    CHECK(aliases == result.alias_arg.has_value())
+        << "Buffer operator '" << name_ << "' must name a source argument exactly for Alias/Borrow results";
+    if (result.alias_arg.has_value()) {
+      CHECK(*result.alias_arg < GetArgumentCount() && !GetBufferArgEffect(*result.alias_arg).non_memory)
+          << "Buffer operator '" << name_ << "' result " << i << " has no memory source argument";
+    }
+  }
+  CHECK(buffer_results_.size() == result_count)
+      << "Buffer operator '" << name_ << "' declares behavior for a result outside its output arity";
+}
+
+void OpRegistryEntry::ValidateCall(const std::vector<ExprPtr>& args, const TypePtr& result_type,
+                                   const Span& span) const {
+  INTERNAL_CHECK_SPAN(result_type, span) << "Type deduction failed for '" << name_ << "'";
+  auto tuple = As<TupleType>(result_type);
+  if (output_arity_ == 0) {
+    INTERNAL_CHECK_SPAN(ir_stage_ == OpIRStage::Buffer && As<VoidType>(result_type), span)
+        << "Operator '" << name_ << "' declares zero results but did not deduce VoidType";
+  } else {
+    INTERNAL_CHECK_SPAN(!As<VoidType>(result_type), span)
+        << "Operator '" << name_ << "' declares SSA results but deduced VoidType";
+    if (output_arity_ > 1) {
+      INTERNAL_CHECK_SPAN(tuple, span)
+          << "Operator '" << name_ << "' declares set_output_arity(" << output_arity_
+          << ") but deduced a non-tuple " << result_type->TypeName();
+      INTERNAL_CHECK_SPAN(tuple->types_.size() == output_arity_, span)
+          << "Operator '" << name_ << "' declares set_output_arity(" << output_arity_
+          << ") but deduced a TupleType with " << tuple->types_.size() << " elements";
+    } else {
+      INTERNAL_CHECK_SPAN(!tuple, span)
+          << "Operator '" << name_ << "' deduced a TupleType result without declaring set_output_arity("
+          << tuple->types_.size() << ")";
+    }
+  }
+  if (ir_stage_ != OpIRStage::Buffer) return;
+
+  CHECK(args.size() <= GetArgumentCount()) << "Buffer operator '" << name_ << "' received " << args.size()
+                                           << " arguments, but its schema has " << GetArgumentCount();
+  for (size_t i = 0; i < args.size(); ++i) {
+    CHECK(args[i]) << "Buffer operator '" << name_ << "' argument " << i << " is null";
+    const auto& type = args[i]->GetType();
+    const auto& effect = GetBufferArgEffect(i);
+    const bool memory = IsBufferHandle(type) || AsTensorTypeLike(type);
+    CHECK(effect.non_memory ? IsNonMemoryBufferOperand(type) : memory)
+        << "Buffer operator '" << name_ << "' argument " << i << " has type " << type->TypeName()
+        << " inconsistent with its " << (effect.non_memory ? "non-memory" : "memory") << " effect";
+  }
+  if (output_arity_ == 0) return;
+  for (size_t i = 0; i < output_arity_; ++i) {
+    const TypePtr& type = tuple ? tuple->types_[i] : result_type;
+    const auto& result = GetBufferResultSpec(i);
+    if (result.behavior == BufferResultBehavior::Value) {
+      INTERNAL_CHECK_SPAN(IsNonMemoryBufferOperand(type), span)
+          << "Buffer operator '" << name_ << "' Value result " << i << " must contain only scalar values";
+      continue;
+    }
+    INTERNAL_CHECK_SPAN(IsBufferHandle(type), span)
+        << "Buffer operator '" << name_ << "' storage result " << i << " must be a buffer handle";
+    if (result.alias_arg.has_value()) {
+      const size_t source = *result.alias_arg;
+      CHECK(source < args.size() && IsBufferHandle(args[source]->GetType()))
+          << "Buffer operator '" << name_ << "' result " << i << " must alias an actual buffer operand";
+    }
+  }
+}
+
 void ValidateKwargs(const std::vector<std::pair<std::string, std::any>>& kwargs,
                     const std::unordered_map<std::string, std::type_index>& allowed_kwargs,
                     const std::string& op_name) {
@@ -235,9 +380,65 @@ CallPtr OpRegistry::CreateInternal(const std::string& op_name, const std::vector
   return CreateImpl(op_name, args, kwargs, std::move(span), /*allow_internal=*/true);
 }
 
+CallPtr OpRegistry::CreateInternal(const std::string& op_name, const std::vector<ExprPtr>& args,
+                                   const std::vector<std::pair<std::string, std::any>>& kwargs,
+                                   const TypePtr& result_type, Span span) const {
+  CHECK_SPAN(result_type, span) << "Operator '" << op_name << "' explicit result type must not be null";
+  return CreateImpl(op_name, args, kwargs, std::move(span), /*allow_internal=*/true, result_type);
+}
+
+TypePtr OpRegistry::ResolveAndValidateCallType(const OpRegistryEntry& entry, const std::vector<ExprPtr>& args,
+                                               const std::vector<std::pair<std::string, std::any>>& kwargs,
+                                               const TypePtr& explicit_type, const Span& span) const {
+  const auto& op = entry.GetOp();  // Also validates the registration's stage and complete contracts.
+  const auto& op_name = entry.GetName();
+  TypePtr result_type;
+  try {
+    if (!kwargs.empty()) {
+      const auto& allowed_kwargs = op->GetAttrs();
+      if (!allowed_kwargs.empty() || entry.GetIRStage() == OpIRStage::Buffer) {
+        ValidateKwargs(kwargs, allowed_kwargs, op_name);
+      }
+    }
+
+    if (entry.validate_explicit_type_.has_value()) {
+      CHECK(explicit_type) << "Operator '" << op_name << "' requires an explicit result type";
+      (*entry.validate_explicit_type_)(args, kwargs, explicit_type);
+      result_type = explicit_type;
+    } else {
+      CHECK(!explicit_type) << "Operator '" << op_name
+                            << "' uses type deduction and does not accept an explicit result type";
+      result_type = entry.GetDeduceType()(args, kwargs);
+    }
+  } catch (const Error& e) {
+    // Preserve the original exception class and attach the source location.
+    e.RethrowWithMessage(std::string(e.what()) + LocationSuffix(span));
+  } catch (const std::exception& e) {
+    throw ValueError(std::string(e.what()) + LocationSuffix(span));
+  }
+  entry.ValidateCall(args, result_type, span);
+  return result_type;
+}
+
+void OpRegistry::ValidateBufferCall(const CallPtr& call) const {
+  CHECK(call) << "Cannot validate a null Buffer call";
+  CHECK_SPAN(call->op_, call->span_) << "Buffer call must name a registered operator";
+  CHECK_SPAN(!As<GlobalVar>(call->op_), call->span_)
+      << "A GlobalVar call cannot use a registered buffer operator contract";
+  const auto& entry = GetEntry(call->op_->name_);
+  CHECK_SPAN(entry.GetIRStage() == OpIRStage::Buffer, call->span_)
+      << "Operator '" << entry.GetName() << "' is not a buffer operator";
+  const auto& original_type = call->GetType();
+  CHECK_SPAN(original_type, call->span_) << "Buffer call must have a result type";
+  const TypePtr expected_type = ResolveAndValidateCallType(
+      entry, call->args_, call->kwargs_, entry.RequiresExplicitType() ? original_type : nullptr, call->span_);
+  CHECK_SPAN(structural_equal(original_type, expected_type), call->span_)
+      << "Buffer operator '" << entry.GetName() << "' stored result type does not match its deduced type";
+}
+
 CallPtr OpRegistry::CreateImpl(const std::string& op_name, const std::vector<ExprPtr>& args,
                                const std::vector<std::pair<std::string, std::any>>& kwargs, Span span,
-                               bool allow_internal) const {
+                               bool allow_internal, const TypePtr& explicit_type) const {
   // Look up operator in registry
   auto it = registry_.find(op_name);
   if (it == registry_.end()) {
@@ -256,57 +457,8 @@ CallPtr OpRegistry::CreateImpl(const std::string& op_name, const std::vector<Exp
                      "' is internal-only and cannot be created from user-facing op creation paths");
   }
 
-  // Get operator instance (shared definition)
-  OpPtr op = entry.GetOp();
-
-  // Validate kwargs against allowed attributes (stored in Op)
-  if (!kwargs.empty()) {
-    const auto& allowed_kwargs = op->GetAttrs();
-    if (!allowed_kwargs.empty()) {
-      ValidateKwargs(kwargs, allowed_kwargs, op_name);
-    }
-  }
-
-  const auto& deduce_type_fn = entry.GetDeduceType();
-
-  // Deduce result type (pass args and kwargs separately)
-  TypePtr result_type;
-  try {
-    result_type = deduce_type_fn(args, kwargs);
-  } catch (const Error& e) {
-    // Append the IR location but keep the concrete exception type and the stack trace
-    // captured at the original throw. Flattening every PyPTO exception to ValueError
-    // here erased the CHECK / INTERNAL_CHECK distinction for all op type deduction.
-    e.RethrowWithMessage(std::string(e.what()) + LocationSuffix(span));
-  } catch (const std::exception& e) {
-    // Non-PyPTO exceptions (e.g. std::bad_any_cast from a wrong-typed kwarg) stay
-    // ValueError: they are reachable from user input and carry no PyPTO trace to keep.
-    throw ValueError(std::string(e.what()) + LocationSuffix(span));
-  }
-  INTERNAL_CHECK_SPAN(result_type, span) << "Type deduction failed for '" + op_name + "'";
-
-  // The declared output arity and the deduced shape must agree. A mismatch means
-  // the registration and its f_deduce_type disagree about what the operator
-  // produces, which would surface much later as a null element var inside
-  // multi-output codegen. The reverse direction matters just as much: a tuple
-  // result nobody declared has no arity for codegen to read, so its elements
-  // would never be resolved.
-  const size_t declared_arity = entry.GetOutputArity();
-  auto deduced_tuple = As<TupleType>(result_type);
-  if (declared_arity > 1) {
-    INTERNAL_CHECK_SPAN(deduced_tuple, span)
-        << "Internal error: '" << op_name << "' declares set_output_arity(" << declared_arity
-        << ") but deduced a non-tuple " << result_type->TypeName();
-    INTERNAL_CHECK_SPAN(deduced_tuple->types_.size() == declared_arity, span)
-        << "Internal error: '" << op_name << "' declares set_output_arity(" << declared_arity
-        << ") but deduced a TupleType with " << deduced_tuple->types_.size() << " elements";
-  } else {
-    INTERNAL_CHECK_SPAN(!deduced_tuple, span)
-        << "Internal error: '" << op_name << "' deduced a TupleType result without declaring "
-        << "set_output_arity(" << deduced_tuple->types_.size()
-        << "); multi-output codegen reads the arity from the registry and would not "
-           "resolve this call's elements";
-  }
+  TypePtr result_type = ResolveAndValidateCallType(entry, args, kwargs, explicit_type, span);
+  OpPtr op = entry.op_;  // ResolveAndValidateCallType already validated the registration.
 
   // Apply OpMemorySpaceSpec to TileType results that lack memory_space.
   // This ensures the deduced type carries memory_space even when individual
@@ -414,6 +566,7 @@ void OpRegistry::ValidateArgEffects() const {
   std::vector<std::string> unclassified;
   std::vector<std::string> channel_without_write;
   for (const auto& [name, entry] : registry_) {
+    if (entry.GetIRStage() != OpIRStage::Functional) continue;
     // A write channel describes *how* an operator writes, so declaring one
     // while writing nothing is incoherent — and it is the shape that hides a
     // missing classification, since `set_write_channel()` creates the effect
@@ -465,6 +618,7 @@ void OpRegistry::ValidateMultiOutputOps() const {
   std::vector<std::string> workspace_never_written;
   std::vector<std::string> reuses_input;
   for (const auto& [name, entry] : registry_) {
+    if (entry.GetIRStage() != OpIRStage::Functional) continue;
     if (entry.GetOutputArity() <= 1) continue;
     const size_t arg_count = entry.GetArgumentCount();
     for (size_t i = 0; i < arg_count; ++i) {
@@ -546,6 +700,12 @@ void OpRegistry::ValidateMultiOutputOps() const {
         "results, \"the output reuses input N\" cannot say which one, and InitMemRef would "
         "bind the tuple temporary rather than an element. Drop the declaration:",
         std::move(reuses_input));
+  }
+}
+
+void OpRegistry::ValidateBufferOps() const {
+  for (const auto& [name, entry] : registry_) {
+    entry.ValidateIRStage();
   }
 }
 

--- a/tests/ut/ir/operators/test_buffer_alloc.py
+++ b/tests/ut/ir/operators/test_buffer_alloc.py
@@ -1,0 +1,186 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Allocation keeps physical descriptors in types and runtime values in operands."""
+
+from collections.abc import Sequence
+from typing import Any
+
+import pytest
+from pypto import DataType, ir
+from pypto.pypto_core import ir as _ir
+
+
+def descriptor(**overrides: Any) -> ir.BufferType:
+    options: dict[str, Any] = dict(shape=[16, 32], dtype=DataType.FP32, memory_space=ir.MemorySpace.Vec)
+    return ir.BufferType(**(options | overrides))
+
+
+def integer(value: int, dtype: DataType = DataType.INDEX) -> ir.ConstInt:
+    return ir.ConstInt(value, dtype, ir.Span.unknown())
+
+
+def scalar(name: str, dtype: DataType = DataType.INDEX) -> ir.Var:
+    return ir.Var(name, ir.ScalarType(dtype), ir.Span.unknown())
+
+
+def allocate(
+    result_type: ir.Type,
+    valid: Sequence[ir.Expr] = (),
+    address: ir.Expr | None = None,
+    **kwargs: Any,
+) -> ir.Call:
+    span = ir.Span.unknown()
+    args: list[ir.Expr] = [ir.MakeTuple(valid, span)]
+    if address is not None:
+        args.append(address)
+    return _ir._create_internal_op_call("buffer.alloc", args, kwargs, result_type, span)
+
+
+def test_addressless_allocation_has_no_address_operand_or_descriptor_kwargs():
+    type_ = descriptor()
+    call = allocate(type_)
+    assert isinstance(call.type, ir.BufferType)
+    ir.assert_structural_equal(call.type, type_)
+    assert call.kwargs == {}
+    assert len(call.args) == 1
+    assert isinstance(call.args[0], ir.MakeTuple)
+    assert len(call.args[0].elements) == 0
+    assert ir.get_op_ir_stage("buffer.alloc") == ir.OpIRStage.Buffer
+    assert ir.get_op_output_arity("buffer.alloc") == 1
+    assert ir.get_op_buffer_result_spec("buffer.alloc").behavior == ir.BufferResultBehavior.Allocate
+    assert ir.get_op_buffer_result_spec("buffer.alloc").alias_arg is None
+    for index in (0, 1):
+        effect = ir.get_op_buffer_arg_effect("buffer.alloc", index)
+        assert effect.non_memory
+        assert effect.data == ir.BufferAccess.None_
+        assert effect.metadata == ir.BufferAccess.None_
+
+
+@pytest.mark.parametrize("address", [0, 64, 4096])
+def test_effective_address_is_preserved_exactly(address):
+    call = allocate(descriptor(), address=integer(address))
+    assert len(call.args) == 2
+    assert isinstance(call.args[1], ir.ConstInt)
+    assert call.args[1].value == address
+    assert not ir.structural_equal(call, allocate(descriptor()))
+
+
+@pytest.mark.parametrize("valid_shape,valid", [([-1, 32], [8]), ([16, -1], [24]), ([-1, -1], [0, 32])])
+def test_dynamic_descriptor_extents_are_supplied_in_axis_order(valid_shape, valid):
+    call = allocate(descriptor(valid_shape=valid_shape), [integer(value) for value in valid])
+    assert isinstance(call.type, ir.BufferType)
+    assert call.type.valid_shape == valid_shape
+    assert isinstance(call.args[0], ir.MakeTuple)
+    for actual, expected in zip(call.args[0].elements, valid, strict=True):
+        assert isinstance(actual, ir.ConstInt)
+        assert actual.value == expected
+
+
+def test_address_and_valid_extents_are_visible_to_substitution_and_serialization():
+    valid = scalar("valid")
+    address = scalar("effective_address")
+    next_valid = scalar("next_valid")
+    next_address = scalar("next_effective_address")
+    call = allocate(descriptor(valid_shape=[-1, 32]), [valid], address)
+    rewritten = ir.substitute_expr(call, [(valid, next_valid), (address, next_address)])
+    assert isinstance(rewritten, ir.Call)
+    assert isinstance(rewritten.args[0], ir.MakeTuple)
+    assert rewritten.args[0].elements[0].same_as(next_valid)
+    assert rewritten.args[1].same_as(next_address)
+    ir.assert_structural_equal(rewritten.type, call.type)
+    restored = ir.deserialize(ir.serialize(rewritten))
+    ir.assert_structural_equal(rewritten, restored, enable_auto_mapping=True)
+
+
+@pytest.mark.parametrize("dtype", [DataType.INT32, DataType.UINT32, DataType.INT64, DataType.INDEX])
+def test_integer_runtime_values_are_accepted(dtype):
+    value = scalar("runtime", dtype)
+    call = allocate(descriptor(valid_shape=[16, -1]), [value], value)
+    assert call.args[1].same_as(value)
+
+
+@pytest.mark.parametrize("dtype", [DataType.FP32, DataType.BOOL, DataType.TASK_ID])
+@pytest.mark.parametrize("operand", ["valid", "address"])
+def test_non_integer_runtime_values_are_rejected(dtype, operand):
+    value = scalar("invalid", dtype)
+    with pytest.raises(ValueError, match="integer or INDEX scalar"):
+        if operand == "valid":
+            allocate(descriptor(valid_shape=[-1, 32]), [value])
+        else:
+            allocate(descriptor(), address=value)
+
+
+@pytest.mark.parametrize("value", [-1, -64])
+def test_negative_address_is_not_an_addressless_sentinel(value):
+    with pytest.raises(ValueError, match="effective address must be nonnegative"):
+        allocate(descriptor(), address=integer(value))
+
+
+@pytest.mark.parametrize("valid_shape,valid", [([-1, 32], [-1]), ([-1, 32], [17]), ([16, -1], [33])])
+def test_constant_valid_extents_must_fit_their_physical_axes(valid_shape, valid):
+    with pytest.raises(ValueError, match="valid extent for dimension .* must be between"):
+        allocate(descriptor(valid_shape=valid_shape), [integer(value) for value in valid])
+
+
+@pytest.mark.parametrize("valid_shape,valid", [([16, 32], [16]), ([-1, 32], []), ([-1, -1], [16])])
+def test_valid_operand_count_matches_dynamic_dimensions_only(valid_shape, valid):
+    with pytest.raises(ValueError, match="one per dynamic descriptor dimension"):
+        allocate(descriptor(valid_shape=valid_shape), [integer(value) for value in valid])
+
+
+@pytest.mark.parametrize("arg_count", [0, 3])
+def test_allocation_operand_arity_is_checked(arg_count):
+    with pytest.raises(ValueError, match="runtime-valid tuple and an optional effective address"):
+        _ir._create_internal_op_call(
+            "buffer.alloc", [integer(0)] * arg_count, {}, descriptor(), ir.Span.unknown()
+        )
+
+
+def test_runtime_valid_extents_require_an_explicit_tuple():
+    tuple_value = ir.Var("dims", ir.TupleType([ir.ScalarType(DataType.INDEX)]), ir.Span.unknown())
+    with pytest.raises(ValueError, match="runtime valid extents must be a MakeTuple"):
+        _ir._create_internal_op_call(
+            "buffer.alloc", [tuple_value], {}, descriptor(valid_shape=[-1, 32]), ir.Span.unknown()
+        )
+
+
+@pytest.mark.parametrize(
+    "result_type",
+    [
+        ir.UnknownType(),
+        ir.VoidType(),
+        ir.TileType([16, 32], DataType.FP32),
+        ir.ScalarType(DataType.INDEX),
+        ir.MultiBufferType(descriptor(), 2),
+        ir.TupleType([descriptor()]),
+    ],
+)
+def test_allocation_requires_one_buffer_descriptor(result_type):
+    with pytest.raises(ValueError, match="result must have BufferType"):
+        allocate(result_type)
+
+
+@pytest.mark.parametrize("kwarg", ["shape", "base", "byte_offset", "dtype", "address"])
+def test_descriptor_and_address_cannot_be_duplicated_in_kwargs(kwarg):
+    with pytest.raises(ValueError, match=f"Unknown kwarg '{kwarg}'"):
+        _ir._create_internal_op_call(
+            "buffer.alloc", [ir.MakeTuple([], ir.Span.unknown())], {kwarg: 0}, descriptor(), ir.Span.unknown()
+        )
+
+
+def test_allocation_requires_the_internal_explicit_type_builder():
+    args = [ir.MakeTuple([], ir.Span.unknown())]
+    with pytest.raises(ValueError, match="internal-only"):
+        ir.create_op_call("buffer.alloc", args, ir.Span.unknown())
+    with pytest.raises(ValueError, match="explicit result type"):
+        _ir._create_internal_op_call("buffer.alloc", args, {}, ir.Span.unknown())
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/ir/operators/test_buffer_ops.py
+++ b/tests/ut/ir/operators/test_buffer_ops.py
@@ -1,0 +1,234 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Internal buffer writes expose destination operands and zero SSA results."""
+
+from collections.abc import Sequence
+from typing import Any
+
+import pytest
+from pypto import DataType, ir
+from pypto.pypto_core import ir as _ir
+from pypto.pypto_core import testing
+
+
+def buffer_var(name: str, **descriptor: Any) -> ir.Var:
+    options: dict[str, Any] = dict(shape=[16, 32], dtype=DataType.FP32, memory_space=ir.MemorySpace.Vec)
+    options.update(descriptor)
+    return ir.Var(name, ir.BufferType(**options), ir.Span.unknown())
+
+
+def internal_call(name: str, args: Sequence[ir.Expr], **kwargs: Any) -> ir.Call:
+    return _ir._create_internal_op_call(name, args, kwargs, ir.Span.unknown())
+
+
+@pytest.mark.parametrize("op_name,arg_count", [("buffer.copy", 2), ("buffer.mul", 3)])
+def test_buffer_write_has_explicit_destination_and_void_result(op_name, arg_count):
+    args = [buffer_var(f"arg_{i}") for i in range(arg_count)]
+    call = internal_call(op_name, args)
+    assert isinstance(call.type, ir.VoidType)
+    assert len(call.args) == arg_count
+    ir.assert_structural_equal(call.args[-1], args[-1])
+    assert isinstance(ir.EvalStmt(call, ir.Span.unknown()), ir.EvalStmt)
+    assert ir.get_op_ir_stage(op_name) == ir.OpIRStage.Buffer
+    assert ir.get_op_output_arity(op_name) == 0
+    assert ir.get_op_buffer_result_spec(op_name).behavior == ir.BufferResultBehavior.None_
+    assert ir.get_op_buffer_result_spec(op_name).alias_arg is None
+    assert not ir.op_arg_is_workspace(op_name, arg_count - 1)
+
+
+@pytest.mark.parametrize("op_name,arg_count", [("buffer.copy", 2), ("buffer.mul", 3)])
+def test_data_and_metadata_effects_are_explicit(op_name, arg_count):
+    for index in range(arg_count):
+        effect = ir.get_op_buffer_arg_effect(op_name, index)
+        assert not effect.non_memory
+        assert effect.metadata == ir.BufferAccess.Read
+        assert effect.data == (ir.BufferAccess.Write if index == arg_count - 1 else ir.BufferAccess.Read)
+    with pytest.raises(ValueError, match="no buffer effect"):
+        ir.get_op_buffer_arg_effect(op_name, arg_count)
+    with pytest.raises(ValueError, match="requires GetBufferArgEffect"):
+        ir.get_op_arg_effect(op_name, 0)
+    assert testing.get_execution_memory_access_evidence(op_name) == "unknown"
+
+
+@pytest.mark.parametrize("op_name,arg_count", [("buffer.copy", 2), ("buffer.mul", 3)])
+def test_buffer_ops_are_internal_only(op_name, arg_count):
+    args = [buffer_var(f"arg_{i}") for i in range(arg_count)]
+    with pytest.raises(ValueError, match="internal-only"):
+        ir.create_op_call(op_name, args, ir.Span.unknown())
+
+
+@pytest.mark.parametrize("op_name,arg_count", [("buffer.copy", 2), ("buffer.mul", 3)])
+def test_exact_input_destination_alias_is_legal(op_name, arg_count):
+    value = buffer_var("shared")
+    call = internal_call(op_name, [value] * arg_count)
+    assert isinstance(call.type, ir.VoidType)
+
+
+@pytest.mark.parametrize("op_name,arg_count", [("buffer.copy", 2), ("buffer.mul", 3)])
+def test_dynamic_valid_descriptor_is_preserved(op_name, arg_count):
+    args = [buffer_var(f"arg_{i}", valid_shape=[-1, 32]) for i in range(arg_count)]
+    call = internal_call(op_name, args)
+    destination_type = call.args[-1].type
+    assert isinstance(destination_type, ir.BufferType)
+    assert list(destination_type.valid_shape) == [-1, 32]
+
+
+@pytest.mark.parametrize(
+    "difference",
+    [
+        {"shape": [8, 32]},
+        {"dtype": DataType.FP16},
+        {"valid_shape": [8, 32]},
+        {"valid_shape": [-1, 32]},
+        {"blayout": ir.TileLayout.col_major},
+        {"slayout": ir.TileLayout.row_major},
+        {"fractal": 1024},
+        {"pad": ir.PadValue.zero},
+        {"compact": ir.CompactMode.normal},
+    ],
+)
+@pytest.mark.parametrize("op_name,arg_count", [("buffer.copy", 2), ("buffer.mul", 3)])
+def test_every_physical_descriptor_field_must_match(op_name, arg_count, difference):
+    args = [buffer_var(f"arg_{i}") for i in range(arg_count - 1)] + [buffer_var("dst", **difference)]
+    with pytest.raises(ValueError, match="identical physical descriptors"):
+        internal_call(op_name, args)
+
+
+@pytest.mark.parametrize("op_name,arg_count", [("buffer.copy", 2), ("buffer.mul", 3)])
+def test_non_vector_buffer_is_rejected(op_name, arg_count):
+    args = [buffer_var(f"arg_{i}", memory_space=ir.MemorySpace.Mat) for i in range(arg_count)]
+    with pytest.raises(ValueError, match="must be in Vec memory"):
+        internal_call(op_name, args)
+
+
+@pytest.mark.parametrize("op_name,arg_count", [("buffer.copy", 2), ("buffer.mul", 3)])
+def test_argument_arity_is_exact(op_name, arg_count):
+    for count in (arg_count - 1, arg_count + 1):
+        with pytest.raises(ValueError, match="buffer operands"):
+            internal_call(op_name, [buffer_var(f"arg_{i}") for i in range(count)])
+
+
+@pytest.mark.parametrize("op_name,arg_count", [("buffer.copy", 2), ("buffer.mul", 3)])
+def test_logical_tiles_do_not_satisfy_buffer_schema(op_name, arg_count):
+    tile = ir.Var("tile", ir.TileType([16, 32], DataType.FP32), ir.Span.unknown())
+    with pytest.raises(ValueError, match="must have BufferType"):
+        internal_call(op_name, [tile] * arg_count)
+
+
+@pytest.mark.parametrize("op_name,arg_count", [("buffer.copy", 2), ("buffer.mul", 3)])
+def test_unknown_kwargs_do_not_silently_change_buffer_semantics(op_name, arg_count):
+    with pytest.raises(ValueError, match="Unknown kwarg 'transpose'"):
+        internal_call(op_name, [buffer_var(f"arg_{i}") for i in range(arg_count)], transpose=True)
+
+
+@pytest.mark.parametrize("op_name,arg_count", [("buffer.copy", 2), ("buffer.mul", 3)])
+def test_buffer_statement_round_trip_preserves_destination_identity(op_name, arg_count):
+    shared = buffer_var("shared")
+    call = internal_call(op_name, [shared] * arg_count)
+    statement = ir.EvalStmt(call, ir.Span.unknown())
+    restored = ir.deserialize(ir.serialize(statement))
+    ir.assert_structural_equal(statement, restored, enable_auto_mapping=True)
+    assert isinstance(restored, ir.EvalStmt)
+    assert isinstance(restored.expr, ir.Call)
+    assert isinstance(restored.expr.type, ir.VoidType)
+    assert restored.expr.args[-1].same_as(restored.expr.args[0])
+    assert ir.get_op_ir_stage(restored.expr.op.name) == ir.OpIRStage.Buffer
+
+
+def valid_extents(*values: int | ir.Expr) -> ir.MakeTuple:
+    span = ir.Span.unknown()
+    return ir.MakeTuple(
+        [ir.ConstInt(value, DataType.INDEX, span) if isinstance(value, int) else value for value in values],
+        span,
+    )
+
+
+def test_set_validshape_mutates_only_metadata_and_preserves_handle_type():
+    buffer = buffer_var("buffer", valid_shape=[16, -1])
+    columns = ir.Var("columns", ir.ScalarType(DataType.INDEX), ir.Span.unknown())
+    call = internal_call("buffer.set_validshape", [buffer, valid_extents(16, columns)])
+    assert isinstance(call.type, ir.VoidType)
+    assert call.args[0].same_as(buffer)
+    assert isinstance(buffer.type, ir.BufferType)
+    assert buffer.type.valid_shape == [16, -1]
+    effect = ir.get_op_buffer_arg_effect("buffer.set_validshape", 0)
+    assert effect.data == ir.BufferAccess.None_
+    assert effect.metadata == ir.BufferAccess.Write
+    assert not effect.non_memory
+    assert ir.get_op_buffer_arg_effect("buffer.set_validshape", 1).non_memory
+    assert ir.get_op_output_arity("buffer.set_validshape") == 0
+    assert ir.get_op_buffer_result_spec("buffer.set_validshape").behavior == ir.BufferResultBehavior.None_
+    assert isinstance(ir.EvalStmt(call, ir.Span.unknown()), ir.EvalStmt)
+
+
+@pytest.mark.parametrize("valid", [(0, 0), (8, 24), (16, 32)])
+def test_set_validshape_accepts_empty_and_full_valid_regions(valid):
+    call = internal_call(
+        "buffer.set_validshape", [buffer_var("buffer", valid_shape=[-1, -1]), valid_extents(*valid)]
+    )
+    assert isinstance(call.type, ir.VoidType)
+
+
+@pytest.mark.parametrize("valid", [(8, 32), (16, 24)])
+def test_set_validshape_cannot_change_static_descriptor_dimensions(valid):
+    with pytest.raises(ValueError, match="cannot change static valid dimension"):
+        internal_call("buffer.set_validshape", [buffer_var("buffer"), valid_extents(*valid)])
+
+
+def test_set_validshape_cannot_make_a_static_dimension_dynamic():
+    rows = ir.Var("rows", ir.ScalarType(DataType.INDEX), ir.Span.unknown())
+    with pytest.raises(ValueError, match="descriptor must already mark changing dimensions dynamic"):
+        internal_call("buffer.set_validshape", [buffer_var("buffer"), valid_extents(rows, 32)])
+
+
+@pytest.mark.parametrize("valid", [(-1, 32), (17, 32), (16, 33)])
+def test_set_validshape_checks_constant_extent_bounds(valid):
+    with pytest.raises(ValueError, match="valid extent for dimension .* must be between"):
+        internal_call(
+            "buffer.set_validshape", [buffer_var("buffer", valid_shape=[-1, -1]), valid_extents(*valid)]
+        )
+
+
+@pytest.mark.parametrize("dtype", [DataType.FP32, DataType.BOOL, DataType.TASK_ID])
+def test_set_validshape_rejects_non_integer_extents(dtype):
+    value = ir.Var("extent", ir.ScalarType(dtype), ir.Span.unknown())
+    with pytest.raises(ValueError, match="integer or INDEX scalar"):
+        internal_call(
+            "buffer.set_validshape", [buffer_var("buffer", valid_shape=[-1, 32]), valid_extents(value, 32)]
+        )
+
+
+@pytest.mark.parametrize("count", [0, 1, 3])
+def test_set_validshape_requires_every_descriptor_dimension(count):
+    with pytest.raises(ValueError, match="one valid extent per physical dimension"):
+        internal_call("buffer.set_validshape", [buffer_var("buffer"), valid_extents(*([16] * count))])
+
+
+def test_set_validshape_requires_an_explicit_tuple():
+    dims = ir.Var("dims", ir.TupleType([ir.ScalarType(DataType.INDEX)] * 2), ir.Span.unknown())
+    with pytest.raises(ValueError, match="valid extents must be a MakeTuple"):
+        internal_call("buffer.set_validshape", [buffer_var("buffer"), dims])
+
+
+def test_set_validshape_runtime_operand_survives_rewriting_and_serialization():
+    buffer = buffer_var("buffer", valid_shape=[-1, 32])
+    rows = ir.Var("rows", ir.ScalarType(DataType.INDEX), ir.Span.unknown())
+    new_rows = ir.Var("new_rows", ir.ScalarType(DataType.INDEX), ir.Span.unknown())
+    call = internal_call("buffer.set_validshape", [buffer, valid_extents(rows, 32)])
+    rewritten = ir.substitute_expr(call, [(rows, new_rows)])
+    assert isinstance(rewritten, ir.Call)
+    assert rewritten.args[0].same_as(buffer)
+    assert isinstance(rewritten.args[1], ir.MakeTuple)
+    assert rewritten.args[1].elements[0].same_as(new_rows)
+    restored = ir.deserialize(ir.serialize(rewritten))
+    ir.assert_structural_equal(restored, rewritten, enable_auto_mapping=True)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/ir/operators/test_op_registry.py
+++ b/tests/ut/ir/operators/test_op_registry.py
@@ -24,7 +24,264 @@ from pathlib import Path
 import pypto
 import pytest
 from pypto import DataType, ir
+from pypto.pypto_core import ir as _ir
 from pypto.pypto_core import testing
+
+
+class TestExplicitBufferResultTyping:
+    """Explicit descriptors are validated at creation and again on existing IR."""
+
+    @staticmethod
+    def descriptor():
+        return ir.BufferType([16, 32], DataType.FP32, ir.MemorySpace.Vec)
+
+    @staticmethod
+    def alloc_args():
+        return [ir.MakeTuple([], ir.Span.unknown())]
+
+    @pytest.mark.parametrize("modes", [["deduced", "explicit"], ["explicit", "deduced"]])
+    def test_typing_modes_are_mutually_exclusive(self, modes):
+        with pytest.raises(ValueError, match="cannot combine type deduction with explicit type validation"):
+            testing.validate_op_type_registration(ir.OpIRStage.Buffer, True, modes)
+
+    def test_explicit_validator_cannot_be_registered_twice(self):
+        with pytest.raises(ValueError, match="explicit type validator is already set"):
+            testing.validate_op_type_registration(ir.OpIRStage.Buffer, True, ["explicit", "explicit"])
+
+    @pytest.mark.parametrize(
+        "stage,internal_only",
+        [(ir.OpIRStage.Functional, True), (ir.OpIRStage.Functional, False), (ir.OpIRStage.Buffer, False)],
+    )
+    def test_explicit_typing_requires_internal_buffer_stage(self, stage, internal_only):
+        with pytest.raises(ValueError, match="explicit type validation requires an internal-only Buffer"):
+            testing.validate_op_type_registration(stage, internal_only, ["explicit"])
+
+    def test_internal_buffer_explicit_typing_is_valid(self):
+        testing.validate_op_type_registration(ir.OpIRStage.Buffer, True, ["explicit"])
+
+    @pytest.mark.parametrize("op_name", ["buffer.mul", "tile.mul"])
+    def test_deduced_ops_reject_explicit_type_even_through_internal_api(self, op_name):
+        with pytest.raises(ValueError, match="does not accept an explicit result type"):
+            _ir._create_internal_op_call(op_name, [], {}, self.descriptor(), ir.Span.unknown())
+
+    def test_alloc_requires_explicit_result_descriptor(self):
+        with pytest.raises(ValueError, match="requires an explicit result type"):
+            _ir._create_internal_op_call("buffer.alloc", self.alloc_args(), {}, ir.Span.unknown())
+
+    def test_alloc_preserves_original_descriptor_and_operands(self):
+        descriptor = self.descriptor()
+        args = self.alloc_args()
+        call = _ir._create_internal_op_call("buffer.alloc", args, {}, descriptor, ir.Span.unknown())
+        testing.validate_buffer_call(call)
+        ir.assert_structural_equal(call.type, descriptor)
+        assert call.args[0].same_as(args[0])
+        assert not call.kwargs
+
+    def test_creation_runs_explicit_type_validator(self):
+        with pytest.raises(ValueError, match="BufferType"):
+            _ir._create_internal_op_call(
+                "buffer.alloc", self.alloc_args(), {}, ir.ScalarType(DataType.INT64), ir.Span.unknown()
+            )
+
+    def test_existing_call_runs_explicit_type_validator(self):
+        forged = ir.Call(
+            ir.get_op("buffer.alloc"),
+            self.alloc_args(),
+            {},
+            ir.ScalarType(DataType.INT64),
+            ir.Span.unknown(),
+        )
+        with pytest.raises(ValueError, match="BufferType"):
+            testing.validate_buffer_call(forged)
+
+    def test_existing_call_does_not_deduce_away_a_forged_result_type(self):
+        value = ir.Var("buffer", self.descriptor(), ir.Span.unknown())
+        forged = ir.Call(ir.get_op("buffer.mul"), [value] * 3, self.descriptor(), ir.Span.unknown())
+        with pytest.raises(ValueError, match="stored result type does not match its deduced type"):
+            testing.validate_buffer_call(forged)
+        assert isinstance(forged.type, ir.BufferType)
+
+    @pytest.mark.parametrize("op_name", ["buffer.alloc", "buffer.mul"])
+    def test_existing_call_checks_original_kwargs(self, op_name):
+        value = ir.Var("buffer", self.descriptor(), ir.Span.unknown())
+        is_alloc = op_name == ir.get_op("buffer.alloc").name
+        args = self.alloc_args() if is_alloc else [value] * 3
+        result_type = self.descriptor() if is_alloc else ir.VoidType()
+        forged = ir.Call(ir.get_op(op_name), args, {"bogus": 1}, result_type, ir.Span.unknown())
+        with pytest.raises(ValueError, match="Unknown kwarg 'bogus'"):
+            testing.validate_buffer_call(forged)
+
+    def test_existing_call_checks_operands_again(self):
+        tile = ir.Var("tile", ir.TileType([16, 32], DataType.FP32), ir.Span.unknown())
+        forged = ir.Call(ir.get_op("buffer.mul"), [tile] * 3, ir.VoidType(), ir.Span.unknown())
+        with pytest.raises(ValueError, match="must have BufferType"):
+            testing.validate_buffer_call(forged)
+
+    def test_function_call_cannot_impersonate_registered_buffer_operator(self):
+        value = ir.Var("buffer", self.descriptor(), ir.Span.unknown())
+        forged = ir.Call(ir.GlobalVar("buffer.copy"), [value, value], ir.VoidType(), ir.Span.unknown())
+        with pytest.raises(ValueError, match="GlobalVar call cannot use a registered buffer"):
+            testing.validate_buffer_call(forged)
+
+    def test_binary_round_trip_keeps_explicit_type_validation(self):
+        call = _ir._create_internal_op_call(
+            "buffer.alloc", self.alloc_args(), {}, self.descriptor(), ir.Span.unknown()
+        )
+        restored = ir.deserialize(ir.serialize(call))
+        assert isinstance(restored, ir.Call)
+        testing.validate_buffer_call(restored)
+        ir.assert_structural_equal(call, restored)
+
+
+class TestBufferRegistryContracts:
+    """Check registration failures without leaving poisoned singleton entries."""
+
+    @staticmethod
+    def check(
+        *,
+        stage=ir.OpIRStage.Buffer,
+        arity=0,
+        args=(),
+        result_type=None,
+        effects=(),
+        results=((0, ir.BufferResultBehavior.None_, None),),
+        internal_only=True,
+    ):
+        testing.validate_buffer_op_contract(
+            stage,
+            arity,
+            list(args),
+            ir.VoidType() if result_type is None else result_type,
+            list(effects),
+            list(results),
+            internal_only,
+        )
+
+    @staticmethod
+    def buffer_var(name="buffer"):
+        return ir.Var(name, ir.BufferType([16, 32], DataType.FP32, ir.MemorySpace.Vec), ir.Span.unknown())
+
+    def test_existing_ops_keep_functional_stage_and_arity(self):
+        assert ir.get_op_ir_stage("tile.mul") == ir.OpIRStage.Functional
+        assert ir.get_op_output_arity("tile.mul") == 1
+        assert ir.get_op_output_arity("tile.gather_compare") == 2
+        with pytest.raises(ValueError, match="not a buffer operator"):
+            ir.get_op_buffer_arg_effect("tile.mul", 0)
+
+    def test_functional_stage_cannot_produce_zero_results(self):
+        with pytest.raises(ValueError, match="functional operators produce at least one value"):
+            self.check(stage=ir.OpIRStage.Functional, results=())
+
+    @pytest.mark.parametrize(
+        "changes,message",
+        [
+            ({"arity": None}, "explicitly declare output arity"),
+            ({"internal_only": False}, "internal-only"),
+            ({"results": ()}, "no buffer result behavior"),
+            ({"results": ((0, ir.BufferResultBehavior.Allocate, None),)}, "None behavior"),
+        ],
+    )
+    def test_incomplete_buffer_registration_fails(self, changes, message):
+        with pytest.raises(ValueError, match=message):
+            self.check(**changes)
+
+    def test_zero_result_means_void_not_unknown(self):
+        self.check()
+        with pytest.raises(pypto.InternalError, match="did not deduce VoidType"):
+            self.check(result_type=ir.UnknownType())
+
+    def test_nonzero_result_cannot_be_void(self):
+        with pytest.raises(pypto.InternalError, match="declares SSA results but deduced VoidType"):
+            self.check(arity=1, results=((0, ir.BufferResultBehavior.Value, None),))
+
+    def test_every_argument_requires_effect_even_when_read_only(self):
+        with pytest.raises(ValueError, match="no buffer effect for argument 0"):
+            self.check(args=(self.buffer_var(),))
+
+    def test_effect_index_must_exist(self):
+        with pytest.raises(ValueError, match="outside its schema"):
+            self.check(effects=((0, False, ir.BufferAccess.Read, ir.BufferAccess.Read),))
+
+    def test_effect_cannot_be_declared_twice(self):
+        effect = (0, False, ir.BufferAccess.Read, ir.BufferAccess.Read)
+        with pytest.raises(ValueError, match="already classified buffer argument 0"):
+            self.check(args=(self.buffer_var(),), effects=(effect, effect))
+
+    def test_non_memory_classification_cannot_hide_buffer(self):
+        with pytest.raises(ValueError, match="inconsistent with its non-memory effect"):
+            self.check(
+                args=(self.buffer_var(),),
+                effects=((0, True, ir.BufferAccess.None_, ir.BufferAccess.None_),),
+            )
+
+    def test_scalar_argument_requires_non_memory_classification(self):
+        value = ir.ConstInt(0, DataType.INDEX, ir.Span.unknown())
+        with pytest.raises(ValueError, match="inconsistent with its memory effect"):
+            self.check(args=(value,), effects=((0, False, ir.BufferAccess.None_, ir.BufferAccess.None_),))
+        self.check(args=(value,), effects=((0, True, ir.BufferAccess.None_, ir.BufferAccess.None_),))
+
+    def test_logical_tile_cannot_be_a_buffer_operand(self):
+        tile = ir.Var("tile", ir.TileType([16, 32], DataType.FP32), ir.Span.unknown())
+        with pytest.raises(ValueError, match="inconsistent with its memory effect"):
+            self.check(args=(tile,), effects=((0, False, ir.BufferAccess.Read, ir.BufferAccess.Read),))
+
+    def test_metadata_write_is_independent_of_data_write(self):
+        self.check(
+            args=(self.buffer_var(),),
+            effects=((0, False, ir.BufferAccess.None_, ir.BufferAccess.Write),),
+        )
+
+    def test_allocation_does_not_imply_data_initialization(self):
+        self.check(
+            arity=1,
+            result_type=self.buffer_var().type,
+            results=((0, ir.BufferResultBehavior.Allocate, None),),
+        )
+
+    @pytest.mark.parametrize("behavior", [ir.BufferResultBehavior.Alias, ir.BufferResultBehavior.Borrow])
+    def test_alias_and_borrow_require_actual_buffer_operand(self, behavior):
+        with pytest.raises(ValueError, match="name a source argument"):
+            self.check(arity=1, result_type=self.buffer_var().type, results=((0, behavior, None),))
+        self.check(
+            arity=1,
+            args=(self.buffer_var(),),
+            result_type=self.buffer_var().type,
+            effects=((0, False, ir.BufferAccess.None_, ir.BufferAccess.Read),),
+            results=((0, behavior, 0),),
+        )
+        tensor = ir.Var("tensor", ir.TensorType([16, 32], DataType.FP32), ir.Span.unknown())
+        with pytest.raises(ValueError, match="alias an actual buffer operand"):
+            self.check(
+                arity=1,
+                args=(tensor,),
+                result_type=self.buffer_var().type,
+                effects=((0, False, ir.BufferAccess.None_, ir.BufferAccess.Read),),
+                results=((0, behavior, 0),),
+            )
+
+    def test_value_result_cannot_hide_buffer(self):
+        with pytest.raises(pypto.InternalError, match="must contain only scalar values"):
+            self.check(
+                arity=1,
+                result_type=self.buffer_var().type,
+                results=((0, ir.BufferResultBehavior.Value, None),),
+            )
+
+    def test_multi_result_contract_classifies_each_actual_result(self):
+        pair = ir.TupleType([ir.ScalarType(DataType.INDEX), self.buffer_var().type])
+        self.check(
+            arity=2,
+            result_type=pair,
+            results=((0, ir.BufferResultBehavior.Value, None), (1, ir.BufferResultBehavior.Allocate, None)),
+        )
+        with pytest.raises(ValueError, match="no buffer result behavior for result 1"):
+            self.check(arity=2, result_type=pair, results=((0, ir.BufferResultBehavior.Value, None),))
+        with pytest.raises(pypto.InternalError, match="TupleType with 2 elements"):
+            self.check(
+                arity=3,
+                result_type=pair,
+                results=tuple((i, ir.BufferResultBehavior.Value, None) for i in range(3)),
+            )
 
 
 def test_dynamic_dimension_constant():


### PR DESCRIPTION
## Summary

Adds internal Buffer-stage operator contracts on top of the type and persistence foundation merged in #2698. Buffer operators declare result arity and ownership, plus independent data and metadata effects for every buffer operand. Functional operators retain their existing type-deduction and result contract.

`buffer.alloc` stores its descriptor in the explicit call result type, with runtime valid extents and an optional effective address as ordinary operands. `buffer.copy`, `buffer.mul`, and `buffer.set_validshape` write explicit destinations or metadata and return `VoidType`. Addressed allocation roots may overlap.

## Changes

- Add mutually exclusive deduced-result and explicit-result validation modes, with shared validation for construction and existing calls.
- Register the four internal buffer operations and synchronize native APIs, Python bindings, and stubs.
- Test malformed effects, ownership, arity, result types, kwargs, valid extents, and addresses; document each operator contract in English and Chinese.

This is the next review and merge step in the Buffer IR stack. Representation verification and PTO emission are supplied by later draft PRs.

## Verification

Rebased the operator-contract commit onto `main` at `706285c602d42accd627fe75385c935251af789f`. The rebase had no conflicts, and `git range-diff` confirms the patch is unchanged. The PR diff is +1,614 / -77 lines. Validation on `5dacb0b4377da2d67e3a0a68a6c20fdfdf988760` used the repository resource-limit loader and the worktree's own build and interpreter.

- `cmake --build build --parallel "$PYPTO_BUILD_JOBS"`: passed.
- Focused operator contracts, allocation, registry, VoidType, and type-verifier tests: **568 passed**.
- Full `tests/ut/` suite: **12,677 passed, 10 skipped, 1 expected failure**.
- All 22 applicable configured checks: passed, including Pyright.
- Full clang-tidy check: passed.

Remote CI results for this rebased head are tracked in the PR checks.
