### PR TITLE
fix(ir): keep the writes of a discarded inline return expression

### DIFF
--- a/docs/en/dev/passes/01-inline_functions.md
+++ b/docs/en/dev/passes/01-inline_functions.md
@@ -122,7 +122,44 @@ The scope is preserved verbatim and gets outlined by `OutlineIncoreScopes` later
 | Recursive Inline (self or mutual) | `pypto::ValueError` raised before any splicing, with the cycle named (`a -> b -> a`). |
 | Multi-return inline | No `LHS = MakeTuple([rets...])` is emitted — orchestration codegen cannot lower `MakeTuple`. The cloned return values are recorded against the LHS `Var` and downstream `TupleGetItemExpr(LHS, i)` uses are rewritten to value `i`, leaving the LHS binding unreferenced (see `SpliceInlineCallAsTupleSub`). |
 | Nested call to Inline (e.g. `pl.add(inline_fn(x), y)`) | Not handled in v1 — left as-is. The `InlineFunctionsEliminated` verifier flags any surviving Call. |
-| `EvalStmt(inline_call(...))` — return value ignored | The value is discarded, its **evaluation** is not. A discarded cross-function `Call` / `Submit` is re-emitted as an `EvalStmt` (then expanded by the fixpoint loop when its callee is also Inline), so an ignored wrapper ending in `return self.inner(x, out)` keeps `inner`'s write to `out`. A pure value (`Var`, constant, builtin op `Call`) is dropped. A value that merely *wraps* a cross-function call raises `pypto::ValueError` rather than silently deleting the write — return that call directly, or bind the wrapper's result at the call site. |
+| `EvalStmt(inline_call(...))` — return value ignored | The value is discarded, its **evaluation** is not. See [Discarding a return value](#discarding-a-return-value) below. |
+
+## Discarding a return value
+
+An `EvalStmt` call site — `self.wrapper(x, out)` with no LHS — has nowhere to put the callee's trailing return value. Dropping that **value** is correct; dropping its **evaluation** is not, because evaluating it can write through `Out` / `InOut` arguments. Each discarded value is therefore classified:
+
+| Discarded value | Behaviour |
+| --------------- | --------- |
+| A `Call` the operator registry does not positively classify as non-writing — a cross-function dispatch, a writing builtin such as `tile.store`, or any operator nobody has classified yet | Re-emitted as an `EvalStmt`, in return order. The fixpoint loop expands a cross-function one on its next iteration when that callee is also Inline; otherwise it stays an ordinary dispatch, exactly as if the author had written it at the call site. |
+| A `Submit` | Re-emitted as an `EvalStmt`. A task launch is effectful whatever its callee does. |
+| A `Call` whose operator declared it writes through no argument, or any other value that hides nothing effectful (`Var`, constant) | Dropped. |
+| A value that is not itself call-like but *wraps* something effectful — scalar arithmetic such as `self.bump(n) + 1`, a `MakeTuple`, a `TupleGetItemExpr` | `pypto::ValueError`. It cannot become an `EvalStmt`, and deleting it would delete the nested call's write. Return that call directly, or bind the wrapper's result at the call site. |
+
+The registry distinguishes "declared to write through no argument" from "nobody has classified this operator yet" (`OpRegistryEntry::HasDeclaredArgEffects`), and most operators are still in the second group — including plainly effectful ones such as `tile.tpush_to_aiv` and `system.aic_initialize_pipe`, which `dce::IsSideEffectOp` lists as side-effecting. Only a positive verdict allows deletion, so an unclassified pure operator is conservatively kept as a dead-but-harmless `EvalStmt`.
+
+**Before**:
+
+```python
+@pl.function(type=pl.FunctionType.Inline)
+def writeout(self, t, out: pl.Out[...]):
+    return pl.tile.store(t, [0, 0], out)   # the write IS the return expression
+
+@pl.function(type=pl.FunctionType.InCore)
+def kernel(self, a, out: pl.Out[...]):
+    t = pl.tile.load(a, [0, 0], [64, 64])
+    self.writeout(t, out)                  # return value ignored
+    return out
+```
+
+**After** — the store survives:
+
+```python
+@pl.function(type=pl.FunctionType.InCore)
+def kernel(self, a, out: pl.Out[...]):
+    t = pl.tile.load(a, [0, 0], [64, 64])
+    pl.tile.store(t, [0, 0], out)
+    return out
+```
 
 ## Verification
 

--- a/docs/en/dev/passes/01-inline_functions.md
+++ b/docs/en/dev/passes/01-inline_functions.md
@@ -126,16 +126,21 @@ The scope is preserved verbatim and gets outlined by `OutlineIncoreScopes` later
 
 ## Discarding a return value
 
-An `EvalStmt` call site — `self.wrapper(x, out)` with no LHS — has nowhere to put the callee's trailing return value. Dropping that **value** is correct; dropping its **evaluation** is not, because evaluating it can write through `Out` / `InOut` arguments. Each discarded value is therefore classified:
+An `EvalStmt` call site — `self.wrapper(x, out)` with no LHS — has nowhere to put the callee's trailing return value. Dropping that **value** is correct; dropping its **evaluation** is not, because evaluating it can write through `Out` / `InOut` arguments, launch a task, block on a signal, or set up hardware. Each discarded value is therefore classified:
 
 | Discarded value | Behaviour |
 | --------------- | --------- |
-| A `Call` the operator registry does not positively classify as non-writing — a cross-function dispatch, a writing builtin such as `tile.store`, or any operator nobody has classified yet | Re-emitted as an `EvalStmt`, in return order. The fixpoint loop expands a cross-function one on its next iteration when that callee is also Inline; otherwise it stays an ordinary dispatch, exactly as if the author had written it at the call site. |
+| A `Call` — any callee, cross-function or builtin | Re-emitted as an `EvalStmt`, in return order. The fixpoint loop expands a cross-function one on its next iteration when that callee is also Inline; otherwise it stays an ordinary dispatch, exactly as if the author had written it at the call site. |
 | A `Submit` | Re-emitted as an `EvalStmt`. A task launch is effectful whatever its callee does. |
-| A `Call` whose operator declared it writes through no argument, or any other value that hides nothing effectful (`Var`, constant) | Dropped. |
-| A value that is not itself call-like but *wraps* something effectful — scalar arithmetic such as `self.bump(n) + 1`, a `MakeTuple`, a `TupleGetItemExpr` | `pypto::ValueError`. It cannot become an `EvalStmt`, and deleting it would delete the nested call's write. Return that call directly, or bind the wrapper's result at the call site. |
+| Anything else that hides no call — a `Var`, a constant | Dropped. |
+| A value that is not itself call-like but *wraps* a call — scalar arithmetic such as `self.bump(n) + 1`, a `MakeTuple`, a `TupleGetItemExpr` | `pypto::ValueError`. It cannot become an `EvalStmt`, and deleting it would delete the nested call with it. Return that call directly, or bind the wrapper's result at the call site. |
 
-The registry distinguishes "declared to write through no argument" from "nobody has classified this operator yet" (`OpRegistryEntry::HasDeclaredArgEffects`), and most operators are still in the second group — including plainly effectful ones such as `tile.tpush_to_aiv` and `system.aic_initialize_pipe`, which `dce::IsSideEffectOp` lists as side-effecting. Only a positive verdict allows deletion, so an unclassified pure operator is conservatively kept as a dead-but-harmless `EvalStmt`.
+**Why every call, rather than only the ones that write.** Nothing in the IR answers "is this call safe to delete". The nearest registry data, `OpRegistryEntry::WritesAnyArg`, answers whether an operator writes *through an argument*, and keying deletion on it is wrong in both directions:
+
+- Most operators are simply unclassified — 263 of 315 at the time of writing, among them `tile.tpush_to_aiv` and `system.aic_initialize_pipe`, which `dce::IsSideEffectOp` lists as side-effecting. `OpRegistryEntry::HasDeclaredArgEffects` exists precisely so an analysis can tell "declared to write nothing" from "nobody looked yet".
+- A *positive* `no_arg_writes()` verdict does not mean deletable either. `pld.system.wait` blocks until a signal slot satisfies a threshold, `pld.system.defer_wait` registers a completion condition, and `system.set_ffts` hands the FFTS unit its workspace pointer — all three declare `no_arg_writes()` while carrying synchronization or hardware-setup semantics.
+
+So the pass keeps every call. A discarded genuinely pure call survives as a dead `EvalStmt`, which the pipeline carries harmlessly. Narrowing this needs a real "safely deletable" operator property, declared per operator rather than inferred from writes.
 
 **Before**:
 

--- a/docs/en/dev/passes/01-inline_functions.md
+++ b/docs/en/dev/passes/01-inline_functions.md
@@ -38,7 +38,7 @@ program_inlined = inline_pass(program)
      - Build the param-substitution map (formal `Var` → actual `Expr`).
      - Alpha-rename every locally-bound `Var` in the inlined body to a fresh name (`<orig>_inline<counter>`, with any trailing `_` trimmed off `<orig>`) to avoid collisions across multiple call sites.
      - Splice the renamed-and-substituted body's statements before the call site.
-     - Replace the call with: `LHS = renamed_return` (single-return) or `LHS = MakeTuple([renamed_returns...])` (multi-return). When `LHS` resolves to the same `Var` as the substituted return value, the assignment is omitted to avoid a redundant SSA copy.
+     - Wire up the callee's trailing return value according to the call-site form: `LHS = renamed_return` (single-return assign; omitted when `LHS` resolves to the same `Var` as the substituted value, to avoid a redundant SSA copy), per-element `TupleGetItemExpr` substitution instead of a `MakeTuple` binding (multi-return assign), a fresh `ReturnStmt` (`return inline_call(...)`), or a fresh `EvalStmt` when the value is discarded but its evaluation is observable (`EvalStmt` call site — see [Edge cases](#edge-cases)).
 4. **Drop** all Inline functions from the program.
 
 The pass uses a single underscore (`_inline`) in the rename suffix because `__` is reserved by the IR's auto-naming convention (see `auto_name_utils.h`).
@@ -120,8 +120,9 @@ The scope is preserved verbatim and gets outlined by `OutlineIncoreScopes` later
 | Inline function as program entry | Not detected as an error here — but no Call to it exists, so it is removed in the cleanup phase like any other no-caller function. |
 | Inline calls Inline (transitive) | Iteratively expanded to fixpoint. |
 | Recursive Inline (self or mutual) | `pypto::ValueError` raised before any splicing, with the cycle named (`a -> b -> a`). |
-| Multi-return inline | `LHS = MakeTuple([rets...])` emitted at the call site. Subsequent `Simplify` may fold `TupleGetItemExpr(MakeTuple(...), i)`. |
+| Multi-return inline | No `LHS = MakeTuple([rets...])` is emitted — orchestration codegen cannot lower `MakeTuple`. The cloned return values are recorded against the LHS `Var` and downstream `TupleGetItemExpr(LHS, i)` uses are rewritten to value `i`, leaving the LHS binding unreferenced (see `SpliceInlineCallAsTupleSub`). |
 | Nested call to Inline (e.g. `pl.add(inline_fn(x), y)`) | Not handled in v1 — left as-is. The `InlineFunctionsEliminated` verifier flags any surviving Call. |
+| `EvalStmt(inline_call(...))` — return value ignored | The value is discarded, its **evaluation** is not. A discarded cross-function `Call` / `Submit` is re-emitted as an `EvalStmt` (then expanded by the fixpoint loop when its callee is also Inline), so an ignored wrapper ending in `return self.inner(x, out)` keeps `inner`'s write to `out`. A pure value (`Var`, constant, builtin op `Call`) is dropped. A value that merely *wraps* a cross-function call raises `pypto::ValueError` rather than silently deleting the write — return that call directly, or bind the wrapper's result at the call site. |
 
 ## Verification
 

--- a/docs/zh/dev/passes/01-inline_functions.md
+++ b/docs/zh/dev/passes/01-inline_functions.md
@@ -126,16 +126,21 @@ scope 被原样保留,稍后由 `OutlineIncoreScopes` 提取为独立的 InCore 
 
 ## 丢弃返回值
 
-`EvalStmt` 调用点(`self.wrapper(x, out)`,没有 LHS)无处安放被调用者的尾部返回值。丢弃那个**值**是对的,丢弃它的**求值**则不对 —— 求值过程可能通过 `Out` / `InOut` 参数写入。因此每个被丢弃的值都要分类:
+`EvalStmt` 调用点(`self.wrapper(x, out)`,没有 LHS)无处安放被调用者的尾部返回值。丢弃那个**值**是对的,丢弃它的**求值**则不对 —— 求值过程可能通过 `Out` / `InOut` 参数写入、启动任务、阻塞等待信号,或完成硬件设置。因此每个被丢弃的值都要分类:
 
 | 被丢弃的值 | 行为 |
 | ---------- | ---- |
-| 算子注册表未正面判定为"不写入"的 `Call` —— 跨函数派发、`tile.store` 这类会写的 builtin,或任何尚无人分类的算子 | 按 return 顺序重新发出为 `EvalStmt`。若跨函数调用的被调用者同样是 Inline,不动点循环会在下一轮展开它;否则它就保持为一次普通派发,与作者在调用点直接写出来完全一致。 |
+| `Call` —— 无论被调用者是跨函数还是 builtin | 按 return 顺序重新发出为 `EvalStmt`。若跨函数调用的被调用者同样是 Inline,不动点循环会在下一轮展开它;否则它就保持为一次普通派发,与作者在调用点直接写出来完全一致。 |
 | `Submit` | 重新发出为 `EvalStmt`。任务启动本身就是有副作用的,与被调用者做什么无关。 |
-| 算子已声明"不通过任何参数写入"的 `Call`,或其它不藏有副作用的值(`Var`、常量) | 丢弃。 |
-| 本身不是 call-like、但**包裹**了有副作用内容的值 —— `self.bump(n) + 1` 这类标量算术、`MakeTuple`、`TupleGetItemExpr` | 抛出 `pypto::ValueError`。它无法变成 `EvalStmt`,而删除它会连带删除内层调用的写入。请直接返回该调用,或在调用点绑定 wrapper 的结果。 |
+| 其它不藏有调用的值 —— `Var`、常量 | 丢弃。 |
+| 本身不是 call-like、但**包裹**了调用的值 —— `self.bump(n) + 1` 这类标量算术、`MakeTuple`、`TupleGetItemExpr` | 抛出 `pypto::ValueError`。它无法变成 `EvalStmt`,而删除它会连带删除内层的调用。请直接返回该调用,或在调用点绑定 wrapper 的结果。 |
 
-注册表刻意区分"已声明不通过任何参数写入"与"尚无人分类此算子"(`OpRegistryEntry::HasDeclaredArgEffects`),而目前大多数算子仍属于后者 —— 其中包括 `tile.tpush_to_aiv`、`system.aic_initialize_pipe` 这些明显有副作用、被 `dce::IsSideEffectOp` 列为副作用算子的项。只有正面判定才允许删除,因此未分类的纯算子会被保守地保留为一条无用但无害的 `EvalStmt`。
+**为什么是"所有调用",而不只是"会写的调用"。** IR 里没有任何东西能回答"这次调用可以安全删除吗"。最接近的注册表数据 `OpRegistryEntry::WritesAnyArg` 回答的是另一个问题 —— 算子是否**通过参数**写入 —— 以它为删除依据在两个方向上都会出错:
+
+- 大多数算子根本没有分类 —— 撰写时 315 个里有 263 个,其中就包括被 `dce::IsSideEffectOp` 列为副作用算子的 `tile.tpush_to_aiv` 和 `system.aic_initialize_pipe`。`OpRegistryEntry::HasDeclaredArgEffects` 存在的意义正是让分析能区分"已声明不写"和"尚无人查看"。
+- **正面**的 `no_arg_writes()` 判定也不等于可删除。`pld.system.wait` 会阻塞直到信号槽满足阈值,`pld.system.defer_wait` 注册任务完成条件,`system.set_ffts` 把 workspace 指针交给 FFTS 单元 —— 三者都声明了 `no_arg_writes()`,却都承担同步或硬件设置语义。
+
+因此该 pass 保留所有调用。被丢弃的真·纯调用会留下一条无用的 `EvalStmt`,流水线可以无害地带着它走完。要收窄这一点,需要一个真正的"可安全删除"算子属性 —— 逐算子声明,而不是从写入行为反推。
 
 **变换前**:
 

--- a/docs/zh/dev/passes/01-inline_functions.md
+++ b/docs/zh/dev/passes/01-inline_functions.md
@@ -122,7 +122,44 @@ scope 被原样保留,稍后由 `OutlineIncoreScopes` 提取为独立的 InCore 
 | 递归 Inline(自递归或互相调用) | 在任何展开发生之前抛出 `pypto::ValueError`,消息中标明环路径(`a -> b -> a`)。 |
 | 多返回值 Inline | **不**发出 `LHS = MakeTuple([rets...])` — 编排层 codegen 无法 lower `MakeTuple`。改为把克隆后的返回值记录在 LHS `Var` 上,并把下游 `TupleGetItemExpr(LHS, i)` 的使用改写为第 `i` 个值,使该 LHS 绑定最终无人引用(参见 `SpliceInlineCallAsTupleSub`)。 |
 | 嵌套 Call 到 Inline(如 `pl.add(inline_fn(x), y)`) | v1 不处理 — 保持原样。`InlineFunctionsEliminated` verifier 会标记任何残留的 Call。 |
-| `EvalStmt(inline_call(...))` — 返回值被忽略 | 被丢弃的是返回**值**,不是它的**求值**。被丢弃的跨函数 `Call` / `Submit` 会重新发出为 `EvalStmt`(其被调用者同样是 Inline 时,由不动点循环继续展开),因此以 `return self.inner(x, out)` 结尾的被忽略 wrapper 仍会保留 `inner` 对 `out` 的写入。纯值(`Var`、常量、builtin op `Call`)照旧丢弃。若某个值只是**包裹**了跨函数调用,则抛出 `pypto::ValueError` 而不是静默删除该写入 — 请直接返回该调用,或在调用点绑定 wrapper 的结果。 |
+| `EvalStmt(inline_call(...))` — 返回值被忽略 | 被丢弃的是返回**值**,不是它的**求值**。参见下方[丢弃返回值](#丢弃返回值)。 |
+
+## 丢弃返回值
+
+`EvalStmt` 调用点(`self.wrapper(x, out)`,没有 LHS)无处安放被调用者的尾部返回值。丢弃那个**值**是对的,丢弃它的**求值**则不对 —— 求值过程可能通过 `Out` / `InOut` 参数写入。因此每个被丢弃的值都要分类:
+
+| 被丢弃的值 | 行为 |
+| ---------- | ---- |
+| 算子注册表未正面判定为"不写入"的 `Call` —— 跨函数派发、`tile.store` 这类会写的 builtin,或任何尚无人分类的算子 | 按 return 顺序重新发出为 `EvalStmt`。若跨函数调用的被调用者同样是 Inline,不动点循环会在下一轮展开它;否则它就保持为一次普通派发,与作者在调用点直接写出来完全一致。 |
+| `Submit` | 重新发出为 `EvalStmt`。任务启动本身就是有副作用的,与被调用者做什么无关。 |
+| 算子已声明"不通过任何参数写入"的 `Call`,或其它不藏有副作用的值(`Var`、常量) | 丢弃。 |
+| 本身不是 call-like、但**包裹**了有副作用内容的值 —— `self.bump(n) + 1` 这类标量算术、`MakeTuple`、`TupleGetItemExpr` | 抛出 `pypto::ValueError`。它无法变成 `EvalStmt`,而删除它会连带删除内层调用的写入。请直接返回该调用,或在调用点绑定 wrapper 的结果。 |
+
+注册表刻意区分"已声明不通过任何参数写入"与"尚无人分类此算子"(`OpRegistryEntry::HasDeclaredArgEffects`),而目前大多数算子仍属于后者 —— 其中包括 `tile.tpush_to_aiv`、`system.aic_initialize_pipe` 这些明显有副作用、被 `dce::IsSideEffectOp` 列为副作用算子的项。只有正面判定才允许删除,因此未分类的纯算子会被保守地保留为一条无用但无害的 `EvalStmt`。
+
+**变换前**:
+
+```python
+@pl.function(type=pl.FunctionType.Inline)
+def writeout(self, t, out: pl.Out[...]):
+    return pl.tile.store(t, [0, 0], out)   # 写入本身就是返回表达式
+
+@pl.function(type=pl.FunctionType.InCore)
+def kernel(self, a, out: pl.Out[...]):
+    t = pl.tile.load(a, [0, 0], [64, 64])
+    self.writeout(t, out)                  # 返回值被忽略
+    return out
+```
+
+**变换后** —— store 被保留:
+
+```python
+@pl.function(type=pl.FunctionType.InCore)
+def kernel(self, a, out: pl.Out[...]):
+    t = pl.tile.load(a, [0, 0], [64, 64])
+    pl.tile.store(t, [0, 0], out)
+    return out
+```
 
 ## 验证
 

--- a/docs/zh/dev/passes/01-inline_functions.md
+++ b/docs/zh/dev/passes/01-inline_functions.md
@@ -38,7 +38,7 @@ program_inlined = inline_pass(program)
      - 构建参数替换映射(形参 `Var` → 实参 `Expr`)。
      - 对内联体中每个本地绑定的 `Var` 做 alpha 重命名(`<orig>_inline<counter>`,并去掉 `<orig>` 末尾的 `_`),避免多个调用点之间冲突。
      - 在调用点之前插入重命名+替换后的函数体语句。
-     - 用 `LHS = renamed_return`(单返回值)或 `LHS = MakeTuple([renamed_returns...])`(多返回值)替换调用。当 `LHS` 与替换后的返回 `Var` 是同一个 `Var` 时,赋值被省略以避免冗余 SSA 拷贝。
+     - 按调用点形态接线被内联函数的尾部返回值:`LHS = renamed_return`(单返回值赋值;当 `LHS` 与替换后的返回 `Var` 是同一个 `Var` 时省略该赋值,以避免冗余 SSA 拷贝)、逐元素替换 `TupleGetItemExpr` 而不发出 `MakeTuple` 绑定(多返回值赋值)、新的 `ReturnStmt`(`return inline_call(...)`),或者当返回值被丢弃但其求值可观测时发出新的 `EvalStmt`(`EvalStmt` 调用点 — 参见[边界情况](#边界情况))。
 4. **删除**所有 Inline 函数。
 
 重命名后缀使用单下划线(`_inline`),因为 `__` 被 IR 自动命名约定保留(参见 `auto_name_utils.h`)。
@@ -120,8 +120,9 @@ scope 被原样保留,稍后由 `OutlineIncoreScopes` 提取为独立的 InCore 
 | 作为程序入口的 Inline 函数 | 此处不视为错误 — 但因为没有任何 Call 指向它,清理阶段会像任何无调用者函数那样移除。 |
 | Inline 调用 Inline(传递) | 迭代到不动点。 |
 | 递归 Inline(自递归或互相调用) | 在任何展开发生之前抛出 `pypto::ValueError`,消息中标明环路径(`a -> b -> a`)。 |
-| 多返回值 Inline | 在调用点发出 `LHS = MakeTuple([rets...])`。后续 `Simplify` 可能把 `TupleGetItemExpr(MakeTuple(...), i)` 折叠掉。 |
+| 多返回值 Inline | **不**发出 `LHS = MakeTuple([rets...])` — 编排层 codegen 无法 lower `MakeTuple`。改为把克隆后的返回值记录在 LHS `Var` 上,并把下游 `TupleGetItemExpr(LHS, i)` 的使用改写为第 `i` 个值,使该 LHS 绑定最终无人引用(参见 `SpliceInlineCallAsTupleSub`)。 |
 | 嵌套 Call 到 Inline(如 `pl.add(inline_fn(x), y)`) | v1 不处理 — 保持原样。`InlineFunctionsEliminated` verifier 会标记任何残留的 Call。 |
+| `EvalStmt(inline_call(...))` — 返回值被忽略 | 被丢弃的是返回**值**,不是它的**求值**。被丢弃的跨函数 `Call` / `Submit` 会重新发出为 `EvalStmt`(其被调用者同样是 Inline 时,由不动点循环继续展开),因此以 `return self.inner(x, out)` 结尾的被忽略 wrapper 仍会保留 `inner` 对 `out` 的写入。纯值(`Var`、常量、builtin op `Call`)照旧丢弃。若某个值只是**包裹**了跨函数调用,则抛出 `pypto::ValueError` 而不是静默删除该写入 — 请直接返回该调用,或在调用点绑定 wrapper 的结果。 |
 
 ## 验证
 

--- a/src/ir/transforms/inline_functions_pass.cpp
+++ b/src/ir/transforms/inline_functions_pass.cpp
@@ -189,6 +189,33 @@ class NestedReturnCounter : public IRVisitor {
   }
 };
 
+// Counts call-like nodes whose *evaluation* is observable even when the value
+// they produce is thrown away: a cross-function Call can write through its
+// Out/InOut arguments, and a Submit launches a task. Builtin op Calls (OpExpr
+// callee) are deliberately not counted — they are value-producing, and the
+// observable write of an in-place op is the AssignStmt that rebinds a param
+// (`out = pl.tensor.assemble(out, ...)`), which lives in
+// SplicedInlineBody::stmts and is never dropped.
+class EffectfulCallCounter : public IRVisitor {
+ public:
+  int count = 0;
+  void VisitExpr_(const CallPtr& op) override {
+    if (op && As<GlobalVar>(op->op_)) ++count;
+    IRVisitor::VisitExpr_(op);
+  }
+  void VisitExpr_(const SubmitPtr& op) override {
+    if (op) ++count;
+    IRVisitor::VisitExpr_(op);
+  }
+};
+
+// Is `value` ITSELF an effectful call-like node, as opposed to merely wrapping
+// one? Only such a value can be re-emitted verbatim as an EvalStmt.
+bool IsEffectfulCallLike(const ExprPtr& value) {
+  if (auto call = As<Call>(value)) return As<GlobalVar>(call->op_) != nullptr;
+  return As<Submit>(value) != nullptr;
+}
+
 // Result of splicing an inline call's body without yet wiring up its return
 // values into a specific caller statement. The caller picks the wiring form
 // (assign / drop / return / ...) based on its own statement kind.
@@ -297,10 +324,42 @@ SplicedInlineBody CloneInlineBody(const FunctionPtr& callee, const std::vector<E
   return SplicedInlineBody{std::move(spliced), std::move(return_values), has_return};
 }
 
-// Splice an EvalStmt-shaped call (no LHS) — drop the return, return only
-// the pre-return statements.
+// Splice an EvalStmt-shaped call (no LHS) — the callee's trailing return VALUE
+// has no destination, but *evaluating* it can still be observable, so the value
+// may not simply be discarded along with the ReturnStmt that carried it.
+//
+// A discarded cross-function Call / Submit is re-emitted as an EvalStmt, in
+// return order. The fixpoint loop in InlineFunctions() picks that EvalStmt up on
+// the next iteration and expands it when the callee is itself Inline; a
+// non-Inline callee stays an ordinary dispatch, exactly as if the author had
+// written `self.inner(...)` at the call site. Without this, an ignored wrapper
+// whose body is `return self.inner(x, out)` silently lost `inner`'s write to
+// `out` (#2705) — the assign and return call-site forms never had the hole
+// because they re-emit the value into an AssignStmt / ReturnStmt.
+//
+// A value that is not itself call-like is dropped, as before: a Var, a constant
+// or a builtin op Call produces a value and nothing else. But such a value may
+// *wrap* a cross-function call (`return pl.add(self.inner(x), x)`), whose write
+// we can neither keep nor honestly discard — reject that loudly instead of
+// deleting it.
 std::vector<StmtPtr> SpliceInlineCallAsEval(const FunctionPtr& callee, const std::vector<ExprPtr>& args) {
   auto body = CloneInlineBody(callee, args);
+  for (const auto& value : body.return_values) {
+    if (!value) continue;
+    if (IsEffectfulCallLike(value)) {
+      body.stmts.push_back(std::make_shared<const EvalStmt>(value, value->span_));
+      continue;
+    }
+    EffectfulCallCounter counter;
+    counter.VisitExpr(value);
+    CHECK_SPAN(counter.count == 0, value->span_)
+        << "Inline function '" << callee->name_
+        << "' is called for its side effects only (its result is discarded), but its return "
+           "expression wraps a cross-function call whose writes cannot be preserved once the "
+           "value is dropped. Either return that call directly ('return self.inner(...)'), or "
+           "bind the result at the call site ('result = self."
+        << callee->name_ << "(...)').";
+  }
   return std::move(body.stmts);
 }
 
@@ -708,6 +767,10 @@ namespace pass {
  *  - `return inline_call(...)`: spliced via `SpliceInlineCallAsReturn` to the
  *    cloned pre-return body followed by a fresh ReturnStmt over the cloned
  *    trailing values (single or multi).
+ *  - `EvalStmt(inline_call(...))` discards the callee's trailing return value,
+ *    but not its evaluation: a discarded cross-function Call / Submit is
+ *    re-emitted as an EvalStmt (see `SpliceInlineCallAsEval`) so an ignored
+ *    wrapper ending in `return self.inner(...)` keeps `inner`'s writes.
  *  - Nested Call to inline (e.g. inside a binary expression) is left alone in
  *    v1; the verifier flags any surviving Calls to Inline functions.
  *  - Inline function with no callers is silently dropped in step (5) — that

--- a/src/ir/transforms/inline_functions_pass.cpp
+++ b/src/ir/transforms/inline_functions_pass.cpp
@@ -24,7 +24,6 @@
 #include "pypto/ir/expr.h"
 #include "pypto/ir/function.h"
 #include "pypto/ir/kind_traits.h"
-#include "pypto/ir/op_registry.h"
 #include "pypto/ir/program.h"
 #include "pypto/ir/span.h"
 #include "pypto/ir/stmt.h"
@@ -190,34 +189,32 @@ class NestedReturnCounter : public IRVisitor {
   }
 };
 
-// May this Call be deleted without losing an effect?
+// Counts call-like nodes whose *evaluation* must survive even when the value
+// they produce is thrown away — which, deliberately, is every Call and every
+// Submit.
 //
-// Only a *positively classified* non-writing operator qualifies. The registry
-// keeps "declared to write through no argument" and "nobody has classified this
-// operator yet" apart on purpose (`HasDeclaredArgEffects`), and today most
-// operators sit in the second group — including plainly effectful ones such as
-// `tile.tpush_to_aiv` and `system.aic_initialize_pipe`, which the shared DCE
-// lists as side-effecting (see dead_code_elimination.cpp::IsSideEffectOp).
-// Reading an unclassified operator as read-only would silently delete those, so
-// anything short of a positive verdict counts as effectful here.
+// Nothing in the IR answers "is this call safe to delete". The nearest
+// registry data, `OpRegistryEntry::WritesAnyArg`, answers a different question:
+// whether the operator writes *through an argument*. Deleting on that basis is
+// wrong in both directions. Most operators are simply unclassified — 263 of 315
+// at the time of writing, among them `tile.tpush_to_aiv` and
+// `system.aic_initialize_pipe`, which the shared DCE lists as side-effecting
+// (dead_code_elimination.cpp::IsSideEffectOp). And a *positive*
+// `no_arg_writes()` verdict does not mean deletable either: `pld.system.wait`
+// blocks until a signal slot satisfies a threshold, `pld.system.defer_wait`
+// registers a completion condition, and `system.set_ffts` hands the FFTS unit
+// its workspace pointer — all three declare `no_arg_writes()` while carrying
+// synchronization or hardware-setup semantics that deleting would break.
 //
-// `LookupOpEntry` answers null for a `GlobalVar` callee and for an unregistered
-// name, so a cross-function call and an unknown operator both stay effectful.
-bool IsProvablyPureCall(const CallPtr& call) {
-  if (!call) return false;
-  const auto* entry = LookupOpEntry(call->op_);
-  if (entry == nullptr) return false;
-  return entry->HasDeclaredArgEffects() && !entry->WritesAnyArg();
-}
-
-// Counts call-like nodes whose *evaluation* is observable even when the value
-// they produce is thrown away: any Call we cannot prove pure, plus every Submit
-// (a task launch is intrinsically effectful, whatever its callee does).
+// So the pass keeps every call. The cost is that a discarded genuinely pure call
+// survives as a dead EvalStmt, which the pipeline carries harmlessly; the
+// alternative costs correctness. Narrowing this needs a real "safely deletable"
+// operator property, declared per operator, not an inference from writes.
 class EffectfulCallCounter : public IRVisitor {
  public:
   int count = 0;
   void VisitExpr_(const CallPtr& op) override {
-    if (op && !IsProvablyPureCall(op)) ++count;
+    if (op) ++count;
     IRVisitor::VisitExpr_(op);
   }
   void VisitExpr_(const SubmitPtr& op) override {
@@ -226,12 +223,10 @@ class EffectfulCallCounter : public IRVisitor {
   }
 };
 
-// Is `value` ITSELF a call-like node whose evaluation must survive, as opposed
-// to merely wrapping one? Only such a value can be re-emitted verbatim as an
-// EvalStmt.
+// Is `value` ITSELF a call-like node, as opposed to merely wrapping one? Only
+// such a value can be re-emitted verbatim as an EvalStmt.
 bool IsEffectfulCallLike(const ExprPtr& value) {
-  if (auto call = As<Call>(value)) return !IsProvablyPureCall(call);
-  return As<Submit>(value) != nullptr;
+  return As<Call>(value) != nullptr || As<Submit>(value) != nullptr;
 }
 
 // Result of splicing an inline call's body without yet wiring up its return
@@ -346,23 +341,23 @@ SplicedInlineBody CloneInlineBody(const FunctionPtr& callee, const std::vector<E
 // has no destination, but *evaluating* it can still be observable, so the value
 // may not simply be discarded along with the ReturnStmt that carried it.
 //
-// A discarded Call we cannot prove pure — a cross-function dispatch, a writing
-// builtin such as `tile.store`, or any unclassified operator — is re-emitted as
-// an EvalStmt, in return order, as is every discarded Submit. The fixpoint loop
+// A discarded Call or Submit is re-emitted as an EvalStmt, in return order —
+// every one of them, for the reasons on EffectfulCallCounter. The fixpoint loop
 // in InlineFunctions() picks a cross-function EvalStmt up on the next iteration
 // and expands it when the callee is itself Inline; a non-Inline callee stays an
 // ordinary dispatch, exactly as if the author had written `self.inner(...)` at
 // the call site. Without this, an ignored wrapper whose body is
 // `return self.inner(x, out)` silently lost `inner`'s write to `out` (#2705),
-// and one whose body is `return pl.tile.store(t, [0, 0], out)` lost the store —
+// one whose body is `return pl.tile.store(t, [0, 0], out)` lost the store, and
+// one whose body is `return pl.system.set_ffts(ws)` lost the hardware setup —
 // the assign and return call-site forms never had the hole, because they re-emit
 // the value into an AssignStmt / ReturnStmt.
 //
-// A provably pure Call is dropped, as is any other value that hides nothing
-// effectful — a Var, a constant. But such a value may *wrap* something effectful
-// (`return (self.inner(x, out), x)` reaching here as one MakeTuple), whose write
-// we can neither keep nor honestly discard — reject that loudly instead of
-// deleting it.
+// Any other value is dropped: a Var or a constant hides nothing. But such a
+// value may *wrap* a call (`return self.bump(n) + 1` reaching here as one `Add`,
+// or a MakeTuple / TupleGetItemExpr over a call), and that cannot become an
+// EvalStmt the way a call-like value can — reject it loudly instead of deleting
+// the nested call with it.
 std::vector<StmtPtr> SpliceInlineCallAsEval(const FunctionPtr& callee, const std::vector<ExprPtr>& args) {
   auto body = CloneInlineBody(callee, args);
   for (const auto& value : body.return_values) {
@@ -376,9 +371,9 @@ std::vector<StmtPtr> SpliceInlineCallAsEval(const FunctionPtr& callee, const std
     CHECK_SPAN(counter.count == 0, value->span_)
         << "Inline function '" << callee->name_
         << "' is called for its side effects only (its result is discarded), but its return "
-           "expression wraps a call whose writes cannot be preserved once the value is dropped. "
-           "Either return that call directly ('return self.inner(...)'), or bind the result at "
-           "the call site ('result = self."
+           "expression wraps a call whose evaluation cannot be preserved once the value is "
+           "dropped. Either return that call directly ('return self.inner(...)'), or bind the "
+           "result at the call site ('result = self."
         << callee->name_ << "(...)').";
   }
   return std::move(body.stmts);
@@ -789,11 +784,10 @@ namespace pass {
  *    cloned pre-return body followed by a fresh ReturnStmt over the cloned
  *    trailing values (single or multi).
  *  - `EvalStmt(inline_call(...))` discards the callee's trailing return value,
- *    but not its evaluation: a discarded Call that the operator registry does
- *    not positively classify as non-writing, and every discarded Submit, is
- *    re-emitted as an EvalStmt (see `SpliceInlineCallAsEval`) so an ignored
- *    wrapper ending in `return self.inner(...)` or
- *    `return pl.tile.store(...)` keeps its writes.
+ *    but not its evaluation: every discarded Call and Submit is re-emitted as
+ *    an EvalStmt (see `SpliceInlineCallAsEval`) so an ignored wrapper ending in
+ *    `return self.inner(...)`, `return pl.tile.store(...)` or
+ *    `return pl.system.set_ffts(...)` keeps its write, store or hardware setup.
  *  - Nested Call to inline (e.g. inside a binary expression) is left alone in
  *    v1; the verifier flags any surviving Calls to Inline functions.
  *  - Inline function with no callers is silently dropped in step (5) — that

--- a/src/ir/transforms/inline_functions_pass.cpp
+++ b/src/ir/transforms/inline_functions_pass.cpp
@@ -24,6 +24,7 @@
 #include "pypto/ir/expr.h"
 #include "pypto/ir/function.h"
 #include "pypto/ir/kind_traits.h"
+#include "pypto/ir/op_registry.h"
 #include "pypto/ir/program.h"
 #include "pypto/ir/span.h"
 #include "pypto/ir/stmt.h"
@@ -189,18 +190,34 @@ class NestedReturnCounter : public IRVisitor {
   }
 };
 
+// May this Call be deleted without losing an effect?
+//
+// Only a *positively classified* non-writing operator qualifies. The registry
+// keeps "declared to write through no argument" and "nobody has classified this
+// operator yet" apart on purpose (`HasDeclaredArgEffects`), and today most
+// operators sit in the second group — including plainly effectful ones such as
+// `tile.tpush_to_aiv` and `system.aic_initialize_pipe`, which the shared DCE
+// lists as side-effecting (see dead_code_elimination.cpp::IsSideEffectOp).
+// Reading an unclassified operator as read-only would silently delete those, so
+// anything short of a positive verdict counts as effectful here.
+//
+// `LookupOpEntry` answers null for a `GlobalVar` callee and for an unregistered
+// name, so a cross-function call and an unknown operator both stay effectful.
+bool IsProvablyPureCall(const CallPtr& call) {
+  if (!call) return false;
+  const auto* entry = LookupOpEntry(call->op_);
+  if (entry == nullptr) return false;
+  return entry->HasDeclaredArgEffects() && !entry->WritesAnyArg();
+}
+
 // Counts call-like nodes whose *evaluation* is observable even when the value
-// they produce is thrown away: a cross-function Call can write through its
-// Out/InOut arguments, and a Submit launches a task. Builtin op Calls (OpExpr
-// callee) are deliberately not counted — they are value-producing, and the
-// observable write of an in-place op is the AssignStmt that rebinds a param
-// (`out = pl.tensor.assemble(out, ...)`), which lives in
-// SplicedInlineBody::stmts and is never dropped.
+// they produce is thrown away: any Call we cannot prove pure, plus every Submit
+// (a task launch is intrinsically effectful, whatever its callee does).
 class EffectfulCallCounter : public IRVisitor {
  public:
   int count = 0;
   void VisitExpr_(const CallPtr& op) override {
-    if (op && As<GlobalVar>(op->op_)) ++count;
+    if (op && !IsProvablyPureCall(op)) ++count;
     IRVisitor::VisitExpr_(op);
   }
   void VisitExpr_(const SubmitPtr& op) override {
@@ -209,10 +226,11 @@ class EffectfulCallCounter : public IRVisitor {
   }
 };
 
-// Is `value` ITSELF an effectful call-like node, as opposed to merely wrapping
-// one? Only such a value can be re-emitted verbatim as an EvalStmt.
+// Is `value` ITSELF a call-like node whose evaluation must survive, as opposed
+// to merely wrapping one? Only such a value can be re-emitted verbatim as an
+// EvalStmt.
 bool IsEffectfulCallLike(const ExprPtr& value) {
-  if (auto call = As<Call>(value)) return As<GlobalVar>(call->op_) != nullptr;
+  if (auto call = As<Call>(value)) return !IsProvablyPureCall(call);
   return As<Submit>(value) != nullptr;
 }
 
@@ -328,18 +346,21 @@ SplicedInlineBody CloneInlineBody(const FunctionPtr& callee, const std::vector<E
 // has no destination, but *evaluating* it can still be observable, so the value
 // may not simply be discarded along with the ReturnStmt that carried it.
 //
-// A discarded cross-function Call / Submit is re-emitted as an EvalStmt, in
-// return order. The fixpoint loop in InlineFunctions() picks that EvalStmt up on
-// the next iteration and expands it when the callee is itself Inline; a
-// non-Inline callee stays an ordinary dispatch, exactly as if the author had
-// written `self.inner(...)` at the call site. Without this, an ignored wrapper
-// whose body is `return self.inner(x, out)` silently lost `inner`'s write to
-// `out` (#2705) — the assign and return call-site forms never had the hole
-// because they re-emit the value into an AssignStmt / ReturnStmt.
+// A discarded Call we cannot prove pure — a cross-function dispatch, a writing
+// builtin such as `tile.store`, or any unclassified operator — is re-emitted as
+// an EvalStmt, in return order, as is every discarded Submit. The fixpoint loop
+// in InlineFunctions() picks a cross-function EvalStmt up on the next iteration
+// and expands it when the callee is itself Inline; a non-Inline callee stays an
+// ordinary dispatch, exactly as if the author had written `self.inner(...)` at
+// the call site. Without this, an ignored wrapper whose body is
+// `return self.inner(x, out)` silently lost `inner`'s write to `out` (#2705),
+// and one whose body is `return pl.tile.store(t, [0, 0], out)` lost the store —
+// the assign and return call-site forms never had the hole, because they re-emit
+// the value into an AssignStmt / ReturnStmt.
 //
-// A value that is not itself call-like is dropped, as before: a Var, a constant
-// or a builtin op Call produces a value and nothing else. But such a value may
-// *wrap* a cross-function call (`return pl.add(self.inner(x), x)`), whose write
+// A provably pure Call is dropped, as is any other value that hides nothing
+// effectful — a Var, a constant. But such a value may *wrap* something effectful
+// (`return (self.inner(x, out), x)` reaching here as one MakeTuple), whose write
 // we can neither keep nor honestly discard — reject that loudly instead of
 // deleting it.
 std::vector<StmtPtr> SpliceInlineCallAsEval(const FunctionPtr& callee, const std::vector<ExprPtr>& args) {
@@ -355,9 +376,9 @@ std::vector<StmtPtr> SpliceInlineCallAsEval(const FunctionPtr& callee, const std
     CHECK_SPAN(counter.count == 0, value->span_)
         << "Inline function '" << callee->name_
         << "' is called for its side effects only (its result is discarded), but its return "
-           "expression wraps a cross-function call whose writes cannot be preserved once the "
-           "value is dropped. Either return that call directly ('return self.inner(...)'), or "
-           "bind the result at the call site ('result = self."
+           "expression wraps a call whose writes cannot be preserved once the value is dropped. "
+           "Either return that call directly ('return self.inner(...)'), or bind the result at "
+           "the call site ('result = self."
         << callee->name_ << "(...)').";
   }
   return std::move(body.stmts);
@@ -768,9 +789,11 @@ namespace pass {
  *    cloned pre-return body followed by a fresh ReturnStmt over the cloned
  *    trailing values (single or multi).
  *  - `EvalStmt(inline_call(...))` discards the callee's trailing return value,
- *    but not its evaluation: a discarded cross-function Call / Submit is
+ *    but not its evaluation: a discarded Call that the operator registry does
+ *    not positively classify as non-writing, and every discarded Submit, is
  *    re-emitted as an EvalStmt (see `SpliceInlineCallAsEval`) so an ignored
- *    wrapper ending in `return self.inner(...)` keeps `inner`'s writes.
+ *    wrapper ending in `return self.inner(...)` or
+ *    `return pl.tile.store(...)` keeps its writes.
  *  - Nested Call to inline (e.g. inside a binary expression) is left alone in
  *    v1; the verifier flags any surviving Calls to Inline functions.
  *  - Inline function with no callers is silently dropped in step (5) — that

--- a/tests/ut/ir/transforms/test_inline_functions.py
+++ b/tests/ut/ir/transforms/test_inline_functions.py
@@ -306,17 +306,63 @@ class TestInlineFunctionsCallSiteForms:
         After = passes.inline_functions()(Before)
         ir.assert_structural_equal(After, Expected)
 
-    def test_eval_stmt_call_site_keeps_unclassified_builtin(self):
-        """An operator the registry has never classified is kept, not dropped.
+    def test_eval_stmt_call_site_keeps_returned_sync_op(self):
+        """An operator that writes through no argument is still not deletable.
 
-        ``OpRegistryEntry`` distinguishes "declared to write through no argument"
-        from "nobody has classified this operator yet", and most operators are
-        still in the second group — including plainly effectful ones such as
-        ``tile.tpush_to_aiv`` and ``system.aic_initialize_pipe``, which
-        ``dce::IsSideEffectOp`` lists as side-effecting. Deleting an unclassified
-        call would therefore be unsound, so the pass keeps it. ``tensor.add``
-        happens to be pure, and the resulting `EvalStmt` is dead but harmless;
-        that is the deliberate cost of not guessing."""
+        ``system.set_ffts`` declares ``no_arg_writes()`` — it moves no data —
+        yet it hands the FFTS unit its workspace pointer, and the same holds for
+        ``pld.system.wait`` (blocks on a signal threshold) and
+        ``pld.system.defer_wait`` (registers a completion condition). "Writes
+        through no argument" is not "safe to delete", so the discarded-value
+        classification cannot key deletion on
+        ``OpRegistryEntry::WritesAnyArg``; the pass keeps every call until a real
+        deletability property exists."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Inline)
+            def setup(self, ws: pl.Tensor[[256], pl.INT64]) -> pl.Tensor[[256], pl.INT64]:
+                # The DSL return annotation is parser metadata for the IR, while
+                # the Python surface types `set_ffts` as `-> Call`; the two never
+                # meet at runtime because the body is parsed, not executed.
+                return pl.system.set_ffts(ws)  # type: ignore[reportReturnType]
+
+            @pl.function(type=pl.FunctionType.AIV)
+            def main(
+                self,
+                ws: pl.Tensor[[256], pl.INT64],
+                x: pl.Tensor[[64], pl.FP32],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                self.setup(ws)  # EvalStmt call site — return value ignored
+                return x
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.AIV)
+            def main(
+                self,
+                ws: pl.Tensor[[256], pl.INT64],
+                x: pl.Tensor[[64], pl.FP32],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                pl.system.set_ffts(ws)
+                return x
+
+        After = passes.inline_functions()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_eval_stmt_call_site_keeps_side_effect_free_builtin(self):
+        """Even a builtin that happens to be pure is kept, because nothing in the
+        IR can prove it.
+
+        No operator property answers "is this call safe to delete".
+        ``OpRegistryEntry::WritesAnyArg`` answers a narrower question and is
+        wrong in both directions here: 263 of 315 operators are unclassified
+        (among them ``tile.tpush_to_aiv`` and ``system.aic_initialize_pipe``,
+        which ``dce::IsSideEffectOp`` lists as side-effecting), and a positive
+        ``no_arg_writes()`` verdict covers synchronization ops as well — see
+        ``test_eval_stmt_call_site_keeps_returned_sync_op``. So the pass keeps
+        every call. ``tensor.add`` is genuinely pure and its `EvalStmt` is dead
+        but harmless; that is the deliberate cost of not guessing."""
 
         @pl.program
         class Before:

--- a/tests/ut/ir/transforms/test_inline_functions.py
+++ b/tests/ut/ir/transforms/test_inline_functions.py
@@ -260,16 +260,93 @@ class TestInlineFunctionsCallSiteForms:
         After = passes.inline_functions()(Before)
         ir.assert_structural_equal(After, Expected)
 
-    def test_eval_stmt_call_site_wrapping_a_call_errors(self):
-        """A discarded return value that only *wraps* a cross-function call
-        cannot keep that call's write, so the pass raises instead of deleting it.
+    def test_eval_stmt_call_site_preserves_returned_builtin_store(self):
+        """An ignored wrapper that directly returns an effectful *builtin* keeps
+        its write too — the callee does not have to be a cross-function call.
 
-        ``pl.add(self.inner(x, out), x)`` is a builtin op Call — a pure value,
-        which the EvalStmt call site is free to drop. But dropping it here would
-        also drop the nested ``Call(inner, x, out)`` and its write to ``out``,
-        with no verifier to catch it (``inner`` is not Inline, so
-        ``InlineFunctionsEliminated`` sees nothing wrong). Reject it loudly
-        instead; the message names both workarounds."""
+        ``return pl.tile.store(t, [0, 0], out)`` is a supported return form, and
+        ``tile.store`` declares argument 2 as ``ArgEffect::Write`` /
+        ``ReadWrite`` (``src/ir/op/tile_ops/memory.cpp``). The write lives in the
+        return expression itself, not in a preceding ``AssignStmt``, so the
+        discarded-value classification has to consult the operator registry
+        rather than assume every builtin call is a pure value."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Inline)
+            def writeout(
+                self,
+                t: pl.Tile[[64, 64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                return pl.tile.store(t, [0, 0], out)
+
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                a: pl.Tensor[[64, 64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                t: pl.Tile[[64, 64], pl.FP32] = pl.tile.load(a, [0, 0], [64, 64])
+                self.writeout(t, out)  # EvalStmt call site — return value ignored
+                return out
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                a: pl.Tensor[[64, 64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                t: pl.Tile[[64, 64], pl.FP32] = pl.tile.load(a, [0, 0], [64, 64])
+                pl.tile.store(t, [0, 0], out)
+                return out
+
+        After = passes.inline_functions()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_eval_stmt_call_site_keeps_unclassified_builtin(self):
+        """An operator the registry has never classified is kept, not dropped.
+
+        ``OpRegistryEntry`` distinguishes "declared to write through no argument"
+        from "nobody has classified this operator yet", and most operators are
+        still in the second group — including plainly effectful ones such as
+        ``tile.tpush_to_aiv`` and ``system.aic_initialize_pipe``, which
+        ``dce::IsSideEffectOp`` lists as side-effecting. Deleting an unclassified
+        call would therefore be unsound, so the pass keeps it. ``tensor.add``
+        happens to be pure, and the resulting `EvalStmt` is dead but harmless;
+        that is the deliberate cost of not guessing."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Inline)
+            def compute(self, x: pl.Tensor[[1], pl.INT32]) -> pl.Tensor[[1], pl.INT32]:
+                return pl.add(x, x)
+
+            @pl.function
+            def main(self, a: pl.Tensor[[1], pl.INT32]) -> pl.Tensor[[1], pl.INT32]:
+                self.compute(a)  # EvalStmt call site — return value ignored
+                return a
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(self, a: pl.Tensor[[1], pl.INT32]) -> pl.Tensor[[1], pl.INT32]:
+                pl.add(a, a)
+                return a
+
+        After = passes.inline_functions()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_eval_stmt_call_site_keeps_call_wrapping_a_call(self):
+        """A discarded builtin op Call that *wraps* a cross-function call is kept
+        whole, so the nested call's write rides along inside it.
+
+        ``pl.add`` is an unclassified operator, so the outer Call is preserved by
+        the same rule as any other non-provably-pure call — and preserving it
+        preserves the nested ``Call(inner, x, out)`` verbatim. Nothing is
+        deleted and nothing has to be rejected."""
 
         @pl.program
         class Before:
@@ -299,7 +376,62 @@ class TestInlineFunctionsCallSiteForms:
                 self.forward(x, out)
                 return x
 
-        with pytest.raises(ValueError, match="wraps a cross-function call"):
+        @pl.program
+        class Expected:
+            @pl.function
+            def inner(
+                self,
+                x: pl.Tensor[[4], pl.FP32],
+                out: pl.Out[pl.Tensor[[4], pl.FP32]],
+            ) -> pl.Tensor[[4], pl.FP32]:
+                out = pl.tensor.assemble(out, x, [0])
+                return out
+
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[4], pl.FP32],
+                out: pl.Out[pl.Tensor[[4], pl.FP32]],
+            ) -> pl.Tensor[[4], pl.FP32]:
+                pl.add(self.inner(x, out), x)
+                return x
+
+        After = passes.inline_functions()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_eval_stmt_call_site_wrapping_a_call_errors(self):
+        """A discarded return value that is *not itself call-like* but hides a
+        call cannot keep that call's evaluation, so the pass raises instead of
+        deleting it.
+
+        Scalar arithmetic is a dedicated Expr kind (`Add`), not a `Call`, so
+        ``self.bump(n) + 1`` cannot be re-emitted as an `EvalStmt` the way a
+        call-like value can. Dropping it would drop the nested
+        ``Call(bump, n)`` with no verifier to catch it (``bump`` is not Inline,
+        so ``InlineFunctionsEliminated`` sees nothing wrong). Reject it loudly
+        instead; the message names both workarounds."""
+
+        @pl.program
+        class Before:
+            @pl.function
+            def bump(self, n: pl.Scalar[pl.INDEX]) -> pl.Scalar[pl.INDEX]:
+                m: pl.Scalar[pl.INDEX] = n + 1
+                return m
+
+            @pl.function(type=pl.FunctionType.Inline)
+            def forward(self, n: pl.Scalar[pl.INDEX]) -> pl.Scalar[pl.INDEX]:
+                return self.bump(n) + 1
+
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[4], pl.FP32],
+                n: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[4], pl.FP32]:
+                self.forward(n)
+                return x
+
+        with pytest.raises(ValueError, match="wraps a call"):
             passes.inline_functions()(Before)
 
     def test_self_aliasing_assign_skips_redundant_copy(self):

--- a/tests/ut/ir/transforms/test_inline_functions.py
+++ b/tests/ut/ir/transforms/test_inline_functions.py
@@ -97,9 +97,12 @@ class TestInlineFunctionsCallSiteForms:
         """A bare ``self.writeout(...)`` (EvalStmt, no LHS) splices only the
         pre-return body and drops the trailing return value.
 
-        ``SpliceInlineCallAsEval`` (src lines 293-296) calls ``CloneInlineBody``
-        and returns ``body.stmts`` only — the trailing ``return out`` value is
-        discarded since there is no LHS to bind it to. The in-place rebinding
+        ``SpliceInlineCallAsEval`` calls ``CloneInlineBody`` and keeps
+        ``body.stmts``; the trailing ``return out`` value is discarded because
+        there is no LHS to bind it to *and* a bare ``Var`` produces a value and
+        nothing else — dropping it loses no side effect (contrast
+        ``test_eval_stmt_call_site_preserves_nested_write`` below, where the
+        discarded value is a cross-function Call). The in-place rebinding
         ``out = pl.assemble(out, x, ...)`` collapses to ``ext = pl.assemble(ext,
         a, ...)`` under the ``x→a``, ``out→ext`` param substitution. The caller
         deliberately does not read ``ext`` back (that would trip the
@@ -141,6 +144,163 @@ class TestInlineFunctionsCallSiteForms:
 
         After = passes.inline_functions()(Before)
         ir.assert_structural_equal(After, Expected)
+
+    def test_eval_stmt_call_site_preserves_nested_write(self):
+        """Regression test for #2705: an ignored wrapper whose body is
+        ``return self.writeout(x, out)`` must still perform ``writeout``'s write.
+
+        Dropping a return VALUE is not the same as dropping its EVALUATION.
+        ``CloneInlineBody`` strips the trailing ReturnStmt's expression into
+        ``return_values``, so before the fix ``SpliceInlineCallAsEval`` returned
+        an empty ``body.stmts`` for ``forward`` and the nested cross-function
+        Call — together with its write through the ``pl.Out`` arg — vanished
+        without a diagnostic. ``main`` collapsed to a bare ``return x``.
+
+        Now the discarded ``Call(writeout, x, out)`` is re-emitted as an
+        EvalStmt, which the fixpoint loop expands on the next iteration into
+        ``writeout``'s own spliced body — the assemble below."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Inline)
+            def writeout(
+                self,
+                x: pl.Tensor[[4], pl.FP32],
+                out: pl.Out[pl.Tensor[[4], pl.FP32]],
+            ) -> pl.Tensor[[4], pl.FP32]:
+                out = pl.tensor.assemble(out, x, [0])
+                return out
+
+            @pl.function(type=pl.FunctionType.Inline)
+            def forward(
+                self,
+                x: pl.Tensor[[4], pl.FP32],
+                out: pl.Out[pl.Tensor[[4], pl.FP32]],
+            ) -> pl.Tensor[[4], pl.FP32]:
+                return self.writeout(x, out)
+
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[4], pl.FP32],
+                out: pl.Out[pl.Tensor[[4], pl.FP32]],
+            ) -> pl.Tensor[[4], pl.FP32]:
+                self.forward(x, out)  # EvalStmt call site — return value ignored
+                return x
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[4], pl.FP32],
+                out: pl.Out[pl.Tensor[[4], pl.FP32]],
+            ) -> pl.Tensor[[4], pl.FP32]:
+                out = pl.tensor.assemble(out, x, [0])
+                return x
+
+        After = passes.inline_functions()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_eval_stmt_call_site_keeps_non_inline_dispatch(self):
+        """Same shape as above, but the wrapper forwards to a NON-Inline
+        function: the re-emitted EvalStmt stays an ordinary cross-function
+        dispatch, exactly as if the author had written ``self.inner(...)`` at the
+        call site. Nothing in the fixpoint loop expands it (``inner`` is not
+        Inline), and nothing may delete it either — ``inner`` writes ``out``."""
+
+        @pl.program
+        class Before:
+            @pl.function
+            def inner(
+                self,
+                x: pl.Tensor[[4], pl.FP32],
+                out: pl.Out[pl.Tensor[[4], pl.FP32]],
+            ) -> pl.Tensor[[4], pl.FP32]:
+                out = pl.tensor.assemble(out, x, [0])
+                return out
+
+            @pl.function(type=pl.FunctionType.Inline)
+            def forward(
+                self,
+                x: pl.Tensor[[4], pl.FP32],
+                out: pl.Out[pl.Tensor[[4], pl.FP32]],
+            ) -> pl.Tensor[[4], pl.FP32]:
+                return self.inner(x, out)
+
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[4], pl.FP32],
+                out: pl.Out[pl.Tensor[[4], pl.FP32]],
+            ) -> pl.Tensor[[4], pl.FP32]:
+                self.forward(x, out)
+                return x
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def inner(
+                self,
+                x: pl.Tensor[[4], pl.FP32],
+                out: pl.Out[pl.Tensor[[4], pl.FP32]],
+            ) -> pl.Tensor[[4], pl.FP32]:
+                out = pl.tensor.assemble(out, x, [0])
+                return out
+
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[4], pl.FP32],
+                out: pl.Out[pl.Tensor[[4], pl.FP32]],
+            ) -> pl.Tensor[[4], pl.FP32]:
+                self.inner(x, out)
+                return x
+
+        After = passes.inline_functions()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_eval_stmt_call_site_wrapping_a_call_errors(self):
+        """A discarded return value that only *wraps* a cross-function call
+        cannot keep that call's write, so the pass raises instead of deleting it.
+
+        ``pl.add(self.inner(x, out), x)`` is a builtin op Call — a pure value,
+        which the EvalStmt call site is free to drop. But dropping it here would
+        also drop the nested ``Call(inner, x, out)`` and its write to ``out``,
+        with no verifier to catch it (``inner`` is not Inline, so
+        ``InlineFunctionsEliminated`` sees nothing wrong). Reject it loudly
+        instead; the message names both workarounds."""
+
+        @pl.program
+        class Before:
+            @pl.function
+            def inner(
+                self,
+                x: pl.Tensor[[4], pl.FP32],
+                out: pl.Out[pl.Tensor[[4], pl.FP32]],
+            ) -> pl.Tensor[[4], pl.FP32]:
+                out = pl.tensor.assemble(out, x, [0])
+                return out
+
+            @pl.function(type=pl.FunctionType.Inline)
+            def forward(
+                self,
+                x: pl.Tensor[[4], pl.FP32],
+                out: pl.Out[pl.Tensor[[4], pl.FP32]],
+            ) -> pl.Tensor[[4], pl.FP32]:
+                return pl.add(self.inner(x, out), x)
+
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[4], pl.FP32],
+                out: pl.Out[pl.Tensor[[4], pl.FP32]],
+            ) -> pl.Tensor[[4], pl.FP32]:
+                self.forward(x, out)
+                return x
+
+        with pytest.raises(ValueError, match="wraps a cross-function call"):
+            passes.inline_functions()(Before)
 
     def test_self_aliasing_assign_skips_redundant_copy(self):
         """``a = self.passthrough(a)`` where the inline returns its param


### PR DESCRIPTION
## Summary

An `EvalStmt` call site of an Inline function discarded not just the callee's
trailing return *value* but its whole *evaluation*, so an ignored wrapper whose
body is `return self.inner(x, out)` spliced to nothing: the nested call
disappeared together with its write through `out`, without a diagnostic. The
same held for a directly returned effectful builtin — the store in
`return pl.tile.store(t, [0, 0], out)`, or the hardware setup in
`return pl.system.set_ffts(ws)`. `Inline` now re-emits every discarded `Call`
and `Submit` as an `EvalStmt`, so the effect survives. Callers no longer have to
bind an otherwise unused result (`result = self.inner(...); return result`) to
keep it.

Refs #2705.

## Changes

- `src/ir/transforms/inline_functions_pass.cpp`: `SpliceInlineCallAsEval`
  returned only `CloneInlineBody`'s pre-return statements, after the trailing
  `ReturnStmt`'s expression had already been split off into `return_values`. It
  now re-emits each discarded `Call` and `Submit` as an `EvalStmt`, in return
  order. The fixpoint loop expands a cross-function one on its next iteration
  when that callee is also Inline; otherwise it stays an ordinary dispatch,
  exactly as if the author had written `self.inner(...)` at the call site. The
  assign and return call-site forms never had the hole; they already re-emit the
  value into an `AssignStmt` / `ReturnStmt`.
- **Every call, not only the ones that write.** Nothing in the IR answers "is
  this call safe to delete", and the nearest registry data,
  `OpRegistryEntry::WritesAnyArg`, answers whether an operator writes *through
  an argument* — wrong in both directions. Most operators are unclassified (263
  of 315), among them `tile.tpush_to_aiv` and `system.aic_initialize_pipe`,
  which `dce::IsSideEffectOp` lists as side-effecting; that is exactly what
  `HasDeclaredArgEffects` exists to distinguish. And a *positive*
  `no_arg_writes()` verdict does not mean deletable either: `pld.system.wait`
  blocks on a signal threshold, `pld.system.defer_wait` registers a completion
  condition, and `system.set_ffts` hands the FFTS unit its workspace pointer.
  So the pass keeps every call. The cost is that a discarded genuinely pure call
  survives as a dead `EvalStmt`, which the Default pipeline carries unaltered.
  Narrowing this needs a real "safely deletable" operator property, declared per
  operator rather than inferred from writes — a separate change.
- `src/ir/transforms/inline_functions_pass.cpp`: a discarded value that is *not
  itself call-like* yet wraps a call — scalar arithmetic such as
  `self.bump(n) + 1`, a `MakeTuple`, a `TupleGetItemExpr` — raises
  `pypto::ValueError` naming both workarounds instead of deleting the nested
  call with it. Such a value cannot be re-emitted as an `EvalStmt` the way a
  call-like one can. This is a new user-facing error on IR that previously
  compiled to silently wrong code; no verifier catches the case when the nested
  callee is not Inline.
- `tests/ut/ir/transforms/test_inline_functions.py`: add the ignored-wrapper
  regression, its non-Inline-callee variant, the returned-`tile.store`
  regression, the returned-`system.set_ffts` regression, a side-effect-free
  builtin that is kept anyway, a builtin-wrapping case preserved whole, and the
  scalar-arithmetic case that rejects. The existing
  `test_eval_stmt_call_site_drops_return` keeps asserting that a pure `Var`
  return value is still dropped; its docstring now says why the two cases differ
  instead of citing line numbers.
- `docs/{en,zh}/dev/passes/01-inline_functions.md`: add a "Discarding a return
  value" section with the classification table, the two-directions argument
  above, and a before/after example; and correct the stale claim that a
  multi-return inline emits `LHS = MakeTuple([rets...])` —
  `SpliceInlineCallAsTupleSub` deliberately emits no `MakeTuple`, because
  orchestration codegen cannot lower one.

### Before / after

Input (the reduced reproduction from #2705):

```python
@pl.function(type=pl.FunctionType.Inline)
def writeout(self, x, out: pl.Out[...]):
    out = pl.tensor.assemble(out, x, [0])
    return out

@pl.function(type=pl.FunctionType.Inline)
def forward(self, x, out: pl.Out[...]):
    return self.writeout(x, out)

@pl.function
def main(self, x, out: pl.Out[...]):
    self.forward(x, out)     # return value ignored
    return x
```

`passes.inline_functions()` before this change — the write is gone:

```python
@pl.function
def main(self, x, out: pl.Out[...]):
    return x
```

and after:

```python
@pl.function
def main(self, x, out: pl.Out[...]):
    out = pl.tensor.assemble(out, x, [0])
    return x
```

The same holds when the effect *is* the return expression: a
`return pl.tile.store(t, [0, 0], out)` wrapper used to lose the store, and a
`return pl.system.set_ffts(ws)` wrapper used to lose the FFTS setup; both are now
kept as bare statements.

## Verification

Run in a worktree on this branch after `source .claude/skills/testing/load-env.sh`,
against the pushed head `078bc2b6e` (based on `a9b9e0be9`), through the push
transaction's validation runner so the validated tree and the pushed tree are
identical:

- `cmake --build build --parallel "$PYPTO_BUILD_JOBS"`: exit 0.
- `python -m pytest tests/ut/ir/transforms/test_inline_functions.py`: exit 0;
  **33 passed**.
- `python -m pytest tests/ut -n "$PYPTO_TEST_JOBS"`: exit 0; **12,096 passed**,
  10 skipped, 1 xfailed. One case is deselected:
  `tests/ut/language/test_unified_ops.py::TestUnifiedSlicePadValue::test_symlinked_import_path_still_names_the_caller`,
  which cannot pass in this environment because an editable install pins `pypto`
  to a different checkout; reverting only this pass to its pristine source and
  rebuilding reproduces that same failure, so it is not caused by this change.
- `ctest --parallel "$PYPTO_TEST_JOBS"`: exit 0; 1/1 passed.
- The reproduction script from #2705 prints the issue's Expected IR
  (`out = pl.tensor.assemble(out, x, [0])` followed by `return x`); before the
  change `main` collapsed to a bare `return x`.
- A/B on the returned-`tile.store` case, rebuilt with only this pass at
  `a3cd69a56`: the kernel loses the store and keeps just the load.
- A/B on the returned-`system.set_ffts` case, rebuilt with only this pass at
  `bc7f277f0`: the AIV kernel loses the setup and collapses to `return x`.
- `clang-format --dry-run --Werror`, `cpplint 2.0.0`,
  `tests/lint/clang_tidy.py --diff-base=HEAD` (clang-tidy 21.1.0),
  `ruff 0.14.8 check` and `format --check`, `pyright 1.1.407`,
  `markdownlint-cli2 0.20.0`, and all 13 `tests/lint/*.py` checks: exit 0.

No system tests were run locally: this is a pure IR-pass change with no device,
PTOAS, or runtime involvement, and the issue's reproduction needs none. CI's
system-test jobs cover the rest.
