### PR TITLE
fix(ir): give every compile its own output directory

### DIFF
--- a/python/pypto/ir/compile.py
+++ b/python/pypto/ir/compile.py
@@ -11,8 +11,8 @@
 
 import logging
 import os
+import tempfile
 from contextlib import AbstractContextManager, nullcontext
-from datetime import datetime
 from typing import TYPE_CHECKING, Any, NamedTuple
 
 from pypto.backend import BackendType
@@ -380,14 +380,22 @@ def compile(  # noqa: PLR0913
     _select_backend(backend_type=backend_type, platform=platform)
 
     if output_dir is None:
-        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
         # ``or`` (not get's default arg) so an empty-but-set env var
         # (``export PYPTO_PROG_BUILD_DIR=``) still falls back to build_output
         # rather than writing artifacts into the current working directory.
         base = os.environ.get("PYPTO_PROG_BUILD_DIR") or "build_output"
-        output_dir = os.path.join(base, f"{program.name}_{timestamp}")
-
-    os.makedirs(output_dir, exist_ok=True)
+        os.makedirs(base, exist_ok=True)
+        # mkdtemp, not ``<name>_<timestamp>``: the timestamp had one-second
+        # resolution and the directory was created with ``exist_ok=True``, so two
+        # compiles of same-named programs within one second shared a directory
+        # and the second silently overwrote the first's kernels. A caller that
+        # compiles one program and runs it before compiling the next never saw
+        # it; one that compiles a batch up front and dispatches afterwards gets
+        # the wrong kernel with no error -- only a numeric assertion catches it.
+        # `@pl.jit` already resolves its own output directory this way.
+        output_dir = tempfile.mkdtemp(prefix=f"{program.name}_", dir=base)
+    else:
+        os.makedirs(output_dir, exist_ok=True)
 
     _validate_pass_context_conflicts(
         operation="compile",

--- a/tests/ut/ir/test_compile_pipeline.py
+++ b/tests/ut/ir/test_compile_pipeline.py
@@ -10,6 +10,7 @@
 """Tests for the shared IR pass pipeline."""
 
 import json
+from pathlib import Path
 
 import pytest
 from pypto import DataType, ir
@@ -143,6 +144,28 @@ def test_compile_outer_profiler_retains_ownership(tmp_path):
     assert [stage["name"] for stage in stages] == ["passes", "codegen"]
     assert stages[0]["children"]
     assert not (output_dir / "report" / "pipeline_profile.json").exists()
+
+
+def test_default_output_dirs_are_unique_per_compile(tmp_path, monkeypatch):
+    """Two compiles of one program never share a directory.
+
+    The default used to be ``<program name>_<timestamp>`` at one-second
+    resolution, created with ``exist_ok=True``. Two same-named programs compiled
+    inside one second therefore landed in one directory and the second's kernels
+    overwrote the first's, silently: a caller that compiled a batch up front and
+    dispatched afterwards got the wrong kernel with no error, and only a numeric
+    assertion could catch it.
+
+    Asserted on distinctness rather than on the naming scheme, so it still holds
+    if the scheme changes again.
+    """
+    monkeypatch.setenv("PYPTO_PROG_BUILD_DIR", str(tmp_path))
+
+    dirs = [ir.compile(_scalar_program(), dump_passes=False, skip_ptoas=True).output_dir for _ in range(3)]
+
+    assert len({str(d) for d in dirs}) == 3, f"compiles shared an output directory: {dirs}"
+    for d in dirs:
+        assert Path(d).is_dir()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`ir.compile` derived its default output directory from the program name and a
one-second timestamp, then created it with `exist_ok=True`:

```python
output_dir = os.path.join(base, f"{program.name}_{timestamp}")
os.makedirs(output_dir, exist_ok=True)
```

Two compiles of same-named programs inside one second therefore shared a
directory, and the second's kernels overwrote the first's. Nothing raised. The
caller kept a `DistributedCompiledProgram` whose `output_dir` pointed at another
program's artifacts, so dispatching it ran the wrong kernel — only a numeric
assertion could notice.

## How it surfaced

Preparing several programs before dispatching any of them. Three FP16 reduce
variants sharing the class name `HostTensorAllReduceArbitraryLength`:

```
max   -> build_output/HostTensorAllReduceArbitraryLength_20260908_232837
min   -> build_output/HostTensorAllReduceArbitraryLength_20260908_232837
prod  -> build_output/HostTensorAllReduceArbitraryLength_20260908_232838
```

The `min` dispatch returned `i * (100 + i)` — prod's answer.

Every caller in tree today compiles one program and runs it before compiling the
next, which is why this has not bitten: the overwrite lands after the artifacts
have been used. It bites the moment a batch is compiled up front.

## The fix

`tempfile.mkdtemp` under the same base, which is how `@pl.jit` has always
resolved its own output directory (`decorator.py`). An explicit `output_dir=` is
untouched.

The test asserts three compiles land in three directories rather than pinning the
naming scheme, so it survives the scheme changing again; it fails against the
timestamp form.

## Note

Split out of https://github.com/hw-native-sys/pypto/pull/2696 (hw-native-sys/pypto),
which keeps the distributed-ST changes that motivated finding this. This half is an
independent correctness fix and does not depend on them.
