### PR TITLE
test(st): cover the ND x NZ matmul end to end on device

### DIFF
--- a/docs/en/dev/passes/15-block_nz_tensor_views.md
+++ b/docs/en/dev/passes/15-block_nz_tensor_views.md
@@ -295,10 +295,12 @@ the repository's pinned version is not yet the one that works.
 | ≤ 0.60 | Infers the layout structurally. Blocked NZ and ND are structurally identical (both row-major), so it infers `nd`, overrides the explicit `nz` annotation, and fails with `layout mismatch: user-specified layout=nz but inferred=nd`. No NZ view assembles, at any rank. |
 | ≥ 0.61 | Treats an explicit `ND` / `DN` / `NZ` annotation as authoritative and validates it, so the descriptor above assembles. It also enforces NZ's arity directly: a view of any rank but 5 is refused with `'pto.make_tensor_view' op user-specified layout=nz requires a rank-5 view`. |
 
-`toolchain/versions.env` currently pins **v0.60**, so `pl.NZ` does not yet work
-end to end on the pinned toolchain, and no test in the tree reaches the
-assembler with an NZ tensor. To exercise the path, point `PTOAS_ROOT` at a 0.61
-or later install.
+`toolchain/versions.env` pins **v0.61**, so `pl.NZ` works end to end on the
+pinned toolchain. `tests/st/runtime/ops/test_matmul_nz.py` is what holds that:
+an ND activation against an NZ weight, with the host packer that produces the
+fractal bytes, plus sliced cases that pin both offset axes — the row fractal
+(`n0 // 16`) and the C0 column block (`k0 // c0`). A whole-tensor load leaves
+every offset zero, so the baseline case alone would exercise neither.
 
 The 0.60 failure is safe rather than silent in both directions: it stops at the
 layout mismatch above, and even past that, pto-isa's ND→NZ `TLOAD` path requires

--- a/docs/zh/dev/passes/15-block_nz_tensor_views.md
+++ b/docs/zh/dev/passes/15-block_nz_tensor_views.md
@@ -266,9 +266,11 @@ shape"。因此本 pass 会在每个改写过的函数上打 `nz_tensor_views_bl
 | ≤ 0.60 | 通过结构推断 layout。分块 NZ 与 ND 在结构上完全相同（都是行主序），因此推断出 `nd` 并覆盖显式的 `nz` 标注，报 `layout mismatch: user-specified layout=nz but inferred=nd`。任何秩的 NZ view 都无法汇编。 |
 | ≥ 0.61 | 把显式的 `ND` / `DN` / `NZ` 标注视为权威并加以校验，因此上面的描述符可以汇编。它同时直接强制 NZ 的 arity：秩不为 5 的 view 会被 `'pto.make_tensor_view' op user-specified layout=nz requires a rank-5 view` 拒绝。 |
 
-`toolchain/versions.env` 目前钉的是 **v0.60**，所以在钉住的工具链上 `pl.NZ` 尚未端到端可用，
-仓库里也没有任何测试会带着 NZ 张量走到汇编器。要走通这条路径，请把 `PTOAS_ROOT`
-指向 0.61 或更高的安装。
+`toolchain/versions.env` 钉的是 **v0.61**，所以在钉住的工具链上 `pl.NZ` 已经端到端可用。
+`tests/st/runtime/ops/test_matmul_nz.py` 是这一点的保障：ND 激活乘 NZ 权重，配套的 host
+packer 负责生成 fractal 字节；此外还有切片用例分别钉住两个偏移轴——行 fractal
+(`n0 // 16`) 和 C0 列块 (`k0 // c0`)。整张量 load 的所有偏移都是 0，因此仅靠基线用例
+两者都覆盖不到。
 
 0.60 上的失败在两个方向上都是安全而非静默的：它先停在上面的 layout mismatch；
 即便越过那一步，pto-isa 的 ND→NZ `TLOAD` 路径要求 `staticShape[0..2] == 1`，

