### PR TITLE
feat(distributed): register INT8 variant for builtin all_to_all_v

### DIFF
--- a/docs/en/dev/distributed_ops.md
+++ b/docs/en/dev/distributed_ops.md
@@ -412,7 +412,9 @@ Variable-size all-to-all (MPI_Alltoallv). Flat 2D layouts:
 - `recv_counts` — DistributedTensor INT32 `[NR, 1]` (InOut recvcounts)
 
 `input` and `target` are addressed by flat element arithmetic, so both must be
-packed row-major views and must be two distinct buffers. A statically provable
+packed row-major views and must be two distinct buffers. Supported payload
+dtypes on the HOST and CHIP builtin rails are **FP32 and INT8** (INT8 is the
+RFC #2521 A1 canonical benchmark dtype). A statically provable
 violation — a non-ND layout, a stride vector that is not the packed one, a
 `valid_shape` narrower than the shape, or the same operand in both roles — is
 rejected by the type deducer. Two *distinct* `pld.window()` views of one
@@ -741,7 +743,9 @@ dispatches before the final `Simplify`.
   `test_l3_ep_dispatch_combine.py`, `test_l3_notify_wait.py`,
   `test_l3_tensor_all_to_all_v_intrinsic.py` (InCore composite),
   `test_l3_host_tensor_all_to_all_v.py` (HOST builtin),
-  `test_l2_tensor_all_to_all_v.py` (CHIP builtin), and related L3 STs
+  `test_l2_tensor_all_to_all_v.py` (CHIP builtin),
+  `all_to_all_v_benchmark.py` (RFC #2521 A1 INT8 harness, HOST and CHIP rails),
+  and related L3 STs
   under `tests/st/distributed/`. **Put/get canonical e2e contracts** are now
   enabled: `test_l3_put.py` (ring overwrite, row-offset put, atomic-add put, and
   chunked/pipelined transfers ✅), `test_l3_get.py` (ring read, row-offset get ✅),

--- a/docs/en/dev/distributed_ops.md
+++ b/docs/en/dev/distributed_ops.md
@@ -744,7 +744,6 @@ dispatches before the final `Simplify`.
   `test_l3_tensor_all_to_all_v_intrinsic.py` (InCore composite),
   `test_l3_host_tensor_all_to_all_v.py` (HOST builtin),
   `test_l2_tensor_all_to_all_v.py` (CHIP builtin),
-  `all_to_all_v_benchmark.py` (RFC #2521 A1 INT8 harness, HOST and CHIP rails),
   and related L3 STs
   under `tests/st/distributed/`. **Put/get canonical e2e contracts** are now
   enabled: `test_l3_put.py` (ring overwrite, row-offset put, atomic-add put, and

--- a/docs/en/dev/passes/40-lower_l2_tensor_collectives.md
+++ b/docs/en/dev/passes/40-lower_l2_tensor_collectives.md
@@ -59,9 +59,11 @@ the collective becomes:
 
 ```python
 data = self.__builtin_all_to_all_v__fp32(stage, data, signal, counts, recv)
+# INT8 (RFC #2521 A1 canonical payload) synthesizes __builtin_all_to_all_v__int8
+# with builtin_template_vars = "dtype_cpp=int8_t"
 ```
 
-where `__builtin_all_to_all_v__fp32` is a synthesized `FunctionType.AIV`
+where `__builtin_all_to_all_v__{fp32,int8}` is a synthesized `FunctionType.AIV`
 function added to the program:
 
 | Aspect | Value |
@@ -197,7 +199,13 @@ passes earlier, so re-reporting them here would blame the wrong pass.
 
 - `tests/ut/ir/transforms/test_lower_l2_tensor_collectives.py` — lowered shape,
   synthesized signature and directions, template attrs, variant sharing,
-  InCore pass-through, `core_num > 1` rejection.
+  InCore pass-through, `core_num > 1` rejection, INT8 variant.
+- `tests/ut/codegen/distributed/test_builtin_collective_kernel_source.py` —
+  HOST and CHIP rails render a byte-identical kernel for FP32 and INT8.
+- `tests/ut/codegen/distributed/test_all_to_all_v_benchmark.py` — RFC #2521 A1
+  harness (`tests/st/distributed/collectives/all_to_all_v_benchmark.py`):
+  `L→B` map, canonical INT8 shape, count patterns, JSON schema, compile-only
+  smoke.
 - `tests/ut/ir/transforms/test_lower_composite_ops.py` — the composite rail
   defers a CHIP-orchestration collective to this pass and rejects
   `core_num != 1` in an InCore body.

--- a/docs/en/dev/passes/40-lower_l2_tensor_collectives.md
+++ b/docs/en/dev/passes/40-lower_l2_tensor_collectives.md
@@ -139,7 +139,7 @@ since every operand of one collective belongs to one comm domain.
 | Condition | Diagnostic |
 | --------- | ---------- |
 | `core_num != 1` | rejected — the multi-AIV launch is not implemented yet |
-| `dtype != FP32` | rejected — the same single-dtype support the HOST rail declares |
+| `dtype != FP32 && dtype != INT8` | rejected — FP32 and INT8 are supported (same allowlist as the HOST rail) |
 | collective left in a non-HOST orchestration body | rejected by the pass's own postcondition check |
 
 The residual check runs over every orchestration body except a HOST
@@ -202,10 +202,6 @@ passes earlier, so re-reporting them here would blame the wrong pass.
   InCore pass-through, `core_num > 1` rejection, INT8 variant.
 - `tests/ut/codegen/distributed/test_builtin_collective_kernel_source.py` —
   HOST and CHIP rails render a byte-identical kernel for FP32 and INT8.
-- `tests/ut/codegen/distributed/test_all_to_all_v_benchmark.py` — RFC #2521 A1
-  harness (`tests/st/distributed/collectives/all_to_all_v_benchmark.py`):
-  `L→B` map, canonical INT8 shape, count patterns, JSON schema, compile-only
-  smoke.
 - `tests/ut/ir/transforms/test_lower_composite_ops.py` — the composite rail
   defers a CHIP-orchestration collective to this pass and rejects
   `core_num != 1` in an InCore body.

--- a/docs/zh/dev/distributed_ops.md
+++ b/docs/zh/dev/distributed_ops.md
@@ -364,7 +364,8 @@ pld.tensor.all_to_all_v(
 - `recv_counts` — DistributedTensor INT32 `[NR, 1]`（InOut recvcounts）
 
 `input` 和 `target` 都以扁平元素算术寻址，因此两者都必须是紧凑行主序视图，且必须是
-两个不同的 buffer。静态可证的违规——非 ND 布局、与紧凑步长不符的 stride 向量、比
+两个不同的 buffer。HOST / CHIP builtin 通路支持的负载 dtype 为 **FP32 与 INT8**
+（INT8 是 RFC #2521 A1 规范基准 dtype）。静态可证的违规——非 ND 布局、与紧凑步长不符的 stride 向量、比
 shape 更窄的 `valid_shape`，或同一个操作数同时充当两种角色——由类型推导直接拒绝。
 但同一块 allocation 上的两个**不同** `pld.window()` 视图**不会**被拒绝：类型推导在
 构造 Call 时运行，早于 `DistributedTensorType::window_buffer_` 被绑定。只有 HOST
@@ -648,7 +649,8 @@ host_orch 函数体包裹进嵌套的 `CommDomainScopeStmt` 节点（按推断�
   `test_l3_ep_dispatch_combine.py`、`test_l3_notify_wait.py`、
   `test_l3_tensor_all_to_all_v_intrinsic.py`（InCore composite）、
   `test_l3_host_tensor_all_to_all_v.py`（HOST builtin）、
-  `test_l2_tensor_all_to_all_v.py`（CHIP builtin），以及
+  `test_l2_tensor_all_to_all_v.py`（CHIP builtin），
+  `all_to_all_v_benchmark.py`（RFC #2521 A1 INT8 harness，HOST / CHIP），以及
   `tests/st/distributed/` 下其他 L3 ST。**Put/Get 端到端权威契约** 已启用：
   `test_l3_put.py`（环形覆写、行偏移 put、原子加 put、分块/流水 transfer ✅）、
   `test_l3_get.py`（环形读、行偏移 get ✅）、以及 `test_l3_remote_store.py`

--- a/docs/zh/dev/distributed_ops.md
+++ b/docs/zh/dev/distributed_ops.md
@@ -649,8 +649,7 @@ host_orch 函数体包裹进嵌套的 `CommDomainScopeStmt` 节点（按推断�
   `test_l3_ep_dispatch_combine.py`、`test_l3_notify_wait.py`、
   `test_l3_tensor_all_to_all_v_intrinsic.py`（InCore composite）、
   `test_l3_host_tensor_all_to_all_v.py`（HOST builtin）、
-  `test_l2_tensor_all_to_all_v.py`（CHIP builtin），
-  `all_to_all_v_benchmark.py`（RFC #2521 A1 INT8 harness，HOST / CHIP），以及
+  `test_l2_tensor_all_to_all_v.py`（CHIP builtin），以及
   `tests/st/distributed/` 下其他 L3 ST。**Put/Get 端到端权威契约** 已启用：
   `test_l3_put.py`（环形覆写、行偏移 put、原子加 put、分块/流水 transfer ✅）、
   `test_l3_get.py`（环形读、行偏移 get ✅）、以及 `test_l3_remote_store.py`

--- a/docs/zh/dev/passes/40-lower_l2_tensor_collectives.md
+++ b/docs/zh/dev/passes/40-lower_l2_tensor_collectives.md
@@ -126,7 +126,7 @@ rank 数，`pld.system.nranks` 只有 InCore 代码生成，没有 orchestration
 | 条件 | 诊断 |
 | ---- | ---- |
 | `core_num != 1` | 拒绝 —— 多 AIV 启动尚未实现 |
-| `dtype != FP32` | 拒绝 —— 与 HOST 通路声明的单 dtype 支持一致 |
+| `dtype != FP32 && dtype != INT8` | 拒绝 —— 支持 FP32 与 INT8（与 HOST 通路的 allowlist 一致） |
 | 集合通信残留在非 HOST 的 orchestration 函数体中 | 被本 pass 自身的后置条件检查拒绝 |
 
 残留检查覆盖除 HOST orchestrator 之外的每个 orchestration 函数体（HOST 交由自己的
@@ -178,9 +178,6 @@ pass 之前就已运行，在这里重复报告会指向错误的 pass。
   INT8 variant。
 - `tests/ut/codegen/distributed/test_builtin_collective_kernel_source.py` ——
   HOST 与 CHIP 通路对 FP32 / INT8 渲染逐字节相同的 kernel。
-- `tests/ut/codegen/distributed/test_all_to_all_v_benchmark.py` —— RFC #2521 A1
-  harness（`tests/st/distributed/collectives/all_to_all_v_benchmark.py`）：
-  `L→B` 映射、规范 INT8 形状、计数模式、JSON schema、compile-only smoke。
 - `tests/ut/ir/transforms/test_lower_composite_ops.py` —— composite 通路把
   CHIP orchestration 中的集合通信交给本 pass，并在 InCore 函数体中拒绝
   `core_num != 1`。

--- a/docs/zh/dev/passes/40-lower_l2_tensor_collectives.md
+++ b/docs/zh/dev/passes/40-lower_l2_tensor_collectives.md
@@ -55,9 +55,11 @@ def chip_pipeline(self, inp, out, stage, data, signal, counts, recv):
 
 ```python
 data = self.__builtin_all_to_all_v__fp32(stage, data, signal, counts, recv)
+# INT8（RFC #2521 A1 规范负载）合成为 __builtin_all_to_all_v__int8，
+# builtin_template_vars = "dtype_cpp=int8_t"
 ```
 
-其中 `__builtin_all_to_all_v__fp32` 是新增到 program 中的合成
+其中 `__builtin_all_to_all_v__{fp32,int8}` 是新增到 program 中的合成
 `FunctionType.AIV` 函数：
 
 | 方面 | 取值 |
@@ -172,7 +174,13 @@ pass 之前就已运行，在这里重复报告会指向错误的 pass。
 ## 测试
 
 - `tests/ut/ir/transforms/test_lower_l2_tensor_collectives.py` —— 改写后的形态、
-  合成签名与方向、模板 attrs、variant 共享、InCore 透传、`core_num > 1` 拒绝。
+  合成签名与方向、模板 attrs、variant 共享、InCore 透传、`core_num > 1` 拒绝、
+  INT8 variant。
+- `tests/ut/codegen/distributed/test_builtin_collective_kernel_source.py` ——
+  HOST 与 CHIP 通路对 FP32 / INT8 渲染逐字节相同的 kernel。
+- `tests/ut/codegen/distributed/test_all_to_all_v_benchmark.py` —— RFC #2521 A1
+  harness（`tests/st/distributed/collectives/all_to_all_v_benchmark.py`）：
+  `L→B` 映射、规范 INT8 形状、计数模式、JSON schema、compile-only smoke。
 - `tests/ut/ir/transforms/test_lower_composite_ops.py` —— composite 通路把
   CHIP orchestration 中的集合通信交给本 pass，并在 InCore 函数体中拒绝
   `core_num != 1`。

--- a/python/pypto/language/distributed/op/tensor_ops.py
+++ b/python/pypto/language/distributed/op/tensor_ops.py
@@ -1070,7 +1070,8 @@ def all_to_all_v(
             (``LowerL2TensorCollectives``); the first version accepts only
             ``core_num=1``.  Called from an InCore function, the composite rail
             expands the exchange into point-to-point primitives and requires
-            ``core_num=1``.
+            ``core_num=1``.  Payload dtype is ``FP32`` or ``INT8`` (INT8 is the
+            RFC #2521 A1 canonical benchmark dtype); other dtypes are rejected.
 
     Returns:
         The ``target`` :class:`pld.DistributedTensor` with received chunks.

--- a/python/pypto/language/distributed/op/tensor_ops.py
+++ b/python/pypto/language/distributed/op/tensor_ops.py
@@ -1070,8 +1070,11 @@ def all_to_all_v(
             (``LowerL2TensorCollectives``); the first version accepts only
             ``core_num=1``.  Called from an InCore function, the composite rail
             expands the exchange into point-to-point primitives and requires
-            ``core_num=1``.  Payload dtype is ``FP32`` or ``INT8`` (INT8 is the
-            RFC #2521 A1 canonical benchmark dtype); other dtypes are rejected.
+            ``core_num=1``.  On the HOST and managed CHIP builtin rails, payload
+            dtype is ``FP32`` or ``INT8`` (INT8 is the RFC #2521 A1 canonical
+            benchmark dtype); other dtypes are rejected there.  The InCore
+            composite rail accepts matching input/target payload dtypes and
+            does not apply that FP32/INT8 allowlist.
 
     Returns:
         The ``target`` :class:`pld.DistributedTensor` with received chunks.

--- a/python/pypto/runtime/builtins/collectives/all_to_all_v/templates/kernel.cpp.in
+++ b/python/pypto/runtime/builtins/collectives/all_to_all_v/templates/kernel.cpp.in
@@ -114,7 +114,7 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
 
   int tile_cols = static_cast<int>(row_numel < kTileCount ? row_numel : kTileCount);
   TileData send_tile(1, tile_cols);
-  TASSIGN(send_tile, 0x10000);
+  TASSIGN(send_tile, 0x0);
 
   // ==================================================================
   // Phase 1: per-destination push + inline count publish. Include self

--- a/src/codegen/distributed/distributed_ops_codegen.cpp
+++ b/src/codegen/distributed/distributed_ops_codegen.cpp
@@ -107,17 +107,20 @@ std::string Fp32TypeCpp(const DataType& dtype) {
 std::string AllToAllVVariantSuffix(const DataType& dtype) {
   if (dtype == DataType::FP32) return "fp32";
   if (dtype == DataType::INT8) return "int8";
-  CHECK(false) << "builtin.tensor.all_to_all_v variant mangling currently supports only FP32 or INT8, got "
-               << dtype.ToString();
+  // DeduceBuiltinTensorAllToAllVType already rejects other dtypes; reaching
+  // here means malformed IR, not a user-facing dtype error.
+  INTERNAL_CHECK(false) << "builtin.tensor.all_to_all_v variant mangling currently supports only FP32 or "
+                           "INT8, got "
+                        << dtype.ToString();
   return "fp32";
 }
 
 std::string AllToAllVTypeCpp(const DataType& dtype) {
   if (dtype == DataType::FP32) return "float";
   if (dtype == DataType::INT8) return "int8_t";
-  CHECK(false) << "builtin.tensor.all_to_all_v template instantiation currently supports only FP32 or "
-                  "INT8, got "
-               << dtype.ToString();
+  INTERNAL_CHECK(false) << "builtin.tensor.all_to_all_v template instantiation currently supports only "
+                           "FP32 or INT8, got "
+                        << dtype.ToString();
   return "float";
 }
 

--- a/src/codegen/distributed/distributed_ops_codegen.cpp
+++ b/src/codegen/distributed/distributed_ops_codegen.cpp
@@ -104,26 +104,6 @@ std::string Fp32TypeCpp(const DataType& dtype) {
   return "float";
 }
 
-std::string AllToAllVVariantSuffix(const DataType& dtype) {
-  if (dtype == DataType::FP32) return "fp32";
-  if (dtype == DataType::INT8) return "int8";
-  // DeduceBuiltinTensorAllToAllVType already rejects other dtypes; reaching
-  // here means malformed IR, not a user-facing dtype error.
-  INTERNAL_CHECK(false) << "builtin.tensor.all_to_all_v variant mangling currently supports only FP32 or "
-                           "INT8, got "
-                        << dtype.ToString();
-  return "fp32";
-}
-
-std::string AllToAllVTypeCpp(const DataType& dtype) {
-  if (dtype == DataType::FP32) return "float";
-  if (dtype == DataType::INT8) return "int8_t";
-  INTERNAL_CHECK(false) << "builtin.tensor.all_to_all_v template instantiation currently supports only "
-                           "FP32 or INT8, got "
-                        << dtype.ToString();
-  return "float";
-}
-
 std::string ArgDirectionToTensorArgType(ir::ArgDirection dir) {
   switch (dir) {
     case ir::ArgDirection::Input:
@@ -428,10 +408,10 @@ REGISTER_DISTRIBUTED_OP(builtin_tensor_all_to_all_v, "builtin.tensor.all_to_all_
   auto* dist_codegen = dynamic_cast<DistributedCodegen*>(&codegen);
   INTERNAL_CHECK(dist_codegen) << "builtin.tensor.all_to_all_v codegen requires DistributedCodegen";
   const auto dtype = op->GetAttr<DataType>("dtype");
-  const std::string variant = op->op_->name_ + "__" + AllToAllVVariantSuffix(dtype);
+  const std::string variant = op->op_->name_ + "__" + dtype.ToString();
 
   if (dist_codegen->MarkBuiltinEmitted(variant)) {
-    dist_codegen->RecordBuiltinNextLevel(op, variant, {{"dtype_cpp", AllToAllVTypeCpp(dtype)}});
+    dist_codegen->RecordBuiltinNextLevel(op, variant, {{"dtype_cpp", dtype.ToCTypeString()}});
   }
   // No rank-count scalar: this kernel reads CommContext::rankNum, which is the
   // same number (see EmitBuiltinWindowCollectiveDispatch). Dropping it makes

--- a/src/codegen/distributed/distributed_ops_codegen.cpp
+++ b/src/codegen/distributed/distributed_ops_codegen.cpp
@@ -104,6 +104,23 @@ std::string Fp32TypeCpp(const DataType& dtype) {
   return "float";
 }
 
+std::string AllToAllVVariantSuffix(const DataType& dtype) {
+  if (dtype == DataType::FP32) return "fp32";
+  if (dtype == DataType::INT8) return "int8";
+  CHECK(false) << "builtin.tensor.all_to_all_v variant mangling currently supports only FP32 or INT8, got "
+               << dtype.ToString();
+  return "fp32";
+}
+
+std::string AllToAllVTypeCpp(const DataType& dtype) {
+  if (dtype == DataType::FP32) return "float";
+  if (dtype == DataType::INT8) return "int8_t";
+  CHECK(false) << "builtin.tensor.all_to_all_v template instantiation currently supports only FP32 or "
+                  "INT8, got "
+               << dtype.ToString();
+  return "float";
+}
+
 std::string ArgDirectionToTensorArgType(ir::ArgDirection dir) {
   switch (dir) {
     case ir::ArgDirection::Input:
@@ -408,10 +425,10 @@ REGISTER_DISTRIBUTED_OP(builtin_tensor_all_to_all_v, "builtin.tensor.all_to_all_
   auto* dist_codegen = dynamic_cast<DistributedCodegen*>(&codegen);
   INTERNAL_CHECK(dist_codegen) << "builtin.tensor.all_to_all_v codegen requires DistributedCodegen";
   const auto dtype = op->GetAttr<DataType>("dtype");
-  const std::string variant = op->op_->name_ + "__" + Fp32VariantSuffix(dtype);
+  const std::string variant = op->op_->name_ + "__" + AllToAllVVariantSuffix(dtype);
 
   if (dist_codegen->MarkBuiltinEmitted(variant)) {
-    dist_codegen->RecordBuiltinNextLevel(op, variant, {{"dtype_cpp", Fp32TypeCpp(dtype)}});
+    dist_codegen->RecordBuiltinNextLevel(op, variant, {{"dtype_cpp", AllToAllVTypeCpp(dtype)}});
   }
   // No rank-count scalar: this kernel reads CommContext::rankNum, which is the
   // same number (see EmitBuiltinWindowCollectiveDispatch). Dropping it makes

--- a/src/ir/op/distributed/collective.cpp
+++ b/src/ir/op/distributed/collective.cpp
@@ -77,6 +77,11 @@ void CheckSupportedFp32BuiltinVariant(DataType dtype, const std::string& op_name
                                  << dtype.ToString();
 }
 
+void CheckSupportedAllToAllVBuiltinVariant(DataType dtype, const std::string& op_name) {
+  CHECK(dtype == DataType::FP32 || dtype == DataType::INT8)
+      << op_name << " currently supports only dtype=FP32 or INT8; got " << dtype.ToString();
+}
+
 void CheckSignalDistributedTensor(const DistributedTensorTypePtr& signal_type, const std::string& op_name) {
   CHECK(signal_type) << op_name << " signal must be a DistributedTensor";
   CHECK(signal_type->dtype_ == DataType::INT32)
@@ -1310,7 +1315,7 @@ TypePtr DeduceBuiltinTensorAllToAllVType(const std::vector<ExprPtr>& args,
   CHECK(dtype == target_type->dtype_)
       << kOpName << " dtype kwarg (" << dtype.ToString() << ") must match target dtype ("
       << target_type->dtype_.ToString() << ")";
-  CheckSupportedFp32BuiltinVariant(dtype, kOpName);
+  CheckSupportedAllToAllVBuiltinVariant(dtype, kOpName);
 
   return args[1]->GetType();
 }

--- a/src/ir/transforms/lower_l2_tensor_collectives_pass.cpp
+++ b/src/ir/transforms/lower_l2_tensor_collectives_pass.cpp
@@ -116,18 +116,21 @@ constexpr const char* kAllToAllV = "pld.tensor.all_to_all_v";
 /// Variant suffix and C++ element type the builtin kernel template is
 /// instantiated with.
 ///
-/// Deliberately the same single-dtype support the HOST rail declares
-/// (``Fp32VariantSuffix`` / ``Fp32TypeCpp`` in distributed_ops_codegen.cpp):
-/// both rails render the same template, so widening the dtype set is one change
-/// for both, not a CHIP-only divergence.
+/// Shared with the HOST rail (`AllToAllVVariantSuffix` /
+/// `AllToAllVTypeCpp` in distributed_ops_codegen.cpp): both rails render the
+/// same template, so widening the dtype set is one change for both. FP32 and
+/// INT8 are the current pair; INT8 is the RFC #2521 A1 canonical payload.
 struct BuiltinDType {
   const char* suffix;
   const char* cpp;
 };
 
 [[nodiscard]] BuiltinDType ResolveBuiltinDType(const DataType& dtype, const Span& span) {
-  CHECK_SPAN(dtype == DataType::FP32, span)
-      << "managed pld.tensor.all_to_all_v currently supports only dtype=FP32, got " << dtype.ToString();
+  if (dtype == DataType::FP32) return {"fp32", "float"};
+  if (dtype == DataType::INT8) return {"int8", "int8_t"};
+  CHECK_SPAN(false, span) << "managed pld.tensor.all_to_all_v currently supports only dtype=FP32 or "
+                             "INT8, got "
+                          << dtype.ToString();
   return {"fp32", "float"};
 }
 

--- a/src/ir/transforms/lower_l2_tensor_collectives_pass.cpp
+++ b/src/ir/transforms/lower_l2_tensor_collectives_pass.cpp
@@ -116,22 +116,18 @@ constexpr const char* kAllToAllV = "pld.tensor.all_to_all_v";
 /// Variant suffix and C++ element type the builtin kernel template is
 /// instantiated with.
 ///
-/// Shared with the HOST rail (`AllToAllVVariantSuffix` /
-/// `AllToAllVTypeCpp` in distributed_ops_codegen.cpp): both rails render the
-/// same template, so widening the dtype set is one change for both. FP32 and
-/// INT8 are the current pair; INT8 is the RFC #2521 A1 canonical payload.
+/// Both rails use DataType's string conversions to render the same template.
+/// FP32 and INT8 are the current pair; INT8 is the RFC #2521 A1 canonical payload.
 struct BuiltinDType {
-  const char* suffix;
-  const char* cpp;
+  std::string suffix;
+  std::string cpp;
 };
 
 [[nodiscard]] BuiltinDType ResolveBuiltinDType(const DataType& dtype, const Span& span) {
-  if (dtype == DataType::FP32) return {"fp32", "float"};
-  if (dtype == DataType::INT8) return {"int8", "int8_t"};
-  CHECK_SPAN(false, span) << "managed pld.tensor.all_to_all_v currently supports only dtype=FP32 or "
-                             "INT8, got "
-                          << dtype.ToString();
-  return {"fp32", "float"};
+  CHECK_SPAN(dtype == DataType::FP32 || dtype == DataType::INT8, span)
+      << "managed pld.tensor.all_to_all_v currently supports only dtype=FP32 or INT8, got "
+      << dtype.ToString();
+  return {dtype.ToString(), dtype.ToCTypeString()};
 }
 
 /// Encode the template substitutions as a ``k=v`` list for the Function attr.

--- a/tests/ut/codegen/distributed/test_builtin_collective_kernel_source.py
+++ b/tests/ut/codegen/distributed/test_builtin_collective_kernel_source.py
@@ -63,42 +63,54 @@ NR = 2
 MAX_RECV = 4
 TOTAL = NR * MAX_RECV
 
-_VARIANT = "builtin.tensor.all_to_all_v__fp32"
-_L2_KERNEL = "__builtin_all_to_all_v__fp32.cpp"
+
+def _dtype_of(name: str):
+    return {"fp32": pl.FP32, "int8": pl.INT8}[name]
 
 
-def _build_chip_rail_program():
+def _variant_of(name: str) -> str:
+    return f"builtin.tensor.all_to_all_v__{name}"
+
+
+def _l2_kernel_of(name: str) -> str:
+    return f"__builtin_all_to_all_v__{name}.cpp"
+
+
+def _build_chip_rail_program(dtype_name: str = "fp32"):
     """CHIP/L2 rail: the collective written in a CHIP orchestration body.
 
     Identical to the HOST program below except for *where* the collective is
     written — same five windows, same host allocation, same comm domain. That
     one difference is the whole point of the comparison.
     """
+    dtype = _dtype_of(dtype_name)
+    payload_bytes = TOTAL * SIZE * dtype.get_byte()
+    i32_bytes = NR * pl.INT32.get_byte()
 
     @pl.program
     class ChipRail:
         @pl.function(type=pl.FunctionType.Orchestration)
         def chip_pipeline(
             self,
-            stage: pl.InOut[pld.DistributedTensor[[TOTAL, SIZE], pl.FP32]],
-            data: pl.InOut[pld.DistributedTensor[[TOTAL, SIZE], pl.FP32]],
+            stage: pl.InOut[pld.DistributedTensor[[TOTAL, SIZE], dtype]],
+            data: pl.InOut[pld.DistributedTensor[[TOTAL, SIZE], dtype]],
             signal: pl.InOut[pld.DistributedTensor[[NR, 1], pl.INT32]],
             counts: pl.InOut[pld.DistributedTensor[[NR, 1], pl.INT32]],
             recv: pl.InOut[pld.DistributedTensor[[NR, 1], pl.INT32]],
-        ) -> pld.DistributedTensor[[TOTAL, SIZE], pl.FP32]:
+        ) -> pld.DistributedTensor[[TOTAL, SIZE], dtype]:
             return pld.tensor.all_to_all_v(stage, data, signal, counts, recv, core_num=1)
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(self):
-            stage_buf = pld.alloc_window_buffer(TOTAL * SIZE * pl.FP32.get_byte())
-            data_buf = pld.alloc_window_buffer(TOTAL * SIZE * pl.FP32.get_byte())
-            signal_buf = pld.alloc_window_buffer(NR * pl.INT32.get_byte())
-            counts_buf = pld.alloc_window_buffer(NR * pl.INT32.get_byte())
-            recv_buf = pld.alloc_window_buffer(NR * pl.INT32.get_byte())
+            stage_buf = pld.alloc_window_buffer(payload_bytes)
+            data_buf = pld.alloc_window_buffer(payload_bytes)
+            signal_buf = pld.alloc_window_buffer(i32_bytes)
+            counts_buf = pld.alloc_window_buffer(i32_bytes)
+            recv_buf = pld.alloc_window_buffer(i32_bytes)
 
             for r in pl.range(pld.world_size()):
-                stage = pld.window(stage_buf, [TOTAL, SIZE], dtype=pl.FP32)
-                data = pld.window(data_buf, [TOTAL, SIZE], dtype=pl.FP32)
+                stage = pld.window(stage_buf, [TOTAL, SIZE], dtype=dtype)
+                data = pld.window(data_buf, [TOTAL, SIZE], dtype=dtype)
                 sig = pld.window(signal_buf, [NR, 1], dtype=pl.INT32)
                 counts = pld.window(counts_buf, [NR, 1], dtype=pl.INT32)
                 recv = pld.window(recv_buf, [NR, 1], dtype=pl.INT32)
@@ -107,7 +119,7 @@ def _build_chip_rail_program():
     return ChipRail
 
 
-def _build_host_rail_program():
+def _build_host_rail_program(dtype_name: str = "fp32"):
     """HOST/L3 rail: the collective written in the host orchestrator.
 
     Mirrors the CHIP program: same five windows, same one dispatch per rank.
@@ -116,14 +128,17 @@ def _build_host_rail_program():
     ``MaterializeCommDomainScopes`` infers a window's comm domain from the
     dispatches that consume it.
     """
+    dtype = _dtype_of(dtype_name)
+    payload_bytes = TOTAL * SIZE * dtype.get_byte()
+    i32_bytes = NR * pl.INT32.get_byte()
 
     @pl.program
     class HostRail:
         @pl.function(type=pl.FunctionType.InCore)
         def touch_step(
             self,
-            stage: pl.InOut[pld.DistributedTensor[[TOTAL, SIZE], pl.FP32]],
-            data: pl.InOut[pld.DistributedTensor[[TOTAL, SIZE], pl.FP32]],
+            stage: pl.InOut[pld.DistributedTensor[[TOTAL, SIZE], dtype]],
+            data: pl.InOut[pld.DistributedTensor[[TOTAL, SIZE], dtype]],
             signal: pl.InOut[pld.DistributedTensor[[NR, 1], pl.INT32]],
             counts: pl.InOut[pld.DistributedTensor[[NR, 1], pl.INT32]],
             recv: pl.InOut[pld.DistributedTensor[[NR, 1], pl.INT32]],
@@ -143,8 +158,8 @@ def _build_host_rail_program():
         @pl.function(type=pl.FunctionType.Orchestration)
         def touch_orch(
             self,
-            stage: pl.InOut[pld.DistributedTensor[[TOTAL, SIZE], pl.FP32]],
-            data: pl.InOut[pld.DistributedTensor[[TOTAL, SIZE], pl.FP32]],
+            stage: pl.InOut[pld.DistributedTensor[[TOTAL, SIZE], dtype]],
+            data: pl.InOut[pld.DistributedTensor[[TOTAL, SIZE], dtype]],
             signal: pl.InOut[pld.DistributedTensor[[NR, 1], pl.INT32]],
             counts: pl.InOut[pld.DistributedTensor[[NR, 1], pl.INT32]],
             recv: pl.InOut[pld.DistributedTensor[[NR, 1], pl.INT32]],
@@ -153,21 +168,21 @@ def _build_host_rail_program():
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(self):
-            stage_buf = pld.alloc_window_buffer(TOTAL * SIZE * pl.FP32.get_byte())
-            data_buf = pld.alloc_window_buffer(TOTAL * SIZE * pl.FP32.get_byte())
-            signal_buf = pld.alloc_window_buffer(NR * pl.INT32.get_byte())
-            counts_buf = pld.alloc_window_buffer(NR * pl.INT32.get_byte())
-            recv_buf = pld.alloc_window_buffer(NR * pl.INT32.get_byte())
+            stage_buf = pld.alloc_window_buffer(payload_bytes)
+            data_buf = pld.alloc_window_buffer(payload_bytes)
+            signal_buf = pld.alloc_window_buffer(i32_bytes)
+            counts_buf = pld.alloc_window_buffer(i32_bytes)
+            recv_buf = pld.alloc_window_buffer(i32_bytes)
 
-            stage = pld.window(stage_buf, [TOTAL, SIZE], dtype=pl.FP32)
-            data = pld.window(data_buf, [TOTAL, SIZE], dtype=pl.FP32)
+            stage = pld.window(stage_buf, [TOTAL, SIZE], dtype=dtype)
+            data = pld.window(data_buf, [TOTAL, SIZE], dtype=dtype)
             sig = pld.window(signal_buf, [NR, 1], dtype=pl.INT32)
             counts = pld.window(counts_buf, [NR, 1], dtype=pl.INT32)
             recv = pld.window(recv_buf, [NR, 1], dtype=pl.INT32)
 
             for r in pl.range(pld.world_size()):
-                r_stage = pld.window(stage_buf, [TOTAL, SIZE], dtype=pl.FP32)
-                r_data = pld.window(data_buf, [TOTAL, SIZE], dtype=pl.FP32)
+                r_stage = pld.window(stage_buf, [TOTAL, SIZE], dtype=dtype)
+                r_data = pld.window(data_buf, [TOTAL, SIZE], dtype=dtype)
                 r_sig = pld.window(signal_buf, [NR, 1], dtype=pl.INT32)
                 r_counts = pld.window(counts_buf, [NR, 1], dtype=pl.INT32)
                 r_recv = pld.window(recv_buf, [NR, 1], dtype=pl.INT32)
@@ -195,14 +210,19 @@ def _sole_file(directory, pattern):
     return matches[0]
 
 
-def test_both_rails_render_a_byte_identical_builtin_kernel(tmp_path):
+@pytest.mark.parametrize("dtype_name", ["fp32", "int8"])
+def test_both_rails_render_a_byte_identical_builtin_kernel(tmp_path, dtype_name):
     """The two rails' rendered kernel sources must match exactly."""
-    chip = _compile(_build_chip_rail_program(), tmp_path, "chip")
-    host = _compile(_build_host_rail_program(), tmp_path, "host")
+    chip = _compile(_build_chip_rail_program(dtype_name), tmp_path, f"chip_{dtype_name}")
+    host = _compile(_build_host_rail_program(dtype_name), tmp_path, f"host_{dtype_name}")
 
-    chip_kernel = chip.output_dir / "next_levels" / "chip_pipeline" / "kernels" / "aiv" / _L2_KERNEL
+    chip_kernel = (
+        chip.output_dir / "next_levels" / "chip_pipeline" / "kernels" / "aiv" / _l2_kernel_of(dtype_name)
+    )
     assert chip_kernel.is_file(), f"expected the rendered CHIP kernel at {chip_kernel}"
-    host_kernel = _sole_file(host.output_dir / "next_levels" / _VARIANT / "kernels" / "aiv", "*.cpp")
+    host_kernel = _sole_file(
+        host.output_dir / "next_levels" / _variant_of(dtype_name) / "kernels" / "aiv", "*.cpp"
+    )
 
     assert host_kernel.read_text() == chip_kernel.read_text(), (
         "HOST and CHIP rails must render the same builtin kernel source; a difference means "
@@ -232,7 +252,7 @@ def test_host_rail_still_emits_its_builtin_chip_dispatch(tmp_path):
     host = _compile(_build_host_rail_program(), tmp_path, "host")
 
     next_levels = sorted(p.name for p in (host.output_dir / "next_levels").iterdir())
-    assert _VARIANT in next_levels, next_levels
+    assert _variant_of("fp32") in next_levels, next_levels
 
 
 if __name__ == "__main__":

--- a/tests/ut/ir/transforms/test_lower_l2_tensor_collectives.py
+++ b/tests/ut/ir/transforms/test_lower_l2_tensor_collectives.py
@@ -352,5 +352,29 @@ def test_multi_core_request_is_rejected():
         passes.lower_l2_tensor_collectives()(_build_program(core_num=2))
 
 
+def test_int8_synthesizes_int8_variant():
+    """INT8 is the RFC #2521 A1 canonical payload and must share the CHIP rail."""
+
+    @pl.program
+    class Int8Exchange:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_pipeline(
+            self,
+            stage: pl.InOut[pld.DistributedTensor[[TOTAL, SIZE], pl.INT8]],
+            data: pl.InOut[pld.DistributedTensor[[TOTAL, SIZE], pl.INT8]],
+            signal: pl.InOut[pld.DistributedTensor[[NR, 1], pl.INT32]],
+            counts: pl.InOut[pld.DistributedTensor[[NR, 1], pl.INT32]],
+            recv: pl.InOut[pld.DistributedTensor[[NR, 1], pl.INT32]],
+        ) -> pld.DistributedTensor[[TOTAL, SIZE], pl.INT8]:
+            return pld.tensor.all_to_all_v(stage, data, signal, counts, recv)
+
+    result = passes.lower_l2_tensor_collectives()(Int8Exchange)
+    kernel = _get_func(result, "__builtin_all_to_all_v__int8")
+    assert kernel is not None
+    attrs = dict(kernel.attrs)
+    template_vars = dict(item.split("=", 1) for item in attrs["builtin_template_vars"].split(","))
+    assert template_vars == {"dtype_cpp": "int8_t"}
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- Register **INT8** alongside FP32 for managed `pld.tensor.all_to_all_v` on both HOST and L2 rails (variant mangling, lowering synthesis, codegen).
- Fix the shared kernel template tile UB assignment to `0x0` (dtype-agnostic; the prior `0x10000` was not INT8-safe and `static_cast<float>(0)` is invalid for `TASSIGN`).
- Document the FP32/INT8 contract and add UT coverage for INT8 kernel source generation and L2 lowering.

Prerequisite for RFC #2521 / A1 AllToAllV benchmark (canonical DSV4 dispatch payload is INT8 `4160 B/route`).

## Test plan
- [x] `pytest tests/ut/codegen/distributed/test_builtin_collective_kernel_source.py -q`
- [x] `pytest tests/ut/ir/transforms/test_lower_l2_tensor_collectives.py::test_int8_synthesizes_int8_variant -q`
- [x] pre-commit on all touched files (headers, docs parity, clang-format, cpplint, ruff, pyright)