### PR TITLE
feat(codegen): emit the declared GM cache policy as pto.tload's cache_policy

### DIFF
--- a/docs/en/dev/language/05-cache-policy.md
+++ b/docs/en/dev/language/05-cache-policy.md
@@ -8,11 +8,10 @@ The policy is a *contract the author states*, never a hint the compiler infers.
 It is therefore written explicitly, at one of two granularities, and is carried
 unchanged from the DSL to codegen.
 
-> **Current status**: PTOAS has no L2-bypass path yet
-> ([PTOAS#1356](https://github.com/hw-native-sys/PTOAS/issues/1356)), so a
-> `BYPASS` declaration currently **warns and compiles as an ordinary cached
-> access**. Generated code is byte-identical with and without it. See
-> [Current status](#current-status).
+> **Requires PTOAS >= v0.61** (`PTOAS_VERSION` in `toolchain/versions.env`). A
+> `BYPASS` declaration becomes a `cache_policy` attribute on `pto.tload`, which
+> the assembler lowers to pto-isa's own L2 hint. See
+> [What codegen emits](#what-codegen-emits).
 
 ## Two surfaces
 
@@ -143,7 +142,7 @@ pl.set_cache_policy(b, BYPASS)                 statement, consumed at parse
   -> ScopeStmt.attrs_["cache_policy_vars"]     parse .. pass 9   (Var identity)
   -> Function attr "cache_policy"              pass 9 .. pass 11 (param INDICES)
   -> tile.load kwarg "cache"                   pass 11 .. codegen
-  -> codegen: warn, emit an ordinary cached access
+  -> codegen: `cache_policy` attribute on each emitted `pto.tload`
 ```
 
 | Hop | Carrier | Payload type | Written by | Consumed by |
@@ -195,24 +194,41 @@ with pl.at(level=pl.Level.CORE_GROUP, name_hint="mm"):
 | Otherwise-empty scope | A scope holding only a declaration prints the marker instead of `pass` |
 | Function attr (`cache_policy`) | Prints as a list of `(index, policy)` tuples, so a pass dump taken between pass 9 and pass 11 — the only window where it exists — re-parses |
 
-## Current status
+## What codegen emits
 
-PTOAS has no L2-bypass path yet
-([PTOAS#1356](https://github.com/hw-native-sys/PTOAS/issues/1356)). Codegen
-therefore carries the request all the way down, then compiles it as an ordinary
-cached access and warns once per tensor per kernel (not once per emitted load —
-an unrolled loop emits the same load many times):
+A `BYPASS` read becomes one attribute on the emitted load — there is no extra
+operation, no second tensor view, and no architecture-specific address alias:
 
-```text
-[warning] [CacheBypassUnsupported] tensor 'b' requests CachePolicy.BYPASS, but PTOAS
-has no L2-bypass path yet (https://github.com/hw-native-sys/PTOAS/issues/1356);
-compiling as an ordinary cached access at <file>:<line>
+```mlir
+pto.tload ins(%b__ssa_v0_pview : !pto.partition_tensor_view<256x256xf32>)
+          outs(%b__ssa_v0_mat  : !pto.tile_buf<loc=mat, ...>)
+          {cache_policy = #pto.load_cache_policy<l2_bypass>}
 ```
 
-The generated MLIR is **byte-identical** with and without the declaration.
-Writing it today is what makes a kernel pick the bypass up for free when the
-PTOAS side lands: at that point the warn site is replaced in place by a
-bypass-rooted tensor view, and nothing upstream of codegen changes.
+PTOAS >= v0.61 lowers that to pto-isa's own L2 hint, which is the whole
+difference in the generated CCE:
+
+```diff
+-  TLOAD(v45, v50);
++  TLOAD<pto::TLoadL2Hint::NotAllocKeep>(v45, v50);
+```
+
+Three properties of the emit are worth stating, because each one is asserted in
+`tests/ut/codegen/test_cache_policy_codegen.py`:
+
+| Property | Why |
+| -------- | --- |
+| `CachePolicy.DEFAULT` emits **nothing** | A kernel that states no policy keeps the PTO form it had before this existed, so the attribute is the only difference between two otherwise identical kernels |
+| The attribute is emitted **per load**, not per tensor | It is a property of the instruction; a hint on only the first of two loads would leave the second one allocating in L2 (the superseded `[CacheBypassUnsupported]` diagnostic was deliberately once-per-tensor — the opposite granularity) |
+| It joins the MX `layout` in **one** attribute dict, after it | PTOAS takes all present attributes in a single dict; keeping `layout` first leaves an MX load that declares no policy byte-identical |
+
+### Older assemblers
+
+The emit is unconditional: there is no version gate, and no mechanism in the
+tree reads the pinned assembler version at compile time. A build pointed at an
+assembler older than the `PTOAS_VERSION` this repo pins is therefore out of
+contract — `cache_policy` is a v0.61 addition, so expect it to fail the
+`pto.tload` verifier there.
 
 ### Limits
 

--- a/docs/en/user/performance/05-memory.md
+++ b/docs/en/user/performance/05-memory.md
@@ -265,11 +265,9 @@ coherency bug, which is why this is never a default and never inferred. The
 compiler rejects the case it can see — declaring `BYPASS` on a tensor the scope
 writes is an error — but it cannot prove the general case.
 
-**Current status:** the toolchain has no bypass path yet
-([PTOAS#1356](https://github.com/hw-native-sys/PTOAS/issues/1356)). A `BYPASS`
-declaration is accepted and carried, warns at compile time, and generates exactly
-the same code as an ordinary cached read. Declaring it now costs nothing and
-starts working when that lands.
+**Requires PTOAS >= v0.61.** A `BYPASS` read compiles to
+a real L2 hint on the load instruction (`TLOAD<pto::TLoadL2Hint::NotAllocKeep>`);
+a read that declares nothing is unaffected, byte for byte.
 
 ## See also
 

--- a/docs/zh/dev/language/05-cache-policy.md
+++ b/docs/zh/dev/language/05-cache-policy.md
@@ -7,10 +7,9 @@
 该策略是*作者声明的契约（contract）*，绝不是编译器推断出来的提示（hint）。因此它必须
 显式书写，粒度二选一，并且从 DSL 一路原样传递到代码生成（codegen）。
 
-> **当前状态**：PTOAS 尚未提供 L2 bypass 通路
-> （[PTOAS#1356](https://github.com/hw-native-sys/PTOAS/issues/1356)），因此
-> `BYPASS` 声明目前会**告警，并按普通缓存访问编译**。生成代码在有无该声明时逐字节
-> 一致。参见[当前状态](#当前状态)。
+> **要求 PTOAS >= v0.61**（`toolchain/versions.env` 中的 `PTOAS_VERSION`）。`BYPASS`
+> 声明会变成 `pto.tload` 上的一个 `cache_policy` 属性，由汇编器降级为 pto-isa 自带的
+> L2 hint。参见[codegen 发射什么](#codegen-发射什么)。
 
 ## 两个书写面
 
@@ -133,7 +132,7 @@ pl.set_cache_policy(b, BYPASS)                 statement, consumed at parse
   -> ScopeStmt.attrs_["cache_policy_vars"]     parse .. pass 9   (Var identity)
   -> Function attr "cache_policy"              pass 9 .. pass 11 (param INDICES)
   -> tile.load kwarg "cache"                   pass 11 .. codegen
-  -> codegen: warn, emit an ordinary cached access
+  -> codegen: `cache_policy` attribute on each emitted `pto.tload`
 ```
 
 | 跳 | 载体 | 负载类型 | 写入方 | 消费方 |
@@ -179,22 +178,38 @@ with pl.at(level=pl.Level.CORE_GROUP, name_hint="mm"):
 | 其余为空的作用域 | 只含一条声明的作用域打印该标记，而不是 `pass` |
 | 函数 attr（`cache_policy`） | 打印为 `(索引, 策略)` 元组列表，因此在 pass 9 与 pass 11 之间 —— 它唯一存在的窗口 —— 抓取的 pass dump 可以重新解析 |
 
-## 当前状态
+## codegen 发射什么
 
-PTOAS 尚未提供 L2 bypass 通路
-（[PTOAS#1356](https://github.com/hw-native-sys/PTOAS/issues/1356)）。因此 codegen 会把
-该请求一路携带下来，然后按普通缓存访问编译，并按"每 kernel 每张量一次"告警（而不是
-每条发射出的 load 一次 —— 展开后的循环会发射同一条 load 很多次）：
+一次 `BYPASS` 读取只会变成发射出的那条 load 上的一个属性 —— 没有额外的操作、没有第二个
+tensor view，也没有与架构绑定的地址别名：
 
-```text
-[warning] [CacheBypassUnsupported] tensor 'b' requests CachePolicy.BYPASS, but PTOAS
-has no L2-bypass path yet (https://github.com/hw-native-sys/PTOAS/issues/1356);
-compiling as an ordinary cached access at <file>:<line>
+```mlir
+pto.tload ins(%b__ssa_v0_pview : !pto.partition_tensor_view<256x256xf32>)
+          outs(%b__ssa_v0_mat  : !pto.tile_buf<loc=mat, ...>)
+          {cache_policy = #pto.load_cache_policy<l2_bypass>}
 ```
 
-生成的 MLIR 在有无该声明时**逐字节一致**。今天就写上它的意义在于：等 PTOAS 侧落地
-后，kernel 可以零成本地享受到 bypass —— 届时告警点会被原地替换为一个以 bypass 为根的
-tensor view，codegen 之上的一切都无需改动。
+PTOAS >= v0.61 会把它降级为 pto-isa 自带的 L2 hint，这也是生成的 CCE 中唯一的差异：
+
+```diff
+-  TLOAD(v45, v50);
++  TLOAD<pto::TLoadL2Hint::NotAllocKeep>(v45, v50);
+```
+
+这次发射有三条性质值得写明，因为每一条都在
+`tests/ut/codegen/test_cache_policy_codegen.py` 中有对应断言：
+
+| 性质 | 原因 |
+| ---- | ---- |
+| `CachePolicy.DEFAULT` **什么都不发射** | 未声明策略的 kernel 保持本特性出现之前的 PTO 形态，因此该属性就是两个在其余方面完全相同的 kernel 之间唯一的差异 |
+| 该属性按 **load** 发射，而不是按张量 | 它是指令的性质；若两条 load 只有第一条带 hint，第二条仍会在 L2 中分配（被取代的 `[CacheBypassUnsupported]` 诊断刻意是"每张量一次"—— 粒度正好相反） |
+| 它与 MX 的 `layout` 合并进**同一个**属性字典，且排在其后 | PTOAS 要求所有存在的属性在同一个字典里；把 `layout` 留在前面可使未声明策略的 MX load 保持逐字节一致 |
+
+### 更旧的汇编器
+
+该发射是无条件的：没有版本门控，代码树中也没有任何机制在编译期读取所固定的汇编器版本。
+指向比本仓库所固定 `PTOAS_VERSION` 更旧的汇编器的构建因此处于契约之外 —— `cache_policy`
+是 v0.61 新增的，预期会在那里无法通过 `pto.tload` 的校验。
 
 ### 限制
 

--- a/docs/zh/user/performance/05-memory.md
+++ b/docs/zh/user/performance/05-memory.md
@@ -217,10 +217,8 @@ load 上显式的 `cache=` 永远优先于作用域声明，两个方向都成�
 （coherency）缺陷 —— 这正是它绝不作为默认、也绝不由编译器推断的原因。编译器会拒绝它能看见的
 那种情况（在作用域会写入的张量上声明 `BYPASS` 是错误），但无法证明一般情形。
 
-**当前状态：** 工具链尚无 bypass 通路
-（[PTOAS#1356](https://github.com/hw-native-sys/PTOAS/issues/1356)）。`BYPASS` 声明会被接受
-并向下传递，在编译期给出告警，生成的代码与普通带缓存读取完全一致。现在就写上不会有任何代价，
-等该 issue 落地后即可自动生效。
+**要求 PTOAS >= v0.61。** `BYPASS` 读取会编译成 load 指令上一个真实的
+L2 hint（`TLOAD<pto::TLoadL2Hint::NotAllocKeep>`）；未作声明的读取逐字节不受影响。
 
 ## 参见
 

--- a/include/pypto/codegen/pto/pto_codegen.h
+++ b/include/pypto/codegen/pto/pto_codegen.h
@@ -204,21 +204,6 @@ class PTOCodegen : public CodegenBase {
   [[nodiscard]] std::string TryGetTensorView(const ir::VarPtr& tensor) const;
 
   /**
-   * @brief Record that a tensor's `CachePolicy.BYPASS` request has been reported.
-   *
-   * A declaration is made once per tensor but read by every load of it, and a
-   * load inside an unrolled loop is emitted many times over. Diagnose the
-   * declaration, not the emission: this returns true only the FIRST time the
-   * current function sees @p tensor, so the caller warns once per tensor per
-   * kernel. State lives on the per-function frame, so the next kernel warns
-   * about its own tensors again.
-   *
-   * @param tensor Tensor variable key (`VarPtr::get()`, like `tensor_to_view`)
-   * @return true if this is the first report for @p tensor in this function
-   */
-  bool NoteCacheBypassWarned(const ir::Var* tensor);
-
-  /**
    * @brief Get or emit a numeric constant of any dtype (int, index, or float).
    *
    * Both overloads write the constant to the constants section on first use and
@@ -998,11 +983,6 @@ class PTOCodegen : public CodegenBase {
     /// SSA names emitted as tile views (`pto.subview` / `pto.treshape`).
     std::set<std::string> tile_view_names;
 
-    /// Tensor vars whose `CachePolicy.BYPASS` request has already been reported
-    /// (pypto #2534). Keeps the diagnostic one-per-tensor instead of
-    /// one-per-emitted-load. See NoteCacheBypassWarned.
-    std::set<const ir::Var*> cache_bypass_warned;
-
     /// Eligible multi-buffer regions, keyed by the allocation's base Ptr.
     std::map<const ir::Var*, MultiBufferRegion> multi_buffer_regions;
     /// The same regions in discovery order — the map is keyed by pointer, which
@@ -1100,7 +1080,6 @@ class PTOCodegen : public CodegenBase {
       ssa_to_tile_buf_type.clear();
       subview_materializations.clear();
       tile_view_names.clear();
-      cache_bypass_warned.clear();
 
       temp_counter = 0;
       used_ssa_names.clear();

--- a/python/pypto/language/op/tensor_ops.py
+++ b/python/pypto/language/op/tensor_ops.py
@@ -395,12 +395,10 @@ def set_cache_policy(tensor: Tensor, policy: CachePolicy) -> None:
       ``cache=pl.CachePolicy.DEFAULT`` opts a single read back into the cache
       inside a bypassing scope.
 
-    Current status: PTOAS has no L2-bypass path yet
-    (https://github.com/hw-native-sys/PTOAS/issues/1356). The declaration is
-    carried all the way to codegen, but codegen emits a warning and compiles it
-    as an ordinary cached access, so generated code is unchanged today. Writing
-    the declaration now is what makes the kernel pick the bypass up for free
-    once that lands.
+    Requires PTOAS >= v0.61: a declared read compiles to
+    a ``cache_policy`` attribute on ``pto.tload``, which the assembler lowers to
+    pto-isa's own L2 hint. ``CachePolicy.DEFAULT`` emits nothing, so a read that
+    declares no policy generates exactly the code it did before.
 
     Args:
         tensor: The tensor whose reads the policy applies to. Must be a

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -440,9 +440,9 @@ def load(
             the full contract). An explicit value here always wins over a
             scope-level ``pl.set_cache_policy`` declaration for the same tensor,
             in both directions: ``cache=CachePolicy.DEFAULT`` opts this one read
-            back into the cache inside a bypassing scope. PTOAS has no L2-bypass
-            path yet (https://github.com/hw-native-sys/PTOAS/issues/1356), so a
-            BYPASS request warns and compiles as an ordinary cached access today.
+            back into the cache inside a bypassing scope. Requires PTOAS >= v0.61,
+            where a BYPASS read compiles to an L2 hint on the emitted load;
+            DEFAULT emits nothing.
 
     Returns:
         Tile wrapping the load operation

--- a/src/backend/common/pto_ops_memory.cpp
+++ b/src/backend/common/pto_ops_memory.cpp
@@ -39,7 +39,6 @@
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/span.h"
 #include "pypto/ir/tile_view_semantics.h"
-#include "pypto/ir/transforms/utils/auto_name_utils.h"
 #include "pypto/ir/transforms/utils/tensor_view_semantics.h"
 #include "pypto/ir/type.h"
 #include "src/backend/common/pto_ops_internal.h"
@@ -110,20 +109,12 @@ static std::string MakeTileLoadCodegenPTO(const CallPtr& op, codegen::CodegenBas
   INTERNAL_CHECK_SPAN(!shapes_tuple->elements_.empty(), op->span_)
       << "tile.load shapes tuple must have at least one element";
 
-  // TEMPORARY (pypto #2534): PTOAS has no L2-bypass path yet
-  // (https://github.com/hw-native-sys/PTOAS/issues/1356), so a BYPASS request is
-  // carried through the IR but compiles as an ordinary cached access. When that
-  // issue closes, this warn is REPLACED in place by
-  // `GetOrCreateTensorView(tensor, policy)` against an addptr-rooted view — the
-  // declaration already reaches here, so nothing upstream changes.
+  // The declared GM cache-access policy (pypto #2680). PTOAS >= v0.61 carries a
+  // streaming read as a `cache_policy` attribute on `pto.tload`, which lowers to
+  // pto-isa's own L2 hint (`TLOAD<pto::TLoadL2Hint::NotAllocKeep>`), so there is
+  // no architecture-specific address alias to build here. It is attached below,
+  // alongside the MX layout attribute when both apply.
   const auto policy = static_cast<ir::CachePolicy>(op->GetKwarg<int>("cache", 0));
-  if (policy == ir::CachePolicy::kBypass && codegen.NoteCacheBypassWarned(tensor.get())) {
-    LOG_WARN << "[warning] [CacheBypassUnsupported] tensor '"
-             << ir::auto_name::GetBaseName(tensor->name_hint_)
-             << "' requests CachePolicy.BYPASS, but PTOAS has no L2-bypass path yet "
-             << "(https://github.com/hw-native-sys/PTOAS/issues/1356); compiling as an "
-             << "ordinary cached access" << (op->span_.is_valid() ? " at " + op->span_.to_string() : "");
-  }
 
   std::string dtype_str = codegen.GetTypeString(tensor_type->dtype_);
   std::string tile_buf = codegen.GetCurrentResultTarget();
@@ -169,8 +160,25 @@ static std::string MakeTileLoadCodegenPTO(const CallPtr& op, codegen::CodegenBas
   std::ostringstream tload_line;
   tload_line << "pto.tload ins(" << partition_view << " : " << partition_type << ") outs(";
   tload_line << tile_buf << " : " << tile_buf_type << ")";
+
+  std::vector<std::string> attrs;
   if (is_mx_load) {
-    tload_line << " {layout = #pto.layout<" << pto_layout << ">}";
+    attrs.push_back("layout = #pto.layout<" + pto_layout + ">");
+  }
+  if (policy == ir::CachePolicy::kBypass) {
+    attrs.emplace_back("cache_policy = #pto.load_cache_policy<l2_bypass>");
+  }
+
+  // Default-valued attributes are omitted so an undeclared load keeps its
+  // byte-identical PTO form. PTOAS expects all present attributes in one dict
+  // (same contract as tile.store below).
+  if (!attrs.empty()) {
+    tload_line << " {";
+    for (size_t i = 0; i < attrs.size(); ++i) {
+      if (i != 0) tload_line << ", ";
+      tload_line << attrs[i];
+    }
+    tload_line << "}";
   }
   codegen.Emit(tload_line.str());
 

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -2557,11 +2557,6 @@ std::string PTOCodegen::TryGetTensorView(const VarPtr& tensor_var) const {
   return "";
 }
 
-bool PTOCodegen::NoteCacheBypassWarned(const ir::Var* tensor) {
-  INTERNAL_CHECK(tensor != nullptr) << "Internal error: null tensor passed to NoteCacheBypassWarned";
-  return fs_.cache_bypass_warned.insert(tensor).second;
-}
-
 std::string PTOCodegen::GetOrCreateTensorView(const VarPtr& tensor_var) {
   std::string view = TryGetTensorView(tensor_var);
   INTERNAL_CHECK_SPAN(!view.empty(), tensor_var->span_)

--- a/tests/ut/codegen/test_cache_policy_codegen.py
+++ b/tests/ut/codegen/test_cache_policy_codegen.py
@@ -7,37 +7,44 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 
-"""Codegen behaviour of the declared GM cache-access policy (pypto #2534).
+"""Codegen behaviour of the declared GM cache-access policy (pypto #2534, #2680).
 
-PTOAS has no L2-bypass path yet
-(https://github.com/hw-native-sys/PTOAS/issues/1356), so a ``CachePolicy.BYPASS``
-declaration is carried all the way to codegen but changes nothing it emits. That
-makes the codegen contract two-sided, and both sides are asserted here:
+PTOAS >= v0.61 carries a streaming GM read as a ``cache_policy`` attribute on
+``pto.tload``, which the assembler lowers to pto-isa's own L2 hint
+(``TLOAD<pto::TLoadL2Hint::NotAllocKeep>``). ``CachePolicy.BYPASS`` therefore
+stopped being a no-op: codegen now emits that attribute, and the
+``[CacheBypassUnsupported]`` warning that stood in for it is gone.
 
-1. **The generated MLIR is byte-identical** with and without the declaration.
-   Anything else would mean the "compiles as an ordinary cached access" promise
-   is already broken.
-2. **The user is told.** The declaration is diagnosed once per tensor per
-   kernel — not once per emitted load — and the message points at the PTOAS
-   issue so the reader can see when the request will start to mean something.
+The contract asserted here has three sides:
 
-The warning travels the C++ ``LOG_WARN`` channel, which writes to ``std::cerr``
-from native code, so it is read with pytest's ``capfd`` (file-descriptor level)
-rather than ``capsys`` — the same mechanism ``tests/ut/core/test_logging.py``
-and the MemoryReuse fallback diagnostics use.
+1. **A declared read carries the attribute** — once per emitted load, since the
+   hint belongs to the instruction rather than to the tensor (an unrolled loop
+   emits the same load many times, and each one must carry it).
+2. **An undeclared read carries nothing.** ``CachePolicy.DEFAULT`` emits no
+   attribute at all, so a kernel that states no policy keeps the PTO form it had
+   before the feature existed. That is also what makes the emitted dict the
+   *only* difference between the two otherwise identical kernels below.
+3. **The per-access surface still wins.** An explicit
+   ``cache=CachePolicy.DEFAULT`` inside a bypassing scope re-caches that one
+   read, which is observable in the emitted MLIR for the first time — while
+   BYPASS was a no-op, the documented precedence could only be checked on the IR
+   (``tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py``).
+
+The assembler's own acceptance of the attribute is not asserted here: every UT
+runs with ``skip_ptoas=True``, so these tests stop at the emitted MLIR text (the
+same contract as the MX ``layout`` attribute in ``test_mx_ops_codegen.py``).
 """
 
 import pypto.language as pl
 import pytest
-from _pto_loc_common import strip_loc
 from pypto import LogLevel, backend, codegen, ir, set_log_level
 from pypto.backend import BackendType
 from pypto.ir import OptimizationStrategy, PassManager
 
-# The exact link the message must carry: it is the only thing in the warning
-# that tells a reader when BYPASS stops being a no-op.
-PTOAS_ISSUE_URL = "https://github.com/hw-native-sys/PTOAS/issues/1356"
-# Diagnostic tag, used to pick this warning out of unrelated pipeline output.
+# The exact attribute PTOAS >= v0.61 consumes on `pto.tload`.
+BYPASS_ATTR = "cache_policy = #pto.load_cache_policy<l2_bypass>"
+# The diagnostic that stood in for the attribute while PTOAS had no bypass path.
+# It must never be emitted again — the request is now honoured, not reported.
 BYPASS_WARNING_TAG = "[CacheBypassUnsupported]"
 
 M, K, N = 256, 128, 256
@@ -63,8 +70,8 @@ def _setup_backend_and_log_level():
 # Programs
 #
 # `DeclaredBypass` and `PlainMatmul` are the SAME kernel; the declaration line
-# is the only difference between them, which is what makes the byte-identity
-# comparison meaningful.
+# is the only difference between them, which is what makes the "the attribute is
+# the whole difference" comparison meaningful.
 # ---------------------------------------------------------------------------
 
 
@@ -88,7 +95,7 @@ class DeclaredBypass:
 
 @pl.program
 class PlainMatmul:
-    """The same kernel with no declaration — the byte-identity reference."""
+    """The same kernel with no declaration — the comparison reference."""
 
     @pl.function
     def main(
@@ -105,7 +112,7 @@ class PlainMatmul:
 
 @pl.program
 class TwoDeclaredTensors:
-    """Both operands declared: the diagnostic is per tensor, so two warnings."""
+    """Both operands declared: both synthesised loads carry the attribute."""
 
     @pl.function
     def main(
@@ -124,7 +131,7 @@ class TwoDeclaredTensors:
 
 @pl.program
 class TwoBypassingLoadsOfOneTensor:
-    """Two `pl.load(..., cache=BYPASS)` reads of ONE tensor — still one warning."""
+    """Two `pl.load(..., cache=BYPASS)` reads of ONE tensor — two hinted loads."""
 
     @pl.function(type=pl.FunctionType.InCore)
     def kernel(
@@ -137,6 +144,30 @@ class TwoBypassingLoadsOfOneTensor:
         out_0: pl.Tensor[[ROWS, COLS], pl.FP32] = pl.store(top, [0, 0], out)
         out_1: pl.Tensor[[ROWS, COLS], pl.FP32] = pl.store(bottom, [16, 0], out_0)
         return out_1
+
+
+@pl.program
+class ReCachedSingleLoad:
+    """A declared parameter with one access explicitly opted back into the cache.
+
+    The declaration is written the way pass 9 leaves it — ``cache_policy`` on the
+    outlined kernel, ``(param index, policy)`` — because the override has to be
+    stated at the access, and a hand-written InCore kernel is where an access is
+    spelled out. See the pass-level pair in
+    ``tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py``.
+    """
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(
+        self,
+        x: pl.Tensor[[ROWS, COLS], pl.FP32],
+        out: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+    ) -> pl.Tensor[[ROWS, COLS], pl.FP32]:
+        # (param index, policy-as-int); 1 is CachePolicy.BYPASS. The parser takes
+        # integer literals here only, which is also how pass 9 writes the attr.
+        pl.func_attr({"cache_policy": [(0, 1)]})
+        t: pl.Tile[[16, COLS], pl.FP32] = pl.load(x, [0, 0], [16, COLS], cache=pl.CachePolicy.DEFAULT)
+        return pl.store(t, [0, 0], out)
 
 
 # ---------------------------------------------------------------------------
@@ -156,7 +187,7 @@ def _incore_mlir(program_cls, *, emit_source_loc: bool = False) -> str:
             ``loc("file":line:col)``. Off by default: the declaration line shifts
             every following statement down by one, so the locations legitimately
             differ between two otherwise identical kernels and would mask a
-            byte-for-byte comparison of what is actually emitted.
+            comparison of what is actually emitted.
 
     Returns:
         The generated MLIR text.
@@ -169,112 +200,130 @@ def _incore_mlir(program_cls, *, emit_source_loc: bool = False) -> str:
     return result if isinstance(result, str) else "".join(result.values())
 
 
-def _bypass_warnings(capfd) -> list[str]:
-    """Drain captured stderr and return only the cache-bypass warning lines."""
+def _tload_lines(mlir: str) -> list[str]:
+    """Every emitted ``pto.tload`` — the operation the declaration changes."""
+    return [line.strip() for line in mlir.splitlines() if "pto.tload" in line]
+
+
+def _hinted_tloads(mlir: str) -> list[str]:
+    """The emitted loads that carry the L2-bypass attribute."""
+    return [line for line in _tload_lines(mlir) if BYPASS_ATTR in line]
+
+
+def _source_of(tload_line: str) -> str:
+    """The declared tensor a ``pto.tload`` reads, taken from its partition view.
+
+    ``pto.tload ins(%b__ssa_v0_pview : ...)`` → ``b``. The SSA name is built from
+    the source tensor's name, which is what makes the operand identifiable at all.
+    """
+    ins = tload_line.split("ins(%", 1)[1]
+    return ins.split("__", 1)[0]
+
+
+def _warnings(capfd) -> list[str]:
+    """Drain captured stderr and return any cache-bypass warning lines."""
     err = capfd.readouterr().err
     return [line for line in err.splitlines() if BYPASS_WARNING_TAG in line]
 
 
-def _tload_lines(mlir: str) -> list[str]:
-    """Every emitted ``pto.tload`` — the operation a declaration would change."""
-    return [line.strip() for line in mlir.splitlines() if "pto.tload" in line]
-
-
 # ---------------------------------------------------------------------------
-# (a) The declaration must not change a single byte of the generated MLIR
+# (a) A declared read carries the attribute, and it is the whole difference
 # ---------------------------------------------------------------------------
 
 
-def test_declaration_leaves_generated_mlir_byte_identical():
-    """`pl.set_cache_policy(b, BYPASS)` compiles to exactly today's MLIR.
+def test_declared_tensor_load_carries_the_bypass_attribute():
+    """Only the declared operand's load is hinted; the other is untouched."""
+    mlir = _incore_mlir(DeclaredBypass)
+    loads = _tload_lines(mlir)
 
-    The policy reaches codegen through the ``cache`` kwarg on ``tile.load``, and
-    codegen deliberately consumes it without emitting anything: no extra
-    operation, no extra attribute, no reordering. Comparing the whole module
-    text — not just the tload lines — is what makes "emit nothing else" testable.
+    assert len(loads) == 2, f"expected one load per matmul operand:\n{mlir}"
+    hinted = {_source_of(line) for line in loads if BYPASS_ATTR in line}
+    plain = {_source_of(line) for line in loads if BYPASS_ATTR not in line}
+    assert hinted == {"b"}, f"only the declared tensor may be hinted, got {hinted}"
+    assert plain == {"a"}, f"the undeclared tensor must stay cached, got {plain}"
+
+
+def test_the_attribute_is_the_only_difference_from_the_undeclared_kernel():
+    """`pl.set_cache_policy(b, BYPASS)` adds an attribute and nothing else.
+
+    No extra operation, no extra view, no reordering: stripping the attribute
+    from the declared kernel's MLIR must reproduce the undeclared kernel's,
+    line for line. That is what keeps the declaration a property of the load
+    rather than a codegen mode.
     """
     with_decl = _incore_mlir(DeclaredBypass)
     without_decl = _incore_mlir(PlainMatmul)
 
-    # Guard against a vacuous pass: there must be real loads to have changed.
-    assert _tload_lines(without_decl), f"reference kernel emitted no pto.tload:\n{without_decl}"
-    assert with_decl == without_decl, (
-        "CachePolicy.BYPASS must not change generated code while PTOAS lacks a "
-        f"bypass path ({PTOAS_ISSUE_URL})"
-    )
+    assert BYPASS_ATTR in with_decl, f"declared kernel emitted no bypass hint:\n{with_decl}"
+    assert BYPASS_ATTR not in without_decl, f"undeclared kernel must carry no hint:\n{without_decl}"
+    stripped = with_decl.replace(" {" + BYPASS_ATTR + "}", "")
+    assert stripped == without_decl
 
 
-def test_declaration_leaves_generated_mlir_identical_with_source_locations():
-    """The same, through the default emit path that also writes `loc(...)`.
-
-    ``emit_source_loc=True`` is what production codegen uses, so it is worth
-    exercising; the locations themselves must differ, because the declaration
-    is a real source line that shifts the statements after it. Everything else
-    — every operation, in order — must still match.
-    """
-    with_decl = _incore_mlir(DeclaredBypass, emit_source_loc=True)
-    without_decl = _incore_mlir(PlainMatmul, emit_source_loc=True)
-
-    assert "loc(" in with_decl, f"expected source locations in the emitted MLIR:\n{with_decl}"
-    stripped_with = [strip_loc(line) for line in with_decl.splitlines()]
-    stripped_without = [strip_loc(line) for line in without_decl.splitlines()]
-    assert stripped_with == stripped_without
+def test_each_declared_tensor_gets_its_own_hinted_load():
+    """Two declared operands produce two hinted loads."""
+    mlir = _incore_mlir(TwoDeclaredTensors)
+    hinted = {_source_of(line) for line in _hinted_tloads(mlir)}
+    assert hinted == {"a", "b"}, f"expected both operands hinted, got {hinted}:\n{mlir}"
 
 
-# ---------------------------------------------------------------------------
-# (b) The warning: once per tensor, and it names the PTOAS issue
-# ---------------------------------------------------------------------------
+def test_every_emitted_load_of_a_declared_tensor_is_hinted():
+    """Many loads, one declaration, one hint each.
 
-
-def test_undeclared_kernel_emits_no_bypass_warning(capfd):
-    """No declaration, no warning: the diagnostic tracks the request, not loads."""
-    _incore_mlir(PlainMatmul)
-    assert _bypass_warnings(capfd) == []
-
-
-def test_declared_bypass_warns_once_and_links_the_ptoas_issue(capfd):
-    """One declared tensor produces exactly one warning naming it and the issue.
-
-    The link is asserted verbatim: it is the message's only forward reference,
-    and it is what tells the reader the request is recorded rather than ignored.
-    """
-    _incore_mlir(DeclaredBypass)
-    warnings = _bypass_warnings(capfd)
-
-    assert len(warnings) == 1, f"expected exactly one bypass warning, got {warnings}"
-    message = warnings[0]
-    assert "tensor 'b'" in message, f"warning must name the declared tensor: {message}"
-    assert "CachePolicy.BYPASS" in message, message
-    assert PTOAS_ISSUE_URL in message, f"warning must link the PTOAS issue: {message}"
-
-
-def test_each_declared_tensor_warns_exactly_once(capfd):
-    """Two declared tensors get one warning each — the state is keyed by tensor."""
-    _incore_mlir(TwoDeclaredTensors)
-    warnings = _bypass_warnings(capfd)
-
-    assert len(warnings) == 2, f"expected one warning per declared tensor, got {warnings}"
-    assert len([w for w in warnings if "tensor 'a'" in w]) == 1, warnings
-    assert len([w for w in warnings if "tensor 'b'" in w]) == 1, warnings
-    assert all(PTOAS_ISSUE_URL in w for w in warnings), warnings
-
-
-def test_repeated_bypassing_loads_of_one_tensor_warn_once(capfd):
-    """Many loads, one declaration, one warning.
-
-    The policy is read by every load of the tensor and a load inside an unrolled
-    loop is emitted many times over, so the naive placement would produce one
-    line per emitted ``pto.tload``. This kernel reads `x` twice with
-    ``cache=BYPASS``; the MLIR is asserted to really carry both loads, so a
-    single warning proves de-duplication rather than a missing load.
+    The hint belongs to the instruction, not to the tensor: the old diagnostic
+    was deliberately once-per-tensor, but an L2 hint that lands on only the
+    first of two loads would leave the second one allocating in L2. This kernel
+    reads `x` twice with ``cache=BYPASS``; both emitted loads must carry it.
     """
     mlir = _incore_mlir(TwoBypassingLoadsOfOneTensor)
-    warnings = _bypass_warnings(capfd)
+    loads = _tload_lines(mlir)
 
-    assert len(_tload_lines(mlir)) == 2, f"expected two emitted loads:\n{mlir}"
-    assert len(warnings) == 1, f"warning must be once per tensor, not once per load: {warnings}"
-    assert "tensor 'x'" in warnings[0], warnings[0]
-    assert PTOAS_ISSUE_URL in warnings[0], warnings[0]
+    assert len(loads) == 2, f"expected two emitted loads:\n{mlir}"
+    assert len(_hinted_tloads(mlir)) == 2, f"every emitted load must carry the hint:\n{mlir}"
+
+
+# ---------------------------------------------------------------------------
+# (b) An undeclared read — and an explicitly re-cached one — carry nothing
+# ---------------------------------------------------------------------------
+
+
+def test_undeclared_kernel_emits_no_cache_attribute():
+    """`CachePolicy.DEFAULT` emits nothing, so unrelated kernels are unchanged."""
+    mlir = _incore_mlir(PlainMatmul)
+
+    assert _tload_lines(mlir), f"reference kernel emitted no pto.tload:\n{mlir}"
+    assert "cache_policy" not in mlir, f"an undeclared kernel must emit no cache attribute:\n{mlir}"
+
+
+def test_explicit_default_load_beats_the_declaration_and_emits_no_attribute():
+    """An explicit ``cache=CachePolicy.DEFAULT`` re-caches that one read.
+
+    The documented precedence — the per-access kwarg wins over the scope
+    declaration, in both directions — becomes observable in codegen only now
+    that BYPASS emits something.
+    """
+    mlir = _incore_mlir(ReCachedSingleLoad)
+
+    assert _tload_lines(mlir), f"kernel emitted no pto.tload:\n{mlir}"
+    assert "cache_policy" not in mlir, f"the re-cached access must carry no hint:\n{mlir}"
+
+
+# ---------------------------------------------------------------------------
+# (c) The stand-in diagnostic is gone
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("program_cls", [PlainMatmul, DeclaredBypass, TwoBypassingLoadsOfOneTensor])
+def test_no_cache_bypass_warning_is_emitted(program_cls, capfd):
+    """Nothing warns any more: the request is honoured rather than reported.
+
+    The warning travelled the C++ ``LOG_WARN`` channel, which writes to
+    ``std::cerr`` from native code, so it is read with pytest's ``capfd``
+    (file-descriptor level) rather than ``capsys`` — the same mechanism
+    ``tests/ut/core/test_logging.py`` uses.
+    """
+    _incore_mlir(program_cls)
+    assert _warnings(capfd) == []
 
 
 if __name__ == "__main__":

--- a/tests/ut/codegen/test_mx_ops_codegen.py
+++ b/tests/ut/codegen/test_mx_ops_codegen.py
@@ -115,6 +115,36 @@ class TestMxMatmulCodegen:
             "sizes = [%c1_index, %c1_index, %c1_index, %c16_index, %c2_index]" in line for line in partitions
         )
 
+    def test_mx_scale_load_joins_layout_and_cache_policy_in_one_attr_dict(self):
+        """An MX scale load declared `cache=BYPASS` carries BOTH attributes.
+
+        The MX ``layout`` and the L2-bypass ``cache_policy`` (pypto #2680) can
+        co-occur on one ``pto.tload``, and PTOAS takes all present attributes in
+        a single dict — two dicts, or a dropped attribute, would not assemble.
+        ``layout`` stays first so an MX load that declares no policy keeps its
+        byte-identical form.
+
+        Verified against a real ptoas v0.61 run of this emit (accepted; the load
+        lowers to ``TLOAD<pto::TLoadL2Hint::NotAllocKeep>``). UTs themselves run
+        with ``skip_ptoas=True``, so the assertion here is on the emitted text.
+        """
+
+        @pl.program
+        class Program:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main(
+                self,
+                a_s: pl.Tensor[[128, 8], pl.FP8E8M0, pl.MX_A_ZZ],
+            ):
+                _ = pl.load(a_s, [0, 0], [16, 2], target_memory=pl.Mem.Mat, cache=pl.CachePolicy.BYPASS)
+
+        mlir = _emit_incore_mlir(Program)
+        tloads = [line for line in mlir.splitlines() if "pto.tload" in line]
+        assert len(tloads) == 1, f"expected one MX scale load:\n{mlir}"
+        assert (
+            "{layout = #pto.layout<mx_a_zz>, cache_policy = #pto.load_cache_policy<l2_bypass>}" in tloads[0]
+        ), tloads[0]
+
     def test_mx_scale_load_rejects_unprovable_dynamic_offset(self):
         """Unaligned / unprovable dynamic MX offsets fail at BlockMxScaleTensorViews."""
 


### PR DESCRIPTION
Closes hw-native-sys/pypto#2680.

> **Merge after hw-native-sys/pypto#2686.** The emit needs the PTOAS v0.61 pin
> that PR moves, and this branch deliberately carries **only its own commit** —
> it sits on `main`, where `PTOAS_VERSION` is still `v0.60`. Nothing here reads
> the pin at compile time, so CI on this PR exercises the new code against the
> old assembler; re-run it once #2686 lands. (Supersedes #2740, which was the
> same change stacked on #2686's branch and therefore listed its eight commits.)

`CachePolicy.BYPASS` was accepted by the DSL, survived every pass, and was then
dropped in codegen: `MakeTileLoadCodegenPTO` logged a `[CacheBypassUnsupported]`
warning and emitted an ordinary cached `pto.tload`. Generated code was
byte-identical with and without the declaration, so the feature was a no-op end
to end. That was correct while PTOAS had no bypass path, and the code said so —
naming, in a comment, the replacement this PR performs.

PTOAS v0.61 has that path, with one simplification over what the comment
anticipated: 0.61 takes an attribute on `pto.tload`, so no addptr-rooted view is
needed.

```mlir
pto.tload ins(%b__ssa_v0_pview : !pto.partition_tensor_view<256x256xf32>)
          outs(%b__ssa_v0_mat  : !pto.tile_buf<loc=mat, ...>)
          {cache_policy = #pto.load_cache_policy<l2_bypass>}
```

The assembler lowers that to pto-isa's own L2 hint, which is the whole difference
in the emitted CCE:

```diff
-  TLOAD(v45, v50);
+  TLOAD<pto::TLoadL2Hint::NotAllocKeep>(v45, v50);
```

## Three properties of the emit

Each is asserted by a test, and each is a way this could have gone wrong.

| Property | Why it matters |
| --- | --- |
| `CachePolicy.DEFAULT` emits **nothing** | A kernel that declares no policy keeps the PTO form it had before this existed. Stripping the attribute from the declared kernel's MLIR reproduces the undeclared kernel's, line for line — so the attribute is the *only* difference, not a codegen mode |
| The attribute is emitted **per load**, not per tensor | It is a property of the instruction. A hint on only the first of two loads would leave the second one allocating in L2. The superseded diagnostic was deliberately once-per-tensor — the opposite granularity — so its de-duplication state (`NoteCacheBypassWarned` / `cache_bypass_warned`) is **deleted**, not rewired |
| It joins the MX `layout` in **one** dict, after it | PTOAS takes all present attributes in a single dict. This follows the `attrs` vector `MakeTileStoreCodegenPTO` already uses in the same file, and keeping `layout` first leaves an MX load that declares no policy byte-identical |

## The per-access override is now observable

An explicit `cache=CachePolicy.DEFAULT` inside a bypassing scope emits no
attribute. The precedence was always documented, but while BYPASS was a no-op it
could only be checked on the IR
(`tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py`); there is now a
codegen-level test for it.

## No version gate

The emit is unconditional. Nothing in the tree reads the pinned assembler
version at compile time, and adding that plumbing — so this could land
independently of #2686 — would be new machinery with no precedent in the
repository. Hence the merge order above instead.

## Testing

- `tests/ut/codegen` + `tests/ut/ir/transforms`: **5008 passed, 2 skipped**, on
  this branch (rebuilt after rebasing onto `main`).
- **`tests/ut/codegen/test_cache_policy_codegen.py` is rewritten, not adjusted.**
  Its previous assertions — "the generated MLIR is byte-identical with and
  without the declaration" and "the declaration warns once per tensor" — pinned
  exactly the behaviour this change removes. Five of its six tests are inverted
  or deleted on that basis; the surviving one now asserts the warning is *never*
  emitted again. Nine tests in total.
- **ptoas v0.61 run by hand on pypto's own emit.** Every UT runs with
  `skip_ptoas=True`, so no test in the tree would catch the assembler rejecting
  the attribute. Both paths were therefore assembled manually against the v0.61
  release: the a2/a3 kernel above (accepted; only the declared operand's `TLOAD`
  carries the hint) and an a5 MX scale load, where `layout` and `cache_policy`
  share one dict (accepted; same hint). This is what the "one dict" property
  above rests on — the issue asserted co-occurrence without evidence.
- ruff check/format, pyright 1.1.407, clang-format 21.1.0, markdownlint, and the
  repo lint scripts (`check_docs_en_zh_parity`, `check_english_only`,
  `check_headers`, `check_emitter_check_classification`,
  `check_docs_symbol_coverage`): clean.

### Not covered locally

- **No hardware run.** The device measurements that motivate the request — the
  L2-bypass half is worth -7.9% on the DeepSeek-V4 Flash routed-expert kernel /
  -2.8% of a decode step — were taken in pypto-lib by hand-editing generated C++,
  and are tracked in hw-native-sys/pypto-lib#1039. This PR makes the declaration
  produce that code; it does not re-measure it.
- **No ST or example coverage of cache policy exists** (before or after this PR),
  which is why the assembler check above is manual. A future ST case would be the
  only thing that catches an assembler-side regression in CI.

## Docs

`docs/{en,zh}/dev/language/05-cache-policy.md` lose their "Current status"
no-op admonition for a **What codegen emits** section carrying the MLIR and CCE
above plus the three properties; `docs/{en,zh}/user/performance/05-memory.md`
state the v0.61 requirement instead of the warning. The `pl.set_cache_policy` and
`pl.load(cache=...)` docstrings follow. None of them asserts what
`PTOAS_VERSION` currently is, so they stay accurate whichever order these two
PRs land in.