--- a/tests/st/runtime/ops/test_matmul_nz.py
+++ b/tests/st/runtime/ops/test_matmul_nz.py
@@ -1,0 +1,258 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Runtime tests for an ND x NZ matmul: an ND activation against a GM weight
+annotated ``pl.NZ``.
+
+``pl.NZ`` is an *assertion about the bytes already in GM* — that they are in
+pto-isa's NZ fractal order — not a request to convert anything. So the host has
+to produce those bytes (``_pack_nz``) and the golden has to read them back
+logically (``_unpack_nz``). The DSL keeps the logical ``[N, K]`` shape and
+logical slicing throughout; ``BlockNzTensorViews`` supplies the physical rank-5
+description the backend needs.
+
+What this guards is that the weight's ``TLOAD`` is NZ->NZ rather than ND->NZ,
+so no online fractal conversion runs on the weight load.
+
+Three kernels cover the two coordinate axes the pass has to map, because a
+whole-tensor load leaves every offset zero and so exercises none of them:
+
+| Kernel | Weight window | Offset under test |
+| ------ | ------------- | ----------------- |
+| ``nz_matmul`` | all of ``[N, K]`` | none — the baseline |
+| ``nz_matmul_n_sliced`` | two ``[N/2, K]`` halves | row fractal, ``n0 // 16`` |
+| ``nz_matmul_k_sliced`` | ``[N, K/2]`` upper half | C0 column block, ``k0 // c0`` |
+
+Inputs are small integers so the FP32 accumulation is exact and the comparison
+runs at ``rtol=atol=0``: a mis-addressed fractal reads entirely different
+elements, which must not be able to hide under a numeric tolerance.
+
+Requires PTOAS >= 0.61, the first release that treats an explicit ``layout=nz``
+annotation on ``pto.make_tensor_view`` as authoritative instead of re-inferring
+it structurally (see ``docs/en/dev/passes/15-block_nz_tensor_views.md``).
+"""
+
+import pypto.language as pl
+import pytest
+import torch
+from harness import st
+
+M, K, N = 64, 256, 128
+N_TILE = N // 2
+K_TILE = K // 2
+
+# One 32-byte C0 line and a 16-row fractal are the two constants that define
+# pto-isa's NZ blocking; `c0` is the number of *elements* in that line, so it
+# follows from the dtype width.
+_C0_BYTES = 32
+_FRACTAL_ROWS = 16
+
+
+def _c0_elems(dtype: torch.dtype) -> int:
+    """Number of elements in one 32-byte C0 line for *dtype*."""
+    return _C0_BYTES // torch.empty((), dtype=dtype).element_size()
+
+
+def _pack_nz(logical: torch.Tensor) -> torch.Tensor:
+    """Reorder a logical row-major ``[R, C]`` matrix into NZ fractal order.
+
+    NZ is "column blocks outside, row fractals inside": ``c0`` contiguous
+    elements form one C0 line, 16 rows form one ``16 x c0`` fractal, ``R/16``
+    fractals walk down the row axis, and ``C/c0`` steps between column blocks —
+    the blocked shape ``[C/c0, R/16, 16, c0]`` that ``BlockNzTensorViews`` gives
+    the GM view.
+
+    The result is reshaped back to ``[R, C]`` so the buffer the harness
+    allocates matches the *logical* shape the kernel is annotated with. Only the
+    byte order differs; the element count is identical.
+    """
+    rows, cols = logical.shape
+    c0 = _c0_elems(logical.dtype)
+    assert rows % _FRACTAL_ROWS == 0, f"NZ needs {_FRACTAL_ROWS}-row fractals, got {rows} rows"
+    assert cols % c0 == 0, f"NZ needs whole C0 lines of {c0} elements, got {cols} cols"
+    return (
+        logical.reshape(rows // _FRACTAL_ROWS, _FRACTAL_ROWS, cols // c0, c0)
+        .permute(2, 0, 1, 3)
+        .contiguous()
+        .reshape(rows, cols)
+    )
+
+
+def _unpack_nz(packed: torch.Tensor) -> torch.Tensor:
+    """Restore NZ-ordered bytes to the logical row-major ``[R, C]`` matrix."""
+    rows, cols = packed.shape
+    c0 = _c0_elems(packed.dtype)
+    return (
+        packed.reshape(cols // c0, rows // _FRACTAL_ROWS, _FRACTAL_ROWS, c0)
+        .permute(1, 2, 0, 3)
+        .contiguous()
+        .reshape(rows, cols)
+    )
+
+
+# ============================================================================
+# Kernels
+#
+# `target_memory=pl.Mem.Mat` is required on an NZ load, not merely preferred:
+# NZ->NZ is the cube operand path, and BlockNzTensorViews rejects any other
+# target rather than mis-addressing the tensor.
+# ============================================================================
+
+
+@pl.jit.incore
+def _nz_matmul_kernel(
+    x: pl.Tensor[[M, K], pl.FP16],
+    w: pl.Tensor[[N, K], pl.FP16, pl.NZ],
+    out: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+) -> pl.Tensor[[M, N], pl.FP32]:
+    """out = x @ w^T, with w read straight out of its NZ fractal layout."""
+    xt = pl.load(x, [0, 0], [M, K], target_memory=pl.Mem.Mat)
+    wt = pl.load(w, [0, 0], [N, K], target_memory=pl.Mem.Mat)
+    return pl.store(pl.matmul(xt, pl.tile.transpose_view(wt)), [0, 0], out)
+
+
+@pl.jit
+def nz_matmul(
+    x: pl.Tensor[[M, K], pl.FP16],
+    w: pl.Tensor[[N, K], pl.FP16, pl.NZ],
+    out: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+) -> pl.Tensor[[M, N], pl.FP32]:
+    return _nz_matmul_kernel(x, w, out)
+
+
+@pl.jit.incore
+def _nz_matmul_n_sliced_kernel(
+    x: pl.Tensor[[M, K], pl.FP16],
+    w: pl.Tensor[[N, K], pl.FP16, pl.NZ],
+    out: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+) -> pl.Tensor[[M, N], pl.FP32]:
+    """The same product, but the weight arrives as two N halves.
+
+    The second load's logical row offset ``N_TILE`` must become the fractal
+    offset ``N_TILE // 16``. Drop the division and the load reads 64 fractals
+    past where it should; drop the offset and both halves read the same rows —
+    either way the right half of ``out`` is wrong while the left half still
+    matches, so the two-half shape localises the failure.
+    """
+    xt = pl.load(x, [0, 0], [M, K], target_memory=pl.Mem.Mat)
+    lo = pl.load(w, [0, 0], [N_TILE, K], target_memory=pl.Mem.Mat)
+    hi = pl.load(w, [N_TILE, 0], [N_TILE, K], target_memory=pl.Mem.Mat)
+    out = pl.store(pl.matmul(xt, pl.tile.transpose_view(lo)), [0, 0], out)
+    return pl.store(pl.matmul(xt, pl.tile.transpose_view(hi)), [0, N_TILE], out)
+
+
+@pl.jit
+def nz_matmul_n_sliced(
+    x: pl.Tensor[[M, K], pl.FP16],
+    w: pl.Tensor[[N, K], pl.FP16, pl.NZ],
+    out: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+) -> pl.Tensor[[M, N], pl.FP32]:
+    return _nz_matmul_n_sliced_kernel(x, w, out)
+
+
+@pl.jit.incore
+def _nz_matmul_k_sliced_kernel(
+    x: pl.Tensor[[M, K], pl.FP16],
+    w: pl.Tensor[[N, K], pl.FP16, pl.NZ],
+    out: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+) -> pl.Tensor[[M, N], pl.FP32]:
+    """A partial-K product over the upper half of the reduction axis.
+
+    This is the other offset axis: the logical column offset ``K_TILE`` maps to
+    the C0 block offset ``K_TILE // c0``, a different slot of the blocked view
+    than the row fractal above.
+    """
+    xt = pl.load(x, [0, K_TILE], [M, K_TILE], target_memory=pl.Mem.Mat)
+    wt = pl.load(w, [0, K_TILE], [N, K_TILE], target_memory=pl.Mem.Mat)
+    return pl.store(pl.matmul(xt, pl.tile.transpose_view(wt)), [0, 0], out)
+
+
+@pl.jit
+def nz_matmul_k_sliced(
+    x: pl.Tensor[[M, K], pl.FP16],
+    w: pl.Tensor[[N, K], pl.FP16, pl.NZ],
+    out: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+) -> pl.Tensor[[M, N], pl.FP32]:
+    return _nz_matmul_k_sliced_kernel(x, w, out)
+
+
+# ============================================================================
+# Cases
+# ============================================================================
+
+
+def _inputs() -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Small integers, so the FP32 accumulation is exact at rtol=atol=0."""
+    generator = torch.Generator().manual_seed(17)
+    x = torch.randint(-4, 5, (M, K), generator=generator).to(torch.float16)
+    w_logical = torch.randint(-4, 5, (N, K), generator=generator).to(torch.float16)
+    return x, _pack_nz(w_logical), torch.zeros((M, N), dtype=torch.float32)
+
+
+def _full_golden(tensors: dict[str, torch.Tensor]) -> torch.Tensor:
+    x = tensors["x"].to(torch.float32)
+    w = _unpack_nz(tensors["w"]).to(torch.float32)
+    return torch.matmul(x, w.T)
+
+
+def _k_sliced_golden(tensors: dict[str, torch.Tensor]) -> torch.Tensor:
+    x = tensors["x"].to(torch.float32)[:, K_TILE:]
+    w = _unpack_nz(tensors["w"]).to(torch.float32)[:, K_TILE:]
+    return torch.matmul(x, w.T)
+
+
+def _nz_cases():
+    for kernel, label, golden in (
+        (nz_matmul, "full", _full_golden),
+        (nz_matmul_n_sliced, "n_sliced", _full_golden),
+        (nz_matmul_k_sliced, "k_sliced", _k_sliced_golden),
+    ):
+        yield st.case(
+            kernel,
+            *_inputs(),
+            name=f"matmul_nz_{label}_{M}x{K}x{N}",
+            golden=golden,
+            rtol=0.0,
+            atol=0.0,
+        )
+
+
+def test_pack_places_each_element_at_its_blocked_offset():
+    """The host packer is this test's own premise, so pin it independently.
+
+    A roundtrip alone would accept any self-inverse permutation (a plain
+    transpose, say), so check the absolute destination: logical ``(r, c)`` with
+    ``r = i*16 + ii`` and ``c = j*c0 + jj`` must land at flat offset
+    ``j*(R*c0) + i*(16*c0) + ii*c0 + jj``.
+    """
+    rows, cols = 64, 128
+    # int16 shares FP16's 2-byte width, hence its c0, and indexes every element
+    # of this shape exactly — which FP16 itself cannot do past 2048.
+    logical = torch.arange(rows * cols, dtype=torch.int16).reshape(rows, cols)
+    c0 = _c0_elems(logical.dtype)
+    assert c0 == 16
+
+    flat = _pack_nz(logical).reshape(-1)
+    for r, c in ((0, 0), (0, c0), (1, 0), (17, 33), (rows - 1, cols - 1)):
+        i, ii = divmod(r, _FRACTAL_ROWS)
+        j, jj = divmod(c, c0)
+        offset = j * (rows * c0) + i * (_FRACTAL_ROWS * c0) + ii * c0 + jj
+        assert flat[offset] == logical[r, c], f"({r}, {c}) is not at blocked offset {offset}"
+
+    assert torch.equal(_unpack_nz(_pack_nz(logical)), logical)
+
+
+@st.cases(*_nz_cases())
+def test_matmul_nz(case_run):
+    """An NZ weight is consumed from its fractal layout with no conversion."""
+    case_run.assert_passed()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
`pl.NZ` has had no test that reaches the assembler since the GM layout landed in #2727, so the ptoas >= 0.61 path it depends on stayed unverified on device even after the v0.61 bump in #2686. `grep -rn "pl.NZ" tests/st/ examples/` was empty.

