### PR TITLE
ci: notify the central documentation workflow after Docs succeeds

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,6 +16,10 @@ name: Docs
 #
 # The site is a build artifact and is never committed; the markdown under `docs/`
 # stays the single source of truth.
+#
+# The central pilot can observe successful runs without changing publication.
+# Set DOCS_SITE_PUBLISHER=central only after the website's artifact and route
+# handoff are verified; notify-docs-site.yml controls the independent CI trigger.
 
 on:
   push:
@@ -91,14 +95,19 @@ jobs:
         run: mkdocs build --strict
 
       - name: Upload artifact
-        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+        if: >-
+          github.event_name != 'pull_request' && github.ref == 'refs/heads/main' &&
+          vars.DOCS_SITE_PUBLISHER != 'central'
         uses: actions/upload-pages-artifact@v3
         with:
           path: site
 
   deploy:
     # Only main publishes; a pull request builds to prove the docs still compile.
-    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+    # Switch only after the central artifact and Pages route have been verified.
+    if: >-
+      github.event_name != 'pull_request' && github.ref == 'refs/heads/main' &&
+      vars.DOCS_SITE_PUBLISHER != 'central'
     needs: build
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/notify-docs-site.yml
+++ b/.github/workflows/notify-docs-site.yml
@@ -1,0 +1,72 @@
+name: Notify central documentation
+
+on:
+  workflow_run:
+    workflows: [Docs]
+    branches: [main]
+    types: [completed]
+
+permissions:
+  contents: read
+
+jobs:
+  notify:
+    if: >-
+      github.repository == 'hw-native-sys/pypto' &&
+      vars.DOCS_SITE_NOTIFY_ENABLED == 'true' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_branch == 'main' &&
+      github.event.workflow_run.head_repository.full_name == 'hw-native-sys/pypto' &&
+      (github.event.workflow_run.event == 'push' || github.event.workflow_run.event == 'workflow_dispatch')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # No source checkout: this workflow only authenticates and sends metadata.
+      - name: Check notification configuration
+        env:
+          APP_ID: ${{ vars.DOCS_SITE_APP_ID }}
+          APP_PRIVATE_KEY: ${{ secrets.DOCS_SITE_APP_PRIVATE_KEY }}
+        run: |
+          if [ -z "$APP_ID" ] || [ -z "$APP_PRIVATE_KEY" ]; then
+            echo '::error::Configure DOCS_SITE_APP_ID and DOCS_SITE_APP_PRIVATE_KEY before enabling notifications.'
+            exit 1
+          fi
+      - name: Create a website-scoped token
+        uses: actions/create-github-app-token@v2
+        id: app
+        with:
+          app-id: ${{ vars.DOCS_SITE_APP_ID }}
+          private-key: ${{ secrets.DOCS_SITE_APP_PRIVATE_KEY }}
+          owner: hw-native-sys
+          repositories: hw-native-sys.github.io
+          permission-actions: write
+      - name: Request the central documentation build
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.app.outputs.token }}
+          retries: 3
+          script: |
+            const run = context.payload.workflow_run;
+            if (run.path !== '.github/workflows/docs.yml') {
+              throw new Error('Only the configured Docs workflow can request publication');
+            }
+            await github.rest.actions.createWorkflowDispatch({
+              owner: 'hw-native-sys',
+              repo: 'hw-native-sys.github.io',
+              workflow_id: 'docs-site.yml',
+              ref: 'main',
+              inputs: {
+                source_repository: context.repo.owner + '/' + context.repo.repo,
+                source_sha: run.head_sha,
+                source_run_id: String(run.id),
+                source_run_attempt: String(run.run_attempt)
+              }
+            });
+            await core.summary
+              .addHeading('Central documentation build requested')
+              .addLink('Source Docs run', run.html_url)
+              .addBreak()
+              .addLink('Central build and publication status',
+                'https://github.com/hw-native-sys/hw-native-sys.github.io/actions/workflows/docs-site.yml')
+              .addRaw('\nNotification acceptance does not mean the website is published.\n')
+              .write();


### PR DESCRIPTION
## Summary
After a successful upstream main Docs run, an opt-in completion listener requests the website's central documentation build using a website-scoped GitHub App token. Notification failures are reported separately from the completed Docs validation. Existing Pages publishing remains the default until an explicit handoff switch is set.

## Changes
- Filter notifications to the configured upstream main Docs workflow and send its repository, source SHA, run ID, and attempt to the website's `docs-site.yml` on main.
- Require `DOCS_SITE_NOTIFY_ENABLED`, `DOCS_SITE_APP_ID`, and `DOCS_SITE_APP_PRIVATE_KEY` before notifying; the App token only requests website Actions write permission.
- Allow `DOCS_SITE_PUBLISHER=central` to retire the original artifact upload and deployment after the central artifact and Pages routing handoff are verified.

## Verification
- `pre-commit run --files .github/workflows/docs.yml .github/workflows/notify-docs-site.yml`: all applicable checks passed.
- `actionlint -color .github/workflows/docs.yml .github/workflows/notify-docs-site.yml`: passed.
- `git diff --check`: passed.
- The companion website receiver was exercised against real successful Docs run metadata, with 35 publication tests and a strict bilingual build passing. The live App dispatch remains untested until both workflows are merged into their default branches and the App is configured; notification and publication switches remain disabled.
- Hosted GitHub Actions: the PR Docs build passed and Pages deployment was skipped as intended. Other repository lint jobs are still running.
