### PR TITLE
fix(runtime): fold an L3 swimlane's two captures back into one dispatch

### DIFF
--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -777,9 +777,14 @@ def _run_l3_swimlane_two_pass(
 
     ``run_pass`` owns the execution lifecycle: the one-shot path creates a
     fresh Worker for each call, while a prepared ``DistributedWorker`` reuses
-    its existing Worker and waits on a submitted run handle. Both paths
-    reset their per-card dispatch counters, so matching graph/timing dispatches
-    land in the same ``rank{r}/d{k}`` directory.
+    its existing Worker and waits on a submitted run handle.
+
+    The two passes are two runs, and the ChipWorker child numbers its capture
+    directories per process — so the graph pass's ``deps.json`` and the timing
+    pass's records land in *different* ``rank{r}/d{k}`` directories.
+    :func:`_collect_l3_swimlane` pairs them back up from the child's identity
+    sidecars; without that pairing the converter sees no task graph and renders
+    a swimlane with no dependency edges.
 
     Both calls execute the program. As with the existing one-shot L3 protocol,
     mutable arguments are not snapshotted or restored between passes.
@@ -836,6 +841,18 @@ _DISPATCH_DIR_GLOB = "d[0-9]*"
 # ``next_levels/<program>`` — so naming a dispatch's tasks needs this marker
 # (issue #2169).
 _DISPATCH_PROGRAM_FILE = "dispatch_program.json"
+
+# Written by the ChipWorker child into every capture directory it creates. The
+# child numbers captures per *process* (``local_capture_index``), not per run, so
+# the swimlane two-pass files its graph capture and its timing capture under
+# different ``d{k}`` directories. This sidecar is what pairs them back together
+# (:func:`_pair_graph_capture`); it is absent on an older runtime, which numbered
+# both passes alike and needs no pairing.
+_DISPATCH_IDENTITY_FILE = "dispatch_identity.json"
+
+# The dep_gen pass's task graph. The converter needs it for dependency edges and
+# defaults to the one beside the records — which the two-pass split apart.
+_DEPS_JSON_FILE = "deps.json"
 
 
 def _dfx_rank_label(worker: int) -> str:
@@ -937,11 +954,13 @@ def _submit_chip(orch: Any, callable_id: Any, task_args: Any, config: Any, worke
     offline post-pass — and forwards ``config`` untouched.
 
     ``k`` comes from a per-card counter on ``orch`` reset at the top of every
-    run (see :func:`_reset_dfx_dispatch_state`), so the numbering is
-    deterministic, matches across the swimlane two-pass, and tracks the child's
-    own counter. The dispatched program is stamped into that directory by
-    :func:`_record_dispatch_program`, so the offline post-pass can label the
-    records with the right program's kernel names.
+    run (see :func:`_reset_dfx_dispatch_state`), so it is this run's dispatch
+    ordinal. The child's own counter spans the whole process, so the two
+    numberings agree only on a worker's first run: the marker
+    :func:`_record_dispatch_program` stamps here therefore lands on the first
+    run's capture directory — the graph pass of a swimlane two-pass — and
+    :func:`_collect_l3_swimlane` reads it back through the capture pairing
+    rather than expecting it beside the records.
 
     When DFX is off (``output_prefix`` unset) the call is forwarded unchanged.
 
@@ -969,10 +988,10 @@ def _submit_chip(orch: Any, callable_id: Any, task_args: Any, config: Any, worke
 def _clear_dfx_dispatch_dirs(dfx_base: Path) -> None:
     """Remove stale ``rank*/d{k}`` dispatch dirs before a fresh DFX run.
 
-    The per-card dispatch counter resets to ``d0`` at the start of every run, so
-    a prepared :class:`DistributedWorker` reusing one ``output_dir`` across
-    dispatches would otherwise leave higher-numbered ``d{k}`` dirs from an
-    earlier, larger run on disk. ``_collect_l3_swimlane`` globs ``d[0-9]*``, so
+    A prepared :class:`DistributedWorker` reusing one ``output_dir`` across runs
+    would otherwise leave ``d{k}`` dirs from an earlier, larger run on disk,
+    whether the child restarted its capture numbering or carried it forward.
+    ``_collect_l3_swimlane`` globs ``d[0-9]*``, so
     those stale dirs would be re-converted as if they belonged to the current
     run. Clearing them once, before the first dispatch of a DFX run, scopes the
     artifacts (and their post-processing) to exactly this run. Called only when
@@ -1005,6 +1024,205 @@ def _read_dispatch_program(disp_dir: Path) -> str | None:
     except (OSError, ValueError, KeyError, TypeError):
         return None
     return str(program)
+
+
+def _read_dispatch_identity(disp_dir: Path) -> dict[str, Any] | None:
+    """The child's identity sidecar for this capture, or ``None`` if unusable.
+
+    Absent on a runtime that predates the sidecar, and best-effort like every
+    other marker here: an unreadable one costs the graph/timing pairing, never
+    the run.
+    """
+    try:
+        identity = json.loads((disp_dir / _DISPATCH_IDENTITY_FILE).read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    return identity if isinstance(identity, dict) else None
+
+
+def _pair_rank_captures(rank_dir: Path) -> dict[Path, Path]:
+    """Map each of this card's timing captures to the capture holding its task graph.
+
+    The two swimlane passes are two runs, and the child numbers captures per
+    process — so the ``deps.json`` the converter needs for dependency edges sits
+    in a *different* ``d{k}`` than the records. The identity sidecars say which
+    run each capture came from and which callable it ran, which is enough to pair
+    them *only* when both passes issued the same dispatches: ``run_id`` differs
+    across passes, and ``local_capture_index`` counts captures per process, so
+    nothing in a single sidecar identifies a dispatch across runs on its own.
+
+    So pair whole runs, not individual captures. A timing run pairs with a graph
+    run when their ordered ``callable_digest`` sequences are identical; the
+    dispatches then correspond position by position. When the sequences differ in
+    length or order the run pair is rejected outright: the passes do not restore
+    mutable arguments between them (see :func:`_run_l3_swimlane_two_pass`), so a
+    dispatch count that depends on data can genuinely differ, and a graph pass of
+    ``[A, A]`` against a timing pass of ``[A]`` would otherwise hand the
+    surviving dispatch the *first* ``A``'s edges — plausible and wrong. The
+    nearest earlier graph run wins, since its graph describes the state this
+    timing run started from.
+
+    A card whose captures carry no sidecar at all (an older runtime) pairs only
+    when exactly one capture holds the graph and exactly one holds records:
+    anything else cannot be told apart, and reusing one graph for several timing
+    captures would attach the same edges to different dispatches.
+
+    Captures that already hold both files need no pairing and are left out.
+    """
+    from .runner import _CHIP_SWIMLANE_RECORDS_NAME  # noqa: PLC0415
+
+    captures = {
+        d: _read_dispatch_identity(d) for d in sorted(rank_dir.glob(_DISPATCH_DIR_GLOB)) if d.is_dir()
+    }
+    graph_dirs = [d for d in captures if (d / _DEPS_JSON_FILE).exists()]
+    timing_dirs = [
+        d
+        for d in captures
+        if (d / _CHIP_SWIMLANE_RECORDS_NAME).exists() and not (d / _DEPS_JSON_FILE).exists()
+    ]
+    if not graph_dirs or not timing_dirs:
+        return {}
+
+    if all(identity is None for identity in captures.values()):
+        # Older runtime: one graph and one set of records on the card is the only
+        # shape with a single possible answer.
+        if len(graph_dirs) == 1 and len(timing_dirs) == 1:
+            return {timing_dirs[0]: graph_dirs[0]}
+        return {}
+
+    runs = _captures_by_run(captures)
+    graph_runs = {
+        run_id: sequence for run_id, sequence in runs.items() if all(d in graph_dirs for d, _ in sequence)
+    }
+    pairs: dict[Path, Path] = {}
+    for run_id, sequence in runs.items():
+        if not all(d in timing_dirs for d, _ in sequence):
+            continue
+        digests = [identity.get("callable_digest") for _, identity in sequence]
+        candidates = [
+            other_id
+            for other_id, other in graph_runs.items()
+            if [identity.get("callable_digest") for _, identity in other] == digests
+        ]
+        earlier = [other_id for other_id in candidates if other_id < run_id]
+        graph_run = max(earlier) if earlier else (min(candidates) if candidates else None)
+        if graph_run is None:
+            continue
+        for (timing_dir, _), (graph_dir, _) in zip(sequence, graph_runs[graph_run]):
+            pairs[timing_dir] = graph_dir
+    return pairs
+
+
+_CaptureRuns = dict[int, list[tuple[Path, dict[str, Any]]]]
+
+
+def _captures_by_run(captures: dict[Path, dict[str, Any] | None]) -> _CaptureRuns:
+    """Group a card's captures by ``run_id``, each run ordered by capture index.
+
+    A capture missing either field cannot be placed in a pass's sequence, and a
+    run holding one is dropped whole: a sequence with a hole cannot be compared
+    against another pass's, and comparing it anyway is how the wrong dispatch
+    gets paired.
+    """
+    runs: _CaptureRuns = {}
+    incomplete: set[int] = set()
+    for capture, identity in captures.items():
+        if identity is None:
+            continue
+        run_id = identity.get("run_id")
+        if run_id is None:
+            continue
+        if identity.get("local_capture_index") is None:
+            incomplete.add(run_id)
+            continue
+        runs.setdefault(run_id, []).append((capture, identity))
+    for run_id in incomplete:
+        runs.pop(run_id, None)
+    return {
+        run_id: sorted(sequence, key=lambda entry: entry[1]["local_capture_index"])
+        for run_id, sequence in runs.items()
+    }
+
+
+def _consolidate_two_pass_captures(rank_dir: Path, pairs: dict[Path, Path]) -> None:
+    """Fold each timing capture into the graph capture of the same dispatch.
+
+    A swimlane capture runs the dispatch twice and the child files each run
+    separately, so one dispatch ends up spread over two ``d{k}`` directories: the
+    task graph in one, the records in the other. Every consumer of these
+    artifacts — the converter, ``simpler_setup.tools.critical_path``, the
+    toolkit's viewers, this project's analysis scripts — looks for one dispatch's
+    files *together*, so the split does not merely cost dependency edges in the
+    merged trace: a tool that selects directories by "has ``deps.json`` and a
+    name map" matches neither half.
+
+    Fold forward, into the graph capture. The graph pass runs first, so its
+    captures carry the lower indices — for a card dispatching ``N`` times they
+    are ``d0..d(N-1)``, the dispatch ordinals themselves, while the timing pass's
+    ``dN..d(2N-1)`` are only that offset repeated. Keeping the first of each pair
+    therefore restores both halves of the layout every consumer expects: one
+    directory per dispatch, named by the dispatch.
+
+    Only paired captures are touched (see :func:`_pair_rank_captures`), only
+    after both passes have finished, and only where the pairing is one-to-one.
+    The timing capture's own identity sidecar is kept beside the graph pass's
+    under a distinct name rather than overwriting it — the two describe different
+    runs and both are evidence. Best-effort: a capture that cannot be folded is
+    left exactly as it was, and its records are still converted where they lie.
+    """
+    import collections  # noqa: PLC0415
+    import shutil  # noqa: PLC0415
+
+    # Several timed captures can share one graph pass — a benchmark loop repeats
+    # the timing run against the graph it captured once. Folding them all into
+    # that one directory would have them overwrite each other, so only a pair
+    # that owns its graph capture is folded; the rest keep their own directories
+    # and are converted against the shared graph by path.
+    fold_counts = collections.Counter(pairs.values())
+    for timing_dir, graph_dir in pairs.items():
+        if fold_counts[graph_dir] != 1:
+            continue
+        try:
+            for artifact in sorted(timing_dir.iterdir()):
+                if artifact.name == _DISPATCH_IDENTITY_FILE:
+                    target = graph_dir / "dispatch_identity.timing.json"
+                else:
+                    target = graph_dir / artifact.name
+                if target.exists():
+                    continue
+                shutil.move(str(artifact), str(target))
+            timing_dir.rmdir()
+        except OSError as e:
+            print(
+                f"Could not fold {rank_dir.name}/{timing_dir.name} into "
+                f"{rank_dir.name}/{graph_dir.name} ({type(e).__name__}: {e}); the dispatch's "
+                "artifacts stay split across both directories."
+            )
+
+
+def _resolve_capture_graph(
+    rank_dir: Path, disp_dir: Path, pairs: dict[Path, Path]
+) -> tuple[Path | None, Path | None]:
+    """The ``deps.json`` to convert *disp_dir* with, and the capture it came from.
+
+    Returns ``(None, None)`` when the task graph already sits beside the records —
+    the converter's own default, and what :func:`_consolidate_two_pass_captures`
+    normally arranges — and when no capture could be paired, which is reported
+    here because the resulting swimlane silently loses every dependency edge.
+    The graph capture is returned alongside the path: it also carries the
+    dispatch's program marker (see :func:`_submit_chip`).
+    """
+    if (disp_dir / _DEPS_JSON_FILE).exists():
+        return None, None
+    graph_dir = pairs.get(disp_dir)
+    if graph_dir is None:
+        print(
+            f"No task graph paired with {rank_dir.name}/{disp_dir.name}; its swimlane renders task "
+            "timings without dependency edges (the dep_gen pass writes "
+            f"{_DEPS_JSON_FILE} into its own capture directory)."
+        )
+        return None, None
+    return graph_dir / _DEPS_JSON_FILE, graph_dir
 
 
 def _write_dispatch_name_map(
@@ -1060,9 +1278,11 @@ def _collect_l3_swimlane(output_dir: Path, platform: str, *, run_directory: Path
     """Convert each dispatch's swimlane records into a ``merged_swimlane_*.json``.
 
     The runtime writes ``rank{r}/d{k}/deps.json`` in the graph pass and
-    ``rank{r}/d{k}/chip_swimlane_records.json`` in the clean timing pass
-    (the directory is namespaced by card *and* the card's k-th dispatch, and
-    both passes restart that numbering). Globbing ``rank*`` — rather
+    ``rank{r}/d{k}/chip_swimlane_records.json`` in the clean timing pass. The
+    directory is namespaced by card *and* by the child's own capture counter,
+    which spans the process rather than restarting per run — so those two files
+    belong to one dispatch but sit in two directories, and
+    :func:`_pair_rank_captures` is what joins them. Globbing ``rank*`` — rather
     than iterating a rank count — picks up
     whichever cards actually ran, so a comm-less / single-card L3 program (which never
     creates ``rank{0..n}``) still has its records converted. This best-effort
@@ -1116,6 +1336,12 @@ def _collect_l3_swimlane(output_dir: Path, platform: str, *, run_directory: Path
         # One card may have run several dispatches: ``<rank>/d0``, ``d1``, ...
         # Match only ``d`` + digits (the names the runtime emits) so an
         # unrelated diagnostic dir under rank_dir is never picked up.
+        # One pairing per card: which graph capture belongs to which timing
+        # capture is a property of the two passes' dispatch sequences, not of a
+        # directory on its own. Fold the pairs back together before listing the
+        # directories, so what follows sees one directory per dispatch.
+        pairs = _pair_rank_captures(rank_dir)
+        _consolidate_two_pass_captures(rank_dir, pairs)
         dispatch_dirs = sorted(d for d in rank_dir.glob(_DISPATCH_DIR_GLOB) if d.is_dir())
         for disp_dir in dispatch_dirs:
             records = disp_dir / _CHIP_SWIMLANE_RECORDS_NAME
@@ -1134,7 +1360,10 @@ def _collect_l3_swimlane(output_dir: Path, platform: str, *, run_directory: Path
                 # between ``--func-names``, ``-k`` and the sibling turns out to be.
                 for stale in disp_dir.glob("name_map*.json"):
                     stale.unlink(missing_ok=True)
+                deps_json, graph_dir = _resolve_capture_graph(rank_dir, disp_dir, pairs)
                 program = _read_dispatch_program(disp_dir)
+                if program is None and graph_dir is not None:
+                    program = _read_dispatch_program(graph_dir)
                 if program is None and len(chip_dirs) == 1:
                     # One L2 program in the build: no ambiguity to resolve, so an
                     # unmarked dispatch (e.g. artifacts from an older run) can
@@ -1166,7 +1395,7 @@ def _collect_l3_swimlane(output_dir: Path, platform: str, *, run_directory: Path
                 if run_directory is not None:
                     # Never pass immutable Python sources to the converter's bytecode loader.
                     work_dir = run_directory
-                _generate_swimlane(work_dir, disp_dir, records, func_names=name_map_path)
+                _generate_swimlane(work_dir, disp_dir, records, func_names=name_map_path, deps_json=deps_json)
             except Exception as e:  # noqa: BLE001 - best-effort post-pass, never fatal
                 print(
                     f"Skipping L3 swimlane conversion for {disp_dir.name} of {rank_dir.name} "

--- a/python/pypto/runtime/runner.py
+++ b/python/pypto/runtime/runner.py
@@ -1520,6 +1520,7 @@ def _generate_swimlane(
     swimlane_dir: Path,
     perf_file: Path | None,
     func_names: Path | None = None,
+    deps_json: Path | None = None,
 ) -> None:
     """Run ``python -m simpler_setup.tools.swimlane_converter`` to generate ``merged_swimlane_*.json``.
 
@@ -1536,6 +1537,13 @@ def _generate_swimlane(
         func_names: Optional ``name_map_*.json`` (see :func:`_write_name_map`)
             passed to the converter via ``--func-names``. Takes precedence over
             the ``-k kernel_config.py`` fallback for label resolution.
+        deps_json: Optional ``deps.json`` passed to the converter via
+            ``--deps-json``. Only needed when the task graph does not sit beside
+            the records — the converter's own default is the sibling file — which
+            is the L3 two-pass case, where the graph and timing passes are
+            separate captures in separate directories (see
+            :func:`~pypto.runtime.distributed_runner._collect_l3_swimlane`).
+            Without it the swimlane renders with no dependency edges.
     """
     converter_module = "simpler_setup.tools.swimlane_converter"
     try:
@@ -1572,6 +1580,10 @@ def _generate_swimlane(
     # for label resolution; ``-k`` stays as the fallback when no map was written.
     if func_names is not None:
         cmd += ["--func-names", str(func_names)]
+    # The converter defaults to the records' sibling ``deps.json``; pass the
+    # path only when the caller located the graph elsewhere.
+    if deps_json is not None:
+        cmd += ["--deps-json", str(deps_json)]
 
     try:
         subprocess.run(cmd, check=True)

--- a/tests/ut/runtime/test_distributed_worker.py
+++ b/tests/ut/runtime/test_distributed_worker.py
@@ -2384,6 +2384,46 @@ def _write_dfx_dispatch_dirs(dfx: Path, *rels: str) -> None:
         (dfx / rel / "chip_swimlane_records.json").write_text("{}", encoding="utf-8")
 
 
+def _write_capture(
+    rank_dir: Path,
+    name: str,
+    *,
+    records: bool = False,
+    deps: bool = False,
+    run_id: int | None = None,
+    capture_index: int | None = None,
+    digest: str = "deadbeef",
+) -> Path:
+    """Lay down one ``rank{r}/d{k}`` capture the way the ChipWorker child does.
+
+    The child writes ``deps.json`` in a dep_gen run and the records in a swimlane
+    run — never both in one capture — plus the ``dispatch_identity.json`` sidecar
+    that says which run the capture came from. ``run_id=None`` omits the sidecar,
+    which is what an older runtime's layout looks like.
+    """
+    capture = rank_dir / name
+    capture.mkdir(parents=True)
+    if records:
+        (capture / "chip_swimlane_records.json").write_text(json.dumps({"capture": name}), encoding="utf-8")
+    if deps:
+        (capture / "deps.json").write_text('{"edges": []}', encoding="utf-8")
+    if run_id is not None:
+        (capture / "dispatch_identity.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "run_id": run_id,
+                    "task_slot": 0,
+                    "chip_rank": int(rank_dir.name.removeprefix("rank")),
+                    "local_capture_index": capture_index,
+                    "callable_digest": digest,
+                }
+            ),
+            encoding="utf-8",
+        )
+    return capture
+
+
 def _write_chip_program(output_dir: Path, program: str, *kernel_names: str) -> None:
     """Lay down ``next_levels/<program>/kernel_config.py`` naming *kernel_names*.
 
@@ -2468,9 +2508,15 @@ class TestCollectL3Swimlane:
 
         seen: list[SimpleNamespace] = []
 
-        def _fake(work_dir, out_dir, records, func_names=None):  # noqa: ANN001
+        def _fake(work_dir, out_dir, records, func_names=None, deps_json=None):  # noqa: ANN001
             seen.append(
-                SimpleNamespace(work_dir=work_dir, out_dir=out_dir, records=records, func_names=func_names)
+                SimpleNamespace(
+                    work_dir=work_dir,
+                    out_dir=out_dir,
+                    records=records,
+                    func_names=func_names,
+                    deps_json=deps_json,
+                )
             )
 
         monkeypatch.setattr(_runner, "_generate_swimlane", _fake)
@@ -2639,6 +2685,267 @@ class TestCollectL3Swimlane:
         assert json.loads((dfx / "rank0" / "d0" / "name_map.json").read_text())["callable_id_to_name"] == {
             "0": "rms"
         }
+
+    def test_two_pass_captures_are_paired_for_their_task_graph(
+        self, tmp_path, monkeypatch, fake_swimlane_converter
+    ):
+        # The swimlane two-pass is two runs, and the child numbers captures per
+        # process -> the graph pass's deps.json is in d0 while the timing pass's
+        # records are in d1. Unpaired, the converter finds no graph beside the
+        # records and renders a swimlane with zero dependency edges: task
+        # timings survive, every arrow is gone.
+        seen = self._spy_generate_swimlane(monkeypatch)
+        _write_chip_program(tmp_path, "only_chip", "rms")
+        rank = tmp_path / "dfx_outputs" / "rank0"
+        graph = _write_capture(rank, "d0", deps=True, run_id=1, capture_index=0)
+        timing = _write_capture(rank, "d1", records=True, run_id=2, capture_index=1)
+
+        _collect_l3_swimlane(tmp_path, "a2a3")
+
+        # One dispatch, one directory — and the graph pass's ``d0`` is the one
+        # kept, since the timing pass's index is only that ordinal plus an
+        # offset. Every consumer that looks for a dispatch's files together
+        # (the converter, critical_path, the viewers) finds them in one place.
+        assert not timing.exists()
+        assert sorted(f.name for f in graph.iterdir()) == [
+            "chip_swimlane_records.json",
+            "deps.json",
+            "dispatch_identity.json",
+            "dispatch_identity.timing.json",
+            "name_map.json",
+        ]
+        assert json.loads((graph / "chip_swimlane_records.json").read_text()) == {"capture": "d1"}
+        # The graph is now the records' own sibling, which is the converter's
+        # default, so no explicit path is needed.
+        assert [s.out_dir for s in seen] == [graph]
+        assert seen[0].deps_json is None
+
+    def test_pairing_recovers_the_program_marker_from_the_graph_capture(
+        self, tmp_path, monkeypatch, fake_swimlane_converter
+    ):
+        # ``_submit_chip`` derives the marker's directory from *this run's*
+        # dispatch ordinal, so the marker lands on the graph capture and the
+        # records' own capture has none. With two programs in the build the
+        # single-program fallback cannot save it (issue #2169), so the pairing
+        # has to carry the marker across.
+        seen = self._spy_generate_swimlane(monkeypatch)
+        _write_chip_program(tmp_path, "lm_head", "lm_head_dispatch_push")
+        _write_chip_program(tmp_path, "mtp_decode_layer", "mtp_projection_rms")
+        rank = tmp_path / "dfx_outputs" / "rank0"
+        graph = _write_capture(rank, "d0", deps=True, run_id=1, capture_index=0)
+        _mark_dispatch_program(graph, "mtp_decode_layer")
+        _write_capture(rank, "d1", records=True, run_id=2, capture_index=1)
+
+        _collect_l3_swimlane(tmp_path, "a2a3")
+
+        assert seen[0].work_dir == tmp_path / "next_levels" / "mtp_decode_layer"
+        assert json.loads((graph / "name_map.json").read_text())["callable_id_to_name"] == {
+            "0": "mtp_projection_rms"
+        }
+
+    def test_pairing_follows_the_dispatch_not_the_directory_order(
+        self, tmp_path, monkeypatch, fake_swimlane_converter
+    ):
+        # A card that ran two dispatches per pass fills d0-d1 in the graph pass
+        # and d2-d3 in the timing pass. Pairing by bare ``d{k}`` order or by
+        # ``local_capture_index`` would hand d2 the *second* dispatch's graph;
+        # the ordinal within a run plus the callable digest is what keeps each
+        # dispatch with its own edges.
+        seen = self._spy_generate_swimlane(monkeypatch)
+        _write_chip_program(tmp_path, "only_chip", "rms")
+        rank = tmp_path / "dfx_outputs" / "rank0"
+        first_graph = _write_capture(rank, "d0", deps=True, run_id=1, capture_index=0, digest="aaa")
+        second_graph = _write_capture(rank, "d1", deps=True, run_id=1, capture_index=1, digest="bbb")
+        _write_capture(rank, "d2", records=True, run_id=2, capture_index=2, digest="aaa")
+        _write_capture(rank, "d3", records=True, run_id=2, capture_index=3, digest="bbb")
+
+        _collect_l3_swimlane(tmp_path, "a2a3")
+
+        # ``d0``/``d1`` are the two dispatches; ``d2``/``d3`` were the same two
+        # captured again. Each set of records lands on its own dispatch, and the
+        # card is left with exactly one directory per dispatch.
+        assert sorted(d.name for d in rank.iterdir()) == ["d0", "d1"]
+        assert json.loads((first_graph / "chip_swimlane_records.json").read_text()) == {"capture": "d2"}
+        assert json.loads((second_graph / "chip_swimlane_records.json").read_text()) == {"capture": "d3"}
+        assert sorted(s.out_dir.name for s in seen) == ["d0", "d1"]
+
+    def test_colocated_graph_and_records_pass_no_explicit_path(
+        self, tmp_path, monkeypatch, fake_swimlane_converter
+    ):
+        # A runtime that files both passes under one capture needs no pairing:
+        # the converter's own default (the records' sibling) is already right, so
+        # the collector must not start overriding it.
+        seen = self._spy_generate_swimlane(monkeypatch)
+        _write_chip_program(tmp_path, "only_chip", "rms")
+        rank = tmp_path / "dfx_outputs" / "rank0"
+        _write_capture(rank, "d0", records=True, deps=True, run_id=1, capture_index=0)
+
+        _collect_l3_swimlane(tmp_path, "a2a3")
+
+        assert seen[0].deps_json is None
+
+    def test_sole_graph_capture_pairs_without_identity_sidecars(
+        self, tmp_path, monkeypatch, fake_swimlane_converter
+    ):
+        # An older runtime writes no identity sidecar. Exactly one graph capture
+        # and exactly one timing capture on the card leaves nothing to confuse,
+        # so the edges are still recovered rather than dropped for want of a
+        # sidecar.
+        seen = self._spy_generate_swimlane(monkeypatch)
+        _write_chip_program(tmp_path, "only_chip", "rms")
+        rank = tmp_path / "dfx_outputs" / "rank0"
+        graph = _write_capture(rank, "d0", deps=True)
+        _write_capture(rank, "d1", records=True)
+
+        _collect_l3_swimlane(tmp_path, "a2a3")
+
+        assert sorted(d.name for d in rank.iterdir()) == ["d0"]
+        assert seen[0].out_dir == graph
+        assert seen[0].deps_json is None
+
+    def test_legacy_layout_will_not_reuse_one_graph_for_several_captures(
+        self, tmp_path, monkeypatch, fake_swimlane_converter, capsys
+    ):
+        # Without sidecars, one graph capture beside two sets of records says
+        # nothing about which dispatch that graph belongs to. Handing it to both
+        # gives two dispatches the same edges — each individually plausible.
+        seen = self._spy_generate_swimlane(monkeypatch)
+        _write_chip_program(tmp_path, "only_chip", "rms")
+        rank = tmp_path / "dfx_outputs" / "rank0"
+        _write_capture(rank, "d0", deps=True)
+        _write_capture(rank, "d1", records=True)
+        _write_capture(rank, "d2", records=True)
+
+        _collect_l3_swimlane(tmp_path, "a2a3")
+
+        assert [s.deps_json for s in seen] == [None, None]
+        assert "No task graph paired with rank0/d1" in capsys.readouterr().out
+
+    def test_repeated_callable_pairs_by_position_when_the_passes_agree(
+        self, tmp_path, monkeypatch, fake_swimlane_converter
+    ):
+        # A card that dispatches the same callable twice per pass has two
+        # captures with identical digests, so the digest alone cannot pair them.
+        # Identical sequences make the position meaningful, which is what keeps
+        # each dispatch with its own edges.
+        self._spy_generate_swimlane(monkeypatch)
+        _write_chip_program(tmp_path, "only_chip", "rms")
+        rank = tmp_path / "dfx_outputs" / "rank0"
+        first = _write_capture(rank, "d0", deps=True, run_id=1, capture_index=0, digest="aaa")
+        second = _write_capture(rank, "d1", deps=True, run_id=1, capture_index=1, digest="aaa")
+        _write_capture(rank, "d2", records=True, run_id=2, capture_index=2, digest="aaa")
+        _write_capture(rank, "d3", records=True, run_id=2, capture_index=3, digest="aaa")
+
+        _collect_l3_swimlane(tmp_path, "a2a3")
+
+        assert sorted(d.name for d in rank.iterdir()) == ["d0", "d1"]
+        assert json.loads((first / "chip_swimlane_records.json").read_text()) == {"capture": "d2"}
+        assert json.loads((second / "chip_swimlane_records.json").read_text()) == {"capture": "d3"}
+
+    def test_a_shorter_timing_pass_rejects_the_whole_run_pair(
+        self, tmp_path, monkeypatch, fake_swimlane_converter, capsys
+    ):
+        # The passes do not restore mutable arguments between them, so a
+        # dispatch count that depends on data can differ. Graph ``[A, A]``
+        # against timing ``[A]``: the surviving dispatch may logically be the
+        # second, and pairing it with the first ``A``'s graph would put wrong
+        # edges on a trace that reads as complete.
+        seen = self._spy_generate_swimlane(monkeypatch)
+        _write_chip_program(tmp_path, "only_chip", "rms")
+        rank = tmp_path / "dfx_outputs" / "rank0"
+        _write_capture(rank, "d0", deps=True, run_id=1, capture_index=0, digest="aaa")
+        _write_capture(rank, "d1", deps=True, run_id=1, capture_index=1, digest="aaa")
+        _write_capture(rank, "d2", records=True, run_id=2, capture_index=2, digest="aaa")
+
+        _collect_l3_swimlane(tmp_path, "a2a3")
+
+        assert seen[0].deps_json is None
+        assert "No task graph paired with rank0/d2" in capsys.readouterr().out
+
+    def test_a_longer_timing_pass_rejects_the_whole_run_pair(
+        self, tmp_path, monkeypatch, fake_swimlane_converter
+    ):
+        # The mirror case: the timing pass dispatched more than the graph pass
+        # saw, so the extra dispatch has no graph and the ones before it are no
+        # longer guaranteed to line up either.
+        seen = self._spy_generate_swimlane(monkeypatch)
+        _write_chip_program(tmp_path, "only_chip", "rms")
+        rank = tmp_path / "dfx_outputs" / "rank0"
+        _write_capture(rank, "d0", deps=True, run_id=1, capture_index=0, digest="aaa")
+        _write_capture(rank, "d1", records=True, run_id=2, capture_index=1, digest="aaa")
+        _write_capture(rank, "d2", records=True, run_id=2, capture_index=2, digest="aaa")
+
+        _collect_l3_swimlane(tmp_path, "a2a3")
+
+        assert [s.deps_json for s in seen] == [None, None]
+
+    def test_a_reordered_timing_pass_rejects_the_whole_run_pair(
+        self, tmp_path, monkeypatch, fake_swimlane_converter
+    ):
+        # Same dispatch count, different order: position no longer identifies a
+        # dispatch, and every pairing in the run is suspect rather than just the
+        # moved one.
+        seen = self._spy_generate_swimlane(monkeypatch)
+        _write_chip_program(tmp_path, "only_chip", "rms")
+        rank = tmp_path / "dfx_outputs" / "rank0"
+        _write_capture(rank, "d0", deps=True, run_id=1, capture_index=0, digest="aaa")
+        _write_capture(rank, "d1", deps=True, run_id=1, capture_index=1, digest="bbb")
+        _write_capture(rank, "d2", records=True, run_id=2, capture_index=2, digest="bbb")
+        _write_capture(rank, "d3", records=True, run_id=2, capture_index=3, digest="aaa")
+
+        _collect_l3_swimlane(tmp_path, "a2a3")
+
+        assert [s.deps_json for s in seen] == [None, None]
+
+    def test_later_timing_runs_reuse_the_graph_pass(self, tmp_path, monkeypatch, fake_swimlane_converter):
+        # A benchmark loop captures several timing runs against one graph pass.
+        # Each is the same dispatch sequence, so each keeps the graph's edges.
+        seen = self._spy_generate_swimlane(monkeypatch)
+        _write_chip_program(tmp_path, "only_chip", "rms")
+        rank = tmp_path / "dfx_outputs" / "rank0"
+        graph = _write_capture(rank, "d0", deps=True, run_id=1, capture_index=0)
+        _write_capture(rank, "d1", records=True, run_id=2, capture_index=1)
+        _write_capture(rank, "d2", records=True, run_id=3, capture_index=2)
+
+        _collect_l3_swimlane(tmp_path, "a2a3")
+
+        # Folding both into ``d0`` would have them overwrite each other, so each
+        # timing run keeps its own directory and is converted against the shared
+        # graph by path.
+        assert sorted(d.name for d in rank.iterdir()) == ["d0", "d1", "d2"]
+        assert [s.deps_json for s in seen] == [graph / "deps.json", graph / "deps.json"]
+
+    def test_ambiguous_graph_captures_render_without_edges(
+        self, tmp_path, monkeypatch, fake_swimlane_converter, capsys
+    ):
+        # Two candidate graphs and no identity to tell them apart: guessing would
+        # attach another dispatch's edges, which reads as a real measurement.
+        # Convert without edges and say so instead.
+        seen = self._spy_generate_swimlane(monkeypatch)
+        _write_chip_program(tmp_path, "only_chip", "rms")
+        rank = tmp_path / "dfx_outputs" / "rank0"
+        _write_capture(rank, "d0", deps=True)
+        _write_capture(rank, "d1", deps=True)
+        _write_capture(rank, "d2", records=True)
+
+        _collect_l3_swimlane(tmp_path, "a2a3")
+
+        assert seen[0].deps_json is None
+        assert "No task graph paired with rank0/d2" in capsys.readouterr().out
+
+    def test_pairing_stays_inside_the_card(self, tmp_path, monkeypatch, fake_swimlane_converter):
+        # Ranks run different data and their task graphs are not interchangeable,
+        # so a card with no graph of its own must not borrow its neighbour's.
+        seen = self._spy_generate_swimlane(monkeypatch)
+        _write_chip_program(tmp_path, "only_chip", "rms")
+        dfx = tmp_path / "dfx_outputs"
+        _write_capture(dfx / "rank0", "d0", deps=True, run_id=1, capture_index=0)
+        _write_capture(dfx / "rank1", "d1", records=True, run_id=2, capture_index=1)
+
+        _collect_l3_swimlane(tmp_path, "a2a3")
+
+        assert [s.out_dir.parent.name for s in seen] == ["rank1"]
+        assert seen[0].deps_json is None
 
 
 class _BoolStrictCallConfig:


### PR DESCRIPTION
## Summary

An L3 swimlane capture runs the dispatch twice — a dep_gen pass for the task graph, then a clean timing pass — and the ChipWorker child names its capture directories from `diagnostic_capture_index`, a counter that spans the whole process. One dispatch therefore ends up spread over two `rank{r}/d{k}` directories:

```
dfx_outputs/rank{0..3}/d0/   deps.json + dispatch_program.json    <- graph pass  (run_id 1)
dfx_outputs/rank{0..3}/d1/   chip_swimlane_records.json           <- timing pass (run_id 2)
```

Everything downstream expects a dispatch's artifacts *together*:

- the converter takes the `deps.json` beside the records, finds none, and renders a swimlane whose tasks keep their timings and **lose every dependency edge** — observed on a 4-card DSpark CSA decode capture as 1703 named tasks and 0 flow events, which reads as a complete trace rather than a broken one;
- `simpler_setup.tools.critical_path` selects a rank directory by "has `deps.json` **and** a name map", so it matches **neither** half and finds nothing to analyse;
- the dispatch's program marker is stranded in the first directory, dropping a multi-L2-program build back to anonymous labels (#2169) — saved today only by the single-program fallback.

## What this changes

Fold the pair back together, **forward into the graph capture**. The graph pass runs first, so its captures carry the lower indices — a card dispatching `N` times files them at `d0..d(N-1)`, the dispatch ordinals themselves, while the timing pass's `dN..d(2N-1)` are only that offset repeated. Keeping the first of each pair restores what the layout has always claimed: **one directory per dispatch, named by the dispatch**, holding that dispatch's whole capture. The timing capture's identity sidecar is kept alongside as `dispatch_identity.timing.json`; the emptied directory is removed.

Pairing is per run, not per capture. Nothing in a single sidecar names a dispatch across passes (`run_id` differs; `local_capture_index` and `endpoint_dispatch_id` are per-process counters), so a timing run pairs with a graph run only when their **ordered `callable_digest` sequences are identical**, which is what makes position meaningful. A sequence differing in length or order rejects the run pair outright — the passes do not restore mutable arguments between them, so a data-dependent dispatch count can genuinely differ, and a graph pass of `[A, A]` against a timing pass of `[A]` would otherwise hand the survivor the first `A`'s edges.

Only a one-to-one pair is folded. Several timed captures can share one graph pass (a benchmark loop repeats the timing run); folding those together would have them overwrite each other, so they keep their own directories and are converted against the shared graph through the new `--deps-json` passthrough in `_generate_swimlane`. A card with no sidecars at all folds only when exactly one capture holds the graph and exactly one holds the records. Anything unpairable is left exactly as it was and reported as a swimlane without dependency edges.

Also corrects the docstrings that still claimed both passes land in the same `d{k}` and that the caller-side counter "tracks the child's own counter".

## Verification

Same kernel, same 4 cards, same flag — only pypto changed:

| | before | after |
|---|---|---|
| directories per rank | `d0` (graph) + `d1` (timing) | **`d0`** only |
| contents | split across the two | `deps.json`, `chip_swimlane_records.json`, `name_map.json`, `merged_swimlane_*.json`, `dispatch_program.json` |
| flow events (dependency arrows) | 0 / 0 | **143 / 143** |
| `X` tasks / named | 1703 / 1703 | 1703 / 1703 |
| ranks satisfying `critical_path`'s selection | 0 of 4 | **4 of 4** |

`[RUN] PASS (88.97s)`, all four ranks identical.

- `tests/ut/runtime/` — 843 passed, including cases for: the fold itself (one directory per dispatch, records landing on the right dispatch for a card that dispatched twice per pass), rejection on a shorter / longer / reordered timing pass, repeated digests pairing by position when the passes agree, a shared graph pass across several timing runs staying split and converting by path, the legacy no-sidecar layout folding only one-to-one, and no cross-rank borrowing.
- `ruff check` / `ruff format --check` clean.

## Follow-up (not in this PR)

The naming itself is still the child's process-wide counter, so a capture session that repeats (benchmark rounds) keeps climbing `d2, d3, …`. The real fix is for the directory to come from the side that knows the run structure: pypto already computes `rank{w}/d{k}` with the right semantics and only stopped passing it in #2646. Letting the child use a caller-provided suffix — falling back to its own counter when none is given — would make both passes land in one directory at write time and make this fold unnecessary. That needs a simpler-side change first, so it is left as a follow-up.