## What this adds

`tests/st/runtime/ops/test_matmul_nz.py` — an ND activation against a GM weight annotated `pl.NZ`, with the host packer that produces the fractal bytes and the unpacker the golden reads them back through. `pl.NZ` asserts that the bytes already in GM are NZ-ordered rather than requesting a conversion, so the test has to supply them itself:

```python
def _pack_nz(logical):                      # [R, C] row-major -> NZ fractal order
    rows, cols = logical.shape
    c0 = _c0_elems(logical.dtype)
    return (logical.reshape(rows // 16, 16, cols // c0, c0)
            .permute(2, 0, 1, 3).contiguous().reshape(rows, cols))
```

The result keeps the logical `[R, C]` shape so the harness buffer matches the annotation; only the byte order changes.

Three kernels, because a whole-tensor load leaves every offset zero and so exercises none of the coordinate mapping `BlockNzTensorViews` performs:

| kernel | weight window | offset under test |
| ------ | ------------- | ----------------- |
| `full` | all of `[N, K]` | none — the baseline |
| `n_sliced` | two `[N/2, K]` halves | row fractal, `n0 // 16` |
| `k_sliced` | `[N, K/2]` upper half | C0 column block, `k0 // c0` |

## Verification

4 passed on a 910B1 in ~15 s. The emitted `.pto` confirms the weight really takes the NZ path — rank-5 view with the explicit layout attribute, while the activation and output stay rank-2 ND:

```mlir
%w_view = pto.make_tensor_view %arg1, shape = [%c1, %c16, %c8, %c16, %c16],
    strides = [%c32768, %c2048, %c256, %c16, %c1] {layout = #pto.layout<nz>}
```

and the sliced cases emit the divided offsets: `[0, 0, 4, 0, 0]` for the second `n_sliced` load (`64 // 16`) and `[0, 8, 0, 0, 0]` for `k_sliced` (`128 // c0`).

## Notes for review

- **Tolerances are `rtol=atol=0` on purpose.** Inputs are small integers so the FP32 accumulation is exact. A mis-addressed fractal reads entirely different elements, and that must not be able to hide under a numeric tolerance.
- **The packer gets its own test.** `test_pack_places_each_element_at_its_blocked_offset` pins each element's *absolute* blocked offset rather than just a roundtrip — a roundtrip alone would accept any self-inverse permutation, such as a plain transpose. It runs in-process with no device.
- **Shape is 64x256x128 deliberately.** Larger shapes hit an unrelated `pytest-forked` + PyTorch deadlock: `tests/st` forks a parent that has already started torch's intra-op thread pool (185 threads on the host I used), so a golden whose tensors exceed ATen's 32768-element grain size deadlocks in the child before anything is dispatched to the device. `OMP_NUM_THREADS=1` makes it go away. This shape sits exactly on the safe side. Not addressed here — flagging it because it will bite the next person who sweeps ST matmul shapes, and a `torch.set_num_threads(1)` in `tests/st/conftest.py` would close it.

## Doc fix

The pass doc's "Assembler version" section still said the repo pinned v0.60 and that no test reached the assembler with an NZ tensor. #2686 and this test make both false; corrected in `docs/en/` and `docs/zh/`.
